### PR TITLE
Propogate nullable type information for EncapsulateFieldService 

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -84,6 +84,48 @@ class goo
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        public async Task PrivateNullableFieldToPropertyIgnoringReferences()
+        {
+            var text = @"#nullable enable
+class goo
+{
+    private string? b[|a|]r;
+
+    void baz()
+    {
+        var q = bar;
+    }
+}
+";
+
+            var expected = @"#nullable enable
+class goo
+{
+    private string? bar;
+
+    public string? Bar
+    {
+        get
+        {
+            return bar;
+        }
+
+        set
+        {
+            bar = value;
+        }
+    }
+
+    void baz()
+    {
+        var q = bar;
+    }
+}
+";
+            await TestAllOptionsOffAsync(text, expected, index: 1, parseOptions: TestOptions.Regular8WithNullableAnalysis);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public async Task PrivateFieldToPropertyUpdatingReferences()
         {
             var text = @"

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -216,15 +216,12 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             var newDeclaration = newRoot.GetAnnotatedNodes<SyntaxNode>(declarationAnnotation).First();
             field = semanticModel.GetDeclaredSymbol(newDeclaration, cancellationToken) as IFieldSymbol;
 
-            var fieldType = field.GetSymbolType();
-            var fieldNullability = fieldType.GetNullability();
-
             var generatedProperty = GenerateProperty(
                                         generatedPropertyName,
                                         finalFieldName,
                                         originalField.DeclaredAccessibility,
                                         originalField,
-                                        fieldType.WithNullability(fieldNullability),
+                                        field.GetSymbolType(),
                                         field.ContainingType,
                                         new SyntaxAnnotation(),
                                         document,

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -217,17 +217,15 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             field = semanticModel.GetDeclaredSymbol(newDeclaration, cancellationToken) as IFieldSymbol;
 
             var generatedProperty = GenerateProperty(
-                                        generatedPropertyName,
-                                        finalFieldName,
-                                        originalField.DeclaredAccessibility,
-                                        originalField,
-                                        field.GetSymbolType(),
-                                        field.ContainingType,
-                                        new SyntaxAnnotation(),
-                                        document,
-                                        cancellationToken);
+                generatedPropertyName,
+                finalFieldName,
+                originalField.DeclaredAccessibility,
+                originalField,
+                field.ContainingType,
+                new SyntaxAnnotation(),
+                document,
+                cancellationToken);
 
-            var codeGenerationService = document.GetLanguageService<ICodeGenerationService>();
             var solutionWithProperty = await AddPropertyAsync(
                 document, document.Project.Solution, field, generatedProperty, cancellationToken).ConfigureAwait(false);
 
@@ -302,7 +300,6 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             string propertyName, string fieldName,
             Accessibility accessibility,
             IFieldSymbol field,
-            ITypeSymbol typeWithNullable,
             INamedTypeSymbol containingSymbol,
             SyntaxAnnotation annotation,
             Document document,
@@ -314,7 +311,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 attributes: ImmutableArray<AttributeData>.Empty,
                 accessibility: ComputeAccessibility(accessibility, field.Type),
                 modifiers: new DeclarationModifiers(isStatic: field.IsStatic, isReadOnly: field.IsReadOnly, isUnsafe: field.IsUnsafe()),
-                type: typeWithNullable,
+                type: field.GetSymbolType(),
                 refKind: RefKind.None,
                 explicitInterfaceImplementations: default,
                 name: propertyName,


### PR DESCRIPTION
Fixes #30320 	

Make sure to use `WithNullability` when passing the type.
Add a test for `string?` property generation