### PR TITLE
Reduce dependencies

### DIFF
--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -72,8 +72,11 @@
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
-    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
-    <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" />
+    <!-- Microsoft.VisualStudio.LanugageServices is intended to only be used by VisualStudio and since 
+         Microsoft.CodeAnalysis.EditorFeatures and Microsoft.CodeAnalysis.EditorFeatures.Wpf are not required to
+         access the public API in this package, they are not published to NuGet, so mark them PrivateAssets="all" -->
+    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />


### PR DESCRIPTION
A few issues were found when validating NuGet packages for the 16.2 preview2 release.

1. It looks like Microsoft.CodeAnalysis.editorfeatures.common is missing from NuGet and is preventing me from installing Microsoft.VisualStudio.LanguageServices.3.2.0-beta2-final.nupkg as it is dependent on it. (https://github.com/dotnet/roslyn/issues/30662)
2. ~~Also I’m getting this error on upgrade that Microsoft.CodeAnalysis.FlowAnalysis.Utilities is missing (from Microsoft.CodeAnalysis.Features) as well.~~ We will publish the required packages to NuGet and unlist.

@tmat and @jasonmalinowski  please take a look