### PR TITLE
Pass arguments to StreamJsonRpc as arrays

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/EnumerableExtensions.cs
@@ -244,6 +244,9 @@ namespace Roslyn.Utilities
             return source.Where((Func<T, bool>)s_notNullTest);
         }
 
+        public static T[] AsArray<T>(this IEnumerable<T> source)
+            => source as T[] ?? source.ToArray();
+
         public static ImmutableArray<TResult> SelectAsArray<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
             if (source == null)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcClient.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             try
             {
-                await _rpc.InvokeWithCancellationAsync(targetName, arguments, cancellationToken).ConfigureAwait(false);
+                await _rpc.InvokeWithCancellationAsync(targetName, arguments?.AsArray(), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ReportUnlessCanceled(ex, cancellationToken))
             {
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             try
             {
-                return await _rpc.InvokeWithCancellationAsync<T>(targetName, arguments, cancellationToken).ConfigureAwait(false);
+                return await _rpc.InvokeWithCancellationAsync<T>(targetName, arguments?.AsArray(), cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ReportUnlessCanceled(ex, cancellationToken))
             {

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             // after shutdown.
             try
             {
-                await _rpc.InvokeWithCancellationAsync(targetName, arguments, _shutdownCancellationTokenSource.Token).ConfigureAwait(false);
+                await _rpc.InvokeWithCancellationAsync(targetName, arguments?.AsArray(), _shutdownCancellationTokenSource.Token).ConfigureAwait(false);
             }
             catch (Exception ex) when (ReportUnlessCanceled(ex))
             {

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Remote
         protected Task<TResult> InvokeAsync<TResult>(
             string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            return _rpc.InvokeWithCancellationAsync<TResult>(targetName, arguments, cancellationToken);
+            return _rpc.InvokeWithCancellationAsync<TResult>(targetName, arguments?.AsArray(), cancellationToken);
         }
 
         protected Task<TResult> InvokeAsync<TResult>(
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Remote
         protected Task InvokeAsync(
             string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            return _rpc.InvokeWithCancellationAsync(targetName, arguments, cancellationToken);
+            return _rpc.InvokeWithCancellationAsync(targetName, arguments?.AsArray(), cancellationToken);
         }
 
         protected Task<Solution> GetSolutionAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Works around microsoft/vs-streamjsonrpc#272 so our integration tests don't throw exceptions when we run them on machines with 16.1 installed.