### PR TITLE
mark NFW from OOP critical

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -113,7 +113,7 @@
     <MicrosoftVisualStudioProgressionInterfacesVersion>15.8.27812-alpha</MicrosoftVisualStudioProgressionInterfacesVersion>
     <MicrosoftVisualStudioProjectSystemVersion>15.3.178-pre-g209fb07c2e</MicrosoftVisualStudioProjectSystemVersion>
     <MicrosoftVisualStudioProjectSystemManagedVersion>2.3.6152103</MicrosoftVisualStudioProjectSystemManagedVersion>
-    <MicrosoftVisualStudioRemoteControlVersion>14.0.249-master2E2DC10C</MicrosoftVisualStudioRemoteControlVersion>
+    <MicrosoftVisualStudioRemoteControlVersion>14.1.10</MicrosoftVisualStudioRemoteControlVersion>
     <MicrosoftVisualStudioSDKAnalyzersVersion>15.7.7</MicrosoftVisualStudioSDKAnalyzersVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.15.103</MicrosoftVisualStudioSetupConfigurationInteropVersion>
     <MicrosoftVisualStudioShell150Version>16.0.28226-pre</MicrosoftVisualStudioShell150Version>
@@ -127,7 +127,7 @@
     <MicrosoftVisualStudioShellInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioShellInterop121DesignTimeVersion>
     <MicrosoftVisualStudioShellInterop157DesignTimeVersion>15.7.1</MicrosoftVisualStudioShellInterop157DesignTimeVersion>
     <MicrosoftVisualStudioShellInterop80Version>8.0.50728</MicrosoftVisualStudioShellInterop80Version>
-    <MicrosoftVisualStudioTelemetryVersion>15.8.27812-alpha</MicrosoftVisualStudioTelemetryVersion>
+    <MicrosoftVisualStudioTelemetryVersion>16.0.233</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
     <MicrosoftVisualStudioTextDataVersion>16.0.467</MicrosoftVisualStudioTextDataVersion>
     <MicrosoftVisualStudioTextInternalVersion>16.0.467</MicrosoftVisualStudioTextInternalVersion>

--- a/src/EditorFeatures/TestUtilities/Remote/RemoteHostCrashInfoBar.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/RemoteHostCrashInfoBar.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote
@@ -9,12 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     /// </summary>
     internal static class RemoteHostCrashInfoBar
     {
-        public static void ShowInfoBar()
-        {
-            // do nothing
-        }
-
-        public static void ShowInfoBar(Workspace workspace)
+        public static void ShowInfoBar(Workspace workspace, Exception ex = null)
         {
             // do nothing
         }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         private void ThrowSoftCrashException(Exception ex, CancellationToken token)
         {
-            RemoteHostCrashInfoBar.ShowInfoBar(Workspace);
+            RemoteHostCrashInfoBar.ShowInfoBar(Workspace, ex);
 
             // log disconnect information before throw
             LogDisconnectInfo(_debuggingLastDisconnectReason, _debuggingLastDisconnectCallstack);

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                     // s_lastRemoteClientTask info should be saved in the dump
                     // report NFW when connection is closed unless it is proper shutdown
-                    WatsonReporter.Report(new Exception("Connection to remote host closed"), critical: true);
+                    WatsonReporter.Report(new Exception("Connection to remote host closed"), WatsonSeverity.Critical);
 
                     RemoteHostCrashInfoBar.ShowInfoBar(_workspace);
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                     // s_lastRemoteClientTask info should be saved in the dump
                     // report NFW when connection is closed unless it is proper shutdown
-                    WatsonReporter.Report(new Exception("Connection to remote host closed"));
+                    WatsonReporter.Report(new Exception("Connection to remote host closed"), critical: true);
 
                     RemoteHostCrashInfoBar.ShowInfoBar(_workspace);
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostCrashInfoBar.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostCrashInfoBar.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 var errorReportingService = workspace.Services.GetService<IErrorReportingService>();
                 infoBarUIs.Add(
-                    new InfoBarUI(WorkspacesResources.Show_Stack_Trace, InfoBarUI.UIKind.Button, () =>
+                    new InfoBarUI(WorkspacesResources.Show_Stack_Trace, InfoBarUI.UIKind.HyperLink, () =>
                         errorReportingService.ShowDetailedErrorInfo(exception), closeAfterAction: true));
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostCrashInfoBar.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostCrashInfoBar.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         private static bool s_infoBarReported = false;
 
-        public static void ShowInfoBar(Workspace workspace)
+        public static void ShowInfoBar(Workspace workspace, Exception exception = null)
         {
             // use info bar to show warning to users
             if (workspace == null || s_infoBarReported)
@@ -50,6 +50,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         var unused = service.RequestNewRemoteHostAsync(CancellationToken.None);
                         s_infoBarReported = false;
                     }, closeAfterAction: true));
+            }
+
+            if (exception != null)
+            {
+                var errorReportingService = workspace.Services.GetService<IErrorReportingService>();
+                infoBarUIs.Add(
+                    new InfoBarUI(WorkspacesResources.Show_Stack_Trace, InfoBarUI.UIKind.Button, () =>
+                        errorReportingService.ShowDetailedErrorInfo(exception), closeAfterAction: true));
             }
 
             workspace.Services.GetService<IErrorReportingService>().ShowGlobalErrorInfo(

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.Connections.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.Connections.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     await Task.Delay(retry_delayInMS, cancellationToken).ConfigureAwait(false);
                 }
 
-                RemoteHostCrashInfoBar.ShowInfoBar(workspace);
+                RemoteHostCrashInfoBar.ShowInfoBar(workspace, lastException);
 
                 // raise soft crash exception rather than doing hard crash.
                 // we had enough feedback from users not to crash VS on servicehub failure

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 if (!_shutdownCancellationTokenSource.IsCancellationRequested)
                 {
-                    RemoteHostCrashInfoBar.ShowInfoBar(Workspace);
+                    RemoteHostCrashInfoBar.ShowInfoBar(Workspace, ex);
                 }
             }
         }
@@ -341,7 +341,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return true;
             }
 
-            return FatalError.ReportWithoutCrash(ex);
+            ex.ReportServiceHubNFW("JsonRpc invoke Failed");
+            return true;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -33,17 +33,17 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// <param name="exception">Exception that triggered this non-fatal error</param>
         public static void Report(Exception exception)
         {
-            Report("Roslyn NonFatal Watson", exception, critical: false);
+            Report("Roslyn NonFatal Watson", exception, WatsonSeverity.Default);
         }
 
         /// <summary>
         /// Report Non-Fatal Watson
         /// </summary>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
-        /// <param name="critical">indicate whether reported NFW is critical or not</param>
-        public static void Report(Exception exception, bool critical)
+        /// <param name="severity">indicate <see cref="WatsonSeverity"/> of NFW</param>
+        public static void Report(Exception exception, WatsonSeverity severity)
         {
-            Report("Roslyn NonFatal Watson", exception, critical);
+            Report("Roslyn NonFatal Watson", exception, severity);
         }
 
         /// <summary>
@@ -51,10 +51,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <param name="description">any description you want to save with this watson report</param>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
-        /// <param name="critical">indicate whether reported NFW is critical or not</param>
-        public static void Report(string description, Exception exception, bool critical = false)
+        /// <param name="severity">indicate <see cref="WatsonSeverity"/> of NFW</param>
+        public static void Report(string description, Exception exception, WatsonSeverity severity = WatsonSeverity.Default)
         {
-            Report(description, exception, s_defaultCallback, critical);
+            Report(description, exception, s_defaultCallback, severity);
         }
 
         /// <summary>
@@ -65,9 +65,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// <param name="callback">Callback to include extra data with the NFW. Note that we always collect
         /// a dump of the current process, but this can be used to add further information or files to the
         /// CAB.</param>
-        /// <param name="critical">indicate whether reported NFW is critical or not</param>
-        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, bool critical = false)
+        /// <param name="severity">indicate <see cref="WatsonSeverity"/> of NFW</param>
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, WatsonSeverity severity = WatsonSeverity.Default)
         {
+            var critical = severity == WatsonSeverity.Critical;
             var emptyCallstack = exception.SetCallstackIfEmpty();
 
             if (!WatsonDisabled.s_reportWatson ||
@@ -105,5 +106,18 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 WatsonDisabled.s_reportWatson = false;
             }
         }
+    }
+
+    internal enum WatsonSeverity
+    {
+        /// <summary>
+        /// Indicate that this watson is informative and not urgent
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Indicate that this watson is critical and need to be addressed soon
+        /// </summary>
+        Critical,
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -31,9 +31,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// Report Non-Fatal Watson
         /// </summary>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
-        public static void Report(Exception exception)
+        public static void Report(Exception exception, bool critical = false)
         {
-            Report("Roslyn NonFatal Watson", exception);
+            Report("Roslyn NonFatal Watson", exception, critical);
         }
 
         /// <summary>
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <param name="description">any description you want to save with this watson report</param>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
-        public static void Report(string description, Exception exception)
+        public static void Report(string description, Exception exception, bool critical = false)
         {
-            Report(description, exception, s_defaultCallback);
+            Report(description, exception, s_defaultCallback, critical);
         }
 
         /// <summary>
@@ -54,7 +54,8 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// <param name="callback">Callback to include extra data with the NFW. Note that we always collect
         /// a dump of the current process, but this can be used to add further information or files to the
         /// CAB.</param>
-        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback)
+        /// <param name="critical">indicate whether reported NFW is critical or not</param>
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, bool critical = false)
         {
             var emptyCallstack = exception.SetCallstackIfEmpty();
 
@@ -67,6 +68,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             var faultEvent = new FaultEvent(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
+                critical ? FaultSeverity.Critical : FaultSeverity.Diagnostic,
                 exceptionObject: exception,
                 gatherEventDetails: arg =>
                 {
@@ -83,11 +85,12 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
             TelemetryService.DefaultSession.PostEvent(faultEvent);
 
-            if (exception is OutOfMemoryException)
+            if (exception is OutOfMemoryException || critical)
             {
-                // Once we've encountered one OOM we're likely to see more. There will probably be other
-                // failures as a direct result of the OOM, as well. These aren't helpful so we should just
-                // stop reporting failures.
+                // Once we've encountered one OOM or Critial NFW, 
+                // we're likely to see more. There will probably be other
+                // failures as a direct result of the OOM or critical NFW, as well. 
+                // These aren't helpful so we should just stop reporting failures.
                 WatsonDisabled.s_reportWatson = false;
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// Report Non-Fatal Watson
         /// </summary>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
+        /// <param name="critical">indicate whether reported NFW is critical or not</param>
         public static void Report(Exception exception, bool critical = false)
         {
             Report("Roslyn NonFatal Watson", exception, critical);
@@ -41,6 +42,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <param name="description">any description you want to save with this watson report</param>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
+        /// <param name="critical">indicate whether reported NFW is critical or not</param>
         public static void Report(string description, Exception exception, bool critical = false)
         {
             Report(description, exception, s_defaultCallback, critical);

--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -31,8 +31,17 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// Report Non-Fatal Watson
         /// </summary>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
+        public static void Report(Exception exception)
+        {
+            Report("Roslyn NonFatal Watson", exception, critical: false);
+        }
+
+        /// <summary>
+        /// Report Non-Fatal Watson
+        /// </summary>
+        /// <param name="exception">Exception that triggered this non-fatal error</param>
         /// <param name="critical">indicate whether reported NFW is critical or not</param>
-        public static void Report(Exception exception, bool critical = false)
+        public static void Report(Exception exception, bool critical)
         {
             Report("Roslyn NonFatal Watson", exception, critical);
         }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.ExceptionFormatting.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.ExceptionFormatting.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
@@ -16,7 +19,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return GetStackForAggregateException(exception, aggregate);
             }
 
+            if (exception is RemoteInvocationException remoteException)
+            {
+                return GetStackForRemoteException(remoteException);
+            }
+
             return GetStackForException(exception, includeMessageOnly: false);
+        }
+
+        private static string GetStackForRemoteException(RemoteInvocationException remoteException)
+        {
+            var text = GetStackForException(remoteException, includeMessageOnly: true);
+            if (remoteException.ErrorData == null)
+            {
+                return text;
+            }
+
+            text = $"{text}{Environment.NewLine}---> (Remote Exception) {remoteException.ErrorData.ToString()} <--- {Environment.NewLine}";
+            return text;
         }
 
         private static string GetStackForAggregateException(Exception exception, AggregateException aggregate)
@@ -24,8 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var text = GetStackForException(exception, includeMessageOnly: true);
             for (int i = 0; i < aggregate.InnerExceptions.Count; i++)
             {
-                text = string.Format("{0}{1}---> (Inner Exception #{2}) {3}{4}{5}", text,
-                    Environment.NewLine, i, GetFormattedExceptionStack(aggregate.InnerExceptions[i]), "<---", Environment.NewLine);
+                text = $"{text}{Environment.NewLine}---> (Inner Exception #{i}) {GetFormattedExceptionStack(aggregate.InnerExceptions[i])} <--- {Environment.NewLine}";
             }
 
             return text;

--- a/src/Workspaces/Remote/Razor/Shared/WatsonReporter.cs
+++ b/src/Workspaces/Remote/Razor/Shared/WatsonReporter.cs
@@ -19,14 +19,27 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
     /// </summary>
     internal class WatsonReporter
     {
-        public static void Report(string description, Exception exception, bool critical = false)
+        public static void Report(string description, Exception exception, WatsonSeverity severity = WatsonSeverity.Default)
         {
             // do nothing
         }
 
-        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, bool critical = false)
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, WatsonSeverity severity = WatsonSeverity.Default)
         {
             // do nothing
         }
+    }
+
+    internal enum WatsonSeverity
+    {
+        /// <summary>
+        /// Indicate that this watson is informative and not urgent
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Indicate that this watson is critical and need to be addressed soon
+        /// </summary>
+        Critical,
     }
 }

--- a/src/Workspaces/Remote/Razor/Shared/WatsonReporter.cs
+++ b/src/Workspaces/Remote/Razor/Shared/WatsonReporter.cs
@@ -19,12 +19,12 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
     /// </summary>
     internal class WatsonReporter
     {
-        public static void Report(string description, Exception exception)
+        public static void Report(string description, Exception exception, bool critical = false)
         {
             // do nothing
         }
 
-        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback)
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, bool critical = false)
         {
             // do nothing
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -202,8 +202,8 @@ namespace Microsoft.CodeAnalysis.Remote
             RoslynLogger.SetLogger(AggregateLogger.Create(new VSTelemetryLogger(session), RoslynLogger.GetLogger()));
 
             // set both handler as NFW
-            FatalError.Handler = WatsonReporter.Report;
-            FatalError.NonFatalHandler = WatsonReporter.Report;
+            FatalError.Handler = ex => WatsonReporter.Report(ex, critical: true);
+            FatalError.NonFatalHandler = ex => WatsonReporter.Report(ex);
 
             // start performance reporter
             var diagnosticAnalyzerPerformanceTracker = SolutionService.PrimaryWorkspace.Services.GetService<IPerformanceTrackerService>();

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Remote
             RoslynLogger.SetLogger(AggregateLogger.Create(new VSTelemetryLogger(session), RoslynLogger.GetLogger()));
 
             // set both handler as NFW
-            FatalError.Handler = ex => WatsonReporter.Report(ex, critical: true);
+            FatalError.Handler = ex => WatsonReporter.Report(ex, WatsonSeverity.Critical);
             FatalError.NonFatalHandler = ex => WatsonReporter.Report(ex);
 
             // start performance reporter

--- a/src/Workspaces/Remote/ServiceHub/Shared/Extensions.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/Extensions.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 return;
             }
 
-            WatsonReporter.Report(message, exception, ReportDetailServiceHubLogs, critical: true);
+            WatsonReporter.Report(message, exception, ReportDetailServiceHubLogs, WatsonSeverity.Critical);
         }
 
         private static int ReportDetailServiceHubLogs(IFaultUtility faultUtility)

--- a/src/Workspaces/Remote/ServiceHub/Shared/Extensions.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/Extensions.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 return;
             }
 
-            WatsonReporter.Report(message, exception, ReportDetailServiceHubLogs);
+            WatsonReporter.Report(message, exception, ReportDetailServiceHubLogs, critical: true);
         }
 
         private static int ReportDetailServiceHubLogs(IFaultUtility faultUtility)

--- a/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
@@ -39,9 +39,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// Report Non-Fatal Watson
         /// </summary>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
-        public static void Report(Exception exception, bool critical = false)
+        /// <param name="severity">indicate <see cref="WatsonSeverity"/> of NFW</param>
+        public static void Report(Exception exception, WatsonSeverity severity = WatsonSeverity.Default)
         {
-            Report("Roslyn NonFatal Watson", exception, critical);
+            Report("Roslyn NonFatal Watson", exception, severity);
         }
 
         /// <summary>
@@ -49,9 +50,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// </summary>
         /// <param name="description">any description you want to save with this watson report</param>
         /// <param name="exception">Exception that triggered this non-fatal error</param>
-        public static void Report(string description, Exception exception, bool critical = false)
+        /// <param name="severity">indicate <see cref="WatsonSeverity"/> of NFW</param>
+        public static void Report(string description, Exception exception, WatsonSeverity severity = WatsonSeverity.Default)
         {
-            Report(description, exception, s_defaultCallback, critical);
+            Report(description, exception, s_defaultCallback, severity);
         }
 
         /// <summary>
@@ -62,8 +64,10 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// <param name="callback">Callback to include extra data with the NFW. Note that we always collect
         /// a dump of the current process, but this can be used to add further information or files to the
         /// CAB.</param>
-        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, bool critical = false)
+        /// <param name="severity">indicate <see cref="WatsonSeverity"/> of NFW</param>
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback, WatsonSeverity severity = WatsonSeverity.Default)
         {
+            var critical = severity == WatsonSeverity.Critical;
             var emptyCallstack = exception.SetCallstackIfEmpty();
 
             // if given exception is non recoverable exception,
@@ -116,5 +120,18 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         {
             return exception is OutOfMemoryException;
         }
+    }
+
+    internal enum WatsonSeverity
+    {
+        /// <summary>
+        /// Indicate that this watson is informative and not urgent
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Indicate that this watson is critical and need to be addressed soon
+        /// </summary>
+        Critical,
     }
 }


### PR DESCRIPTION
currently, whenever OOP throws an exception, we show infobar saying "restart VS". whenever that happens, we report NFW. now those NFW will be marked as critical and we will stop reporting NFW after that in VS.

basically making critical NFW behavior same as fatal watson in VS. and management will treat critical NFW same as fatal watson.

also, now we will show callstack like code fix exception when info bar is shown

![image](https://user-images.githubusercontent.com/1333179/58910771-3bb96680-86cb-11e9-8eab-bfaa80f60a41.png)
