### PR TITLE
GetWriteTaskAsync often completes synchronously

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_WriteBatching.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_WriteBatching.cs
@@ -120,7 +120,8 @@ namespace Microsoft.CodeAnalysis.SQLite
             return;
 
             // Local functions
-            async Task<(Task previousTask, TaskCompletionSource<int> taskCompletionSource)> GetWriteTaskAsync()
+            //[PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", OftenCompletesSynchronously = true)]
+            async ValueTask<(Task previousTask, TaskCompletionSource<int> taskCompletionSource)> GetWriteTaskAsync()
             {
                 // Have to acquire the semaphore.  We're going to mutate the shared 'keyToWriteActions'
                 // and 'keyToWriteTask' collections.


### PR DESCRIPTION
This change produced a 595MB (8.3%) allocation reduction in the scenario described by #36114.