### PR TITLE
Fix build with RTM VS image

### DIFF
--- a/eng/cibuild.cmd
+++ b/eng/cibuild.cmd
@@ -1,2 +1,8 @@
 @echo off
+
+REM !!!!TEMPORARY DEBUGGING!!!
+setlocal
+set COREHOST_TRACE=1
+REM !!!!!!!!!!!!!!!!!!!!!!!!!!
+
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0build.ps1""" -ci -restore -build -bootstrap -pack -sign -publish -binaryLog %*"

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "sdk": {
+    "version": "3.0.100-preview"
+  },
   "tools": {
     "dotnet": "3.0.100-preview6-012105",
     "vs": {


### PR DESCRIPTION
Specify a preview version in sdk/version so that VS can use preview SDK without having to check the "Use Previews" box.

Do not put an exact version there because it would be preferred when trying to dogfood a newer version. Also, it would duplicate arcade's tools/dotnet field, which is unnecessary.