### PR TITLE
Add (internal-only) CompletionItem.AutomationText and pass it through to the editor

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -393,6 +393,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 insertText: itemData.InsertionText,
                 sortText: roslynItem.SortText,
                 filterText: roslynItem.FilterText,
+                automationText: roslynItem.AutomationText ?? roslynItem.DisplayText,
                 attributeIcons: itemData.AttributeIcons);
 
             item.Properties.AddProperty(RoslynItem, roslynItem);

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -4934,6 +4934,29 @@ class C
         ' Implementation for the Modern completion only
         <InlineData(CompletionImplementation.Modern)>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAutomationTextPassedToEditor(completionImplementation As CompletionImplementation) As Task
+            Dim provider = New IntelliCodeMockProvider()
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+class C
+{
+    void Method()
+    {
+        var s = "";
+        s.Len$$
+    }
+}
+                              </Document>, {provider})
+
+                state.SendInvokeCompletionList()
+                state.SendSelectCompletionItem("★ Length")
+                Await state.AssertSelectedCompletionItem(displayText:="★ Length", automationText:=provider.AutomationTextString)
+            End Using
+        End Function
+
+        ' Implementation for the Modern completion only
+        <InlineData(CompletionImplementation.Modern)>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestSendCommitIfUniqueWithIntelliCodeAndDuplicateItemsFromIntelliCode(completionImplementation As CompletionImplementation) As Task
             Dim provider = New IntelliCodeMockWeirdProvider()
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
@@ -5297,8 +5320,13 @@ class C
         Private Class IntelliCodeMockProvider
             Inherits CompletionProvider
 
+            Public AutomationTextString As String = "Hello from IntelliCode: Length"
+
             Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
-                context.AddItem(CompletionItem.Create(displayText:="★ Length", filterText:="Length"))
+                Dim intelliCodeItem = CompletionItem.Create(displayText:="★ Length", filterText:="Length")
+                intelliCodeItem.AutomationText = AutomationTextString
+
+                context.AddItem(intelliCodeItem)
                 context.AddItem(CompletionItem.Create(displayText:="Length", filterText:="Length"))
                 context.AddItem(CompletionItem.Create(displayText:="ToString()", filterText:="ToString"))
                 context.AddItem(CompletionItem.Create(displayText:="First()", filterText:="First"))

--- a/src/EditorFeatures/TestUtilities2/Intellisense/LegacyTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/LegacyTestState.vb
@@ -186,6 +186,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                Optional isHardSelected As Boolean? = Nothing,
                                Optional shouldFormatOnCommit As Boolean? = Nothing,
                                Optional inlineDescription As String = Nothing,
+                               Optional automationText As String = Nothing,
                                Optional projectionsView As ITextView = Nothing) As Task
             ' projectionsView is not used in this implementation.
 
@@ -221,6 +222,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                     document, Me.CurrentCompletionPresenterSession.SelectedItem)
                 Assert.Equal(description, itemDescription.Text)
             End If
+
+            ' AutomationText property is only supported by Modern Completion
+            Assert.Null(automationText)
         End Function
 
         Public Overrides Function AssertSessionIsNothingOrNoCompletionItemLike(text As String) As Task

--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -211,6 +211,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                                     Optional isHardSelected As Boolean? = Nothing,
                                                     Optional shouldFormatOnCommit As Boolean? = Nothing,
                                                     Optional inlineDescription As String = Nothing,
+                                                    Optional automationText As String = Nothing,
                                                     Optional projectionsView As ITextView = Nothing) As Task
 
             Dim view = If(projectionsView, TextView)
@@ -261,6 +262,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             If inlineDescription IsNot Nothing Then
                 Assert.Equal(inlineDescription, items.SelectedItem.Suffix)
+            End If
+
+            If automationText IsNot Nothing Then
+                Assert.Equal(automationText, items.SelectedItem.AutomationText)
             End If
         End Function
 

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateBase.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateBase.vb
@@ -253,6 +253,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                Optional isHardSelected As Boolean? = Nothing,
                                Optional shouldFormatOnCommit As Boolean? = Nothing,
                                Optional inlineDescription As String = Nothing,
+                               Optional automationText As String = Nothing,
                                Optional projectionsView As ITextView = Nothing) As Task
 
 #End Region

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -85,6 +85,12 @@ namespace Microsoft.CodeAnalysis.Completion
         internal string ProviderName { get; set; }
 
         /// <summary>
+        /// The automation text to use when narrating the completion item. If set to
+        /// null, narration will use the <see cref="DisplayText"/> instead.
+        /// </summary>
+        internal string AutomationText { get; set; }
+
+        /// <summary>
         /// Indicate whether this <see cref="CompletionItem"/> is cached and reused across completion sessions. 
         /// This might be used by completion system for things like deciding whether it can safaly cache and reuse
         /// other data correspodning to this item.
@@ -252,6 +258,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 displayTextSuffix: newDisplayTextSuffix,
                 inlineDescription: newInlineDescription)
             {
+                AutomationText = AutomationText,
                 ProviderName = ProviderName
             };
         }


### PR DESCRIPTION
Related to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/603447 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/848126, but still requires work from consumers, particularly IntelliCode, to adopt.