### PR TITLE
Add a notice to Tools|Options pages where setting may be overridden by .editorconfig

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d" d:DesignHeight="279" d:DesignWidth="514">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
-            <localOptions:CodeStyleNoticeTextBlock />
+            <localOptions:CodeStyleNoticeTextBlock Margin="5 0 5 0" />
             <GroupBox x:Uid="GroupBox_1" Header="{x:Static local:FormattingGeneralOptionPageStrings.General}">
                 <StackPanel>
                     <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -7,10 +7,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:options="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options;assembly=Microsoft.VisualStudio.LanguageServices.Implementation"
+    xmlns:localOptions="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options"
     xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.CSharp.Options"
     mc:Ignorable="d" d:DesignHeight="279" d:DesignWidth="514">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
+            <localOptions:CodeStyleNoticeTextBlock />
             <GroupBox x:Uid="GroupBox_1" Header="{x:Static local:FormattingGeneralOptionPageStrings.General}">
                 <StackPanel>
                     <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml
@@ -13,7 +13,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <localOptions:CodeStyleNoticeTextBlock Margin="5 0 5 0" />
-            <GroupBox x:Uid="GroupBox_1" Header="{x:Static local:FormattingGeneralOptionPageStrings.General}">
+            <GroupBox x:Uid="GroupBox_1" Header="{x:Static local:FormattingGeneralOptionPageStrings.General}" Margin="0 5 0 0 ">
                 <StackPanel>
                     <CheckBox x:Name="FormatWhenTypingCheckBox" x:Uid="FormatWhenTypingCheckBox" />
                     <StackPanel Margin="15, 0, 0, 0" IsEnabled="{Binding ElementName=FormatWhenTypingCheckBox, Path=IsChecked}">

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
@@ -4,6 +4,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo(typeof(CodeStyleNoticeTextBlock))]
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
@@ -6,7 +6,12 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
 using System.Runtime.CompilerServices;
 
+// 🐉 The XAML markup compiler does not recognize InternalsVisibleTo. However, since it allows type
+// forwarding, we use TypeForwardedTo to make CodeStyleNoticeTextBlock appear to the markup compiler
+// as an internal type in the current assembly instead of an internal type in one of the referenced
+// assemblies.
 [assembly: TypeForwardedTo(typeof(CodeStyleNoticeTextBlock))]
+
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
     /// <summary>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/FormattingOptionPageControl.xaml.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Options;
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(CodeStyleNoticeTextBlock))]
-
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
     /// <summary>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -643,7 +643,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files..
+        ///   Looks up a localized string similar to Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info.
         /// </summary>
         internal static string Code_style_header_use_editor_config {
             get {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1043,7 +1043,7 @@ I agree to all of the foregoing:</value>
     <value>Report invalid regular expressions</value>
   </data>
   <data name="Code_style_header_use_editor_config" xml:space="preserve">
-    <value>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</value>
+    <value>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</value>
   </data>
   <data name="Modifier_preferences_colon" xml:space="preserve">
     <value>Modifier preferences:</value>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -1809,8 +1809,8 @@ Souhlasím se všemi výše uvedenými podmínkami:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Nastavení nakonfigurovaná zde platí pouze pro váš počítač. Pokud je chcete nakonfigurovat tak, aby byla součástí vašeho řešení a přecházela mezi zařízeními, použijte soubory .editorconfig.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Nastavení nakonfigurovaná zde platí pouze pro váš počítač. Pokud je chcete nakonfigurovat tak, aby byla součástí vašeho řešení a přecházela mezi zařízeními, použijte soubory .editorconfig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -1809,8 +1809,8 @@ Ich stimme allen vorstehenden Bedingungen zu:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Die hier konfigurierten Einstellungen gelten nur für Ihren Computer. Verwenden Sie die .editorconfig-Dateien, um diese Einstellungen in Ihrer Projektmappe zu konfigurieren.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Die hier konfigurierten Einstellungen gelten nur für Ihren Computer. Verwenden Sie die .editorconfig-Dateien, um diese Einstellungen in Ihrer Projektmappe zu konfigurieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -1809,8 +1809,8 @@ Estoy de acuerdo con todo lo anterior:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Los parámetros configurados aquí solo son aplicables a su equipo. Para configurar estos parámetros de manera que se desplacen con su solución, use los archivos .editorconfig.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Los parámetros configurados aquí solo son aplicables a su equipo. Para configurar estos parámetros de manera que se desplacen con su solución, use los archivos .editorconfig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -1809,8 +1809,8 @@ Je suis d'accord avec tout ce qui précède :</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Les paramètres configurés ici s'appliquent uniquement à votre machine. Pour configurer ces paramètres afin qu'ils soient liés à votre solution, utilisez les fichiers .editorconfig.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Les paramètres configurés ici s'appliquent uniquement à votre machine. Pour configurer ces paramètres afin qu'ils soient liés à votre solution, utilisez les fichiers .editorconfig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -1809,8 +1809,8 @@ L'utente accetta le condizioni sopra riportate:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Le impostazioni configurate qui si applicano solo al computer locale. Per configurare queste impostazioni in modo che siano associate alla soluzione, usare file con estensione editorconfig.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Le impostazioni configurate qui si applicano solo al computer locale. Per configurare queste impostazioni in modo che siano associate alla soluzione, usare file con estensione editorconfig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -1809,8 +1809,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">ここで構成される設定は、ご使用のマシンにのみ適用されます。これらの設定をソリューションで使用するように構成するには、.editorconfig ファイルを使用します。</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">ここで構成される設定は、ご使用のマシンにのみ適用されます。これらの設定をソリューションで使用するように構成するには、.editorconfig ファイルを使用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -1809,8 +1809,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">여기서 구성하는 설정은 사용자의 컴퓨터에만 적용됩니다. 이러한 설정을 사용자의 솔루션에서 사용하도록 구성하려면 .editorconfig 파일을 사용하세요.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">여기서 구성하는 설정은 사용자의 컴퓨터에만 적용됩니다. 이러한 설정을 사용자의 솔루션에서 사용하도록 구성하려면 .editorconfig 파일을 사용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -1809,8 +1809,8 @@ Wyrażam zgodę na wszystkie następujące postanowienia:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Ustawienia skonfigurowane w tym miejscu mają zastosowanie tylko do Twojej maszyny. Aby skonfigurować te ustawienia tak, aby były przenoszone z Twoim rozwiązaniem, użyj plików .editorconfig.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Ustawienia skonfigurowane w tym miejscu mają zastosowanie tylko do Twojej maszyny. Aby skonfigurować te ustawienia tak, aby były przenoszone z Twoim rozwiązaniem, użyj plików .editorconfig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -1809,8 +1809,8 @@ Eu concordo com todo o conteúdo supracitado:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">As configurações definidas aqui se aplicam somente a seu computador. Para definir essas configurações para viajar com sua solução, use arquivos .editorconfig.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">As configurações definidas aqui se aplicam somente a seu computador. Para definir essas configurações para viajar com sua solução, use arquivos .editorconfig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -1809,8 +1809,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Заданные здесь параметры применяются только на вашем компьютере. Чтобы привязать параметры к решению, используйте EDITORCONFIG-файлы.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Заданные здесь параметры применяются только на вашем компьютере. Чтобы привязать параметры к решению, используйте EDITORCONFIG-файлы.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -1809,8 +1809,8 @@ Aşağıdakilerin tümünü onaylıyorum:</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">Burada yapılandırılan ayarlar yalnızca makineniz için geçerlidir. Bu ayarları çözümünüzle birlikte taşımak için .editorconfig dosyalarını kullanın.</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">Burada yapılandırılan ayarlar yalnızca makineniz için geçerlidir. Bu ayarları çözümünüzle birlikte taşımak için .editorconfig dosyalarını kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -1809,8 +1809,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">此处配置的设置仅适用于计算机。要配置这些设置以使用解决方案，请使用 .editorconfig 文件。</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">此处配置的设置仅适用于计算机。要配置这些设置以使用解决方案，请使用 .editorconfig 文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -1809,8 +1809,8 @@ I agree to all of the foregoing:</source>
         <note />
       </trans-unit>
       <trans-unit id="Code_style_header_use_editor_config">
-        <source>The settings configured here only apply to your machine. To configure these settings to travel with your solution, use .editorconfig files.</source>
-        <target state="translated">在此處進行的設定僅適用於您的電腦。若要這些設定隨著您的解決方案移動，請使用 .editorconfig 檔案。</target>
+        <source>Your .editorconfig file might override the local settings configured on this page which only apply to your machine. To configure these settings to travel with your solution use EditorConfig files. More info</source>
+        <target state="needs-review-translation">在此處進行的設定僅適用於您的電腦。若要這些設定隨著您的解決方案移動，請使用 .editorconfig 檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="Sync_Class_View">

--- a/src/VisualStudio/Core/Impl/Microsoft.VisualStudio.LanguageServices.Implementation.csproj
+++ b/src/VisualStudio/Core/Impl/Microsoft.VisualStudio.LanguageServices.Implementation.csproj
@@ -90,6 +90,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Options\CodeStyleNoticeTextBlock.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Options\GridOptionPreviewControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml
+++ b/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml
@@ -1,16 +1,16 @@
 ﻿<TextBlock x:Class="Microsoft.VisualStudio.LanguageServices.Implementation.Options.CodeStyleNoticeTextBlock"
-           x:ClassModifier="internal"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options"
-             mc:Ignorable="d"
-            TextWrapping="Wrap"
-             d:DesignHeight="450" d:DesignWidth="800">
-              <Run Text="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeader}"/>
-            <Run Text=" "/>
-            <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeaderLearnMoreUri}">
-                <TextBlock Text="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeaderLearnMoreText}"/>
-            </Hyperlink>
+    x:ClassModifier="internal"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+    xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options"
+    mc:Ignorable="d"
+    TextWrapping="Wrap"
+    d:DesignHeight="450" d:DesignWidth="800">
+    <Run Text="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeader}"/>
+    <Run Text=" "/>
+    <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeaderLearnMoreUri}">
+        <TextBlock Text="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeaderLearnMoreText}"/>
+    </Hyperlink>
 </TextBlock>

--- a/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml
+++ b/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml
@@ -1,0 +1,16 @@
+﻿<TextBlock x:Class="Microsoft.VisualStudio.LanguageServices.Implementation.Options.CodeStyleNoticeTextBlock"
+           x:ClassModifier="internal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Options"
+             mc:Ignorable="d"
+            TextWrapping="Wrap"
+             d:DesignHeight="450" d:DesignWidth="800">
+              <Run Text="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeader}"/>
+            <Run Text=" "/>
+            <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeaderLearnMoreUri}">
+                <TextBlock Text="{x:Static local:CodeStyleNoticeTextBlock.CodeStylePageHeaderLearnMoreText}"/>
+            </Hyperlink>
+</TextBlock>

--- a/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Windows.Controls;
+using System.Windows.Navigation;
+using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
+{
+    internal partial class CodeStyleNoticeTextBlock : TextBlock
+    {
+        private const string UseEditorConfigUrl = "https://go.microsoft.com/fwlink/?linkid=866541";
+
+        public CodeStyleNoticeTextBlock()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly Uri CodeStylePageHeaderLearnMoreUri = new Uri(UseEditorConfigUrl);
+        public static string CodeStylePageHeader => ServicesVSResources.Code_style_header_use_editor_config;
+        public static string CodeStylePageHeaderLearnMoreText => ServicesVSResources.Learn_more;
+
+        private void LearnMoreHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (e.Uri == null)
+            {
+                return;
+            }
+
+            BrowserHelper.StartBrowser(e.Uri);
+            e.Handled = true;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/CodeStyleNoticeTextBlock.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Windows.Controls;
 using System.Windows.Navigation;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -36,27 +36,23 @@
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="5" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock TextWrapping="Wrap">
-            <Run Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeader}"/>
-            <Run Text=" "/>
-            <Hyperlink RequestNavigate="LearnMoreHyperlink_RequestNavigate" NavigateUri="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreUri}">
-                <TextBlock Text="{x:Static local:GridOptionPreviewControl.CodeStylePageHeaderLearnMoreText}"/>
-            </Hyperlink>
-        </TextBlock>
+        <options:CodeStyleNoticeTextBlock Grid.Row="0"/>
         <Button
+            Grid.Row="1"
             Name="GenerateEditorConfigButton" 
             Click="Generate_Save_EditorConfig" 
             Content="{x:Static local:GridOptionPreviewControl.GenerateEditorConfigFileFromSettingsText}"
             HorizontalAlignment="Left"
-            Margin="0,35,0,0"
+            Margin="0,5,0,0"
             VerticalAlignment="Center"
             Padding="5"/>
         <DataGrid
-            Grid.Row="1"
+            Grid.Row="2"
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
             Margin="0,5,0,0"
@@ -185,8 +181,8 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <GridSplitter Grid.Row="2" HorizontalAlignment="Stretch"></GridSplitter>
-        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
+        <GridSplitter Grid.Row="3" HorizontalAlignment="Stretch"></GridSplitter>
+        <Border Grid.Row="4" BorderBrush="Gray" BorderThickness="1">
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>
         </Border>
     </Grid>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -41,7 +41,7 @@
             <RowDefinition Height="5" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <options:CodeStyleNoticeTextBlock Grid.Row="0"/>
+        <options:CodeStyleNoticeTextBlock Grid.Row="0" Margin="5 0 5 0" />
         <Button
             Grid.Row="1"
             Name="GenerateEditorConfigButton" 

--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -97,12 +97,13 @@
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-
-        <ContentControl x:Name="listViewContentControl" Grid.Row="0" Grid.Column="0"></ContentControl>
-        <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1">
+        <options:CodeStyleNoticeTextBlock Grid.Row="0"/>
+        <ContentControl x:Name="listViewContentControl" Grid.Row="1" Grid.Column="0"></ContentControl>
+        <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1">
             <!-- The AutomationDelegatingListView is referenced from the .xaml.cs, so we just provide 
                  a container for it here. -->
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>

--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -98,12 +98,13 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="5" />
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <options:CodeStyleNoticeTextBlock Grid.Row="0"/>
-        <ContentControl x:Name="listViewContentControl" Grid.Row="1" Grid.Column="0"></ContentControl>
-        <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1">
+        <options:CodeStyleNoticeTextBlock Grid.Row="0" Margin="5 0 5 0"/>
+        <ContentControl x:Name="listViewContentControl" Grid.Row="2" Grid.Column="0"></ContentControl>
+        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
             <!-- The AutomationDelegatingListView is referenced from the .xaml.cs, so we just provide 
                  a container for it here. -->
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>

--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -98,13 +98,12 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="5" />
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <options:CodeStyleNoticeTextBlock Grid.Row="0" Margin="5 0 5 0"/>
-        <ContentControl x:Name="listViewContentControl" Grid.Row="2" Grid.Column="0"></ContentControl>
-        <Border Grid.Row="3" BorderBrush="Gray" BorderThickness="1">
+        <options:CodeStyleNoticeTextBlock Grid.Row="0" Margin="5 0 5 5"/>
+        <ContentControl x:Name="listViewContentControl" Grid.Row="1" Grid.Column="0"></ContentControl>
+        <Border Grid.Row="2" BorderBrush="Gray" BorderThickness="1">
             <!-- The AutomationDelegatingListView is referenced from the .xaml.cs, so we just provide 
                  a container for it here. -->
             <ContentControl Name="EditorControl" Content="{Binding TextViewHost, Mode=OneWay}" Focusable="False"></ContentControl>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -50,7 +50,7 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Margin="5 0 5 0 " TextWrapping="Wrap" Text="{x:Static style:NamingStyleOptionPageControl.ExplanatoryText}" />
-        <options:CodeStyleNoticeTextBlock Grid.Row="2" />
+        <options:CodeStyleNoticeTextBlock Grid.Row="2" Margin="5 0 5 0" />
         <DataGrid
             Grid.Row="3"
             x:Uid="CodeStyleContent"

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -44,15 +44,14 @@
         </Grid.InputBindings>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="5" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Margin="5 0 5 0 " TextWrapping="Wrap" Text="{x:Static style:NamingStyleOptionPageControl.ExplanatoryText}" />
-        <options:CodeStyleNoticeTextBlock Grid.Row="2" Margin="5 0 5 0" />
+        <options:CodeStyleNoticeTextBlock Grid.Row="1" Margin="5 5 5 0" />
         <DataGrid
-            Grid.Row="3"
+            Grid.Row="2"
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
             Margin="0,5,0,0"
@@ -259,7 +258,7 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <Border Grid.Row="4">
+        <Border Grid.Row="3">
             <StackPanel Orientation="Horizontal"
                         Margin="7">
                 <Button Name="AddButton" 

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -44,12 +44,15 @@
         </Grid.InputBindings>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="5" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0" Margin="5 0 5 0 " TextWrapping="Wrap" Text="{x:Static style:NamingStyleOptionPageControl.ExplanatoryText}" />
+        <options:CodeStyleNoticeTextBlock Grid.Row="2" />
         <DataGrid
-            Grid.Row="1"
+            Grid.Row="3"
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
             Margin="0,5,0,0"
@@ -256,7 +259,7 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <Border Grid.Row="2">
+        <Border Grid.Row="4">
             <StackPanel Orientation="Horizontal"
                         Margin="7">
                 <Button Name="AddButton" 


### PR DESCRIPTION
fixes https://github.com/dotnet/roslyn/issues/19030

Adds text to the following pages:

**VB and C# Code Style | General**
![image](https://user-images.githubusercontent.com/25776963/58920649-08d19b80-86e8-11e9-839c-abca41c14533.png)

**VB and C# Code Style | Naming**
![image](https://user-images.githubusercontent.com/25776963/58920654-0bcc8c00-86e8-11e9-9a2e-93bfc1f7e082.png)

**C# Code Style | Formatting | General**
![image](https://user-images.githubusercontent.com/25776963/58920656-0e2ee600-86e8-11e9-8466-03e6de930793.png)

**C# Code Style | Formatting | Indentation (and New Lines, Spacing, and Wrapping)**
![image](https://user-images.githubusercontent.com/25776963/58920657-0ff8a980-86e8-11e9-95be-d3e9113c9f6d.png)

