### PR TITLE
Fix #36060: Group Completion Providers using IsExclusive

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
@@ -1,0 +1,88 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+    <[UseExportProvider]>
+    Public Class CompletionServiceTests_Exclusivity
+        Public Const CompletionItemNonExclusive As String = "Completion Item from Non Exclusive Provider {0}"
+        Public Const CompletionItemExclusive As String = "Completion Item from Exclusive Provider {0}"
+
+        <Fact>
+        Public Async Function TestExclusiveProvidersAreGroupedTogether() As Task
+            Dim workspaceDefinition =
+            <Workspace>
+                <Project Language="NoCompilation" AssemblyName="TestAssembly" CommonReferencesPortable="true">
+                    <Document>
+                        var x = {}; // e.g., TypeScript code or anything else that doesn't support compilations
+                    </Document>
+                </Project>
+            </Workspace>
+            Using workspace = TestWorkspace.Create(workspaceDefinition)
+                Dim document = workspace.CurrentSolution.Projects.First.Documents.First
+                Dim completionService = New TestCompletionService(workspace)
+
+                Dim list = Await completionService.GetCompletionsAsync(
+                    document, caretPosition:=0, trigger:=CompletionTrigger.Invoke)
+
+                Assert.NotNull(list)
+                Assert.NotEmpty(list.Items)
+                Assert.True(list.Items.Length = 2, "Completion List does not contain exactly two items.")
+                Assert.Equal(String.Format(CompletionItemExclusive, 2), list.Items.First.DisplayText)
+                Assert.Equal(String.Format(CompletionItemExclusive, 3), list.Items.Last.DisplayText)
+            End Using
+        End Function
+
+        Friend Class TestCompletionService
+            Inherits CompletionServiceWithProviders
+
+            Public Sub New(workspace As Workspace)
+                MyBase.New(workspace)
+            End Sub
+
+            Public Overrides ReadOnly Property Language As String
+                Get
+                    Return "NoCompilation"
+                End Get
+            End Property
+
+            Private Shared s_providers As ImmutableArray(Of CompletionProvider) = ImmutableArray.Create(Of CompletionProvider)(
+                New TestCompletionProviderWithMockExclusivity(False, CompletionServiceTests_Exclusivity.CompletionItemNonExclusive, 1),
+                New TestCompletionProviderWithMockExclusivity(True, CompletionServiceTests_Exclusivity.CompletionItemExclusive, 2),
+                New TestCompletionProviderWithMockExclusivity(True, CompletionServiceTests_Exclusivity.CompletionItemExclusive, 3))
+
+            Protected Overrides Function GetBuiltInProviders() As ImmutableArray(Of CompletionProvider)
+                Return s_providers
+            End Function
+        End Class
+
+        Private Class TestCompletionProviderWithMockExclusivity
+            Inherits CompletionProvider
+
+            Private s_isExclusive As Boolean
+            Private s_itemText As String
+            Private s_index As Integer
+
+            Public Sub New(isExclusive As Boolean, text As String, index As Integer)
+                s_isExclusive = isExclusive
+                s_itemText = text
+                s_index = index
+            End Sub
+
+            Public Overrides Function ShouldTriggerCompletion(text As SourceText, position As Int32, trigger As CompletionTrigger, options As OptionSet) As [Boolean]
+                Return True
+            End Function
+
+            Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                context.IsExclusive = s_isExclusive
+                context.AddItem(CompletionItem.Create(String.Format(s_itemText, s_index)))
+                Return Task.CompletedTask
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -258,14 +258,14 @@ namespace Microsoft.CodeAnalysis.Completion
             // All the contexts should be non-empty or have a suggestion item.
             Debug.Assert(triggeredCompletionContexts.All(HasAnyItems));
 
-            // See if there was a completion context provided that was exclusive.  If so, then
+            // See if there were completion contexts provided that were exclusive. If so, then
             // that's all we'll return.
-            var firstExclusiveContext = triggeredCompletionContexts.FirstOrDefault(t => t.IsExclusive);
+            var exclusiveContexts = triggeredCompletionContexts.Where(t => t.IsExclusive);
 
-            if (firstExclusiveContext != null)
+            if (exclusiveContexts.Any())
             {
                 return MergeAndPruneCompletionLists(
-                    SpecializedCollections.SingletonEnumerable(firstExclusiveContext),
+                    exclusiveContexts,
                     defaultItemSpan,
                     isExclusive: true);
             }


### PR DESCRIPTION
As per the discussion in #36060, this PR attempts to introduce the change that would allow a `CompletionProvider` to add items to the list, even if another one sets `IsExclusive`, like in the example of an `OverrideCompletionProvider`. This is partially only there to support a feature used by VS Mac.

~It's marked as a WIP as I'd still like to introduce a test for this, but want comments on the change as soon as possible to see if I should change direction.~