### PR TITLE
Dont try and check tuple conversions in error cases:

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4480,7 +4480,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return operandType;
                         }
                     }
-                    if (operandType.Type?.IsTupleType == true)
+                    if (operandType.Type?.IsTupleType == true || conversionOperand.Kind == BoundKind.TupleLiteral)
                     {
                         goto case ConversionKind.ImplicitTuple;
                     }
@@ -4583,7 +4583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
-                    if (checkConversion)
+                    if (checkConversion && !targetType.IsErrorType())
                     {
                         // https://github.com/dotnet/roslyn/issues/29699: Report warnings for user-defined conversions on tuple elements.
                         conversion = GenerateConversion(_conversions, conversionOperand, operandType.Type, targetType, fromExplicitCast, extensionMethodThisArgument);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -50402,7 +50402,8 @@ class C
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "t.Rest.Item2").WithLocation(11, 13));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/35157")]
+        [Fact]
+        [WorkItem(35157, "https://github.com/dotnet/roslyn/issues/35157")]
         public void TupleTypeInference_08()
         {
             var source =
@@ -50412,11 +50413,23 @@ class C
     void M()
     {
         _ = (null, 2);
+        _ = (null, (2, 3));
+        _ = (null, (null, (2, 3)));
     }
 }";
 
             var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (6,9): error CS8183: Cannot infer the type of implicitly-typed discard.
+                //         _ = (null, 2);
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(6, 9),
+                // (7,9): error CS8183: Cannot infer the type of implicitly-typed discard.
+                //         _ = (null, (2, 3));
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(7, 9),
+                // (8,9): error CS8183: Cannot infer the type of implicitly-typed discard.
+                //         _ = (null, (null, (2, 3)));
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(8, 9)
+                );
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/NameTupleElement/NameTupleElementTests.cs
+++ b/src/EditorFeatures/CSharpTest/NameTupleElement/NameTupleElementTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.NameTupleElement;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NameTupleElement

--- a/src/EditorFeatures/CSharpTest/NameTupleElement/NameTupleElementTests.cs
+++ b/src/EditorFeatures/CSharpTest/NameTupleElement/NameTupleElementTests.cs
@@ -85,7 +85,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NameTupleElement
             await TestMissingAsync(@"class C { void M((int arg1, int arg2) x) => M(([||]arg1: 1, 2)); }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/35157")]
+        [Fact]
+        [WorkItem(35157, "https://github.com/dotnet/roslyn/issues/35157")]
         public async Task TestUntypedTuple()
         {
             await TestMissingAsync(


### PR DESCRIPTION
- When checking an identity converison, also check for a bound tuple if the type isn't a tuple (as we might have a bound tuple with an error type)
- When checking a tuple conversion, don't call GenerateConversion in the error case, as we don't have a target type to generate against
- Update tests

Fixes #35157