### PR TITLE
Make VSWorkspace.GetProjectGuid accessible to XAML

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Extensions.cs
+++ b/src/VisualStudio/Xaml/Impl/Extensions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System;
+using Microsoft.VisualStudio.LanguageServices;
+
+namespace Microsoft.CodeAnalysis.Editor.Xaml
+{
+    internal static class Extensions
+    {
+        public static Guid GetProjectGuid(this VisualStudioWorkspace workspace, ProjectId projectId)
+            => workspace.GetProjectGuid(projectId);
+    }
+}


### PR DESCRIPTION
Enables proper fix for https://github.com/dotnet/roslyn/issues/36223.

DevDiv change: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/185383?_a=overview