### PR TITLE
Fix bug with parsing a range expression.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -10385,6 +10385,7 @@ tryAgain:
                 case SyntaxKind.MinusMinusToken:
                 case SyntaxKind.OpenBracketToken:
                 case SyntaxKind.DotToken:
+                case SyntaxKind.DotDotToken:
                 case SyntaxKind.MinusGreaterThanToken:
                 case SyntaxKind.QuestionQuestionToken:
                 case SyntaxKind.EndOfFileToken:

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -4381,6 +4381,43 @@ select t";
                 Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 6));
         }
 
+        [Fact, WorkItem(36122, "https://github.com/dotnet/roslyn/issues/36122")]
+        public void RangeExpression_NotCast()
+        {
+            UsingExpression("(Offset)..(Offset + Count)");
+            N(SyntaxKind.RangeExpression);
+            {
+                N(SyntaxKind.ParenthesizedExpression);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Offset");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.DotDotToken);
+                N(SyntaxKind.ParenthesizedExpression);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.AddExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Offset");
+                        }
+                        N(SyntaxKind.PlusToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Count");
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            EOF();
+        }
+
         [Fact]
         public void BaseExpression_01()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#define PARSING_TESTS_DUMP
+//#define PARSING_TESTS_DUMP
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-//#define PARSING_TESTS_DUMP
+#define PARSING_TESTS_DUMP
 
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36122

Note: i believe this is a breaking change (if ranges have shipped).  That's because you *technically* could have written something like this before:

```c#
struct Whatever
{
     public static explicit operator Whatever(Range r) => ...;
}

//

(Whatever)..a
```

Previously, this would make a range, but then cast it to the Whatever type.  Now, this will properly think this is not a cast, changing the meaning to have the `(Whatever)` be the lower bound of the range.  I believe this is correct based on a reading of the spec (as well as beter matching a user's intuition):

Specifically:

> To resolve cast_expression ambiguities, the following rule exists: A sequence of one or more tokens (White space) enclosed in parentheses is considered the start of a cast_expression only if at least one of the following are true:
> 
> 1. ~not applicable~
> 2. The sequence of tokens is correct grammar for a type, and the token immediately following the closing parentheses is the token "~", the token "!", the token "(", an identifier (Unicode character escape sequences), a literal (Literals), or any keyword (Keywords) except as and is.

Since `..` is none of those tokens, this should not be a cast expression.

Now, if ranges are still in preview, then this is definitely safe to just fix right now.  If it's shipped, you'll have to make a breaking change call.  Personally, i think the risk is tiny so i think it's worth doing.