### PR TITLE
Disable TypingHelpDirectiveWorks for legacy completion

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
@@ -95,7 +95,8 @@ w.Content = g;");
             VisualStudio.InteractiveWindow.SubmitText("b = null; w.Close(); w = null;");
         }
 
-        [WpfFact]
+        // This test is flaky when legacy completion is enabled
+        [ConditionalWpfFact(typeof(AsyncCompletionCondition))]
         public void TypingHelpDirectiveWorks()
         {
             VisualStudio.InteractiveWindow.ShowWindow(waitForPrompt: true);


### PR DESCRIPTION
This test is flaky in legacy completion, but legacy completion is slated for removal so the test failures were not fully investigated.

This change addresses failures of this test with the following message:

```
System.Exception : Unable to find expected content in REPL within 10000 milliseconds and no exceptions were thrown. Actual content:\r\n[[Resetting execution engine.\r\nLoading context from 'CSharpInteractive.rsp'.]]

Server stack trace: 
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.InteractiveWindow_InProc.WaitForPredicate(Func`1 getValue, Func`2 isExpectedValue)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.InteractiveWindow_InProc.WaitForLastReplOutputContains(String outputText)
   at System.Runtime.Remoting.Messaging.StackBuilderSink._PrivateProcessMessage(IntPtr md, Object[] args, Object server, Object[]& outArgs)
   at System.Runtime.Remoting.Messaging.StackBuilderSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.InteractiveWindow_InProc.WaitForLastReplOutputContains(String outputText)
   at Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpInteractive.TypingHelpDirectiveWorks() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs:line 101
```

During the investigation, I observed that each of the failure cases was preceded by an exception thrown in `ChainTaskAndNotifyControllerWhenFinished` in the awaiter's `GetResult` on this line:

https://github.com/dotnet/roslyn/blob/c78f1e594997b0dae930551101f690708b4db764/src/EditorFeatures/Core/Implementation/IntelliSense/ModelComputation.cs#L150

The failure does not appear to be caused by an _unhandled_ exception, but rather the exception appears to be an observable symptom of a race condition which occurs only when this test is going to fail.