### PR TITLE
Implement generate method and constructor with top-level nullability tracking wrapper

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2,12 +2,14 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMethod
@@ -291,6 +293,72 @@ class Class
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestSimpleInvocationValueNullableReferenceType()
+        {
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+class Class
+{
+    void Method(string? s)
+    {
+        [|Goo|](s);
+    }
+}",
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method(string? s)
+    {
+        Goo(s);
+    }
+
+    private void Goo(string? s)
+    {
+        throw new NotImplementedException();
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestSimpleInvocationValueNestedNullableReferenceType()
+        {
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+using System.Collections.Generic;
+
+class Class
+{
+    void Method(List<string?> l)
+    {
+        [|Goo|](l);
+    }
+}",
+@"#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+class Class
+{
+    void Method(List<string?> l)
+    {
+        Goo(l);
+    }
+
+    private void Goo(List<string?> l)
+    {
+        throw new NotImplementedException();
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
+
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task TestSimpleInvocationNamedValueArg()
@@ -1038,6 +1106,113 @@ class Class
         throw new NotImplementedException();
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestSimpleAssignmentWithNullableReferenceType()
+        {
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method()
+    {
+        string? f = [|Goo|]();
+    }
+}",
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method()
+    {
+        string? f = [|Goo|]();
+    }
+
+    private string? Goo()
+    {
+        throw new NotImplementedException();
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenericAssignmentWithTopLevelNullableReferenceTypeBeingAssignedTo()
+        {
+            // Here we assert that if the type argument was string, but the return value was string?, we still
+            // make the return value T, and assume the user just wanted to assign it to a nullable value because they
+            // might be assigning null later in the caller.
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method()
+    {
+        string? f = [|Goo|]<string>(""s"");
+    }
+}",
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method()
+    {
+        string? f = [|Goo|]<string>(""s"");
+    }
+
+    private T Goo<T>(T v)
+    {
+        throw new NotImplementedException();
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36044"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenericAssignmentWithNestedNullableReferenceTypeBeingAssignedTo()
+        {
+            // Here, we are asserting that the return type of the generated method is T, effectively discarding
+            // the difference of nested nullability. Since there's no way to generate a method any other way,
+            // we're assuming this is betetr than inferring that the return type is explicitly IEnumerable<string>
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method()
+    {
+        IEnumerable<string> e;
+        IEnumerable<string?> f = [|Goo|]<IEnumerable<string>>(e);
+    }
+}",
+@"#nullable enable
+
+using System;
+
+class Class
+{
+    void Method()
+    {
+        IEnumerable<string> e;
+        IEnumerable<string?> f = [|Goo|]<IEnumerable<string>>(e);
+    }
+
+    private T Goo<T>(T e)
+    {
+        throw new NotImplementedException();
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -3714,5 +3714,75 @@ class Program
     }}
 }}");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestWithTopLevelNullability()
+        {
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+class C
+{
+    void M()
+    {
+        string? s = null;
+        new [|C|](s);
+    }
+}",
+@"#nullable enable
+
+class C
+{
+    private string? s;
+
+    public C(string? s)
+    {
+        this.s = s;
+    }
+
+    void M()
+    {
+        string? s = null;
+        new C(s);
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestWitNestedNullability()
+        {
+            await TestInRegularAndScriptAsync(
+@"#nullable enable
+
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        IEnumerable<string?> s;
+        new [|C|](s);
+    }
+}",
+@"#nullable enable
+
+using System.Collections.Generic;
+
+class C
+{
+    private IEnumerable<string?> s;
+
+    public C(IEnumerable<string?> s)
+    {
+        this.s = s;
+    }
+
+    void M()
+    {
+        IEnumerable<string?> s;
+        new C(s);
+    }
+}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             }
 
             return TryGetExpressionType(expression, semanticModel, out var returnType) &&
-            semanticModel.Compilation.ClassifyConversion(taskType.UnwrapNullabilitySymbol(), returnType.UnwrapNullabilitySymbol()).Exists;
+            semanticModel.Compilation.ClassifyConversion(taskType.WithoutNullability(), returnType.WithoutNullability()).Exists;
         }
 
         private static bool DoesExpressionReturnGenericTaskWhoseArgumentsMatchLeftSide(ExpressionSyntax expression, SemanticModel semanticModel, Project project, CancellationToken cancellationToken)
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             }
 
             var compilation = semanticModel.Compilation;
-            if (!compilation.ClassifyConversion(taskType.UnwrapNullabilitySymbol(), rightSideType.UnwrapNullabilitySymbol()).Exists)
+            if (!compilation.ClassifyConversion(taskType.WithoutNullability(), rightSideType.WithoutNullability()).Exists)
             {
                 return false;
             }
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             var typeArguments = rightSideType.TypeArguments;
             var typeInferer = project.LanguageServices.GetService<ITypeInferenceService>();
             var inferredTypes = typeInferer.InferTypes(semanticModel, expression, cancellationToken);
-            return typeArguments.Any(ta => inferredTypes.Any(it => compilation.ClassifyConversion(it.UnwrapNullabilitySymbol(), ta.UnwrapNullabilitySymbol()).Exists));
+            return typeArguments.Any(ta => inferredTypes.Any(it => compilation.ClassifyConversion(it.WithoutNullability(), ta.WithoutNullability()).Exists));
         }
 
         private static bool IsInAsyncFunction(ExpressionSyntax expression)

--- a/src/Features/CSharp/Portable/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Async/CSharpAddAwaitCodeFixProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             }
 
             return TryGetExpressionType(expression, semanticModel, out var returnType) &&
-            semanticModel.Compilation.ClassifyConversion(taskType, returnType).Exists;
+            semanticModel.Compilation.ClassifyConversion(taskType.UnwrapNullabilitySymbol(), returnType.UnwrapNullabilitySymbol()).Exists;
         }
 
         private static bool DoesExpressionReturnGenericTaskWhoseArgumentsMatchLeftSide(ExpressionSyntax expression, SemanticModel semanticModel, Project project, CancellationToken cancellationToken)
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             }
 
             var compilation = semanticModel.Compilation;
-            if (!compilation.ClassifyConversion(taskType, rightSideType).Exists)
+            if (!compilation.ClassifyConversion(taskType.UnwrapNullabilitySymbol(), rightSideType.UnwrapNullabilitySymbol()).Exists)
             {
                 return false;
             }
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Async
             var typeArguments = rightSideType.TypeArguments;
             var typeInferer = project.LanguageServices.GetService<ITypeInferenceService>();
             var inferredTypes = typeInferer.InferTypes(semanticModel, expression, cancellationToken);
-            return typeArguments.Any(ta => inferredTypes.Any(it => compilation.ClassifyConversion(it, ta).Exists));
+            return typeArguments.Any(ta => inferredTypes.Any(it => compilation.ClassifyConversion(it.UnwrapNullabilitySymbol(), ta.UnwrapNullabilitySymbol()).Exists));
         }
 
         private static bool IsInAsyncFunction(ExpressionSyntax expression)

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
 
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
         {
-            return compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
+            return compilation.ClassifyConversion(sourceType.UnwrapNullabilitySymbol(), targetType.UnwrapNullabilitySymbol()).IsImplicit;
         }
 
         internal override IMethodSymbol GetDelegatingConstructor(

--- a/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateConstructor
 
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
         {
-            return compilation.ClassifyConversion(sourceType.UnwrapNullabilitySymbol(), targetType.UnwrapNullabilitySymbol()).IsImplicit;
+            return compilation.ClassifyConversion(sourceType.WithoutNullability(), targetType.WithoutNullability()).IsImplicit;
         }
 
         internal override IMethodSymbol GetDelegatingConstructor(

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 var methodTypeParameter = GetMethodTypeParameter(type, cancellationToken);
                 return methodTypeParameter != null
                     ? methodTypeParameter
-                    : CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique));
+                    : CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique)).WithNullability(NullableAnnotation.NotApplicable);
             }
 
             private ITypeParameterSymbol GetMethodTypeParameter(TypeSyntax type, CancellationToken cancellationToken)
@@ -172,8 +172,8 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 {
                     foreach (var typeArgument in ((GenericNameSyntax)State.SimpleNameOpt).TypeArgumentList.Arguments)
                     {
-                        var type = this.Document.SemanticModel.GetTypeInfo(typeArgument, cancellationToken).Type;
-                        result.Add(type);
+                        var typeInfo = this.Document.SemanticModel.GetTypeInfo(typeArgument, cancellationToken);
+                        result.Add(typeInfo.Type.WithNullability(typeInfo.Nullability.Annotation));
                     }
                 }
 

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -590,7 +590,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
 
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
         {
-            return compilation.ClassifyConversion(sourceType.UnwrapNullabilitySymbol(), targetType.UnwrapNullabilitySymbol()).IsImplicit;
+            return compilation.ClassifyConversion(sourceType.WithoutNullability(), targetType.WithoutNullability()).IsImplicit;
         }
 
         public override async Task<Tuple<INamespaceSymbol, INamespaceOrTypeSymbol, Location>> GetOrGenerateEnclosingNamespaceSymbolAsync(

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -590,7 +590,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
 
         protected override bool IsConversionImplicit(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol targetType)
         {
-            return compilation.ClassifyConversion(sourceType, targetType).IsImplicit;
+            return compilation.ClassifyConversion(sourceType.UnwrapNullabilitySymbol(), targetType.UnwrapNullabilitySymbol()).IsImplicit;
         }
 
         public override async Task<Tuple<INamespaceSymbol, INamespaceOrTypeSymbol, Location>> GetOrGenerateEnclosingNamespaceSymbolAsync(

--- a/src/Features/CSharp/Portable/InternalUtilities/InternalExtensions.cs
+++ b/src/Features/CSharp/Portable/InternalUtilities/InternalExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (argument.Expression.Kind() == SyntaxKind.DeclarationExpression)
             {
                 var decl = (DeclarationExpressionSyntax)argument.Expression;
-                typeInfo = semanticModel.GetTypeInfo(decl.Type);
+                typeInfo = semanticModel.GetTypeInfo(decl.Type, cancellationToken);
                 return typeInfo.Type?.IsErrorType() == false ? typeInfo.Type : semanticModel.Compilation.ObjectType;
             }
 

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
                     ?? semanticModel.GetSymbolInfo(expression).GetAnySymbol().GetSymbolType();
             }
 
-            indexers = semanticModel.LookupSymbols(position, expressionType, WellKnownMemberNames.Indexer)
+            indexers = semanticModel.LookupSymbols(position, expressionType.UnwrapNullabilitySymbol(), WellKnownMemberNames.Indexer)
                 .OfType<IPropertySymbol>()
                 .ToImmutableArray();
             return true;

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
                     ?? semanticModel.GetSymbolInfo(expression).GetAnySymbol().GetSymbolType();
             }
 
-            indexers = semanticModel.LookupSymbols(position, expressionType.UnwrapNullabilitySymbol(), WellKnownMemberNames.Indexer)
+            indexers = semanticModel.LookupSymbols(position, expressionType.WithoutNullability(), WellKnownMemberNames.Indexer)
                 .OfType<IPropertySymbol>()
                 .ToImmutableArray();
             return true;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -44,8 +44,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 options,
                 cancellationToken).ConfigureAwait(false);
 
-            // Don't preselect intrinsic type symbols so we can preselect their keywords instead.
-            return symbols.WhereAsArray(s => inferredTypes.Contains(GetSymbolType(s)) && !IsInstrinsic(s));
+            // Don't preselect intrinsic type symbols so we can preselect their keywords instead. We will also ignore nullability for purposes of preselection
+            // -- if a method is returning a string? but we've inferred we're assigning to a string or vice versa we'll still count those as the same.
+            return symbols.WhereAsArray(s => inferredTypes.Contains(GetSymbolType(s), AllNullabilityIgnoringSymbolComparer.Instance) && !IsInstrinsic(s));
         }
 
         private ITypeSymbol GetSymbolType(ISymbol symbol)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             foreach (var inferredType in inferredTypes)
             {
-                if (semanticModel.Compilation.ClassifyCommonConversion(type.UnwrapNullabilitySymbol(), inferredType.UnwrapNullabilitySymbol()).IsImplicit)
+                if (semanticModel.Compilation.ClassifyCommonConversion(type.WithoutNullability(), inferredType.WithoutNullability()).IsImplicit)
                 {
                     return true;
                 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             foreach (var inferredType in inferredTypes)
             {
-                if (semanticModel.Compilation.ClassifyCommonConversion(type, inferredType).IsImplicit)
+                if (semanticModel.Compilation.ClassifyCommonConversion(type.UnwrapNullabilitySymbol(), inferredType.UnwrapNullabilitySymbol()).IsImplicit)
                 {
                     return true;
                 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 {
                     var type2 = method.Parameters[i].Type;
 
-                    if (!compilation.HasImplicitConversion(fromType: type1, toType: type2))
+                    if (!compilation.HasImplicitConversion(fromType: type1.UnwrapNullabilitySymbol(), toType: type2.UnwrapNullabilitySymbol()))
                     {
                         return false;
                     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/GenerateConstructorHelpers.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 {
                     var type2 = method.Parameters[i].Type;
 
-                    if (!compilation.HasImplicitConversion(fromType: type1.UnwrapNullabilitySymbol(), toType: type2.UnwrapNullabilitySymbol()))
+                    if (!compilation.HasImplicitConversion(fromType: type1.WithoutNullability(), toType: type2.WithoutNullability()))
                     {
                         return false;
                     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.AbstractInvocationInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.AbstractInvocationInfo.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     // a generic method if the expression 'x' captured any method type variables.
                     var capturedTypeParameters = GetCapturedTypeParameters(cancellationToken);
                     var availableTypeParameters = this.State.TypeToGenerateIn.GetAllTypeParameters();
-                    var result = capturedTypeParameters.Except(availableTypeParameters).ToImmutableArray();
+                    var result = capturedTypeParameters.Except<ITypeParameterSymbol>(availableTypeParameters, AllNullabilityIgnoringSymbolComparer.Instance).ToImmutableArray();
                     return result;
                 }
                 else

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.SignatureInfo.cs
@@ -163,7 +163,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 var typeArguments = this.DetermineTypeArguments(cancellationToken);
                 var typeParameters = this.DetermineTypeParameters(cancellationToken);
 
-                var result = new Dictionary<ITypeSymbol, ITypeParameterSymbol>();
+                // We use a nullability-ignoring comparer because top-level and nested nullability won't matter. If we are looking to replace
+                // IEnumerable<string> with T, we want to replace IEnumerable<string?> whenever it appears in an argument or return type, partly because
+                // there's no way to represent something like T-with-only-the-inner-thing-nullable. We could leave the entire argument as is, but we're suspecting
+                // this is closer to the user's desire, even if it might require some tweaking after the fact.
+                var result = new Dictionary<ITypeSymbol, ITypeParameterSymbol>(AllNullabilityIgnoringSymbolComparer.Instance);
 
                 for (var i = 0; i < typeArguments.Length; i++)
                 {

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 // caller.
                 if (_state.IsException &&
                     _state.BaseTypeOrInterfaceOpt.InstanceConstructors.Any(
-                        c => c.Parameters.Select(p => p.Type).SequenceEqual(parameterTypes)))
+                        c => c.Parameters.Select(p => p.Type).SequenceEqual(parameterTypes, AllNullabilityIgnoringSymbolComparer.Instance)))
                 {
                     return;
                 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -567,7 +567,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // will actually return a viable type given where this invocation expression
                         // is.
                         var filteredMethods = instantiatedMethods.Where(m =>
-                            invocationTypes.Any(t => Compilation.ClassifyConversion(m.ReturnType.UnwrapNullabilitySymbol(), t.UnwrapNullabilitySymbol()).IsImplicit)).ToList();
+                            invocationTypes.Any(t => Compilation.ClassifyConversion(m.ReturnType.WithoutNullability(), t.WithoutNullability()).IsImplicit)).ToList();
 
                         // If we filtered down to nothing, then just fall back to the instantiated list.
                         // this is a best effort after all.
@@ -1089,7 +1089,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return rightTypes
                     .Select(x => x.InferredType.IsValueType
                                      // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                                     ? new TypeInferenceInfo(this.Compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(x.InferredType.UnwrapNullabilitySymbol())) // Goo() ?? 0
+                                     ? new TypeInferenceInfo(this.Compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(x.InferredType.WithoutNullability())) // Goo() ?? 0
                                      : x); // Goo() ?? ""
             }
 
@@ -1218,7 +1218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var type = this.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
 
                 // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                return variableTypes.Select(v => new TypeInferenceInfo(type.Construct(v.InferredType.UnwrapNullabilitySymbol())));
+                return variableTypes.Select(v => new TypeInferenceInfo(type.Construct(v.InferredType.WithoutNullability())));
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInForStatement(ForStatementSyntax forStatement, ExpressionSyntax expressionOpt = null, SyntaxToken? previousToken = null)
@@ -1514,7 +1514,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
                             }
 
-                            elementTypesBuilder.Add(patternType.InferredType.UnwrapNullabilitySymbol());
+                            elementTypesBuilder.Add(patternType.InferredType.WithoutNullability());
                         }
 
                         var type = Compilation.CreateTupleTypeSymbol(
@@ -1700,7 +1700,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
 
                                 // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                                return CreateResult(ienumerableType.Construct(typeArg.UnwrapNullabilitySymbol()));
+                                return CreateResult(ienumerableType.Construct(typeArg.WithoutNullability()));
                             }
                         }
                     }
@@ -1880,7 +1880,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // TODO: pass along nullability to Construct when https://github.com/dotnet/roslyn/issues/36046 is fixed.
-                return types.Select(t => t.InferredType.SpecialType == SpecialType.System_Void ? new TypeInferenceInfo(task) : new TypeInferenceInfo(taskOfT.Construct(t.InferredType.UnwrapNullabilitySymbol())));
+                return types.Select(t => t.InferredType.SpecialType == SpecialType.System_Void ? new TypeInferenceInfo(task) : new TypeInferenceInfo(taskOfT.Construct(t.InferredType.WithoutNullability())));
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInYieldStatement(YieldStatementSyntax yieldStatement, SyntaxToken? previousToken = null)
@@ -2138,7 +2138,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // TODO: pass nullability once https://github.com/dotnet/roslyn/issues/36047 is fixed
-                return Compilation.CreateTupleTypeSymbol(elementTypes.SelectAsArray(t => t.UnwrapNullabilitySymbol()), elementNames);
+                return Compilation.CreateTupleTypeSymbol(elementTypes.SelectAsArray(t => t.WithoutNullability()), elementNames);
             }
 
             private bool TryGetTupleTypesAndNames(

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1514,7 +1514,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
                             }
 
-                            elementTypesBuilder.Add(patternType.InferredType);
+                            elementTypesBuilder.Add(patternType.InferredType.UnwrapNullabilitySymbol());
                         }
 
                         var type = Compilation.CreateTupleTypeSymbol(

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -70,6 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public abstract ImmutableArray<IMethodSymbol> StaticConstructors { get; }
         public abstract ImmutableArray<IMethodSymbol> Constructors { get; }
         public abstract ImmutableArray<ITypeSymbol> TypeArguments { get; }
+        public abstract ImmutableArray<NullableAnnotation> TypeArgumentsNullableAnnotations { get; }
 
         public ImmutableArray<CustomModifier> GetTypeArgumentCustomModifiers(int ordinal)
         {
@@ -103,6 +104,5 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public bool IsRefLikeType => Modifiers.IsRef;
 
-        public ImmutableArray<NullableAnnotation> TypeArgumentsNullableAnnotations => throw new NotImplementedException();
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
@@ -26,6 +26,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public override ImmutableArray<ITypeSymbol> TypeArguments => _typeArguments;
 
+        // TODO: implement this once INamedTypeSymbol.Construct is fixed in https://github.com/dotnet/roslyn/issues/36046
+        public override ImmutableArray<NullableAnnotation> TypeArgumentsNullableAnnotations => _typeArguments.SelectAsArray(t => NullableAnnotation.NotAnnotated);
+
         public override int Arity => _constructedFrom.Arity;
 
         public override bool IsGenericType => _constructedFrom.IsGenericType;

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
@@ -122,6 +122,15 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
+        public override ImmutableArray<NullableAnnotation> TypeArgumentsNullableAnnotations
+        {
+            get
+            {
+                // TODO: what should this be?
+                return this.TypeParameters.SelectAsArray(t => NullableAnnotation.NotAnnotated);
+            }
+        }
+
         public override ImmutableArray<ITypeParameterSymbol> TypeParameters
         {
             get

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -86,7 +86,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var updatedTypeParameters = RenameTypeParameters(
                 method.TypeParameters, newNames, typeGenerator);
 
-            var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>();
+            // The use of AllNullabilityIgnoringSymbolComparer is tracked by https://github.com/dotnet/roslyn/issues/36093
+            var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>(AllNullabilityIgnoringSymbolComparer.Instance);
             for (int i = 0; i < method.TypeParameters.Length; i++)
             {
                 mapping[method.TypeParameters[i]] = updatedTypeParameters[i];
@@ -139,7 +140,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // We generate the type parameter in two passes.  The first creates the new type
             // parameter.  The second updates the constraints to point at this new type parameter.
             var newTypeParameters = new List<CodeGenerationTypeParameterSymbol>();
-            var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>();
+
+            // The use of AllNullabilityIgnoringSymbolComparer is tracked by https://github.com/dotnet/roslyn/issues/36093
+            var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>(AllNullabilityIgnoringSymbolComparer.Instance);
             for (int i = 0; i < typeParameters.Length; i++)
             {
                 var typeParameter = typeParameters[i];

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -598,6 +598,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static INamedTypeSymbol TryConstruct(this INamedTypeSymbol type, ITypeSymbol[] typeArguments)
-            => typeArguments.Length > 0 ? type.Construct(typeArguments) : type;
+        {
+            // TODO: pass along nullability once https://github.com/dotnet/roslyn/issues/36046 is fixed
+            return typeArguments.Length > 0 ? type.Construct(typeArguments.Select(t => t.UnwrapNullabilitySymbol()).ToArray()) : type;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -600,7 +600,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static INamedTypeSymbol TryConstruct(this INamedTypeSymbol type, ITypeSymbol[] typeArguments)
         {
             // TODO: pass along nullability once https://github.com/dotnet/roslyn/issues/36046 is fixed
-            return typeArguments.Length > 0 ? type.Construct(typeArguments.Select(t => t.UnwrapNullabilitySymbol()).ToArray()) : type;
+            return typeArguments.Length > 0 ? type.Construct(typeArguments.Select(t => t.WithoutNullability()).ToArray()) : type;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -526,12 +526,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 {
                     var types = method.Parameters
                         .Skip(skip)
-                        .Select(p => p.Type ?? compilation.GetSpecialType(SpecialType.System_Object));
+                        .Select(p => (p.Type ?? compilation.GetSpecialType(SpecialType.System_Object)).WithNullability(p.NullableAnnotation));
 
                     if (!method.ReturnsVoid)
                     {
                         // +1 for the return type.
-                        types = types.Concat(method.ReturnType ?? compilation.GetSpecialType(SpecialType.System_Object));
+                        types = types.Concat((method.ReturnType ?? compilation.GetSpecialType(SpecialType.System_Object)).WithNullability(method.ReturnNullableAnnotation));
                     }
 
                     return delegateType.TryConstruct(types.ToArray());
@@ -867,13 +867,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             switch (symbol)
             {
                 case ILocalSymbol localSymbol:
-                    return localSymbol.Type;
+                    return localSymbol.Type.WithNullability(localSymbol.NullableAnnotation);
                 case IFieldSymbol fieldSymbol:
-                    return fieldSymbol.Type;
+                    return fieldSymbol.Type.WithNullability(fieldSymbol.NullableAnnotation);
                 case IPropertySymbol propertySymbol:
-                    return propertySymbol.Type;
+                    return propertySymbol.Type.WithNullability(propertySymbol.NullableAnnotation);
                 case IParameterSymbol parameterSymbol:
-                    return parameterSymbol.Type;
+                    return parameterSymbol.Type.WithNullability(parameterSymbol.NullableAnnotation);
                 case IAliasSymbol aliasSymbol:
                     return aliasSymbol.Target as ITypeSymbol;
             }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 }
 
                 // TODO: pass nullability to the substituted arguments once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                return _typeGenerator.Construct(symbol.OriginalDefinition, substitutedArguments.Select(t => t.UnwrapNullabilitySymbol()).ToArray()).WithNullability(symbol.GetNullability());
+                return _typeGenerator.Construct(symbol.OriginalDefinition, substitutedArguments.Select(t => t.WithoutNullability()).ToArray()).WithNullability(symbol.GetNullability());
             }
 
             public override ITypeSymbol VisitArrayType(IArrayTypeSymbol symbol)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
@@ -80,13 +80,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     symbol = updatedContainingType.GetTypeMembers(symbol.Name, symbol.Arity).First(m => m.TypeKind == symbol.TypeKind);
                 }
 
-                var substitutedArguments = symbol.TypeArguments.Select(t => t.Accept(this)).ToArray();
-                if (symbol.TypeArguments.SequenceEqual(substitutedArguments))
+                var typeArgumentsWithNullability = symbol.TypeArguments.ZipAsArray(symbol.TypeArgumentsNullableAnnotations, (t, n) => t.WithNullability(n));
+                var substitutedArguments = typeArgumentsWithNullability.Select(t => t.Accept(this));
+                if (typeArgumentsWithNullability.SequenceEqual(substitutedArguments))
                 {
                     return symbol;
                 }
 
-                return _typeGenerator.Construct(symbol.OriginalDefinition, substitutedArguments);
+                // TODO: pass nullability to the substituted arguments once https://github.com/dotnet/roslyn/issues/36046 is fixed
+                return _typeGenerator.Construct(symbol.OriginalDefinition, substitutedArguments.Select(t => t.UnwrapNullabilitySymbol()).ToArray()).WithNullability(symbol.GetNullability());
             }
 
             public override ITypeSymbol VisitArrayType(IArrayTypeSymbol symbol)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -64,14 +64,24 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return semanticModel.GetEnclosingSymbol<INamespaceSymbol>(position, cancellationToken);
         }
 
+        /// <summary>
+        /// Fetches the ITypeSymbol that should be used if we were generating a parameter or local that would accept <paramref name="expression"/>. If
+        /// expression is a type, that's returned; otherwise this will see if it's something like a method group and then choose an appropriate delegate.
+        /// </summary>
         public static ITypeSymbol GetType(
             this SemanticModel semanticModel,
             SyntaxNode expression,
             CancellationToken cancellationToken)
         {
             var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
+
+            if (typeInfo.Type != null)
+            {
+                return typeInfo.Type.WithNullability(typeInfo.Nullability.FlowState);
+            }
+
             var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
-            return typeInfo.Type ?? symbolInfo.GetAnySymbol().ConvertToType(semanticModel.Compilation);
+            return symbolInfo.GetAnySymbol().ConvertToType(semanticModel.Compilation);
         }
 
         private static ISymbol MapSymbol(ISymbol symbol, ITypeSymbol type)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (iequatableType != null)
             {
                 // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                var constructed = iequatableType.Construct(memberType.UnwrapNullabilitySymbol());
+                var constructed = iequatableType.Construct(memberType.WithoutNullability());
                 return memberType.AllInterfaces.Contains(constructed);
             }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -317,7 +317,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (iequatableType != null)
             {
-                var constructed = iequatableType.Construct(memberType);
+                // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
+                var constructed = iequatableType.Construct(memberType.UnwrapNullabilitySymbol());
                 return memberType.AllInterfaces.Contains(constructed);
             }
 

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/AllNullabilityIgnoringSymbolComparer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/AllNullabilityIgnoringSymbolComparer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             {
                 // TODO: also ignore nested nullability. Right now there is no compiler API to do this, but it's being tracked in https://github.com/dotnet/roslyn/issues/35933.
                 // The fixing of this code will be tracked by https://github.com/dotnet/roslyn/issues/36044 and tests can then be unskipped there.
-                return xTypeSymbol.UnwrapNullabilitySymbol().Equals(yTypeSymbol.UnwrapNullabilitySymbol());
+                return xTypeSymbol.WithoutNullability().Equals(yTypeSymbol.WithoutNullability());
             }
 
             return object.Equals(x, y);
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (symbol is ITypeSymbol typeSymbol)
             {
-                return typeSymbol.UnwrapNullabilitySymbol().GetHashCode();
+                return typeSymbol.WithoutNullability().GetHashCode();
             }
             else
             {

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/AllNullabilityIgnoringSymbolComparer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/AllNullabilityIgnoringSymbolComparer.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A comparer that compares symbols but ignores nullability, both top-level and nested.
+    /// </summary>
+    /// <remarks>This is not implemented correctly, which is being tracked by https://github.com/dotnet/roslyn/issues/36044</remarks>
+    internal sealed class AllNullabilityIgnoringSymbolComparer : IEqualityComparer<ISymbol>
+    {
+        public static readonly IEqualityComparer<ISymbol> Instance = new AllNullabilityIgnoringSymbolComparer();
+
+        private AllNullabilityIgnoringSymbolComparer()
+        {
+        }
+
+        public bool Equals(ISymbol x, ISymbol y)
+        {
+            if (x is ITypeSymbol xTypeSymbol && y is ITypeSymbol yTypeSymbol)
+            {
+                // TODO: also ignore nested nullability. Right now there is no compiler API to do this, but it's being tracked in https://github.com/dotnet/roslyn/issues/35933.
+                // The fixing of this code will be tracked by https://github.com/dotnet/roslyn/issues/36044 and tests can then be unskipped there.
+                return xTypeSymbol.UnwrapNullabilitySymbol().Equals(yTypeSymbol.UnwrapNullabilitySymbol());
+            }
+
+            return object.Equals(x, y);
+        }
+
+        public int GetHashCode(ISymbol symbol)
+        {
+            if (symbol is ITypeSymbol typeSymbol)
+            {
+                return typeSymbol.UnwrapNullabilitySymbol().GetHashCode();
+            }
+            else
+            {
+                return symbol.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/ArrayTypeSymbolWithNullableAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/ArrayTypeSymbolWithNullableAnnotation.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        private sealed class ArrayTypeSymbolWithNullableAnnotation : TypeSymbolWithNullableAnnotation, IArrayTypeSymbol
+        {
+            public ArrayTypeSymbolWithNullableAnnotation(ITypeSymbol wrappedSymbol, NullableAnnotation nullability) : base(wrappedSymbol, nullability)
+            {
+            }
+
+            private new IArrayTypeSymbol WrappedSymbol => (IArrayTypeSymbol)base.WrappedSymbol;
+
+            public override void Accept(SymbolVisitor visitor)
+            {
+                visitor.VisitArrayType(this);
+            }
+
+            public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+            {
+                return visitor.VisitArrayType(this);
+            }
+
+            #region IArrayTypeSymbol Implementation Forwards
+
+            public int Rank => WrappedSymbol.Rank;
+
+            public bool IsSZArray => WrappedSymbol.IsSZArray;
+
+            public ImmutableArray<int> LowerBounds => WrappedSymbol.LowerBounds;
+
+            public ImmutableArray<int> Sizes => WrappedSymbol.Sizes;
+
+            public ITypeSymbol ElementType => WrappedSymbol.ElementType;
+
+            public NullableAnnotation ElementNullableAnnotation => WrappedSymbol.ElementNullableAnnotation;
+
+            public ImmutableArray<CustomModifier> CustomModifiers => WrappedSymbol.CustomModifiers;
+
+            public bool Equals(IArrayTypeSymbol other)
+            {
+                return WrappedSymbol.Equals(other);
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/DynamicTypeSymbolWithNullableAnnotations.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/DynamicTypeSymbolWithNullableAnnotations.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        private sealed class DynamicTypeSymbolWithNullableAnnotation : TypeSymbolWithNullableAnnotation, IDynamicTypeSymbol
+        {
+            public DynamicTypeSymbolWithNullableAnnotation(ITypeSymbol wrappedSymbol, NullableAnnotation nullability) : base(wrappedSymbol, nullability)
+            {
+            }
+
+            private new IDynamicTypeSymbol WrappedSymbol => (IDynamicTypeSymbol)base.WrappedSymbol;
+
+            public override void Accept(SymbolVisitor visitor)
+            {
+                visitor.VisitDynamicType(this);
+            }
+
+            public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+            {
+                return visitor.VisitDynamicType(this);
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NamedTypeSymbolWithNullableAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NamedTypeSymbolWithNullableAnnotation.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis
 
             public INamedTypeSymbol Construct(params ITypeSymbol[] typeArguments)
             {
-                return WrappedSymbol.Construct(typeArguments);
+                return WrappedSymbol.Construct(typeArguments).WithNullability(Nullability);
             }
 
             public INamedTypeSymbol ConstructUnboundGenericType()

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NamedTypeSymbolWithNullableAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NamedTypeSymbolWithNullableAnnotation.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        private sealed class NamedTypeSymbolWithNullableAnnotation : TypeSymbolWithNullableAnnotation, INamedTypeSymbol
+        {
+            public NamedTypeSymbolWithNullableAnnotation(INamedTypeSymbol wrappedSymbol, NullableAnnotation nullability) : base(wrappedSymbol, nullability)
+            {
+            }
+
+            private new INamedTypeSymbol WrappedSymbol => (INamedTypeSymbol)base.WrappedSymbol;
+
+            public override void Accept(SymbolVisitor visitor)
+            {
+                visitor.VisitNamedType(this);
+            }
+
+            public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+            {
+                return visitor.VisitNamedType(this);
+            }
+
+            #region INamedTypeSymbol Implementation Forwards
+
+            public int Arity => WrappedSymbol.Arity;
+            public bool IsGenericType => WrappedSymbol.IsGenericType;
+            public bool IsUnboundGenericType => WrappedSymbol.IsUnboundGenericType;
+            public bool IsScriptClass => WrappedSymbol.IsScriptClass;
+            public bool IsImplicitClass => WrappedSymbol.IsImplicitClass;
+            public bool IsComImport => WrappedSymbol.IsComImport;
+            public IEnumerable<string> MemberNames => WrappedSymbol.MemberNames;
+            public ImmutableArray<ITypeParameterSymbol> TypeParameters => WrappedSymbol.TypeParameters;
+            public ImmutableArray<ITypeSymbol> TypeArguments => WrappedSymbol.TypeArguments;
+            public ImmutableArray<NullableAnnotation> TypeArgumentsNullableAnnotations => WrappedSymbol.TypeArgumentsNullableAnnotations;
+            public IMethodSymbol DelegateInvokeMethod => WrappedSymbol.DelegateInvokeMethod;
+            public INamedTypeSymbol EnumUnderlyingType => WrappedSymbol.EnumUnderlyingType;
+            public INamedTypeSymbol ConstructedFrom => WrappedSymbol.ConstructedFrom;
+            public ImmutableArray<IMethodSymbol> InstanceConstructors => WrappedSymbol.InstanceConstructors;
+            public ImmutableArray<IMethodSymbol> StaticConstructors => WrappedSymbol.StaticConstructors;
+            public ImmutableArray<IMethodSymbol> Constructors => WrappedSymbol.Constructors;
+            public ISymbol AssociatedSymbol => WrappedSymbol.AssociatedSymbol;
+            public bool MightContainExtensionMethods => WrappedSymbol.MightContainExtensionMethods;
+            public INamedTypeSymbol TupleUnderlyingType => WrappedSymbol.TupleUnderlyingType;
+            public ImmutableArray<IFieldSymbol> TupleElements => WrappedSymbol.TupleElements;
+            public bool IsSerializable => WrappedSymbol.IsSerializable;
+            INamedTypeSymbol INamedTypeSymbol.OriginalDefinition => WrappedSymbol.OriginalDefinition;
+
+            public INamedTypeSymbol Construct(params ITypeSymbol[] typeArguments)
+            {
+                return WrappedSymbol.Construct(typeArguments);
+            }
+
+            public INamedTypeSymbol ConstructUnboundGenericType()
+            {
+                return WrappedSymbol.ConstructUnboundGenericType();
+            }
+
+            public ImmutableArray<CustomModifier> GetTypeArgumentCustomModifiers(int ordinal)
+            {
+                return WrappedSymbol.GetTypeArgumentCustomModifiers(ordinal);
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        public static T WithNullability<T>(this T typeSymbol, NullableAnnotation nullability) where T : class, ITypeSymbol
+        {
+            if (typeSymbol == null)
+            {
+                return null;
+            }
+
+            // No reason to wrap a wrapper, so unwrap it
+            if (typeSymbol is TypeSymbolWithNullableAnnotation typeSymbolWithNullability)
+            {
+                typeSymbol = (T)typeSymbolWithNullability.WrappedSymbol;
+            }
+
+            return typeSymbol switch
+            {
+                IArrayTypeSymbol arrayTypeSymbol => (ITypeSymbol)new ArrayTypeSymbolWithNullableAnnotation(arrayTypeSymbol, nullability),
+                IDynamicTypeSymbol dynamicTypeSymbol => (ITypeSymbol)new DynamicTypeSymbolWithNullableAnnotation(dynamicTypeSymbol, nullability),
+                INamedTypeSymbol namedTypeSymbol => (ITypeSymbol)new NamedTypeSymbolWithNullableAnnotation(namedTypeSymbol, nullability),
+                IPointerTypeSymbol pointerType => (ITypeSymbol)new PointerTypeSymbolWithNullableAnnotation(pointerType, nullability),
+                ITypeParameterSymbol typeParameterSymbol => (ITypeSymbol)new TypeParameterSymbolWithNullableAnnotation(typeParameterSymbol, nullability),
+                _ => throw ExceptionUtilities.UnexpectedValue(typeSymbol)
+            } as T;
+        }
+
+        public static T WithNullability<T>(this T typeSymbol, NullableFlowState flowState) where T : class, ITypeSymbol
+        {
+            // TODO: call the compiler API once it's available
+            switch (flowState)
+            {
+                case NullableFlowState.NotApplicable:
+                    return typeSymbol.WithNullability(NullableAnnotation.NotApplicable);
+                case NullableFlowState.NotNull:
+                    return typeSymbol.WithNullability(NullableAnnotation.NotAnnotated);
+                case NullableFlowState.MaybeNull:
+                    return typeSymbol.WithNullability(NullableAnnotation.Annotated);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(typeSymbol);
+            }
+        }
+
+        public static NullableAnnotation GetNullability(this ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol is TypeSymbolWithNullableAnnotation typeSymbolWithNullability)
+            {
+                return typeSymbolWithNullability.Nullability;
+            }
+            else
+            {
+                // For now, we'll return this while we transition the codebase over to these helpers. Eventually this should throw, since it means somebody got a type from
+                // the compiler API and didn't wrap it properly.
+                return NullableAnnotation.NotApplicable;
+            }
+        }
+
+        public static T UnwrapNullabilitySymbol<T>(this T typeSymbol) where T : ITypeSymbol
+        {
+            if (typeSymbol is TypeSymbolWithNullableAnnotation typeSymbolWithNullability)
+            {
+                return (T)typeSymbolWithNullability.WrappedSymbol;
+            }
+            else
+            {
+                return typeSymbol;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
@@ -14,9 +14,15 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
 
-            // No reason to wrap a wrapper, so unwrap it
             if (typeSymbol is TypeSymbolWithNullableAnnotation typeSymbolWithNullability)
             {
+                // Check if the wrapper already has the same top-level nullability; in that case we don't need to re-create one.
+                if (typeSymbolWithNullability.Nullability == nullability)
+                {
+                    return typeSymbol;
+                }
+
+                // No reason to wrap a wrapper, so unwrap it
                 typeSymbol = (T)typeSymbolWithNullability.WrappedSymbol;
             }
 

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static T UnwrapNullabilitySymbol<T>(this T typeSymbol) where T : ITypeSymbol
+        public static T WithoutNullability<T>(this T typeSymbol) where T : ITypeSymbol
         {
             if (typeSymbol is TypeSymbolWithNullableAnnotation typeSymbolWithNullability)
             {

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/PointerTypeSymbolWithNullableAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/PointerTypeSymbolWithNullableAnnotation.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        private sealed class PointerTypeSymbolWithNullableAnnotation : TypeSymbolWithNullableAnnotation, IPointerTypeSymbol
+        {
+            public PointerTypeSymbolWithNullableAnnotation(ITypeSymbol wrappedSymbol, NullableAnnotation nullability) : base(wrappedSymbol, nullability)
+            {
+            }
+
+            private new IPointerTypeSymbol WrappedSymbol => (IPointerTypeSymbol)base.WrappedSymbol;
+
+            public override void Accept(SymbolVisitor visitor)
+            {
+                visitor.VisitPointerType(this);
+            }
+
+            public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+            {
+                return visitor.VisitPointerType(this);
+            }
+
+            #region IPointerTypeSymbol Implementation Forwards
+
+            public ITypeSymbol PointedAtType => WrappedSymbol.PointedAtType;
+
+            public ImmutableArray<CustomModifier> CustomModifiers => WrappedSymbol.CustomModifiers;
+
+            #endregion
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/TypeParameterSymbolWithNullableAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/TypeParameterSymbolWithNullableAnnotation.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        private sealed class TypeParameterSymbolWithNullableAnnotation : TypeSymbolWithNullableAnnotation, ITypeParameterSymbol
+        {
+            public TypeParameterSymbolWithNullableAnnotation(ITypeSymbol wrappedSymbol, NullableAnnotation nullability) : base(wrappedSymbol, nullability)
+            {
+            }
+
+
+            private new ITypeParameterSymbol WrappedSymbol => (ITypeParameterSymbol)base.WrappedSymbol;
+
+            ITypeParameterSymbol ITypeParameterSymbol.OriginalDefinition => WrappedSymbol.OriginalDefinition;
+
+            public override void Accept(SymbolVisitor visitor)
+            {
+                visitor.VisitTypeParameter(this);
+            }
+
+            public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+            {
+                return visitor.VisitTypeParameter(this);
+            }
+
+            #region ITypeParameterSymbol Implementation Forwards
+
+            public int Ordinal => WrappedSymbol.Ordinal;
+
+            public VarianceKind Variance => WrappedSymbol.Variance;
+
+            public TypeParameterKind TypeParameterKind => WrappedSymbol.TypeParameterKind;
+
+            public IMethodSymbol DeclaringMethod => WrappedSymbol.DeclaringMethod;
+
+            public INamedTypeSymbol DeclaringType => WrappedSymbol.DeclaringType;
+
+            public bool HasReferenceTypeConstraint => WrappedSymbol.HasReferenceTypeConstraint;
+
+            public NullableAnnotation ReferenceTypeConstraintNullableAnnotation => WrappedSymbol.ReferenceTypeConstraintNullableAnnotation;
+
+            public bool HasValueTypeConstraint => WrappedSymbol.HasValueTypeConstraint;
+
+            public bool HasUnmanagedTypeConstraint => WrappedSymbol.HasUnmanagedTypeConstraint;
+
+            public bool HasConstructorConstraint => WrappedSymbol.HasConstructorConstraint;
+
+            public ImmutableArray<ITypeSymbol> ConstraintTypes => WrappedSymbol.ConstraintTypes;
+
+            public ImmutableArray<NullableAnnotation> ConstraintNullableAnnotations => WrappedSymbol.ConstraintNullableAnnotations;
+
+            public ITypeParameterSymbol ReducedFrom => WrappedSymbol.ReducedFrom;
+
+
+            #endregion
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/TypeSymbolWithNullableAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/TypeSymbolWithNullableAnnotation.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static partial class NullableExtensions
+    {
+        [DebuggerDisplay("{WrappedSymbol,nq}, Nullability = {Nullability,nq}")]
+        private abstract class TypeSymbolWithNullableAnnotation : ITypeSymbol
+        {
+            internal ITypeSymbol WrappedSymbol { get; }
+            internal NullableAnnotation Nullability { get; }
+
+            protected TypeSymbolWithNullableAnnotation(ITypeSymbol wrappedSymbol, NullableAnnotation nullability)
+            {
+                Debug.Assert(!(wrappedSymbol is TypeSymbolWithNullableAnnotation));
+
+                WrappedSymbol = wrappedSymbol;
+                Nullability = nullability;
+            }
+
+            public bool Equals(ISymbol other)
+            {
+                if (other is TypeSymbolWithNullableAnnotation otherWrappingSymbol)
+                {
+                    return this.Nullability == otherWrappingSymbol.Nullability &&
+                           this.WrappedSymbol.Equals(otherWrappingSymbol.WrappedSymbol);
+                }
+                else if (other is ITypeSymbol)
+                {
+                    // Somebody is trying to compare a nullable-wrapped symbol with a regular compiler symbol. By rule Equals must be reflexive,
+                    // and since the compiler's Equals won't respect us as being equal, we can't return anything other than false. Flagging this with an assert
+                    // is helpful while moving features over, because this comparison might be the reason a feature isn't working right. However, for now disabling
+                    // the assert is easiest because we can't update the whole codebase at once. Enabling the assert is tracked in https://github.com/dotnet/roslyn/issues/36045.
+
+                    // Debug.Fail($"A {nameof(TypeSymbolWithNullableAnnotation)} was compared to a regular symbol. This comparison is disallowed.");
+
+                    // We are also going to cheat further: for now, we'll just throw away nullability and compare, because if a core feature (like the type inferrerr) is updated
+                    // but other features aren't, we want to keep those working.
+                    return this.WrappedSymbol.Equals(other);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            public override bool Equals(object obj)
+            {
+                return this.Equals(obj as ISymbol);
+            }
+
+            public override int GetHashCode()
+            {
+                // As a transition mechanism, we allow ourselves to be compared to non-wrapped
+                // symbols and we compare with the existing compiler equality and just throw away our
+                // top-level nullability. Because of that, we can't incorporate the top-level nullability
+                // into our hash code, because if we did we couldn't be both simultaneously equal to
+                // something that has top level nullability and something that doesn't.
+                return this.WrappedSymbol.GetHashCode();
+            }
+
+            #region ITypeSymbol Implementation Forwards
+
+            public TypeKind TypeKind => WrappedSymbol.TypeKind;
+            public INamedTypeSymbol BaseType => WrappedSymbol.BaseType;
+            public ImmutableArray<INamedTypeSymbol> Interfaces => WrappedSymbol.Interfaces;
+            public ImmutableArray<INamedTypeSymbol> AllInterfaces => WrappedSymbol.AllInterfaces;
+            public bool IsReferenceType => WrappedSymbol.IsReferenceType;
+            public bool IsValueType => WrappedSymbol.IsValueType;
+            public bool IsAnonymousType => WrappedSymbol.IsAnonymousType;
+            public bool IsTupleType => WrappedSymbol.IsTupleType;
+            public ITypeSymbol OriginalDefinition => WrappedSymbol.OriginalDefinition;
+            public SpecialType SpecialType => WrappedSymbol.SpecialType;
+            public bool IsRefLikeType => WrappedSymbol.IsRefLikeType;
+            public bool IsUnmanagedType => WrappedSymbol.IsUnmanagedType;
+            public bool IsReadOnly => WrappedSymbol.IsReadOnly;
+            public bool IsNamespace => WrappedSymbol.IsNamespace;
+            public bool IsType => WrappedSymbol.IsType;
+            public SymbolKind Kind => WrappedSymbol.Kind;
+            public string Language => WrappedSymbol.Language;
+            public string Name => WrappedSymbol.Name;
+            public string MetadataName => WrappedSymbol.MetadataName;
+            public ISymbol ContainingSymbol => WrappedSymbol.ContainingSymbol;
+            public IAssemblySymbol ContainingAssembly => WrappedSymbol.ContainingAssembly;
+            public IModuleSymbol ContainingModule => WrappedSymbol.ContainingModule;
+            public INamedTypeSymbol ContainingType => WrappedSymbol.ContainingType;
+            public INamespaceSymbol ContainingNamespace => WrappedSymbol.ContainingNamespace;
+            public bool IsDefinition => WrappedSymbol.IsDefinition;
+            public bool IsStatic => WrappedSymbol.IsStatic;
+            public bool IsVirtual => WrappedSymbol.IsVirtual;
+            public bool IsOverride => WrappedSymbol.IsOverride;
+            public bool IsAbstract => WrappedSymbol.IsAbstract;
+            public bool IsSealed => WrappedSymbol.IsSealed;
+            public bool IsExtern => WrappedSymbol.IsExtern;
+            public bool IsImplicitlyDeclared => WrappedSymbol.IsImplicitlyDeclared;
+            public bool CanBeReferencedByName => WrappedSymbol.CanBeReferencedByName;
+            public ImmutableArray<Location> Locations => WrappedSymbol.Locations;
+            public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => WrappedSymbol.DeclaringSyntaxReferences;
+            public Accessibility DeclaredAccessibility => WrappedSymbol.DeclaredAccessibility;
+            public bool HasUnsupportedMetadata => WrappedSymbol.HasUnsupportedMetadata;
+
+            ISymbol ISymbol.OriginalDefinition => WrappedSymbol.OriginalDefinition;
+
+            public abstract void Accept(SymbolVisitor visitor);
+            public abstract TResult Accept<TResult>(SymbolVisitor<TResult> visitor);
+
+            public ISymbol FindImplementationForInterfaceMember(ISymbol interfaceMember)
+            {
+                return WrappedSymbol.FindImplementationForInterfaceMember(interfaceMember);
+            }
+
+            public ImmutableArray<AttributeData> GetAttributes()
+            {
+                return WrappedSymbol.GetAttributes();
+            }
+
+            public string GetDocumentationCommentId()
+            {
+                return WrappedSymbol.GetDocumentationCommentId();
+            }
+
+            public string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default)
+            {
+                return WrappedSymbol.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
+            }
+
+            public ImmutableArray<ISymbol> GetMembers()
+            {
+                return WrappedSymbol.GetMembers();
+            }
+
+            public ImmutableArray<ISymbol> GetMembers(string name)
+            {
+                return WrappedSymbol.GetMembers(name);
+            }
+
+            public ImmutableArray<INamedTypeSymbol> GetTypeMembers()
+            {
+                return WrappedSymbol.GetTypeMembers();
+            }
+
+            public ImmutableArray<INamedTypeSymbol> GetTypeMembers(string name)
+            {
+                return WrappedSymbol.GetTypeMembers(name);
+            }
+
+            public ImmutableArray<INamedTypeSymbol> GetTypeMembers(string name, int arity)
+            {
+                return WrappedSymbol.GetTypeMembers(name, arity);
+            }
+
+            public ImmutableArray<SymbolDisplayPart> ToDisplayParts(NullableFlowState topLevelNullability, SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToDisplayParts(topLevelNullability, format);
+            }
+
+            public ImmutableArray<SymbolDisplayPart> ToDisplayParts(SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToDisplayParts(format);
+            }
+
+            public string ToDisplayString(NullableFlowState topLevelNullability, SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToDisplayString(topLevelNullability, format);
+            }
+
+            public string ToDisplayString(SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToDisplayString(format);
+            }
+
+            public ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(SemanticModel semanticModel, NullableFlowState topLevelNullability, int position, SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToMinimalDisplayParts(semanticModel, topLevelNullability, position, format);
+            }
+
+            public ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(SemanticModel semanticModel, int position, SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToMinimalDisplayParts(semanticModel, position, format);
+            }
+
+            public string ToMinimalDisplayString(SemanticModel semanticModel, NullableFlowState topLevelNullability, int position, SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToMinimalDisplayString(semanticModel, topLevelNullability, position, format);
+            }
+
+            public string ToMinimalDisplayString(SemanticModel semanticModel, int position, SymbolDisplayFormat format = null)
+            {
+                return WrappedSymbol.ToMinimalDisplayString(semanticModel, position, format);
+            }
+
+            #endregion
+        }
+    }
+}


### PR DESCRIPTION
This is an implementation of generate method with nullability, which tries to use an _experimental_ approach of creating our own implementation of ITypeSymbol that carries along top-level nullability. This means we can avoid having to change all our internal helpers away from passing around ITypeSymbol and incrementally update the support for the IDE.

Commit-at-a-time review suggested, since that'll split apart the wrappers themselves along with the actual "work" needed to fix the feature.