### PR TITLE
Enable preview SDKs for all builds

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -597,7 +597,6 @@ try {
   if ($ci) {
     List-Processes
     Prepare-TempDir
-    EnablePreviewSdks
     if ($testVsi) {
       Setup-IntegrationTestRun 
     }
@@ -615,6 +614,7 @@ try {
   }
 
   if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -or $testCoreClr) {
+    EnablePreviewSdks
     BuildSolution
   }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -613,8 +613,11 @@ try {
     $bootstrapDir = Make-BootstrapBuild -force32:$test32
   }
 
-  if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -or $testCoreClr) {
+  if ($restore -or $ci) {
     EnablePreviewSdks
+  }
+
+  if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -or $testCoreClr) {
     BuildSolution
   }
 


### PR DESCRIPTION
This build prerequisite is not exposed as an MSBuild property or target, so we enable the setting for the current user instead.