### PR TITLE
Avoid captures in SqlConnection.ReadBlob

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_BulkPopulateIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_BulkPopulateIds.cs
@@ -130,14 +130,16 @@ namespace Microsoft.CodeAnalysis.SQLite
                     {
                         try
                         {
-                            connection.RunInTransaction(() =>
-                            {
-                                foreach (var value in stringsToAdd)
+                            connection.RunInTransaction(
+                                state =>
                                 {
-                                    var id = InsertStringIntoDatabase_MustRunInTransaction(connection, value);
-                                    idToString.Object.Add(id, value);
-                                }
-                            });
+                                    foreach (var value in state.stringsToAdd)
+                                    {
+                                        var id = InsertStringIntoDatabase_MustRunInTransaction(state.connection, value);
+                                        state.idToString.Object.Add(id, value);
+                                    }
+                                },
+                                (stringsToAdd, connection, idToString));
                         }
                         catch (SqlException ex) when (ex.Result == Result.CONSTRAINT)
                         {

--- a/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_StringIds.cs
@@ -86,10 +86,9 @@ namespace Microsoft.CodeAnalysis.SQLite
             // values.
             try
             {
-                connection.RunInTransaction(() =>
-                {
-                    stringId = InsertStringIntoDatabase_MustRunInTransaction(connection, value);
-                });
+                stringId = connection.RunInTransaction(
+                    state => InsertStringIntoDatabase_MustRunInTransaction(state.connection, state.value),
+                    (connection, value));
 
                 Contract.ThrowIfTrue(stringId == null);
                 return stringId;

--- a/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_WriteBatching.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_WriteBatching.cs
@@ -222,13 +222,15 @@ namespace Microsoft.CodeAnalysis.SQLite
             try
             {
                 // Create a transaction and perform all writes within it.
-                connection.RunInTransaction(() =>
-                {
-                    foreach (var action in writesToProcess)
+                connection.RunInTransaction(
+                    state =>
                     {
-                        action(connection);
-                    }
-                });
+                        foreach (var action in state.writesToProcess)
+                        {
+                            action(state.connection);
+                        }
+                    },
+                    (writesToProcess, connection));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This change produced a 806MB (11.3%) allocation reduction in the scenario described by #36114.