### PR TITLE
Wait for project system before waiting for workspace

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -117,7 +117,7 @@
     <MicrosoftVisualStudioSDKAnalyzersVersion>15.7.7</MicrosoftVisualStudioSDKAnalyzersVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.15.103</MicrosoftVisualStudioSetupConfigurationInteropVersion>
     <MicrosoftVisualStudioShell150Version>16.0.28226-pre</MicrosoftVisualStudioShell150Version>
-    <MicrosoftVisualStudioShellFrameworkVersion>16.0.28226-pre</MicrosoftVisualStudioShellFrameworkVersion>
+    <MicrosoftVisualStudioShellFrameworkVersion>16.1.28917.181</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioShellDesignVersion>15.7.27703</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftVisualStudioShellImmutable100Version>15.0.25415</MicrosoftVisualStudioShellImmutable100Version>
     <MicrosoftVisualStudioShellImmutable110Version>15.0.25415</MicrosoftVisualStudioShellImmutable110Version>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.Verifier.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.Verifier.cs
@@ -189,6 +189,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             {
                 _instance.Workspace.WaitForAllAsyncOperations(
                     Helper.HangMitigatingTimeout,
+                    FeatureAttribute.Workspace,
                     FeatureAttribute.SolutionCrawler,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles);


### PR DESCRIPTION
Resolves flakiness problems in several tests, including:

* `VerifySyntaxErrorSquiggles`
* `VerifySemanticErrorSquiggles`
* `ErrorLevelWarning`
* `ErrorsDuringMethodBodyEditing`