### PR TITLE
Improve the code gen for a conditional access on a readonly unconstrained field

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -405,32 +405,43 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // if T happens to be a value type, it could be a target of mutating calls.
                     receiverTemp = EmitReceiverRef(receiver, AddressKind.Constrained);
 
-                    // unconstrained case needs to handle case where T is actually a struct.
-                    // such values are never nulls
-                    // we will emit a check for such case, but the check is really a JIT-time 
-                    // constant since JIT will know if T is a struct or not.
+                    if (receiverTemp is null)
+                    {
+                        // unconstrained case needs to handle case where T is actually a struct.
+                        // such values are never nulls
+                        // we will emit a check for such case, but the check is really a JIT-time 
+                        // constant since JIT will know if T is a struct or not.
 
-                    // if ((object)default(T) != null) 
-                    // {
-                    //     goto whenNotNull
-                    // }
-                    // else
-                    // {
-                    //     temp = receiverRef
-                    //     receiverRef = ref temp
-                    // }
-                    EmitDefaultValue(receiverType, true, receiver.Syntax);
-                    EmitBox(receiverType, receiver.Syntax);
-                    _builder.EmitBranch(ILOpCode.Brtrue, whenNotNullLabel);
-                    EmitLoadIndirect(receiverType, receiver.Syntax);
+                        // if ((object)default(T) != null) 
+                        // {
+                        //     goto whenNotNull
+                        // }
+                        // else
+                        // {
+                        //     temp = receiverRef
+                        //     receiverRef = ref temp
+                        // }
+                        EmitDefaultValue(receiverType, true, receiver.Syntax);
+                        EmitBox(receiverType, receiver.Syntax);
+                        _builder.EmitBranch(ILOpCode.Brtrue, whenNotNullLabel);
+                        EmitLoadIndirect(receiverType, receiver.Syntax);
 
-                    cloneTemp = AllocateTemp(receiverType, receiver.Syntax);
-                    _builder.EmitLocalStore(cloneTemp);
-                    _builder.EmitLocalAddress(cloneTemp);
-                    _builder.EmitLocalLoad(cloneTemp);
-                    EmitBox(receiver.Type, receiver.Syntax);
+                        cloneTemp = AllocateTemp(receiverType, receiver.Syntax);
+                        _builder.EmitLocalStore(cloneTemp);
+                        _builder.EmitLocalAddress(cloneTemp);
+                        _builder.EmitLocalLoad(cloneTemp);
+                        EmitBox(receiverType, receiver.Syntax);
 
-                    // here we have loaded a ref to a temp and its boxed value { &T, O }
+                        // here we have loaded a ref to a temp and its boxed value { &T, O }
+                    }
+                    else
+                    {
+                        // we are calling the expression on a copy of the target anyway, 
+                        // so even if T is a struct, we don't need to make sure we call the expression on the original target.
+
+                        _builder.EmitLocalLoad(receiverTemp);
+                        EmitBox(receiverType, receiver.Syntax);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
See #35319

This is my first PR on Emit, and I admit to having only a rough understanding of the intricacies of IL.

So if there's something obvious I missed, or a thousand more tests I need to add, please let me know.

The IL an unconstrained conditional access on a readonly field will now emit is:

```csharp
  .locals init (T V_0)
  IL_0000:  ldarg.0
  IL_0001:  ldfld      ""T Foo<T>.t""
  IL_0006:  stloc.0
  IL_0007:  ldloca.s   V_0
  IL_0009:  ldloc.0
  IL_000a:  box        ""T""
  IL_000f:  brtrue.s   IL_0015
  IL_0011:  pop
  IL_0012:  ldnull
  IL_0013:  br.s       IL_0020
  IL_0015:  constrained. ""T""
  IL_001b:  callvirt   ""string object.ToString()""
  IL_0020:  call       ""void System.Console.WriteLine(string)""
  IL_0025:  ret
```

which is functionally identical to the IL emitted for a read of a readonly unconstrained field, and a conditional access on that:

```csharp
  .locals init (T V_0) //temp
  IL_0000:  ldarg.0
  IL_0001:  ldfld      ""T Foo<T>.t""
  IL_0006:  stloc.0
  IL_0007:  ldloc.0
  IL_0008:  box        ""T""
  IL_000d:  brtrue.s   IL_0012
  IL_000f:  ldnull
  IL_0010:  br.s       IL_001f
  IL_0012:  ldloca.s   V_0
  IL_0014:  constrained. ""T""
  IL_001a:  callvirt   ""string object.ToString()""
  IL_001f:  call       ""void System.Console.WriteLine(string)""
  IL_0024:  ret
```

the only difference being, in once we load the reciever's address, and then pop it if it's null, the other we only load the reciever address if its not null.