### PR TITLE
Initial support for [AllowNull], [DisallowNull], [MaybeNull], [NotNull] in NullableWalker

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2874,7 +2874,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public TypeWithAnnotations ApplyLValueAnnotations(TypeWithAnnotations declaredType, FlowAnalysisAnnotations flowAnalysisAnnotations = FlowAnalysisAnnotations.None)
+        private static TypeWithAnnotations ApplyLValueAnnotations(TypeWithAnnotations declaredType, FlowAnalysisAnnotations flowAnalysisAnnotations = FlowAnalysisAnnotations.None)
         {
             if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.DisallowNull) != 0)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2805,8 +2805,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             for (int i = 0; i < numArguments; i++)
             {
-                (ParameterSymbol parameter, _, _) = GetCorrespondingParameter(i, parameters, argsToParamsOpt, expanded);
-                FlowAnalysisAnnotations annotations = parameter is null ? FlowAnalysisAnnotations.None : GetAnnotations(parameter);
+                (ParameterSymbol parameter, _, FlowAnalysisAnnotations annotations) = GetCorrespondingParameter(i, parameters, argsToParamsOpt, expanded);
 
                 annotations = removeInapplicableAnnotations(parameter, annotations);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2876,7 +2876,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static TypeWithAnnotations ApplyLValueAnnotations(TypeWithAnnotations declaredType, FlowAnalysisAnnotations flowAnalysisAnnotations)
         {
-            if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.DisallowNull) != 0)
+            if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.DisallowNull) == FlowAnalysisAnnotations.DisallowNull)
             {
                 var typeSymbol = declaredType.Type;
                 if (declaredType.NullableAnnotation.IsNotAnnotated() || (typeSymbol.IsValueType && !typeSymbol.IsNullableType()))
@@ -2884,9 +2884,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return declaredType;
                 }
 
-                return TypeWithAnnotations.Create(typeSymbol, NullableAnnotation.NotAnnotated, declaredType.CustomModifiers);
+                return declaredType.AsNotAnnotated();
             }
-            else if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.AllowNull) != 0)
+            else if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.AllowNull) == FlowAnalysisAnnotations.AllowNull)
             {
                 var typeSymbol = declaredType.Type;
                 if (declaredType.NullableAnnotation.IsAnnotated() || (typeSymbol.IsValueType && typeSymbol.IsNullableType()))
@@ -2894,7 +2894,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return declaredType;
                 }
 
-                return TypeWithAnnotations.Create(typeSymbol, NullableAnnotation.Annotated, declaredType.CustomModifiers);
+                return declaredType.AsAnnotated();
             }
 
             return declaredType;
@@ -2910,17 +2910,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return declaredType;
                 }
 
-                return TypeWithAnnotations.Create(typeSymbol, NullableAnnotation.NotAnnotated, declaredType.CustomModifiers);
+                return declaredType.AsNotAnnotated();
             }
             else if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.MaybeNull) == FlowAnalysisAnnotations.MaybeNull)
             {
                 var typeSymbol = declaredType.Type;
-                if (!declaredType.NullableAnnotation.IsNotAnnotated() || (typeSymbol.IsValueType && typeSymbol.IsNullableType()))
+                if (declaredType.NullableAnnotation.IsAnnotated() || (typeSymbol.IsValueType && typeSymbol.IsNullableType()))
                 {
                     return declaredType;
                 }
 
-                return TypeWithAnnotations.Create(typeSymbol, NullableAnnotation.Annotated, declaredType.CustomModifiers);
+                return declaredType.AsAnnotated();
             }
 
             return declaredType;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2874,7 +2874,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static TypeWithAnnotations ApplyLValueAnnotations(TypeWithAnnotations declaredType, FlowAnalysisAnnotations flowAnalysisAnnotations = FlowAnalysisAnnotations.None)
+        private static TypeWithAnnotations ApplyLValueAnnotations(TypeWithAnnotations declaredType, FlowAnalysisAnnotations flowAnalysisAnnotations)
         {
             if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.DisallowNull) != 0)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2878,22 +2878,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.DisallowNull) == FlowAnalysisAnnotations.DisallowNull)
             {
-                var typeSymbol = declaredType.Type;
-                if (declaredType.NullableAnnotation.IsNotAnnotated() || (typeSymbol.IsValueType && !typeSymbol.IsNullableType()))
-                {
-                    return declaredType;
-                }
-
                 return declaredType.AsNotAnnotated();
             }
             else if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.AllowNull) == FlowAnalysisAnnotations.AllowNull)
             {
-                var typeSymbol = declaredType.Type;
-                if (declaredType.NullableAnnotation.IsAnnotated() || (typeSymbol.IsValueType && typeSymbol.IsNullableType()))
-                {
-                    return declaredType;
-                }
-
                 return declaredType.AsAnnotated();
             }
 
@@ -2904,22 +2892,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.NotNull) == FlowAnalysisAnnotations.NotNull)
             {
-                var typeSymbol = declaredType.Type;
-                if (declaredType.NullableAnnotation.IsNotAnnotated() || (typeSymbol.IsValueType && !typeSymbol.IsNullableType()))
-                {
-                    return declaredType;
-                }
-
                 return declaredType.AsNotAnnotated();
             }
             else if ((flowAnalysisAnnotations & FlowAnalysisAnnotations.MaybeNull) == FlowAnalysisAnnotations.MaybeNull)
             {
-                var typeSymbol = declaredType.Type;
-                if (declaredType.NullableAnnotation.IsAnnotated() || (typeSymbol.IsValueType && typeSymbol.IsNullableType()))
-                {
-                    return declaredType;
-                }
-
                 return declaredType.AsAnnotated();
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorFinallyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorFinallyMethodSymbol.cs
@@ -142,6 +142,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { return TypeWithAnnotations.Create(ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
         {
             get { return ImmutableArray<TypeWithAnnotations>.Empty; }

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -139,6 +139,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return this.TypeMap.SubstituteType(this.BaseMethod.OriginalDefinition.ReturnTypeWithAnnotations); }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => BaseMethod.ReturnTypeAnnotationAttributes;
+
         public sealed override bool IsVararg
         {
             get { return this.BaseMethod.IsVararg; }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.SynthesizedMethodBase.cs
@@ -97,6 +97,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return false; }
             }
 
+            public sealed override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
             public sealed override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
             {
                 get { return ImmutableArray<TypeWithAnnotations>.Empty; }

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ReturnTypeWellKnownAttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/WellKnownAttributeData/ReturnTypeWellKnownAttributeData.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class ReturnTypeWellKnownAttributeData : CommonReturnTypeWellKnownAttributeData
+    {
+        private bool _hasMaybeNullAttribute;
+        public bool HasMaybeNullAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasMaybeNullAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasMaybeNullAttribute = value;
+                SetDataStored();
+            }
+        }
+
+        private bool _hasNotNullAttribute;
+        public bool HasNotNullAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasNotNullAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasNotNullAttribute = value;
+                SetDataStored();
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
@@ -161,6 +161,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return this.ReturnType.IsVoidType(); }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override bool IsVararg
         {
             get { return false; }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override TypeWithAnnotations ReturnTypeWithAnnotations => Signature.ReturnParam.TypeWithAnnotations;
 
-        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => Signature.ReturnParam.FlowAnalysisAnnotations;
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers => Signature.ReturnParam.RefCustomModifiers;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -526,6 +526,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override TypeWithAnnotations ReturnTypeWithAnnotations => Signature.ReturnParam.TypeWithAnnotations;
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers => Signature.ReturnParam.RefCustomModifiers;
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -209,6 +209,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public TypeSymbol ReturnType => ReturnTypeWithAnnotations.Type;
 
+        public abstract FlowAnalysisAnnotations ReturnTypeAnnotationAttributes { get; }
+
         /// <summary>
         /// Returns the type arguments that have been substituted for the type parameters.
         /// If nothing has been substituted for a given type parameter,

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -344,6 +344,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _typeMap.SubstituteType(_reducedFrom.ReturnTypeWithAnnotations); }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => _reducedFrom.ReturnTypeAnnotationAttributes;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {
             get { return _typeMap.SubstituteCustomModifiers(_reducedFrom.RefCustomModifiers); }

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -65,6 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override TypeWithAnnotations ReturnTypeWithAnnotations { get { return _returnType; } }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers { get { return _refCustomModifiers; } }
 
         public override ImmutableArray<ParameterSymbol> Parameters { get { return _parameters; } }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -179,6 +179,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _returnType; }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         // In error recovery and type inference scenarios we do not know the return type
         // until after the body is bound, but the symbol is created before the body
         // is bound.  Fill in the return type post hoc in these scenarios; the

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -204,6 +204,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override RefKind RefKind => _refKind;
 
         internal void ComputeReturnType()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -41,7 +41,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private const int MethodKindMask = 0x1F;
             private const int DeclarationModifiersMask = 0x7FFFFF;
 
-            private const int ReturnsVoidBit = 1 << 27;
             private const int IsExtensionMethodBit = 1 << 28;
             private const int IsMetadataVirtualIgnoringInterfaceChangesBit = 1 << 29;
             private const int IsMetadataVirtualBit = 1 << 30;
@@ -357,6 +356,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return this.flags.ReturnsVoid;
             }
         }
+
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes =>
+            DecodeReturnTypeAnnotationAttributes(GetDecodedReturnTypeWellKnownAttributeData());
 
         public sealed override MethodKind MethodKind
         {
@@ -940,7 +942,7 @@ done:
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonReturnTypeWellKnownAttributeData GetDecodedReturnTypeWellKnownAttributeData()
+        internal ReturnTypeWellKnownAttributeData GetDecodedReturnTypeWellKnownAttributeData()
         {
             var attributesBag = _lazyReturnTypeCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -948,7 +950,7 @@ done:
                 attributesBag = this.GetReturnTypeAttributesBag();
             }
 
-            return (CommonReturnTypeWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
+            return (ReturnTypeWellKnownAttributeData)attributesBag.DecodedWellKnownAttributeData;
         }
 
         /// <summary>
@@ -1313,7 +1315,7 @@ done:
             if (attribute.IsTargetAttribute(this, AttributeDescription.MarshalAsAttribute))
             {
                 // MarshalAs applied to the return value:
-                MarshalAsAttributeDecoder<CommonReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
+                MarshalAsAttributeDecoder<ReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
             {
@@ -1343,6 +1345,14 @@ done:
             {
                 // NullableAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
+            {
+                arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().HasMaybeNullAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.NotNullAttribute))
+            {
+                arguments.GetOrCreateData<ReturnTypeWellKnownAttributeData>().HasNotNullAttribute = true;
             }
         }
 
@@ -1499,6 +1509,23 @@ done:
             }
 
             base.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData);
+        }
+
+        private static FlowAnalysisAnnotations DecodeReturnTypeAnnotationAttributes(ReturnTypeWellKnownAttributeData attributeData)
+        {
+            FlowAnalysisAnnotations annotations = FlowAnalysisAnnotations.None;
+            if (attributeData != null)
+            {
+                if (attributeData.HasMaybeNullAttribute)
+                {
+                    annotations |= FlowAnalysisAnnotations.MaybeNull;
+                }
+                if (attributeData.HasNotNullAttribute)
+                {
+                    annotations |= FlowAnalysisAnnotations.NotNull;
+                }
+            }
+            return annotations;
         }
 
         public sealed override bool HidesBaseMethodsByName

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -227,6 +227,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get { return TypeWithAnnotations.Create(_returnType); }
             }
 
+            public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
             public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
             {
                 get { return ImmutableArray<TypeWithAnnotations>.Empty; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -4,9 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Emit;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -139,6 +137,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return ReturnType.IsVoidType(); }
         }
+
+        public sealed override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
 
         public override MethodKind MethodKind
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -116,6 +116,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
+        public sealed override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation
         {
             get { return null; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedImplementationMethod.cs
@@ -3,8 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -100,6 +98,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return _interfaceMethod.ReturnTypeWithAnnotations; }
         }
+
+        public sealed override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
 
         public override ImmutableArray<ParameterSymbol> Parameters
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -151,6 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return TypeWithAnnotations.Create(ContainingAssembly.GetSpecialType(SpecialType.System_Void)); }
         }
 
+        public sealed override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {
             get { return ImmutableArray<CustomModifier>.Empty; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInteractiveInitializerMethod.cs
@@ -140,6 +140,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return TypeWithAnnotations.Create(_returnType); }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {
             get { return ImmutableArray<CustomModifier>.Empty; }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -229,6 +229,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSealedPropertyAccessor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSealedPropertyAccessor.cs
@@ -188,6 +188,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -136,6 +136,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -99,11 +99,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal TypeWithAnnotations AsAnnotated()
         {
+            if (NullableAnnotation.IsAnnotated() || (Type.IsValueType && Type.IsNullableType()))
+            {
+                return this;
+            }
+
             return Create(Type, NullableAnnotation.Annotated, CustomModifiers);
         }
 
         internal TypeWithAnnotations AsNotAnnotated()
         {
+            if (NullableAnnotation.IsNotAnnotated() || (Type.IsValueType && !Type.IsNullableType()))
+            {
+                return this;
+            }
+
             return Create(Type, NullableAnnotation.NotAnnotated, CustomModifiers);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -97,6 +97,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CreateNonLazyType(typeSymbol, nullableAnnotation, customModifiers.NullToEmpty());
         }
 
+        internal TypeWithAnnotations AsAnnotated()
+        {
+            return Create(Type, NullableAnnotation.Annotated, CustomModifiers);
+        }
+
+        internal TypeWithAnnotations AsNotAnnotated()
+        {
+            return Create(Type, NullableAnnotation.NotAnnotated, CustomModifiers);
+        }
+
         internal bool IsPossiblyNullableTypeTypeParameter()
         {
             return NullableAnnotation.IsNotAnnotated() &&

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -50,13 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 else
                 {
-                    state = typeWithAnnotations.NullableAnnotation switch
-                    {
-                        NullableAnnotation.Oblivious => NullableFlowState.NotNull,
-                        NullableAnnotation.NotAnnotated => type.IsPossiblyNullableReferenceTypeTypeParameter() || type.IsNullableTypeOrTypeParameter() ? NullableFlowState.MaybeNull : NullableFlowState.NotNull,
-                        NullableAnnotation.Annotated => NullableFlowState.MaybeNull,
-                        var value => throw ExceptionUtilities.UnexpectedValue(value),
-                    };
+                    return typeWithAnnotations.ToTypeWithState();
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -40,11 +40,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             NullableFlowState state;
             if (type.CanContainNull())
             {
-                if ((annotations & FlowAnalysisAnnotations.MaybeNull) != 0)
+                if ((annotations & FlowAnalysisAnnotations.MaybeNull) == FlowAnalysisAnnotations.MaybeNull)
                 {
                     state = NullableFlowState.MaybeNull;
                 }
-                else if ((annotations & FlowAnalysisAnnotations.NotNull) != 0)
+                else if ((annotations & FlowAnalysisAnnotations.NotNull) == FlowAnalysisAnnotations.NotNull)
                 {
                     state = NullableFlowState.NotNull;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithState.cs
@@ -32,10 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static TypeWithState Create(TypeWithAnnotations typeWithAnnotations, FlowAnalysisAnnotations annotations = FlowAnalysisAnnotations.None)
         {
             var type = typeWithAnnotations.Type;
-            if (type is null)
-            {
-                return new TypeWithState(null, NullableFlowState.MaybeNull);
-            }
+            Debug.Assert((object)type != null);
 
             NullableFlowState state;
             if (type.CanContainNull())

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
@@ -297,6 +297,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        public sealed override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => UnderlyingMethod.ReturnTypeAnnotationAttributes;
+
         internal override bool ReturnValueIsMarshalledExplicitly
         {
             get

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -22128,6 +22128,1242 @@ class C
         }
 
         [Fact]
+        public void AllowNull_01()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1<T>([AllowNull]T t) { }
+    static void F2<T>([AllowNull]T t) where T : class { }
+    static void F3<T>([AllowNull]T t) where T : struct { }
+    static void F4<T>([AllowNull]T? t) where T : class { }
+    static void F5<T>([AllowNull]T? t) where T : struct { }
+    static void M1<T>(T t1)
+    {
+        F1(t1);
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1(t2);
+        F2(t2);
+        F4(t2);
+        t2 = null; // 1
+        F1(t2);
+        F2(t2); // 2
+        F4(t2);
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1(t3);
+        F2(t3); // 3
+        F4(t3);
+        if (t3 == null) return;
+        F1(t3);
+        F2(t3);
+        F4(t3);
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1(t4);
+        F3(t4);
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        F1(t5);
+        F5(t5);
+        if (t5 == null) return;
+        F1(t5);
+        F5(t5);
+    }
+}";
+            var comp = CreateCompilation(new[] { AllowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            // The constraint warnings on F2(t2) and F2(t3) are not ideal but expected.
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (20,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t2); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(20, 9),
+                // (26,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t3); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(26, 9));
+        }
+
+        [Fact]
+        public void AllowNull_02()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1<T>([AllowNull]T t) { }
+    static void F2<T>([AllowNull]T t) where T : class { }
+    static void F3<T>([AllowNull]T t) where T : struct { }
+    static void F4<T>([AllowNull]T? t) where T : class { }
+    static void F5<T>([AllowNull]T? t) where T : struct { }
+    static void M1<T>(T t1)
+    {
+        F1<T>(t1);
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1<T>(t2);
+        F2<T>(t2);
+        F4<T>(t2);
+        t2 = null; // 1
+        F1<T>(t2);
+        F2<T>(t2);
+        F4<T>(t2);
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1<T>(t3);
+        F2<T>(t3);
+        F4<T>(t3);
+        if (t3 == null) return;
+        F1<T>(t3);
+        F2<T>(t3);
+        F4<T>(t3);
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1<T>(t4);
+        F3<T>(t4);
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        F1<T?>(t5);
+        F5<T>(t5);
+        if (t5 == null) return;
+        F1<T?>(t5);
+        F5<T>(t5);
+    }
+}";
+            var comp = CreateCompilation(new[] { AllowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14));
+        }
+
+        [Fact]
+        public void AllowNull_03()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1([AllowNull]string s) { }
+    static void F2([AllowNull]string? s) { }
+    static void M1(string s1)
+    {
+        F1(s1);
+        F2(s1);
+        s1 = null; // 1
+        F1(s1);
+        F2(s1);
+    }
+    static void M2(string? s2)
+    {
+        F1(s2);
+        F2(s2);
+        if (s2 == null) return;
+        F1(s2);
+        F2(s2);
+    }
+}";
+            var comp = CreateCompilation(new[] { AllowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         s1 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(10, 14));
+        }
+
+        [Fact]
+        public void AllowNull_04()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1([AllowNull]int i) { }
+    static void F2([AllowNull]int? i) { }
+    static void M1(int i1)
+    {
+        F1(i1);
+        F2(i1);
+    }
+    static void M2(int? i2)
+    {
+        F2(i2);
+        if (i2 == null) return;
+        F2(i2);
+    }
+}";
+            var comp = CreateCompilation(new[] { AllowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void AllowNull_05()
+        {
+            var source0 =
+@"using System.Runtime.CompilerServices;
+public class A
+{
+    public static void F1<T>(T t) where T : class { }
+    public static void F2<T>([AllowNull]T t) where T : class { }
+}";
+            var comp = CreateCompilation(new[] { AllowNullAttributeDefinition, source0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source =
+@"class B : A
+{
+    static void Main()
+    {
+        object x = null; // 1
+        object? y = new object();
+        F1(x); // 2
+        F1(y);
+        F2(x); // 3
+        F2(y);
+    }
+}";
+            comp = CreateCompilation(source, references: new[] { ref0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (5,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         object x = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 20),
+                // (7,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F1<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F1(x); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F1").WithArguments("A.F1<T>(T)", "T", "object?").WithLocation(7, 9),
+                // (9,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F2<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F2(x); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("A.F2<T>(T)", "T", "object?").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void DisallowNull_01()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1<T>([DisallowNull]T t) { }
+    static void F2<T>([DisallowNull]T t) where T : class { }
+    static void F3<T>([DisallowNull]T? t) where T : class { }
+    static void F4<T>([DisallowNull]T t) where T : struct { }
+    static void F5<T>([DisallowNull]T? t) where T : struct { }
+    static void M1<T>(T t1)
+    {
+        F1(t1);
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1(t2);
+        F2(t2);
+        F3(t2);
+        t2 = null; // 1
+        F1(t2); // 2
+        F2(t2); // 3
+        F3(t2); // 4
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1(t3); // 5
+        F2(t3); // 6
+        F3(t3); // 7
+        if (t3 == null) return;
+        F1(t3);
+        F2(t3);
+        F3(t3);
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1(t4);
+        F4(t4);
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        F1(t5);
+        F5(t5);
+        if (t5 == null) return;
+        F1(t5);
+        F5(t5);
+    }
+}";
+            var comp = CreateCompilation(new[] { DisallowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F1<T?>(T? t)'.
+                //         F1(t2); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F1<T?>(T? t)").WithLocation(19, 12),
+                // (20,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t2); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(20, 9),
+                // (20,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F2<T?>(T? t)'.
+                //         F2(t2); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F2<T?>(T? t)").WithLocation(20, 12),
+                // (21,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F3<T>(T? t)'.
+                //         F3(t2); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F3<T>(T? t)").WithLocation(21, 12),
+                // (25,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F1<T?>(T? t)'.
+                //         F1(t3); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F1<T?>(T? t)").WithLocation(25, 12),
+                // (26,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t3); // 6
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(26, 9),
+                // (26,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F2<T?>(T? t)'.
+                //         F2(t3); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F2<T?>(T? t)").WithLocation(26, 12),
+                // (27,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F3<T>(T? t)'.
+                //         F3(t3); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F3<T>(T? t)").WithLocation(27, 12));
+        }
+
+        [Fact]
+        public void DisallowNull_02()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1<T>([DisallowNull]T t) { }
+    static void F2<T>([DisallowNull]T t) where T : class { }
+    static void F3<T>([DisallowNull]T? t) where T : class { }
+    static void F4<T>([DisallowNull]T t) where T : struct { }
+    static void F5<T>([DisallowNull]T? t) where T : struct { }
+    static void M1<T>(T t1)
+    {
+        F1<T>(t1);
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1<T>(t2);
+        F2<T>(t2);
+        F3<T>(t2);
+        t2 = null; // 1
+        F1<T>(t2); // 2
+        F2<T>(t2); // 3
+        F3<T>(t2); // 4
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1<T>(t3); // 5
+        F2<T>(t3); // 6
+        F3<T>(t3); // 7
+        if (t3 == null) return;
+        F1<T>(t3);
+        F2<T>(t3);
+        F3<T>(t3);
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1<T>(t4);
+        F4<T>(t4);
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        F1<T?>(t5);
+        F5<T>(t5);
+        if (t5 == null) return;
+        F1<T?>(t5);
+        F5<T>(t5);
+    }
+}";
+            var comp = CreateCompilation(new[] { DisallowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,15): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F1<T>(T t)'.
+                //         F1<T>(t2); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F1<T>(T t)").WithLocation(19, 15),
+                // (20,15): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F2<T>(T t)'.
+                //         F2<T>(t2); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F2<T>(T t)").WithLocation(20, 15),
+                // (21,15): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F3<T>(T? t)'.
+                //         F3<T>(t2); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F3<T>(T? t)").WithLocation(21, 15),
+                // (25,15): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F1<T>(T t)'.
+                //         F1<T>(t3); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F1<T>(T t)").WithLocation(25, 15),
+                // (26,15): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F2<T>(T t)'.
+                //         F2<T>(t3); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F2<T>(T t)").WithLocation(26, 15),
+                // (27,15): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F3<T>(T? t)'.
+                //         F3<T>(t3); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F3<T>(T? t)").WithLocation(27, 15));
+        }
+
+        [Fact]
+        public void DisallowNull_03()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1([DisallowNull]string s) { }
+    static void F2([DisallowNull]string? s) { }
+    static void M1(string s1)
+    {
+        F1(s1);
+        F2(s1);
+        s1 = null; // 1
+        F1(s1); // 2
+        F2(s1); // 3
+    }
+    static void M2(string? s2)
+    {
+        F1(s2); // 4
+        F2(s2); // 5
+        if (s2 == null) return;
+        F1(s2);
+        F2(s2);
+    }
+}";
+            var comp = CreateCompilation(new[] { DisallowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (10,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         s1 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(10, 14),
+                // (11,12): warning CS8604: Possible null reference argument for parameter 's' in 'void Program.F1(string s)'.
+                //         F1(s1); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "s1").WithArguments("s", "void Program.F1(string s)").WithLocation(11, 12),
+                // (12,12): warning CS8604: Possible null reference argument for parameter 's' in 'void Program.F2(string? s)'.
+                //         F2(s1); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "s1").WithArguments("s", "void Program.F2(string? s)").WithLocation(12, 12),
+                // (16,12): warning CS8604: Possible null reference argument for parameter 's' in 'void Program.F1(string s)'.
+                //         F1(s2); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "s2").WithArguments("s", "void Program.F1(string s)").WithLocation(16, 12),
+                // (17,12): warning CS8604: Possible null reference argument for parameter 's' in 'void Program.F2(string? s)'.
+                //         F2(s2); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "s2").WithArguments("s", "void Program.F2(string? s)").WithLocation(17, 12));
+        }
+
+        [Fact]
+        public void DisallowNull_04()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1([DisallowNull]int i) { }
+    static void F2([DisallowNull]int? i) { }
+    static void M1(int i1)
+    {
+        F1(i1);
+        F2(i1);
+    }
+    static void M2(int? i2)
+    {
+        F2(i2);
+        if (i2 == null) return;
+        F2(i2);
+    }
+}";
+            var comp = CreateCompilation(new[] { DisallowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void DisallowNull_05()
+        {
+            var source0 =
+@"using System.Runtime.CompilerServices;
+public class A
+{
+    public static void F1<T>(T t) where T : class { }
+    public static void F2<T>([DisallowNull]T t) where T : class { }
+}";
+            var comp = CreateCompilation(new[] { DisallowNullAttributeDefinition, source0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source =
+@"class B : A
+{
+    static void Main()
+    {
+        object x = null; // 1
+        object? y = new object();
+        F1(x); // 2
+        F1(y);
+        F2(x); // 3
+        F2(y);
+    }
+}";
+            comp = CreateCompilation(source, references: new[] { ref0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (5,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         object x = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 20),
+                // (7,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F1<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F1(x); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F1").WithArguments("A.F1<T>(T)", "T", "object?").WithLocation(7, 9),
+                // (9,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F2<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F2(x); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("A.F2<T>(T)", "T", "object?").WithLocation(9, 9),
+                // (9,12): warning CS8604: Possible null reference argument for parameter 't' in 'void A.F2<object?>(object? t)'.
+                //         F2(x); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "x").WithArguments("t", "void A.F2<object?>(object? t)").WithLocation(9, 12));
+        }
+
+        [Fact]
+        public void MaybeNull_01()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: MaybeNull] static T F1<T>(T t) => t;
+    [return: MaybeNull] static T F2<T>(T t) where T : class => t;
+    [return: MaybeNull] static T? F3<T>(T t) where T : class => t;
+    [return: MaybeNull] static T F4<T>(T t) where T : struct => t;
+    [return: MaybeNull] static T? F5<T>(T? t) where T : struct => t;
+    static void M1<T>(T t1)
+    {
+        F1(t1).ToString(); // 1
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1(t2).ToString(); // 2
+        F2(t2).ToString(); // 3
+        F3(t2).ToString(); // 4
+        t2 = null; // 5
+        F1(t2).ToString(); // 6
+        F2(t2).ToString(); // 7
+        F3(t2).ToString(); // 8
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1(t3).ToString(); // 9
+        F2(t3).ToString(); // 10
+        F3(t3).ToString(); // 11
+        if (t3 == null) return;
+        F1(t3).ToString(); // 12
+        F2(t3).ToString(); // 13
+        F3(t3).ToString(); // 14
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1(t4).ToString();
+        F4(t4).ToString();
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        _ = F1(t5).Value; // 15
+        _ = F5(t5).Value; // 16
+        if (t5 == null) return;
+        _ = F1(t5).Value; // 17
+        _ = F5(t5).Value; // 18
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(t1).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(t1)").WithLocation(11, 9),
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(t2).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(t2)").WithLocation(15, 9),
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2(t2).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(t2)").WithLocation(16, 9),
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3(t2).ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3(t2)").WithLocation(17, 9),
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 5
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(t2).ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(t2)").WithLocation(19, 9),
+                // (20,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t2).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(20, 9),
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2(t2).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(t2)").WithLocation(20, 9),
+                // (21,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F3(t2).ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T)", "T", "T?").WithLocation(21, 9),
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3(t2).ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3(t2)").WithLocation(21, 9),
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(t3).ToString(); // 9
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(t3)").WithLocation(25, 9),
+                // (26,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t3).ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(26, 9),
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2(t3).ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(t3)").WithLocation(26, 9),
+                // (27,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F3(t3).ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T)", "T", "T?").WithLocation(27, 9),
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3(t3).ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3(t3)").WithLocation(27, 9),
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(t3).ToString(); // 12
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(t3)").WithLocation(29, 9),
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2(t3).ToString(); // 13
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(t3)").WithLocation(30, 9),
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3(t3).ToString(); // 14
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3(t3)").WithLocation(31, 9),
+                // (40,13): warning CS8629: Nullable value type may be null.
+                //         _ = F1(t5).Value; // 15
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F1(t5)").WithLocation(40, 13),
+                // (41,13): warning CS8629: Nullable value type may be null.
+                //         _ = F5(t5).Value; // 16
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F5(t5)").WithLocation(41, 13),
+                // (43,13): warning CS8629: Nullable value type may be null.
+                //         _ = F1(t5).Value; // 17
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F1(t5)").WithLocation(43, 13),
+                // (44,13): warning CS8629: Nullable value type may be null.
+                //         _ = F5(t5).Value; // 18
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F5(t5)").WithLocation(44, 13));
+        }
+
+        [Fact]
+        public void MaybeNull_02()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: MaybeNull] static T F1<T>(T t) => t;
+    [return: MaybeNull] static T F2<T>(T t) where T : class => t;
+    [return: MaybeNull] static T? F3<T>(T t) where T : class => t;
+    [return: MaybeNull] static T F4<T>(T t) where T : struct => t;
+    [return: MaybeNull] static T? F5<T>(T? t) where T : struct => t;
+    static void M1<T>(T t1)
+    {
+        F1<T>(t1).ToString(); // 1
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1<T>(t2).ToString(); // 2
+        F2<T>(t2).ToString(); // 3
+        F3<T>(t2).ToString(); // 4
+        t2 = null; // 5
+        F1<T>(t2).ToString(); // 6
+        F2<T>(t2).ToString(); // 7
+        F3<T>(t2).ToString(); // 8
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1<T>(t3).ToString(); // 9
+        F2<T>(t3).ToString(); // 10
+        F3<T>(t3).ToString(); // 11
+        if (t3 == null) return;
+        F1<T>(t3).ToString(); // 12
+        F2<T>(t3).ToString(); // 13
+        F3<T>(t3).ToString(); // 14
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1<T>(t4).ToString();
+        F4<T>(t4).ToString();
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        _ = F1<T?>(t5).Value; // 15
+        _ = F5<T>(t5).Value; // 16
+        if (t5 == null) return;
+        _ = F1<T?>(t5).Value; // 17
+        _ = F5<T>(t5).Value; // 18
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t1).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t1)").WithLocation(11, 9),
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t2).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t2)").WithLocation(15, 9),
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t2).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t2)").WithLocation(16, 9),
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t2).ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t2)").WithLocation(17, 9),
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 5
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t2).ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t2)").WithLocation(19, 9),
+                // (19,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F1<T>(T t)'.
+                //         F1<T>(t2).ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T Program.F1<T>(T t)").WithLocation(19, 15),
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t2).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t2)").WithLocation(20, 9),
+                // (20,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F2<T>(T t)'.
+                //         F2<T>(t2).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T Program.F2<T>(T t)").WithLocation(20, 15),
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t2).ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t2)").WithLocation(21, 9),
+                // (21,15): warning CS8604: Possible null reference argument for parameter 't' in 'T? Program.F3<T>(T t)'.
+                //         F3<T>(t2).ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T? Program.F3<T>(T t)").WithLocation(21, 15),
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t3).ToString(); // 9
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t3)").WithLocation(25, 9),
+                // (25,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F1<T>(T t)'.
+                //         F1<T>(t3).ToString(); // 9
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T Program.F1<T>(T t)").WithLocation(25, 15),
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t3).ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t3)").WithLocation(26, 9),
+                // (26,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F2<T>(T t)'.
+                //         F2<T>(t3).ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T Program.F2<T>(T t)").WithLocation(26, 15),
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t3).ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t3)").WithLocation(27, 9),
+                // (27,15): warning CS8604: Possible null reference argument for parameter 't' in 'T? Program.F3<T>(T t)'.
+                //         F3<T>(t3).ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T? Program.F3<T>(T t)").WithLocation(27, 15),
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t3).ToString(); // 12
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t3)").WithLocation(29, 9),
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t3).ToString(); // 13
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t3)").WithLocation(30, 9),
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t3).ToString(); // 14
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t3)").WithLocation(31, 9),
+                // (40,13): warning CS8629: Nullable value type may be null.
+                //         _ = F1<T?>(t5).Value; // 15
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F1<T?>(t5)").WithLocation(40, 13),
+                // (41,13): warning CS8629: Nullable value type may be null.
+                //         _ = F5<T>(t5).Value; // 16
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F5<T>(t5)").WithLocation(41, 13),
+                // (43,13): warning CS8629: Nullable value type may be null.
+                //         _ = F1<T?>(t5).Value; // 17
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F1<T?>(t5)").WithLocation(43, 13),
+                // (44,13): warning CS8629: Nullable value type may be null.
+                //         _ = F5<T>(t5).Value; // 18
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F5<T>(t5)").WithLocation(44, 13));
+        }
+
+        [Fact]
+        public void MaybeNull_03()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: MaybeNull] static string F1() => string.Empty;
+    [return: MaybeNull] static string? F2() => string.Empty;
+    static void M()
+    {
+        F1().ToString(); // 1
+        F2().ToString(); // 2
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (8,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1().ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1()").WithLocation(8, 9),
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2().ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2()").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void MaybeNull_04()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: MaybeNull] static int F1() => 1;
+    [return: MaybeNull] static int? F2() => 2;
+    static void M()
+    {
+        F1().ToString();
+        _ = F2().Value; // 1
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,13): warning CS8629: Nullable value type may be null.
+                //         _ = F2().Value; // 1
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F2()").WithLocation(9, 13));
+        }
+
+        [Fact]
+        public void MaybeNull_05()
+        {
+            var source0 =
+@"using System.Runtime.CompilerServices;
+public class A
+{
+    public static T F1<T>(T t) where T : class => t;
+    [return: MaybeNull] public static T F2<T>(T t) where T : class => t;
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, source0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source =
+@"class B : A
+{
+    static void Main()
+    {
+        object x = null; // 1
+        object? y = new object();
+        F1(x).ToString(); // 2
+        F1(y).ToString();
+        F2(x).ToString(); // 3
+        F2(y).ToString(); // 4
+    }
+}";
+            comp = CreateCompilation(source, references: new[] { ref0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (5,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         object x = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 20),
+                // (7,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F1<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F1(x).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F1").WithArguments("A.F1<T>(T)", "T", "object?").WithLocation(7, 9),
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(x).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(x)").WithLocation(7, 9),
+                // (9,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F2<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F2(x).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("A.F2<T>(T)", "T", "object?").WithLocation(9, 9),
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2(x).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(x)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void MaybeNull_06()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class C<T>
+{
+    [return: MaybeNull] internal static T F() => throw null!;
+}
+class Program
+{
+    static void M<T, U, V>()
+        where U : class
+        where V : struct
+    {
+        C<T>.F().ToString(); // 1
+        C<U>.F().ToString(); // 2
+        C<U?>.F().ToString(); // 3
+        C<V>.F().ToString();
+        _ = C<V?>.F().Value; // 4
+        C<string>.F().ToString(); // 5
+        C<string?>.F().ToString(); // 6
+        C<int>.F().ToString();
+        _ = C<int?>.F().Value; // 7
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
+                //         C<T>.F().ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<T>.F()").WithLocation(12, 9),
+                // (13,9): warning CS8602: Dereference of a possibly null reference.
+                //         C<U>.F().ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<U>.F()").WithLocation(13, 9),
+                // (14,9): warning CS8602: Dereference of a possibly null reference.
+                //         C<U?>.F().ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<U?>.F()").WithLocation(14, 9),
+                // (16,13): warning CS8629: Nullable value type may be null.
+                //         _ = C<V?>.F().Value; // 4
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "C<V?>.F()").WithLocation(16, 13),
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
+                //         C<string>.F().ToString(); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<string>.F()").WithLocation(17, 9),
+                // (18,9): warning CS8602: Dereference of a possibly null reference.
+                //         C<string?>.F().ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "C<string?>.F()").WithLocation(18, 9),
+                // (20,13): warning CS8629: Nullable value type may be null.
+                //         _ = C<int?>.F().Value; // 7
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "C<int?>.F()").WithLocation(20, 13));
+        }
+
+        [Fact]
+        public void NotNull_01()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: NotNull] static T F1<T>(T t) => t;
+    [return: NotNull] static T F2<T>(T t) where T : class => t;
+    [return: NotNull] static T? F3<T>(T t) where T : class => t;
+    [return: NotNull] static T F4<T>(T t) where T : struct => t;
+    [return: NotNull] static T? F5<T>(T? t) where T : struct => t;
+    static void M1<T>(T t1)
+    {
+        F1(t1).ToString();
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1(t2).ToString();
+        F2(t2).ToString();
+        F3(t2).ToString();
+        t2 = null; // 1
+        F1(t2).ToString();
+        F2(t2).ToString(); // 2
+        F3(t2).ToString(); // 3
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1(t3).ToString();
+        F2(t3).ToString(); // 4
+        F3(t3).ToString(); // 5
+        if (t3 == null) return;
+        F1(t3).ToString();
+        F2(t3).ToString();
+        F3(t3).ToString();
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1(t4).ToString();
+        F4(t4).ToString();
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        _ = F1(t5).Value;
+        _ = F5(t5).Value;
+        if (t5 == null) return;
+        _ = F1(t5).Value;
+        _ = F5(t5).Value;
+    }
+}";
+            var comp = CreateCompilation(new[] { NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (20,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t2).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(20, 9),
+                // (21,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F3(t2).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T)", "T", "T?").WithLocation(21, 9),
+                // (26,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t3).ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(26, 9),
+                // (27,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F3(t3).ToString(); // 5
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T)", "T", "T?").WithLocation(27, 9));
+        }
+
+        [Fact]
+        public void NotNull_02()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: NotNull] static T F1<T>(T t) => t;
+    [return: NotNull] static T F2<T>(T t) where T : class => t;
+    [return: NotNull] static T? F3<T>(T t) where T : class => t;
+    [return: NotNull] static T F4<T>(T t) where T : struct => t;
+    [return: NotNull] static T? F5<T>(T? t) where T : struct => t;
+    static void M1<T>(T t1)
+    {
+        F1<T>(t1).ToString();
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1<T>(t2).ToString();
+        F2<T>(t2).ToString();
+        F3<T>(t2).ToString();
+        t2 = null; // 1
+        F1<T>(t2).ToString(); // 2
+        F2<T>(t2).ToString(); // 3
+        F3<T>(t2).ToString(); // 4
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1<T>(t3).ToString(); // 5
+        F2<T>(t3).ToString(); // 6
+        F3<T>(t3).ToString(); // 7
+        if (t3 == null) return;
+        F1<T>(t3).ToString();
+        F2<T>(t3).ToString();
+        F3<T>(t3).ToString();
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1<T>(t4).ToString();
+        F4<T>(t4).ToString();
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        _ = F1<T?>(t5).Value;
+        _ = F5<T>(t5).Value;
+        if (t5 == null) return;
+        _ = F1<T?>(t5).Value;
+        _ = F5<T>(t5).Value;
+    }
+}";
+            var comp = CreateCompilation(new[] { NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F1<T>(T t)'.
+                //         F1<T>(t2).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T Program.F1<T>(T t)").WithLocation(19, 15),
+                // (20,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F2<T>(T t)'.
+                //         F2<T>(t2).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T Program.F2<T>(T t)").WithLocation(20, 15),
+                // (21,15): warning CS8604: Possible null reference argument for parameter 't' in 'T? Program.F3<T>(T t)'.
+                //         F3<T>(t2).ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T? Program.F3<T>(T t)").WithLocation(21, 15),
+                // (25,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F1<T>(T t)'.
+                //         F1<T>(t3).ToString(); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T Program.F1<T>(T t)").WithLocation(25, 15),
+                // (26,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F2<T>(T t)'.
+                //         F2<T>(t3).ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T Program.F2<T>(T t)").WithLocation(26, 15),
+                // (27,15): warning CS8604: Possible null reference argument for parameter 't' in 'T? Program.F3<T>(T t)'.
+                //         F3<T>(t3).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T? Program.F3<T>(T t)").WithLocation(27, 15));
+        }
+
+        [Fact]
+        public void NotNull_03()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: NotNull] static string F1() => string.Empty;
+    [return: NotNull] static string? F2() => string.Empty;
+    static void M()
+    {
+        F1().ToString();
+        F2().ToString();
+    }
+}";
+            var comp = CreateCompilation(new[] { NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NotNull_04()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: NotNull] static int F1() => 1;
+    [return: NotNull] static int? F2() => 2;
+    static void M()
+    {
+        F1().ToString();
+        _ = F2().Value;
+    }
+}";
+            var comp = CreateCompilation(new[] { NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NotNull_05()
+        {
+            var source0 =
+@"using System.Runtime.CompilerServices;
+public class A
+{
+    public static T F1<T>(T t) where T : class => t;
+    [return: NotNull] public static T F2<T>(T t) where T : class => t;
+}";
+            var comp = CreateCompilation(new[] { NotNullAttributeDefinition, source0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source =
+@"class B : A
+{
+    static void Main()
+    {
+        object x = null; // 1
+        object? y = new object();
+        F1(x).ToString(); // 2
+        F1(y).ToString();
+        F2(x).ToString();
+        F2(y).ToString();
+    }
+}";
+            comp = CreateCompilation(source, references: new[] { ref0 }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (5,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         object x = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(5, 20),
+                // (7,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F1<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F1(x).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F1").WithArguments("A.F1<T>(T)", "T", "object?").WithLocation(7, 9),
+                // (7,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1(x).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1(x)").WithLocation(7, 9),
+                // (9,9): warning CS8634: The type 'object?' cannot be used as type parameter 'T' in the generic type or method 'A.F2<T>(T)'. Nullability of type argument 'object?' doesn't match 'class' constraint.
+                //         F2(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("A.F2<T>(T)", "T", "object?").WithLocation(9, 9),
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2(x).ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2(x)").WithLocation(9, 9));
+        }
+
+        [Fact]
+        public void NotNull_06()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class C<T>
+{
+    [return: NotNull] internal static T F() => throw null!;
+}
+class Program
+{
+    static void M<T, U, V>()
+        where U : class
+        where V : struct
+    {
+        C<T>.F().ToString();
+        C<U>.F().ToString();
+        C<U?>.F().ToString();
+        C<V>.F().ToString();
+        _ = C<V?>.F().Value;
+        C<string>.F().ToString();
+        C<string?>.F().ToString();
+        C<int>.F().ToString();
+        _ = C<int?>.F().Value;
+    }
+}";
+            var comp = CreateCompilation(new[] { NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NullableAnnotationAttributes_Deconstruction()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Pair<T, U>
+{
+    internal void Deconstruct([MaybeNull] out T t, [NotNull] out U u) => throw null!;
+}
+class Program
+{
+    static void F1<T>(Pair<T, T> p)
+    {
+        var (x1, y1) = p;
+        x1.ToString(); // 1
+        y1.ToString();
+    }
+    static void F2<T>(Pair<T, T> p) where T : class
+    {
+        var (x2, y2) = p;
+        x2.ToString(); // 2
+        y2.ToString();
+    }
+    static void F3<T>(Pair<T, T> p) where T : class?
+    {
+        var (x3, y3) = p;
+        x3.ToString(); // 3
+        y3.ToString();
+    }
+    static void F4<T>(Pair<T?, T?> p) where T : struct
+    {
+        var (x4, y4) = p;
+        _ = x4.Value; // 4
+        _ = y4.Value;
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
+                //         x1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x1").WithLocation(11, 9),
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
+                //         y1.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y1").WithLocation(12, 9),
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
+                //         x3.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "x3").WithLocation(23, 9),
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
+                //         y3.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "y3").WithLocation(24, 9),
+                // (29,13): warning CS8629: Nullable value type may be null.
+                //         _ = x4.Value; // 4
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "x4").WithLocation(29, 13),
+                // (30,13): warning CS8629: Nullable value type may be null.
+                //         _ = y4.Value;
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "y4").WithLocation(30, 13));
+        }
+
+        [Fact]
+        public void NullableAnnotationAttributes_ExtensionMethodThis()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+delegate void D();
+static class Program
+{
+    static void E1<T>([AllowNull] this T t) where T : class  { }
+    static void E2<T>([DisallowNull] this T t) where T : class? { }
+    static void F1<T>(T t1) where T : class
+    {
+        D d;
+        d = t1.E1;
+        d = t1.E2;
+        t1 = null; // 1
+        d = t1.E1; // 2
+        d = t1.E2; // 3
+    }
+    static void F2<T>(T t2) where T : class?
+    {
+        D d;
+        d = t2.E1; // 4
+        d = t2.E2; // 5
+    }
+}";
+            var comp = CreateCompilation(new[] { AllowNullAttributeDefinition, DisallowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (12,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t1 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(12, 14),
+                // (13,13): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.E1<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         d = t1.E1; // 2
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "t1.E1").WithArguments("Program.E1<T>(T)", "T", "T?").WithLocation(13, 13),
+                // (14,13): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.E2<T?>(T? t)'.
+                //         d = t1.E2; // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t1").WithArguments("t", "void Program.E2<T?>(T? t)").WithLocation(14, 13),
+                // (19,13): warning CS8634: The type 'T' cannot be used as type parameter 'T' in the generic type or method 'Program.E1<T>(T)'. Nullability of type argument 'T' doesn't match 'class' constraint.
+                //         d = t2.E1; // 4
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "t2.E1").WithArguments("Program.E1<T>(T)", "T", "T").WithLocation(19, 13));
+        }
+
+        [Fact]
         public void ConditionalBranching_01()
         {
             CSharpCompilation c = CreateCompilation(new[] { @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -22347,7 +22347,7 @@ public class A
         }
 
         [Fact]
-        public void DisallowNull_01()
+        public void DisallowNull_Parameter_01()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22428,7 +22428,88 @@ class Program
         }
 
         [Fact]
-        public void DisallowNull_02()
+        public void DisallowNull_Parameter_01_WithAllowNull()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    static void F1<T>([DisallowNull, AllowNull]T t) { }
+    static void F2<T>([DisallowNull, AllowNull]T t) where T : class { }
+    static void F3<T>([DisallowNull, AllowNull]T? t) where T : class { }
+    static void F4<T>([DisallowNull, AllowNull]T t) where T : struct { }
+    static void F5<T>([DisallowNull, AllowNull]T? t) where T : struct { }
+    static void M1<T>(T t1)
+    {
+        F1(t1);
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1(t2);
+        F2(t2);
+        F3(t2);
+        t2 = null; // 1
+        F1(t2); // 2
+        F2(t2); // 3
+        F3(t2); // 4
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1(t3); // 5
+        F2(t3); // 6
+        F3(t3); // 7
+        if (t3 == null) return;
+        F1(t3);
+        F2(t3);
+        F3(t3);
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1(t4);
+        F4(t4);
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        F1(t5);
+        F5(t5);
+        if (t5 == null) return;
+        F1(t5);
+        F5(t5);
+    }
+}";
+            var comp = CreateCompilation(new[] { DisallowNullAttributeDefinition, AllowNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F1<T?>(T? t)'.
+                //         F1(t2); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F1<T?>(T? t)").WithLocation(19, 12),
+                // (20,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t2); // 3
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(20, 9),
+                // (20,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F2<T?>(T? t)'.
+                //         F2(t2); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F2<T?>(T? t)").WithLocation(20, 12),
+                // (21,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F3<T>(T? t)'.
+                //         F3(t2); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "void Program.F3<T>(T? t)").WithLocation(21, 12),
+                // (25,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F1<T?>(T? t)'.
+                //         F1(t3); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F1<T?>(T? t)").WithLocation(25, 12),
+                // (26,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t3); // 6
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T)", "T", "T?").WithLocation(26, 9),
+                // (26,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F2<T?>(T? t)'.
+                //         F2(t3); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F2<T?>(T? t)").WithLocation(26, 12),
+                // (27,12): warning CS8604: Possible null reference argument for parameter 't' in 'void Program.F3<T>(T? t)'.
+                //         F3(t3); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "void Program.F3<T>(T? t)").WithLocation(27, 12));
+        }
+
+        [Fact]
+        public void DisallowNull_Parameter_02()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22503,7 +22584,7 @@ class Program
         }
 
         [Fact]
-        public void DisallowNull_03()
+        public void DisallowNull_Parameter_03()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22548,7 +22629,7 @@ class Program
         }
 
         [Fact]
-        public void DisallowNull_04()
+        public void DisallowNull_Parameter_04()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22573,7 +22654,7 @@ class Program
         }
 
         [Fact]
-        public void DisallowNull_05()
+        public void DisallowNull_Parameter_05()
         {
             var source0 =
 @"using System.Runtime.CompilerServices;
@@ -22616,7 +22697,7 @@ public class A
         }
 
         [Fact]
-        public void MaybeNull_01()
+        public void MaybeNull_ReturnValue_01()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22736,7 +22817,7 @@ class Program
         }
 
         [Fact]
-        public void MaybeNull_02()
+        public void MaybeNull_ReturnValue_02()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22862,7 +22943,133 @@ class Program
         }
 
         [Fact]
-        public void MaybeNull_03()
+        public void MaybeNull_ReturnValue_02_WithNotNull()
+        {
+            var source =
+@"using System.Runtime.CompilerServices;
+class Program
+{
+    [return: MaybeNull, NotNull] static T F1<T>(T t) => t;
+    [return: MaybeNull, NotNull] static T F2<T>(T t) where T : class => t;
+    [return: MaybeNull, NotNull] static T? F3<T>(T t) where T : class => t;
+    [return: MaybeNull, NotNull] static T F4<T>(T t) where T : struct => t;
+    [return: MaybeNull, NotNull] static T? F5<T>(T? t) where T : struct => t;
+    static void M1<T>(T t1)
+    {
+        F1<T>(t1).ToString(); // 1
+    }
+    static void M2<T>(T t2) where T : class
+    {
+        F1<T>(t2).ToString(); // 2
+        F2<T>(t2).ToString(); // 3
+        F3<T>(t2).ToString(); // 4
+        t2 = null; // 5
+        F1<T>(t2).ToString(); // 6
+        F2<T>(t2).ToString(); // 7
+        F3<T>(t2).ToString(); // 8
+    }
+    static void M3<T>(T? t3) where T : class
+    {
+        F1<T>(t3).ToString(); // 9
+        F2<T>(t3).ToString(); // 10
+        F3<T>(t3).ToString(); // 11
+        if (t3 == null) return;
+        F1<T>(t3).ToString(); // 12
+        F2<T>(t3).ToString(); // 13
+        F3<T>(t3).ToString(); // 14
+    }
+    static void M4<T>(T t4) where T : struct
+    {
+        F1<T>(t4).ToString();
+        F4<T>(t4).ToString();
+    }
+    static void M5<T>(T? t5) where T : struct
+    {
+        _ = F1<T?>(t5).Value; // 15
+        _ = F5<T>(t5).Value; // 16
+        if (t5 == null) return;
+        _ = F1<T?>(t5).Value; // 17
+        _ = F5<T>(t5).Value; // 18
+    }
+}";
+            var comp = CreateCompilation(new[] { MaybeNullAttributeDefinition, NotNullAttributeDefinition, source }, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t1).ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t1)").WithLocation(11, 9),
+                // (15,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t2).ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t2)").WithLocation(15, 9),
+                // (16,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t2).ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t2)").WithLocation(16, 9),
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t2).ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t2)").WithLocation(17, 9),
+                // (18,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 5
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(18, 14),
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t2).ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t2)").WithLocation(19, 9),
+                // (19,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F1<T>(T t)'.
+                //         F1<T>(t2).ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T Program.F1<T>(T t)").WithLocation(19, 15),
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t2).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t2)").WithLocation(20, 9),
+                // (20,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F2<T>(T t)'.
+                //         F2<T>(t2).ToString(); // 7
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T Program.F2<T>(T t)").WithLocation(20, 15),
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t2).ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t2)").WithLocation(21, 9),
+                // (21,15): warning CS8604: Possible null reference argument for parameter 't' in 'T? Program.F3<T>(T t)'.
+                //         F3<T>(t2).ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t2").WithArguments("t", "T? Program.F3<T>(T t)").WithLocation(21, 15),
+                // (25,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t3).ToString(); // 9
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t3)").WithLocation(25, 9),
+                // (25,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F1<T>(T t)'.
+                //         F1<T>(t3).ToString(); // 9
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T Program.F1<T>(T t)").WithLocation(25, 15),
+                // (26,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t3).ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t3)").WithLocation(26, 9),
+                // (26,15): warning CS8604: Possible null reference argument for parameter 't' in 'T Program.F2<T>(T t)'.
+                //         F2<T>(t3).ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T Program.F2<T>(T t)").WithLocation(26, 15),
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t3).ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t3)").WithLocation(27, 9),
+                // (27,15): warning CS8604: Possible null reference argument for parameter 't' in 'T? Program.F3<T>(T t)'.
+                //         F3<T>(t3).ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "t3").WithArguments("t", "T? Program.F3<T>(T t)").WithLocation(27, 15),
+                // (29,9): warning CS8602: Dereference of a possibly null reference.
+                //         F1<T>(t3).ToString(); // 12
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F1<T>(t3)").WithLocation(29, 9),
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
+                //         F2<T>(t3).ToString(); // 13
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F2<T>(t3)").WithLocation(30, 9),
+                // (31,9): warning CS8602: Dereference of a possibly null reference.
+                //         F3<T>(t3).ToString(); // 14
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "F3<T>(t3)").WithLocation(31, 9),
+                // (40,13): warning CS8629: Nullable value type may be null.
+                //         _ = F1<T?>(t5).Value; // 15
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F1<T?>(t5)").WithLocation(40, 13),
+                // (41,13): warning CS8629: Nullable value type may be null.
+                //         _ = F5<T>(t5).Value; // 16
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F5<T>(t5)").WithLocation(41, 13),
+                // (43,13): warning CS8629: Nullable value type may be null.
+                //         _ = F1<T?>(t5).Value; // 17
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F1<T?>(t5)").WithLocation(43, 13),
+                // (44,13): warning CS8629: Nullable value type may be null.
+                //         _ = F5<T>(t5).Value; // 18
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "F5<T>(t5)").WithLocation(44, 13));
+        }
+
+        [Fact]
+        public void MaybeNull_ReturnValue_03()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22887,7 +23094,7 @@ class Program
         }
 
         [Fact]
-        public void MaybeNull_04()
+        public void MaybeNull_ReturnValue_04()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -22909,7 +23116,7 @@ class Program
         }
 
         [Fact]
-        public void MaybeNull_05()
+        public void MaybeNull_ReturnValue_05()
         {
             var source0 =
 @"using System.Runtime.CompilerServices;
@@ -22955,7 +23162,7 @@ public class A
         }
 
         [Fact]
-        public void MaybeNull_06()
+        public void MaybeNull_ReturnValue_06()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -23006,7 +23213,7 @@ class Program
         }
 
         [Fact]
-        public void NotNull_01()
+        public void NotNull_ReturnValue_01()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -23075,7 +23282,7 @@ class Program
         }
 
         [Fact]
-        public void NotNull_02()
+        public void NotNull_ReturnValue_02()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -23150,7 +23357,7 @@ class Program
         }
 
         [Fact]
-        public void NotNull_03()
+        public void NotNull_ReturnValue_03()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -23169,7 +23376,7 @@ class Program
         }
 
         [Fact]
-        public void NotNull_04()
+        public void NotNull_ReturnValue_04()
         {
             var source =
 @"using System.Runtime.CompilerServices;
@@ -23188,7 +23395,7 @@ class Program
         }
 
         [Fact]
-        public void NotNull_05()
+        public void NotNull_ReturnValue_05()
         {
             var source0 =
 @"using System.Runtime.CompilerServices;
@@ -23234,7 +23441,7 @@ public class A
         }
 
         [Fact]
-        public void NotNull_06()
+        public void NotNull_ReturnValue_06()
         {
             var source =
 @"using System.Runtime.CompilerServices;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -23580,31 +23580,31 @@ class Program
         s6.ToString(); // 6
 
         F2(t2, out var s7); // 7
-        s7.ToString();
+        s7.ToString(); // 8
 
-        F3(t2, out var s8); // 8
-        s8.ToString();
+        F3(t2, out var s8); // 9
+        s8.ToString(); // 10
     }
     static void M3<T>(T? t3) where T : class
     {
         F1(t3, out var s9);
-        s9.ToString(); // 9
+        s9.ToString(); // 11
 
-        F2(t3, out var s10); // 10
-        s10.ToString();
+        F2(t3, out var s10); // 12
+        s10.ToString(); // 13
 
-        F3(t3, out var s11); // 11
-        s11.ToString();
+        F3(t3, out var s11); // 14
+        s11.ToString(); // 15
 
         if (t3 == null) return;
         F1(t3, out var s12);
-        s12.ToString(); // 12
+        s12.ToString(); // 16
 
         F2(t3, out var s13);
-        s13.ToString(); // 13
+        s13.ToString(); // 17
 
         F3(t3, out var s14);
-        s14.ToString(); // 14
+        s14.ToString(); // 18
     }
     static void M4<T>(T t4) where T : struct
     {
@@ -23617,87 +23617,87 @@ class Program
     static void M5<T>(T? t5) where T : struct
     {
         F1(t5, out var s17);
-        _ = s17.Value; // 15
+        _ = s17.Value; // 19
 
         F5(t5, out var s18);
-        _ = s18.Value; // 16
+        _ = s18.Value; // 20
 
         if (t5 == null) return;
         F1(t5, out var s19);
-        _ = s19.Value; // 17
+        _ = s19.Value; // 21
 
         F5(t5, out var s20);
-        _ = s20.Value; // 18
+        _ = s20.Value; // 22
     }
 }";
             var comp = CreateNullableCompilation(new[] { MaybeNullAttributeDefinition, source });
             comp.VerifyDiagnostics(
-                    // (12,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s2.ToString(); // 1
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 9),
-                    // (17,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s3.ToString(); // 2
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s3").WithLocation(17, 9),
-                    // (20,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s4.ToString(); // 3
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s4").WithLocation(20, 9),
-                    // (23,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s5.ToString(); // 4
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s5").WithLocation(23, 9),
-                    // (25,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
-                    //         t2 = null; // 5
-                    Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(25, 14),
-                    // (27,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s6.ToString(); // 6
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s6").WithLocation(27, 9),
-                    // (29,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T, out T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
-                    //         F2(t2, out var s7); // 7
-                    Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T, out T)", "T", "T?").WithLocation(29, 9),
-                    // (30,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s7.ToString();
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s7").WithLocation(30, 9),
-                    // (32,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T, out T?)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
-                    //         F3(t2, out var s8); // 8
-                    Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T, out T?)", "T", "T?").WithLocation(32, 9),
-                    // (33,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s8.ToString();
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s8").WithLocation(33, 9),
-                    // (38,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s9.ToString(); // 9
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s9").WithLocation(38, 9),
-                    // (40,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T, out T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
-                    //         F2(t3, out var s10); // 10
-                    Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T, out T)", "T", "T?").WithLocation(40, 9),
-                    // (41,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s10.ToString();
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s10").WithLocation(41, 9),
-                    // (43,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T, out T?)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
-                    //         F3(t3, out var s11); // 11
-                    Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T, out T?)", "T", "T?").WithLocation(43, 9),
-                    // (44,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s11.ToString();
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s11").WithLocation(44, 9),
-                    // (48,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s12.ToString(); // 12
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s12").WithLocation(48, 9),
-                    // (51,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s13.ToString(); // 13
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s13").WithLocation(51, 9),
-                    // (54,9): warning CS8602: Dereference of a possibly null reference.
-                    //         s14.ToString(); // 14
-                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s14").WithLocation(54, 9),
-                    // (67,13): warning CS8629: Nullable value type may be null.
-                    //         _ = s17.Value; // 15
-                    Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s17").WithLocation(67, 13),
-                    // (70,13): warning CS8629: Nullable value type may be null.
-                    //         _ = s18.Value; // 16
-                    Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s18").WithLocation(70, 13),
-                    // (74,13): warning CS8629: Nullable value type may be null.
-                    //         _ = s19.Value; // 17
-                    Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s19").WithLocation(74, 13),
-                    // (77,13): warning CS8629: Nullable value type may be null.
-                    //         _ = s20.Value; // 18
-                    Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s20").WithLocation(77, 13)
+                // (12,9): warning CS8602: Dereference of a possibly null reference.
+                //         s2.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s2").WithLocation(12, 9),
+                // (17,9): warning CS8602: Dereference of a possibly null reference.
+                //         s3.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s3").WithLocation(17, 9),
+                // (20,9): warning CS8602: Dereference of a possibly null reference.
+                //         s4.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s4").WithLocation(20, 9),
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
+                //         s5.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s5").WithLocation(23, 9),
+                // (25,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         t2 = null; // 5
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(25, 14),
+                // (27,9): warning CS8602: Dereference of a possibly null reference.
+                //         s6.ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s6").WithLocation(27, 9),
+                // (29,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T, out T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t2, out var s7); // 7
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T, out T)", "T", "T?").WithLocation(29, 9),
+                // (30,9): warning CS8602: Dereference of a possibly null reference.
+                //         s7.ToString(); // 8
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s7").WithLocation(30, 9),
+                // (32,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T, out T?)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F3(t2, out var s8); // 9
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T, out T?)", "T", "T?").WithLocation(32, 9),
+                // (33,9): warning CS8602: Dereference of a possibly null reference.
+                //         s8.ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s8").WithLocation(33, 9),
+                // (38,9): warning CS8602: Dereference of a possibly null reference.
+                //         s9.ToString(); // 11
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s9").WithLocation(38, 9),
+                // (40,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F2<T>(T, out T)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F2(t3, out var s10); // 12
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F2").WithArguments("Program.F2<T>(T, out T)", "T", "T?").WithLocation(40, 9),
+                // (41,9): warning CS8602: Dereference of a possibly null reference.
+                //         s10.ToString(); // 13
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s10").WithLocation(41, 9),
+                // (43,9): warning CS8634: The type 'T?' cannot be used as type parameter 'T' in the generic type or method 'Program.F3<T>(T, out T?)'. Nullability of type argument 'T?' doesn't match 'class' constraint.
+                //         F3(t3, out var s11); // 14
+                Diagnostic(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint, "F3").WithArguments("Program.F3<T>(T, out T?)", "T", "T?").WithLocation(43, 9),
+                // (44,9): warning CS8602: Dereference of a possibly null reference.
+                //         s11.ToString(); // 15
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s11").WithLocation(44, 9),
+                // (48,9): warning CS8602: Dereference of a possibly null reference.
+                //         s12.ToString(); // 16
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s12").WithLocation(48, 9),
+                // (51,9): warning CS8602: Dereference of a possibly null reference.
+                //         s13.ToString(); // 17
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s13").WithLocation(51, 9),
+                // (54,9): warning CS8602: Dereference of a possibly null reference.
+                //         s14.ToString(); // 18
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s14").WithLocation(54, 9),
+                // (67,13): warning CS8629: Nullable value type may be null.
+                //         _ = s17.Value; // 19
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s17").WithLocation(67, 13),
+                // (70,13): warning CS8629: Nullable value type may be null.
+                //         _ = s18.Value; // 20
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s18").WithLocation(70, 13),
+                // (74,13): warning CS8629: Nullable value type may be null.
+                //         _ = s19.Value; // 21
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s19").WithLocation(74, 13),
+                // (77,13): warning CS8629: Nullable value type may be null.
+                //         _ = s20.Value; // 22
+                Diagnostic(ErrorCode.WRN_NullableValueTypeMayBeNull, "s20").WithLocation(77, 13)
                 );
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -6,8 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Collections;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -296,6 +294,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 return _lazyReturnType;
             }
         }
+
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
 
         public override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotations
         {

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -155,6 +155,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return _returnType; }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         bool Cci.ISignature.ReturnValueIsByRef
         {
             get { return true; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SynthesizedContextMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SynthesizedContextMethodSymbol.cs
@@ -128,6 +128,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { throw ExceptionUtilities.Unreachable; }
         }
 
+        public override FlowAnalysisAnnotations ReturnTypeAnnotationAttributes => FlowAnalysisAnnotations.None;
+
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {
             get { throw ExceptionUtilities.Unreachable; }


### PR DESCRIPTION
Some support for simple pre- and post-condition nullable annotations on by-value parameters and return types.

---

Added to this PR:
- [x] attributes on ref/out parameters
- [x] test behavior on OHI
- [x] test behavior for implementers of a method
- [x] enforcing attributes from PEMethodSymbol
- [x] test attribute on ref-returning methods (ignored)

A number of scenarios and tests will be covered in later PRs:
- [ ] more scenarios involving return value (search for uses of `ReturnTypeWithAnnotations` in `NullableWalker`)
- [ ] decoding attributes on fields, properties and indexers
- [ ] enforcing attributes on fields, properties and indexers
- [ ] enforcing attributes on nullable value types (issue https://github.com/dotnet/roslyn/issues/36009)
- [ ] enforcing attributes in implementation and OHI (issue https://github.com/dotnet/roslyn/issues/36039)
- [ ] warn on misused attributes (issue https://github.com/dotnet/roslyn/issues/36073)