### PR TITLE
DevDivInsertionFiles: Fix dependency error reporting

### DIFF
--- a/eng/targets/PackageProject.targets
+++ b/eng/targets/PackageProject.targets
@@ -8,7 +8,7 @@
     Projects in this directory do not produce useful binaries, they are only used to generate packages. 
     Build target only needs to build their project dependencies (via ResolveProjectReferences).
   -->
-  <Target Name="Build" DependsOnTargets="ResolveProjectReferences">
+  <Target Name="CoreBuild" DependsOnTargets="ResolveProjectReferences">
     <MakeDir Directories="$(IntermediateOutputPath)" ContinueOnError="True"/>
   </Target>
 

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -93,12 +93,6 @@
     <!--     
       Exclude dependencies that are not inserted from Roslyn repo.
       Note: can't use globs due to https://github.com/Microsoft/msbuild/issues/3791.
-      
-      these dependency should be removed once StreamJsonRpc adds a build target for
-      net472 - https://github.com/dotnet/roslyn/issues/34558
-      
-      <_Dependency Remove="Nerdbank.Streams"/>
-      <_Dependency Remove="System.IO.Pipelines"/>
     -->
     <ItemGroup>
       <_Dependency Remove="@(_Dependency)" Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').StartsWith('Microsoft.VisualStudio.'))"/>
@@ -114,6 +108,7 @@
       <_Dependency Remove="StreamJsonRpc"/>
       <_Dependency Remove="Nerdbank.Streams"/>
       <_Dependency Remove="System.IO.Pipelines"/>
+      <_Dependency Remove="System.ValueTuple"/>
       <_Dependency Remove="System.Threading.Tasks.Dataflow"/>
       <_Dependency Remove="VSLangProj"/>
       <_Dependency Remove="VSLangProj2"/>
@@ -199,7 +194,7 @@
     Write a list of assembly names and versions that the insertion tool uses to update assembly versions in DevDiv.
   -->
   <Target Name="_GenerateDependentAssemblyVersions" 
-          AfterTargets="Build" 
+          BeforeTargets="AfterBuild"
           DependsOnTargets="_CalculateDependenciesToInsert"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(_DependentAssemblyVersionsFile)">
@@ -223,7 +218,7 @@
     Copy NuGet packages to be inserted into VS by the insertion tool.
   -->
   <Target Name="_CopyPackagesToInsert"
-          AfterTargets="Build"
+          BeforeTargets="AfterBuild"
           Condition="'$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true'"
           DependsOnTargets="_CalculateDependenciesToInsert;_UnpackDependencies;ApplyOptimizations">
 


### PR DESCRIPTION
Two issues:
1) Replace `AfterTargets="Build"` with `BeforeTargets="AfterBuild"`
   Workaround for https://github.com/microsoft/msbuild/issues/3345
2) System.ValueTuple
   Seems like the System.ValueTuple package is missing `lib/net472/_._`, so `lib/net47/System.ValueTuple.dll` is identified as a runtime dependency although it is not.

https://github.com/dotnet/roslyn/issues/34558.