### PR TITLE
Filter out missing import fixes that would add references

### DIFF
--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -49,10 +49,6 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
 
             // Find fixes for the diagnostic where there is only a single fix.
             var unambiguousFixes = await GetUnambiguousFixesAsync(document, diagnostics, cancellationToken).ConfigureAwait(false);
-            if (unambiguousFixes.IsEmpty)
-            {
-                return document.Project;
-            }
 
             // We do not want to add project or framework references without the user's input, so filter those out.
             var usableFixes = unambiguousFixes.WhereAsArray(fixData => DoesNotAddReference(fixData, document.Project.Id));


### PR DESCRIPTION
Allow the user to choose when they want to add and which references they want to add to their project.

Resolves #34398, since the error is triggered by a foreground assertion when adding Framework assembly references.