### PR TITLE
Write Roslyn assembly version to DependentAssemblyVersions file

### DIFF
--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -202,6 +202,7 @@
 
     <MakeDir Directories="$(VisualStudioBuildPackagesDir)"/>
     <WriteLinesToFile Lines="@(_Dependency->'%(_AssemblyName),%(_AssemblyVersion)')" File="$(_DependentAssemblyVersionsFile)" Overwrite="true"/>
+    <WriteLinesToFile Lines="Roslyn,$(AssemblyVersion)" File="$(_DependentAssemblyVersionsFile)" Overwrite="false" />
 
     <ItemGroup>
       <FileWrites Include="$(_DependentAssemblyVersionsFile)"/>

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -196,7 +196,7 @@
   -->
   <Target Name="_GenerateDependentAssemblyVersions" 
           BeforeTargets="AfterBuild"
-          DependsOnTargets="_CalculateDependenciesToInsert"
+          DependsOnTargets="_CalculateDependenciesToInsert;GetAssemblyVersion"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(_DependentAssemblyVersionsFile)">
 


### PR DESCRIPTION
Writing the Roslyn assembly version to this file allows the RIT to automatically update binding redirects during insertion.

I ran a fake insertion with the Roslyn version set to 9.9.0 and the files where updated accordingly - https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/184921?_a=files