### PR TITLE
Upgrade Microsoft.CodeAnalysis.FlowAnalysis.Utilities PackageReference to latest version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -47,7 +47,7 @@
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.15</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>
-    <MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>2.9.3-beta1.19271.2+23ca1e2d</MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>
+    <MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>2.9.3-beta1.19301.2+4c8365b9</MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>
     <MicrosoftCodeQualityAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeQualityAnalyzersVersion>
     <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>

--- a/src/EditorFeatures/VisualBasicTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.vb
@@ -1943,8 +1943,8 @@ End Module")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.DisposeAnalysis)>
-        Public Async Function DisposableCreationNotAssignedToAVariable_Diagnostic() As Task
-            Await TestDiagnosticsAsync(
+        Public Async Function DisposableCreationNotAssignedToAVariable_BailOut_NoDiagnostic() As Task
+            Await TestDiagnosticMissingAsync(
 "Imports System
 
 Class A
@@ -1967,8 +1967,7 @@ Class Test
         New A(2).M()    ' Error
         Dim x = New A(3).X
     End Sub|]
-End Class",
-            Diagnostic(IDEDiagnosticIds.DisposeObjectsBeforeLosingScopeDiagnosticId, "New A(3)").WithLocation(21, 17))
+End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.DisposeAnalysis)>

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeAnalysisHelper.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeAnalysisHelper.cs
@@ -109,12 +109,15 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                 if (cfg != null)
                 {
                     var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(context.Compilation);
-                    disposeAnalysisResult = FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
+                    disposeAnalysisResult = FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis.TryGetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
                         context.Options, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
                         exceptionPathsAnalysis: false, context.CancellationToken, out pointsToAnalysisResult,
                         interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
                         defaultDisposeOwnershipTransferAtConstructor: true);
-                    return true;
+                    if (disposeAnalysisResult != null)
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -140,12 +143,15 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                 if (cfg != null)
                 {
                     var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(context.Compilation);
-                    disposeAnalysisResult = FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis.GetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
+                    disposeAnalysisResult = FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis.TryGetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
                         context.Options, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
                         exceptionPathsAnalysis: false, context.CancellationToken, out pointsToAnalysisResult,
                         interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
                         defaultDisposeOwnershipTransferAtConstructor: true);
-                    return true;
+                    if (disposeAnalysisResult != null)
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
+++ b/src/Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj
@@ -125,7 +125,7 @@
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FlowAnalysis.Utilities" Version="$(MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FlowAnalysis.Utilities" Version="$(MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion)" />
   </ItemGroup>
   <Import Project="..\..\..\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems" Label="Shared" />
   <Import Project="..\..\..\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems" Label="Shared" />

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -48,6 +48,7 @@
   -->
   <ItemGroup>
     <ExpectedDependency Include="Humanizer.Core"/>
+    <ExpectedDependency Include="Microsoft.CodeAnalysis.FlowAnalysis.Utilities"/>
     <ExpectedDependency Include="ICSharpCode.Decompiler"/>
     <ExpectedDependency Include="Microsoft.DiaSymReader"/>
     <ExpectedDependency Include="Microsoft.CodeAnalysis.Elfie"/>


### PR DESCRIPTION
Additionally, we do not mark the package reference to in Features.csproj as PrivateAsset as this leads to the assembly not getting included in the Features NuGet package and causes Omnisharp's analyzer execution to throw missing dependency assembly load errors.