### PR TITLE
DisposableWaitAsync often completes synchronously

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/SemaphoreSlimExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SemaphoreSlimExtensions.cs
@@ -14,7 +14,8 @@ namespace Roslyn.Utilities
             return new SemaphoreDisposer(semaphore);
         }
 
-        public async static Task<SemaphoreDisposer> DisposableWaitAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken = default)
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/36114", OftenCompletesSynchronously = true)]
+        public async static ValueTask<SemaphoreDisposer> DisposableWaitAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken = default)
         {
             await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             return new SemaphoreDisposer(semaphore);

--- a/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
+++ b/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
@@ -36,6 +36,7 @@
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\NonReentrantLock.cs" Link="Utilities\NonReentrantLock.cs" />
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\ValuesSources\ValueSource.cs" Link="Utilities\ValueSource.cs" />
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\ValuesSources\ConstantValueSource.cs" Link="Utilities\ConstantValueSource.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\PerformanceSensitiveAttribute.cs" Link="Utilities\PerformanceSensitiveAttribute.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\SemaphoreSlimExtensions.cs" Link="Utilities\SemaphoreSlimExtensions.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs" Link="Utilities\ExceptionUtilities.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FailFast.cs" Link="Utilities\FailFast.cs" />


### PR DESCRIPTION
This change produced a 535MB (7.5%) allocation reduction in the scenario described by #36114.