### PR TITLE
Upgrade LSP version to latest inserted in VS and remove binding redirects

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,8 +105,8 @@
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.8.27812-alpha</MicrosoftVisualStudioLanguageCallHierarchyVersion>
     <MicrosoftVisualStudioLanguageIntellisenseVersion>16.0.467</MicrosoftVisualStudioLanguageIntellisenseVersion>
     <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>16.0.467</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolVersion>16.2.50-develop-g17c3bc90</MicrosoftVisualStudioLanguageServerProtocolVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>16.2.50-develop-g17c3bc90</MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolVersion>16.2.53</MicrosoftVisualStudioLanguageServerProtocolVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>16.2.53</MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>
     <MicrosoftVisualStudioLanguageStandardClassificationVersion>16.0.467</MicrosoftVisualStudioLanguageStandardClassificationVersion>
     <MicrosoftVisualStudioLiveShareLanguageServicesVersion>1.0.181</MicrosoftVisualStudioLiveShareLanguageServicesVersion>
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6071</MicrosoftVisualStudioOLEInteropVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,8 +105,8 @@
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.8.27812-alpha</MicrosoftVisualStudioLanguageCallHierarchyVersion>
     <MicrosoftVisualStudioLanguageIntellisenseVersion>16.0.467</MicrosoftVisualStudioLanguageIntellisenseVersion>
     <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>16.0.467</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolVersion>16.2.53</MicrosoftVisualStudioLanguageServerProtocolVersion>
-    <MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>16.2.53</MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolVersion>16.2.1072</MicrosoftVisualStudioLanguageServerProtocolVersion>
+    <MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>16.2.1072</MicrosoftVisualStudioLanguageServerProtocolExtensionsVersion>
     <MicrosoftVisualStudioLanguageStandardClassificationVersion>16.0.467</MicrosoftVisualStudioLanguageStandardClassificationVersion>
     <MicrosoftVisualStudioLiveShareLanguageServicesVersion>1.0.181</MicrosoftVisualStudioLiveShareLanguageServicesVersion>
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6071</MicrosoftVisualStudioOLEInteropVersion>

--- a/src/Tools/ExternalAccess/LiveShare/CodeActions/RoslynCodeActionProvider.cs
+++ b/src/Tools/ExternalAccess/LiveShare/CodeActions/RoslynCodeActionProvider.cs
@@ -63,29 +63,28 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.CodeActions
 
             foreach (var command in commands)
             {
-                // The command can either wrap a Command or a CodeAction.
-                // If a Command, leave it unchanged; we want to dispatch it to the host to execute.
-                // If a CodeAction, unwrap the CodeAction so the guest can run it locally.
-                var commandArguments = command.Arguments.Single();
-
-                // Unfortunately, older liveshare hosts use liveshare custom code actions instead of the LSP code action.
-                // So determine which one to pass on.
-                if (commandArguments is LSP.CodeAction lspCodeAction)
+                if (command is LSP.Command lspCommand)
                 {
-                    context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, lspCodeAction.Command, lspCodeAction.Edit, lspCodeAction.Title, lspClient));
-                }
-                else if (commandArguments is LiveShareCodeAction liveshareCodeAction)
-                {
-                    context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, liveshareCodeAction.Command, liveshareCodeAction.Edit, liveshareCodeAction.Title, lspClient));
-                }
-                else
-                {
-                    context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, command, command?.Title, lspClient));
-                }
+                    // The command can either wrap a Command or a CodeAction.
+                    // If a Command, leave it unchanged; we want to dispatch it to the host to execute.
+                    // If a CodeAction, unwrap the CodeAction so the guest can run it locally.
+                    var commandArguments = lspCommand.Arguments.Single();
 
-
-                //var codeAction = commandArguments is LSP.CodeAction ? (LSP.CodeAction)commandArguments : null;
-                //context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, codeAction == null ? command : null, codeAction, lspClient));
+                    // Unfortunately, older liveshare hosts use liveshare custom code actions instead of the LSP code action.
+                    // So determine which one to pass on.
+                    if (commandArguments is LSP.CodeAction lspCodeAction)
+                    {
+                        context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, lspCodeAction.Command, lspCodeAction.Edit, lspCodeAction.Title, lspClient));
+                    }
+                    else if (commandArguments is LiveShareCodeAction liveshareCodeAction)
+                    {
+                        context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, liveshareCodeAction.Command, liveshareCodeAction.Edit, liveshareCodeAction.Title, lspClient));
+                    }
+                    else
+                    {
+                        context.RegisterRefactoring(new RoslynRemoteCodeAction(context.Document, lspCommand, lspCommand?.Title, lspClient));
+                    }
+                }
             }
         }
     }

--- a/src/VisualStudio/LiveShare/Test/RunCodeActionsHandlerTests.cs
+++ b/src/VisualStudio/LiveShare/Test/RunCodeActionsHandlerTests.cs
@@ -26,11 +26,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
             var (solution, ranges) = CreateTestSolution(markup);
             var codeActionLocation = ranges["caret"].First();
 
-            var results = await TestHandleAsync<LSP.ExecuteCommandParams, object>(solution, CreateExecuteCommandParams(codeActionLocation));
+            var results = await TestHandleAsync<LSP.ExecuteCommandParams, object>(solution, CreateExecuteCommandParams(codeActionLocation, "Use implicit type"));
             Assert.True((bool)results);
         }
 
-        private static LSP.ExecuteCommandParams CreateExecuteCommandParams(LSP.Location location)
+        private static LSP.ExecuteCommandParams CreateExecuteCommandParams(LSP.Location location, string title)
             => new LSP.ExecuteCommandParams()
             {
                 Command = "_liveshare.remotecommand.Roslyn",
@@ -41,8 +41,9 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
                         CommandIdentifier = "Roslyn.RunCodeAction",
                         Arguments = new RunCodeActionParams[]
                         {
-                            CreateRunCodeActionParams("Use implicit type", location)
-                        }
+                            CreateRunCodeActionParams(title, location)
+                        },
+                        Title = title
                     })
                 }
             };

--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -66,8 +66,8 @@ using Roslyn.VisualStudio.Setup;
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CodeAnalysis.FlowAnalysis.Utilities.dll")]
 
-[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
-[assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\ICSharpCode.Decompiler.dll")]
 

--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -66,9 +66,6 @@ using Roslyn.VisualStudio.Setup;
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CodeAnalysis.FlowAnalysis.Utilities.dll")]
 
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
-
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\ICSharpCode.Decompiler.dll")]
 
 [assembly: ProvideBindingRedirection(

--- a/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
+++ b/src/VisualStudio/Setup/Roslyn.VisualStudio.Setup.csproj
@@ -273,8 +273,6 @@
     <NuGetPackageToIncludeInVsix Include="System.Composition.Convention" />
     <NuGetPackageToIncludeInVsix Include="System.Composition.Hosting" />
     <NuGetPackageToIncludeInVsix Include="ICSharpCode.Decompiler" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\1.1.2\lib\net45\SQLitePCLRaw.batteries_green.dll" />


### PR DESCRIPTION
Insertion failed RPS due to ngen errors on these assemblies.  Upgrading to a proper version that should be inserted into VS and remove binding redirects.

Note that for now we'll be using the in-box version, but we need to figure out what to for future releases.  