### PR TITLE
Fix import completion telemetry

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
             // For type import completion
             SessionWithTypeImportCompletionEnabled,
             CommitWithTypeImportCompletionEnabled,
-            CommitTypeImportCompletionItem,
+            CommitsOfTypeImportCompletionItem,
 
             // For targeted type completion
             SessionHasTargetTypeFilterEnabled,
@@ -36,8 +36,8 @@ namespace Microsoft.CodeAnalysis
         internal static void LogCommitWithTypeImportCompletionEnabled() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.CommitWithTypeImportCompletionEnabled);
 
-        internal static void LogCommitTypeImportCompletionItem() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.CommitTypeImportCompletionItem);
+        internal static void LogCommitOfTypeImportCompletionItem() =>
+            s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfTypeImportCompletionItem);
 
         internal static void LogCommitWithTargetTypeCompletionExperimentEnabled() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.CommitWithTargetTypeCompletionExperimentEnabled);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -148,9 +148,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             {
                 AsyncCompletionLogger.LogCommitWithTypeImportCompletionEnabled();
 
-                if (roslynItem.ProviderName == "TypeImportCompletionProvider")
+                if (roslynItem.IsCached)
                 {
-                    AsyncCompletionLogger.LogCommitTypeImportCompletionItem();
+                    AsyncCompletionLogger.LogCommitOfTypeImportCompletionItem();
                 }
             }
 


### PR DESCRIPTION
This is the cause of missing data for number of import items committed.

@dotnet/roslyn-ide 

FYI @vatsalyaagrawal @jinujoseph 