### PR TITLE
Update ILAsm and ILDasm version to match expected SDK version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,8 +71,8 @@
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
     <MicrosoftNetCompilersToolsetVersion>3.2.0-beta2-19275-07</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
-    <MicrosoftNetCoreILAsmVersion>3.0.0-preview6-27706-71</MicrosoftNetCoreILAsmVersion>
-    <MicrosoftNetCoreILDasmVersion>3.0.0-preview6-27706-71</MicrosoftNetCoreILDasmVersion>
+    <MicrosoftNetCoreILAsmVersion>3.0.0-preview6-27728-04</MicrosoftNetCoreILAsmVersion>
+    <MicrosoftNetCoreILDasmVersion>3.0.0-preview6-27728-04</MicrosoftNetCoreILDasmVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETTestSdkVersion>16.0.1</MicrosoftNETTestSdkVersion>
     <MicrosoftNETCoreTestHostVersion>1.1.0</MicrosoftNETCoreTestHostVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,8 +71,8 @@
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
     <MicrosoftNetCompilersToolsetVersion>3.2.0-beta2-19275-07</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
-    <MicrosoftNetCoreILAsmVersion>3.0.0-preview6-27728-04</MicrosoftNetCoreILAsmVersion>
-    <MicrosoftNetCoreILDasmVersion>3.0.0-preview6-27728-04</MicrosoftNetCoreILDasmVersion>
+    <MicrosoftNetCoreILAsmVersion>3.0.0-preview6-27721-71</MicrosoftNetCoreILAsmVersion>
+    <MicrosoftNetCoreILDasmVersion>3.0.0-preview6-27721-71</MicrosoftNetCoreILDasmVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETTestSdkVersion>16.0.1</MicrosoftNETTestSdkVersion>
     <MicrosoftNETCoreTestHostVersion>1.1.0</MicrosoftNETCoreTestHostVersion>


### PR DESCRIPTION
As pointed out by @AlekseyTs, #36042 should have also bumped the ILAsm and ILDasm version numbers.