### PR TITLE
Use vsBranch: lab/d16.2stg for 16.2-p2 publish

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -60,7 +60,7 @@
             "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
             "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
             "channels": [ "dev16.2p2" ],
-            "vsBranch": "rel/d16.2",
+            "vsBranch": "lab/d16.2stg",
             "vsMajorVersion": 16
           },
           "master-vs-deps": {


### PR DESCRIPTION
cc @genlu

This is a temporary change to help us run some internal jobs until it comes time to complete the divisional snap tomorrow afternoon.