### PR TITLE
Update implicity declared type expression nullability:

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1389,6 +1389,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     type = valueType.ToTypeWithAnnotations();
                     _variableTypes[local] = type;
+
+                    if (node.DeclaredTypeOpt != null)
+                    {
+                        SetAnalyzedNullability(node.DeclaredTypeOpt, new VisitResult(valueType, type), true);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1371,29 +1371,30 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeWithAnnotations type = local.TypeWithAnnotations;
             TypeWithState valueType;
+            bool inferredType = node.InferredType;
             if (local.IsRef)
             {
                 valueType = VisitRefExpression(initializer, type);
             }
             else
             {
-                bool inferredType = node.InferredType;
-                valueType = VisitOptionalImplicitConversion(initializer, targetTypeOpt: inferredType ? default : type, useLegacyWarnings: true, trackMembers: true, AssignmentKind.Assignment);
-                if (inferredType)
+                valueType = VisitOptionalImplicitConversion(initializer, targetTypeOpt: inferredType ? default : type, useLegacyWarnings: true, trackMembers: true, AssignmentKind.Assignment);         
+            }
+
+            if (inferredType)
+            {
+                if (valueType.HasNullType)
                 {
-                    if (valueType.HasNullType)
-                    {
-                        Debug.Assert(type.Type.IsErrorType());
-                        valueType = type.ToTypeWithState();
-                    }
+                    Debug.Assert(type.Type.IsErrorType());
+                    valueType = type.ToTypeWithState();
+                }
 
-                    type = valueType.ToTypeWithAnnotations();
-                    _variableTypes[local] = type;
+                type = valueType.ToTypeWithAnnotations();
+                _variableTypes[local] = type;
 
-                    if (node.DeclaredTypeOpt != null)
-                    {
-                        SetAnalyzedNullability(node.DeclaredTypeOpt, new VisitResult(valueType, type), true);
-                    }
+                if (node.DeclaredTypeOpt != null)
+                {
+                    SetAnalyzedNullability(node.DeclaredTypeOpt, new VisitResult(valueType, type), true);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -97511,39 +97511,5 @@ class Program
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
         }
-
-        [Fact]
-        [WorkItem(35057, "https://github.com/dotnet/roslyn/issues/35057")]
-        public void RefLocal()
-        {
-            var source =
-@"#nullable enable
-class C<T> where T : class
-{
-#nullable disable
-    public static C<T> operator |(
-#nullable enable
-        C<T> a,
-#nullable disable
-        C<T> b) => a;
-}
-class Program
-{
-    static void M<T>(
-#nullable disable
-        C<T> x,
-#nullable enable
-        C<T> y)
-        where T : class
-    {
-        _ = x | x;
-        _ = x | y;
-        _ = y | x;
-        _ = y | y;
-    }
-}";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
-        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -825,23 +825,47 @@ class C
         {
             var source =
 @"#nullable enable
-class C
+class C : System.IDisposable
 {
-    void M(object? x, object x2)
+    void M(C? x, C x2)
     {
-        var/*T:object?*/ y = x;
-        var/*T:object!*/ y2 = x2;
+        var /*T:C?*/ y = x;
+        var /*T:C!*/ y2 = x2;
+
+        using var /*T:C?*/ y3 = x;
+        using var /*T:C!*/ y4 = x2;
+
+        using (var /*T:C?*/ y5 = x) { }
+        using (var /*T:C?*/ y6 = x) { }
+
+        ref var/*T:C?*/ y7 = ref x;
+        ref var/*T:C!*/ y8 = ref x2;
 
         if (x == null) 
             return;
-        var/*T:object!*/ y3 = x;
+        var /*T:C!*/ y9 = x;
+        using var /*T:C!*/ y10 = x;
+        ref var /*T:C!*/ y11 = ref x;
 
         x = null;
-        var /*T:object?*/ y4 = x;
+        var /*T:C?*/ y12 = x;
+        using var /*T:C?*/ y13 = x;
+        ref var /*T:C?*/ y14 = ref x;
+
+        x2 = null; // 1
+        var /*T:C?*/ y15 = x2;
+        using var /*T:C?*/ y16 = x2;
+        ref var /*T:C?*/ y17 = ref x2;
     }
+
+    public void Dispose() { }
 }";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (29,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                //         x2 = null; // 1
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(29, 14)
+                );
             comp.VerifyTypes();
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -824,47 +824,55 @@ class C
         public void InferredDeclarationType()
         {
             var source =
-@"#nullable enable
+@"
+using System.Collections.Generic;
+#nullable enable
 class C : System.IDisposable
 {
     void M(C? x, C x2)
     {
         var /*T:C?*/ y = x;
         var /*T:C!*/ y2 = x2;
-
+        
         using var /*T:C?*/ y3 = x;
         using var /*T:C!*/ y4 = x2;
-
+        
         using (var /*T:C?*/ y5 = x) { }
-        using (var /*T:C?*/ y6 = x) { }
-
+        using (var /*T:C!*/ y6 = x2) { }
+        
         ref var/*T:C?*/ y7 = ref x;
         ref var/*T:C!*/ y8 = ref x2;
-
+        
         if (x == null) 
             return;
         var /*T:C!*/ y9 = x;
         using var /*T:C!*/ y10 = x;
         ref var /*T:C!*/ y11 = ref x;
-
+        
         x = null;
         var /*T:C?*/ y12 = x;
         using var /*T:C?*/ y13 = x;
         ref var /*T:C?*/ y14 = ref x;
-
+        
         x2 = null; // 1
         var /*T:C?*/ y15 = x2;
         using var /*T:C?*/ y16 = x2;
         ref var /*T:C?*/ y17 = ref x2;
+    }
+    
+    void M2(List<C?> l1, List<C> l2)
+    {
+        foreach (var /*T:C?*/ x in l1) { }
+        foreach (var /*T:C!*/ x in l2) { }
     }
 
     public void Dispose() { }
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (29,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                // (31,14): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         x2 = null; // 1
-                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(29, 14)
+                Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(31, 14)
                 );
             comp.VerifyTypes();
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -819,5 +819,30 @@ class C
             Assert.Equal(@null, rightInfo.Nullability);
             Assert.Equal(notNull, rightInfo.ConvertedNullability);
         }
+
+        [Fact]
+        public void InferredDeclarationType()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(object? x, object x2)
+    {
+        var/*T:object?*/ y = x;
+        var/*T:object!*/ y2 = x2;
+
+        if (x == null) 
+            return;
+        var/*T:object!*/ y3 = x;
+
+        x = null;
+        var /*T:object?*/ y4 = x;
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            comp.VerifyTypes();
+        }
     }
 }


### PR DESCRIPTION
Small fix for semantic model bug I found working on other correctness bits

- When updating the implicit type in a declaration also update the bound type declaration nullability
- Add tests