### PR TITLE
Update 'Use pattern matching' to recognize other null checks

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -22,12 +22,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         [InlineData("null != x", "o is string x")]
         [InlineData("(object)x != null", "o is string x")]
         [InlineData("null != (object)x", "o is string x")]
+        [InlineData("x is object", "o is string x")]
         [InlineData("x == null", "!(o is string x)")]
         [InlineData("null == x", "!(o is string x)")]
         [InlineData("(object)x == null", "!(o is string x)")]
         [InlineData("null == (object)x", "!(o is string x)")]
         [InlineData("(x = o as string) != null", "o is string x")]
         [InlineData("null != (x = o as string)", "o is string x")]
+        [InlineData("(x = o as string) is object", "o is string x")]
         [InlineData("(x = o as string) == null", "!(o is string x)")]
         [InlineData("null == (x = o as string)", "!(o is string x)")]
         public async Task InlineTypeCheck1(string input, string output)
@@ -40,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
         [InlineData("(x = o as string) != null", "o is string x")]
         [InlineData("null != (x = o as string)", "o is string x")]
+        [InlineData("(x = o as string) is object", "o is string x")]
         [InlineData("(x = o as string) == null", "!(o is string x)")]
         [InlineData("null == (x = o as string)", "!(o is string x)")]
         public async Task InlineTypeCheck2(string input, string output)

--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -27,11 +27,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         [InlineData("null == x", "!(o is string x)")]
         [InlineData("(object)x == null", "!(o is string x)")]
         [InlineData("null == (object)x", "!(o is string x)")]
+        [InlineData("x is null", "!(o is string x)")]
         [InlineData("(x = o as string) != null", "o is string x")]
         [InlineData("null != (x = o as string)", "o is string x")]
         [InlineData("(x = o as string) is object", "o is string x")]
         [InlineData("(x = o as string) == null", "!(o is string x)")]
         [InlineData("null == (x = o as string)", "!(o is string x)")]
+        [InlineData("(x = o as string) is null", "!(o is string x)")]
         public async Task InlineTypeCheck1(string input, string output)
         {
             await TestStatement($"if ({input}) {{ }}", $"if ({output}) {{ }}");

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -89,18 +89,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             var asExpressionLocation = diagnostic.AdditionalLocations[2];
 
             var declarator = (VariableDeclaratorSyntax)declaratorLocation.FindNode(cancellationToken);
-            var comparison = (BinaryExpressionSyntax)comparisonLocation.FindNode(cancellationToken);
+            var comparison = (ExpressionSyntax)comparisonLocation.FindNode(cancellationToken);
             var asExpression = (BinaryExpressionSyntax)asExpressionLocation.FindNode(cancellationToken);
+
+            var rightSideOfComparison = comparison is BinaryExpressionSyntax binaryExpression
+                ? (SyntaxNode)binaryExpression.Right
+                : ((IsPatternExpressionSyntax)comparison).Pattern;
             var newIdentifier = declarator.Identifier
-                .WithoutTrivia().WithTrailingTrivia(comparison.Right.GetTrailingTrivia());
+                .WithoutTrivia().WithTrailingTrivia(rightSideOfComparison.GetTrailingTrivia());
 
             ExpressionSyntax isExpression = SyntaxFactory.IsPatternExpression(
                 asExpression.Left, SyntaxFactory.DeclarationPattern(
                     ((TypeSyntax)asExpression.Right).WithoutTrivia(),
                     SyntaxFactory.SingleVariableDesignation(newIdentifier)));
 
-            // We should negate the is-expression if we have something like "x == null"
-            if (comparison.IsKind(SyntaxKind.EqualsExpression))
+            // We should negate the is-expression if we have something like "x == null" or "x is null"
+            if (comparison.IsKind(SyntaxKind.EqualsExpression, SyntaxKind.IsPatternExpression))
             {
                 isExpression = SyntaxFactory.PrefixUnaryExpression(
                     SyntaxKind.LogicalNotExpression,

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.Analyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.Analyzer.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 // Keep track of whether the pattern variable is definitely assigned when false/true.
                 // We start by the null-check itself, if it's compared with '==', the pattern variable
                 // will be definitely assigned when false, because we wrap the is-operator in a !-operator.
-                var defAssignedWhenTrue = _comparison.Kind() == SyntaxKind.NotEqualsExpression;
+                var defAssignedWhenTrue = _comparison.IsKind(SyntaxKind.NotEqualsExpression, SyntaxKind.IsExpression);
 
                 foreach (var current in _comparison.Ancestors())
                 {

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.Analyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.Analyzer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         {
             private readonly SemanticModel _semanticModel;
             private readonly ILocalSymbol _localSymbol;
-            private readonly BinaryExpressionSyntax _comparison;
+            private readonly ExpressionSyntax _comparison;
             private readonly ExpressionSyntax _operand;
             private readonly SyntaxNode _localStatement;
             private readonly SyntaxNode _enclosingBlock;
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             private Analyzer(
                 SemanticModel semanticModel,
                 ILocalSymbol localSymbol,
-                BinaryExpressionSyntax comparison,
+                ExpressionSyntax comparison,
                 ExpressionSyntax operand,
                 SyntaxNode localStatement,
                 SyntaxNode enclosingBlock,
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             public static bool CanSafelyConvertToPatternMatching(
                 SemanticModel semanticModel,
                 ILocalSymbol localSymbol,
-                BinaryExpressionSyntax comparison,
+                ExpressionSyntax comparison,
                 ExpressionSyntax operand,
                 SyntaxNode localStatement,
                 SyntaxNode enclosingBlock,

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -36,7 +36,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterSyntaxNodeAction(SyntaxNodeAction,
                 SyntaxKind.EqualsExpression,
-                SyntaxKind.NotEqualsExpression);
+                SyntaxKind.NotEqualsExpression,
+                SyntaxKind.IsExpression);
 
         private void SyntaxNodeAction(SyntaxNodeAnalysisContext syntaxContext)
         {
@@ -275,11 +276,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         {
             if (left.IsKind(SyntaxKind.NullLiteralExpression))
             {
+                // null == x
+                // null != x
                 return right;
             }
 
             if (right.IsKind(SyntaxKind.NullLiteralExpression))
             {
+                // x == null
+                // x != null
+                return left;
+            }
+
+            if (right.IsKind(SyntaxKind.PredefinedType, out PredefinedTypeSyntax predefinedType)
+                && predefinedType.Keyword.IsKind(SyntaxKind.ObjectKeyword))
+            {
+                // x is object
                 return left;
             }
 

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 {
@@ -37,7 +38,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             => context.RegisterSyntaxNodeAction(SyntaxNodeAction,
                 SyntaxKind.EqualsExpression,
                 SyntaxKind.NotEqualsExpression,
-                SyntaxKind.IsExpression);
+                SyntaxKind.IsExpression,
+                SyntaxKind.IsPatternExpression);
 
         private void SyntaxNodeAction(SyntaxNodeAnalysisContext syntaxContext)
         {
@@ -66,8 +68,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 return;
             }
 
-            var comparison = (BinaryExpressionSyntax)node;
-            var operand = GetNullCheckOperand(comparison.Left, comparison.Right)?.WalkDownParentheses();
+            var comparison = (ExpressionSyntax)node;
+            var (comparisonLeft, comparisonRight) = comparison switch
+            {
+                BinaryExpressionSyntax binaryExpression => (binaryExpression.Left, (SyntaxNode)binaryExpression.Right),
+                IsPatternExpressionSyntax isPattern => (isPattern.Expression, isPattern.Pattern),
+                _ => throw ExceptionUtilities.Unreachable,
+            };
+            var operand = GetNullCheckOperand(comparisonLeft, comparisonRight)?.WalkDownParentheses();
             if (operand == null)
             {
                 return;
@@ -272,13 +280,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             return declarator != null;
         }
 
-        private static ExpressionSyntax GetNullCheckOperand(ExpressionSyntax left, ExpressionSyntax right)
+        private static ExpressionSyntax GetNullCheckOperand(ExpressionSyntax left, SyntaxNode right)
         {
             if (left.IsKind(SyntaxKind.NullLiteralExpression))
             {
                 // null == x
                 // null != x
-                return right;
+                return (ExpressionSyntax)right;
             }
 
             if (right.IsKind(SyntaxKind.NullLiteralExpression))
@@ -292,6 +300,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 && predefinedType.Keyword.IsKind(SyntaxKind.ObjectKeyword))
             {
                 // x is object
+                return left;
+            }
+
+            if (right.IsKind(SyntaxKind.ConstantPattern, out ConstantPatternSyntax constantPattern)
+                && constantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                // x is null
                 return left;
             }
 

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 IsPatternExpressionSyntax isPattern => (isPattern.Expression, isPattern.Pattern),
                 _ => throw ExceptionUtilities.Unreachable,
             };
-            var operand = GetNullCheckOperand(comparisonLeft, comparisonRight)?.WalkDownParentheses();
+            var operand = GetNullCheckOperand(comparisonLeft, comparison.Kind(), comparisonRight)?.WalkDownParentheses();
             if (operand == null)
             {
                 return;
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             return declarator != null;
         }
 
-        private static ExpressionSyntax GetNullCheckOperand(ExpressionSyntax left, SyntaxNode right)
+        private static ExpressionSyntax GetNullCheckOperand(ExpressionSyntax left, SyntaxKind comparisonKind, SyntaxNode right)
         {
             if (left.IsKind(SyntaxKind.NullLiteralExpression))
             {
@@ -297,14 +297,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             }
 
             if (right.IsKind(SyntaxKind.PredefinedType, out PredefinedTypeSyntax predefinedType)
-                && predefinedType.Keyword.IsKind(SyntaxKind.ObjectKeyword))
+                && predefinedType.Keyword.IsKind(SyntaxKind.ObjectKeyword)
+                && comparisonKind == SyntaxKind.IsExpression)
             {
                 // x is object
                 return left;
             }
 
             if (right.IsKind(SyntaxKind.ConstantPattern, out ConstantPatternSyntax constantPattern)
-                && constantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression))
+                && constantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression)
+                && comparisonKind == SyntaxKind.IsPatternExpression)
             {
                 // x is null
                 return left;


### PR DESCRIPTION
* Recognize `is object` as a non-null check
* Recognize `is null` as a null check

Fixes #36315