### PR TITLE
pass in cancellation token to bail out early in HasReferenceToAssembly

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -403,18 +403,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 return project.ProjectReferences.Any(p => p.ProjectId == sourceProject.Id);
             }
 
-            return project.HasReferenceToAssembly(containingAssembly);
+            return project.HasReferenceToAssembly(containingAssembly, cancellationToken);
         }
 
-        public static bool HasReferenceToAssembly(this Project project, IAssemblySymbol assemblySymbol)
+        public static bool HasReferenceToAssembly(this Project project, IAssemblySymbol assemblySymbol, CancellationToken cancellationToken)
         {
-            return project.HasReferenceToAssembly(assemblySymbol.Name);
+            return project.HasReferenceToAssembly(assemblySymbol.Name, cancellationToken);
         }
 
-        public static bool HasReferenceToAssembly(this Project project, string assemblyName)
+        public static bool HasReferenceToAssembly(this Project project, string assemblyName, CancellationToken cancellationToken)
         {
             bool? hasMatch = project.GetAssemblyReferenceType(
-                a => a.Name == assemblyName ? true : (bool?)null);
+                a => a.Name == assemblyName ? true : (bool?)null,
+                cancellationToken);
 
             return hasMatch == true;
         }
@@ -427,7 +428,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         private static T? GetAssemblyReferenceType<T>(
             this Project project,
-            Func<IAssemblySymbol, T?> predicate) where T : struct
+            Func<IAssemblySymbol, T?> predicate,
+            CancellationToken cancellationToken) where T : struct
         {
             // If the project we're looking at doesn't even support compilations, then there's no 
             // way for it to have an IAssemblySymbol.  And without that, there is no way for it
@@ -449,6 +451,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             foreach (var reference in project.MetadataReferences)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol symbol)
                 {
                     var result = predicate(symbol);


### PR DESCRIPTION
this particular code path can take a long time if metadata reference hasn't created its symbols yet.

this can get really bad if we try to show code lens for something like IDispose.Dipose and it tries to create all metdata references in the solution.

since it is not cancellable, just passing by a Dipose method can cause this to occupy CPU 100% for several seconds and there is no way to make it go away.

now we pass in cancellation token so that we can bail out  sooner.