### PR TITLE
fixed DeclarationNameCompletionProvider when used via Nuget package

### DIFF
--- a/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
+++ b/src/Features/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Features.csproj
@@ -67,7 +67,7 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="$(HumanizerCoreVersion)" PrivateAssets="all" />
+    <PackageReference Include="Humanizer.Core" Version="$(HumanizerCoreVersion)" PrivateAssets="compile" />
   </ItemGroup>
   <Import Project="..\..\..\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
`Microsoft.CodeAnalysis.CSharp.Features` doesn't declare `Humanizer` as a dependency - instead it uses `PrivateAssets="all"`. 
`PrivateAssets` is intended for build-time dependencies only, so the result is that the produced Nuget package doesn't contain the Humanizer.dll nor does it list it as a dependency.

This is a regression that started with Roslyn 2.11.x-beta and continues into Roslyn 3.x, because it [used to work](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.Features/2.10.0).

The consequence of the missing `Humanizer` is that the `DeclarationNameCompletionProvider` silently breaks when used via the Nuget package. It ends up throwing an exception about missing `Humanizer` reference but that exception [is swallowed](https://github.com/dotnet/roslyn/blob/master/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs#L70).

This actually broke declaration name completion in [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn/pull/1520) and shipped into the latest version of C# extension for VS Code. The current workaround is to reference Humanizer directly in the host application, but obviously the Nuget package should be fixed too.

For the record - repro steps:

```
          // reference Microsoft.CodeAnalysis.CSharp.Features Nuget

          var host = MefHostServices.Create(MefHostServices.DefaultAssemblies);
          var workspace = new AdhocWorkspace(host);

            var code = @"using System;

            public class MyClass
            {
                public static void MyMethod(int value)
                {
                    MyClass 
                }
            }";

            var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(), "MyProject", "MyProject", LanguageNames.CSharp).
                WithMetadataReferences(new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
            var project = workspace.AddProject(projectInfo);
            var document = workspace.AddDocument(project.Id, "MyFile.cs", SourceText.From(code));

            var completionService = CompletionService.GetService(document);
            var results = await completionService.GetCompletionsAsync(document, code.LastIndexOf("MyClass ") + 8);

            // results is null (exception gets swallowed), instead of a completion list with entries like "my", "myClass", "My", "MyClass"
```