### PR TITLE
Fix formatting on closing brace of property pattern

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return false;
             }
 
-            return token.Parent is ExpressionSyntax;
+            return token.Parent is ExpressionSyntax || token.Parent.IsKind(SyntaxKindEx.PropertyPatternClause);
         }
 
         public static bool IsCloseBraceOfEmbeddedBlock(this SyntaxToken token)

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5221,6 +5221,32 @@ _ = this is  C(  ){}  ; }
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(34683, "https://github.com/dotnet/roslyn/issues/34683")]
+        public async Task FormatRecursivePattern_InBinaryOperation()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.SpaceWithinMethodCallParentheses, true);
+            var code = @"class C
+{
+    void M()
+    {
+        return
+            typeWithAnnotations is { } && true;
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M()
+    {
+        return
+            typeWithAnnotations is { } && true;
+    }
+}";
+            await AssertFormatAsync(expectedCode, code, changedOptionSet: changingOptions);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task FormatPropertyPattern_MultilineAndEmpty()
         {
             var code = @"class C

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -5234,14 +5234,7 @@ _ = this is  C(  ){}  ; }
             typeWithAnnotations is { } && true;
     }
 }";
-            var expectedCode = @"class C
-{
-    void M()
-    {
-        return
-            typeWithAnnotations is { } && true;
-    }
-}";
+            var expectedCode = code;
             await AssertFormatAsync(expectedCode, code, changedOptionSet: changingOptions);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/34683

Previously, we didn't treat the closing brace of a property pattern as belonging to an expression, so we'd insert a newline after it in a number of cases.

https://github.com/dotnet/roslyn/blob/6fea5ce25a06b3f8d5d8c0106fda948ef5995bbe/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs#L53-L78