### PR TITLE
Disable move type when the options service isn't present

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -1104,9 +1104,14 @@ class MyClass
             using (var workspace = CreateWorkspaceFromFile(code, new TestParameters(), exportProviderWithoutOptionsService))
             using (var testState = new TestState(workspace))
             {
-                // If the required options service isn't available, the
-                // move to namespace service shouldn't show up either
-                Assert.Null(testState.MoveToNamespaceService);
+                Assert.Null(testState.TestMoveToNamespaceOptionsService);
+
+                var actions = await testState.MoveToNamespaceService.GetCodeActionsAsync(
+                    testState.InvocationDocument,
+                    testState.TestInvocationDocument.SelectedSpans.Single(),
+                    CancellationToken.None);
+
+                Assert.Empty(actions);
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.MoveToNamespace;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.MoveToNamespace;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace;
 using Microsoft.VisualStudio.Composition;
@@ -18,10 +20,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveToNamespace
     [UseExportProvider]
     public class MoveToNamespaceTests : AbstractMoveToNamespaceTests
     {
-        private static readonly ComposableCatalog Catalog = TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic;
-
         private static readonly IExportProviderFactory ExportProviderFactory =
-            ExportProviderCache.GetOrCreateExportProviderFactory(Catalog);
+            ExportProviderCache.GetOrCreateExportProviderFactory(TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic);
 
         protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
             => CreateWorkspaceFromFile(initialMarkup, parameters, ExportProviderFactory);
@@ -1097,7 +1097,8 @@ class MyClass
 }
 }";
 
-            var exportProviderWithoutOptionsService = ExportProviderCache.GetOrCreateExportProviderFactory(Catalog.WithoutPartsOfType(typeof(TestMoveToNamespaceOptionsService)));
+            var exportProviderWithoutOptionsService = ExportProviderCache.GetOrCreateExportProviderFactory(
+                TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic.WithoutPartsOfType(typeof(IMoveToNamespaceOptionsService)));
 
             using (var workspace = CreateWorkspaceFromFile(code, new TestParameters(), exportProviderWithoutOptionsService))
             using (var testState = new TestState(workspace))

--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -2,6 +2,8 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -16,14 +18,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveToNamespace
     [UseExportProvider]
     public class MoveToNamespaceTests : AbstractMoveToNamespaceTests
     {
-        private static readonly IExportProviderFactory CSharpExportProviderFactory =
-            ExportProviderCache.GetOrCreateExportProviderFactory(
-                TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic
-                    .WithPart(typeof(TestMoveToNamespaceOptionsService))
-                    .WithPart(typeof(TestSymbolRenamedCodeActionOperationFactoryWorkspaceService)));
+        private static readonly ComposableCatalog Catalog = TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic;
+
+        private static readonly IExportProviderFactory ExportProviderFactory =
+            ExportProviderCache.GetOrCreateExportProviderFactory(Catalog);
 
         protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
-            => TestWorkspace.CreateCSharp(initialMarkup, parameters.parseOptions, parameters.compilationOptions, exportProvider: CSharpExportProviderFactory.CreateExportProvider());
+            => CreateWorkspaceFromFile(initialMarkup, parameters, ExportProviderFactory);
+
+        protected TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters, IExportProviderFactory exportProviderFactory)
+            => TestWorkspace.CreateCSharp(initialMarkup, parameters.parseOptions, parameters.compilationOptions, exportProvider: exportProviderFactory.CreateExportProvider());
 
         protected override ParseOptions GetScriptOptions() => Options.Script;
 
@@ -1080,5 +1084,30 @@ expectedSymbolChanges: new Dictionary<string, string>()
 {
     {"Two.C2", "Three.C2" }
 });
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.MoveToNamespace)]
+        [WorkItem(35577, "https://github.com/dotnet/roslyn/issues/35577")]
+        public async Task MoveToNamespace_WithoutOptionsService()
+        {
+            var code = @"namespace A[||]
+{
+class MyClass
+{
+    void Method() { }
+}
+}";
+
+            var exportProviderWithoutOptionsService = ExportProviderCache.GetOrCreateExportProviderFactory(Catalog.WithoutPartsOfType(typeof(TestMoveToNamespaceOptionsService)));
+
+            using (var workspace = CreateWorkspaceFromFile(code, new TestParameters(), exportProviderWithoutOptionsService))
+            using (var testState = new TestState(workspace))
+            {
+                var codeActions = await testState.MoveToNamespaceService.GetCodeActionsAsync(testState.InvocationDocument,
+                        testState.TestInvocationDocument.SelectedSpans.Single(),
+                        CancellationToken.None);
+
+                Assert.Empty(codeActions);
+            }
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveToNamespace/MoveToNamespaceTests.cs
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.MoveToNamespace
     public class MoveToNamespaceTests : AbstractMoveToNamespaceTests
     {
         private static readonly IExportProviderFactory ExportProviderFactory =
-            ExportProviderCache.GetOrCreateExportProviderFactory(TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic);
+            ExportProviderCache.GetOrCreateExportProviderFactory(
+                TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic.WithPart(typeof(TestMoveToNamespaceOptionsService)));
 
         protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
             => CreateWorkspaceFromFile(initialMarkup, parameters, ExportProviderFactory);
@@ -1103,11 +1104,9 @@ class MyClass
             using (var workspace = CreateWorkspaceFromFile(code, new TestParameters(), exportProviderWithoutOptionsService))
             using (var testState = new TestState(workspace))
             {
-                var codeActions = await testState.MoveToNamespaceService.GetCodeActionsAsync(testState.InvocationDocument,
-                        testState.TestInvocationDocument.SelectedSpans.Single(),
-                        CancellationToken.None);
-
-                Assert.Empty(codeActions);
+                // If the required options service isn't available, the
+                // move to namespace service shouldn't show up either
+                Assert.Null(testState.MoveToNamespaceService);
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.TestState.cs
+++ b/src/EditorFeatures/TestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.TestState.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
             public Document InvocationDocument => Workspace.CurrentSolution.GetDocument(TestInvocationDocument.Id);
 
             public TestMoveToNamespaceOptionsService TestMoveToNamespaceOptionsService
-                => (TestMoveToNamespaceOptionsService)Workspace.Services.GetService<IMoveToNamespaceOptionsService>();
+                => (TestMoveToNamespaceOptionsService)MoveToNamespaceService.OptionsService;
 
             public IMoveToNamespaceService MoveToNamespaceService
                 => InvocationDocument.GetLanguageService<IMoveToNamespaceService>();

--- a/src/EditorFeatures/TestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.cs
+++ b/src/EditorFeatures/TestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.cs
@@ -16,8 +16,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
     public abstract partial class AbstractMoveToNamespaceTests : AbstractCodeActionTest
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
-            => new MoveToNamespaceCodeActionProvider(
-                workspace.Services.GetLanguageServices(GetLanguage()).GetRequiredService<IMoveToNamespaceService>());
+            => new MoveToNamespaceCodeActionProvider();
 
         public async Task TestMoveToNamespaceAsync(
             string markup,

--- a/src/EditorFeatures/TestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.cs
+++ b/src/EditorFeatures/TestUtilities/MoveToNamespace/AbstractMoveToNamespaceTests.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
     public abstract partial class AbstractMoveToNamespaceTests : AbstractCodeActionTest
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
-            => new MoveToNamespaceCodeActionProvider();
+            => new MoveToNamespaceCodeActionProvider(
+                workspace.Services.GetLanguageServices(GetLanguage()).GetRequiredService<IMoveToNamespaceService>());
 
         public async Task TestMoveToNamespaceAsync(
             string markup,

--- a/src/EditorFeatures/TestUtilities/MoveToNamespace/TestMoveToNamespaceOptionsService.cs
+++ b/src/EditorFeatures/TestUtilities/MoveToNamespace/TestMoveToNamespaceOptionsService.cs
@@ -8,7 +8,7 @@ using System.Composition;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
 {
-    [ExportWorkspaceService(typeof(IMoveToNamespaceOptionsService)), Shared]
+    [Export(typeof(IMoveToNamespaceOptionsService)), Shared]
     class TestMoveToNamespaceOptionsService : IMoveToNamespaceOptionsService
     {
         internal static readonly MoveToNamespaceOptionsResult DefaultOptions = new MoveToNamespaceOptionsResult("TestNewNamespaceValue");

--- a/src/EditorFeatures/TestUtilities/MoveToNamespace/TestMoveToNamespaceOptionsService.cs
+++ b/src/EditorFeatures/TestUtilities/MoveToNamespace/TestMoveToNamespaceOptionsService.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.MoveToNamespace;
-using Microsoft.CodeAnalysis.Host.Mef;
 using System.Composition;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities.MoveToNamespace
 {
     [Export(typeof(IMoveToNamespaceOptionsService)), Shared]
+    [PartNotDiscoverable]
     class TestMoveToNamespaceOptionsService : IMoveToNamespaceOptionsService
     {
         internal static readonly MoveToNamespaceOptionsResult DefaultOptions = new MoveToNamespaceOptionsResult("TestNewNamespaceValue");

--- a/src/Features/CSharp/Portable/MoveToNamespace/CSharpMoveToNamespaceService.cs
+++ b/src/Features/CSharp/Portable/MoveToNamespace/CSharpMoveToNamespaceService.cs
@@ -14,7 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MoveToNamespace
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpMoveToNamespaceService(IMoveToNamespaceOptionsService optionsService)
+        public CSharpMoveToNamespaceService(
+            [Import(AllowDefault = true)] IMoveToNamespaceOptionsService optionsService)
             : base(optionsService)
         {
         }

--- a/src/Features/CSharp/Portable/MoveToNamespace/CSharpMoveToNamespaceService.cs
+++ b/src/Features/CSharp/Portable/MoveToNamespace/CSharpMoveToNamespaceService.cs
@@ -13,7 +13,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MoveToNamespace
         AbstractMoveToNamespaceService<NamespaceDeclarationSyntax, TypeDeclarationSyntax>
     {
         [ImportingConstructor]
-        public CSharpMoveToNamespaceService()
+        public CSharpMoveToNamespaceService(IMoveToNamespaceOptionsService optionsService)
+            : base(optionsService)
         {
         }
 

--- a/src/Features/CSharp/Portable/MoveToNamespace/CSharpMoveToNamespaceService.cs
+++ b/src/Features/CSharp/Portable/MoveToNamespace/CSharpMoveToNamespaceService.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MoveToNamespace
         AbstractMoveToNamespaceService<NamespaceDeclarationSyntax, TypeDeclarationSyntax>
     {
         [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpMoveToNamespaceService(IMoveToNamespaceOptionsService optionsService)
             : base(optionsService)
         {

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -55,6 +55,14 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
             int position,
             CancellationToken cancellationToken)
         {
+            var moveToNamespaceOptionsService = document.Project.Solution.Workspace.Services.GetService<IMoveToNamespaceOptionsService>();
+            if (moveToNamespaceOptionsService == null)
+            {
+                // If the user can't provide options then there's no reason
+                // to do an analysis, they won't be able to use the feature
+                return MoveToNamespaceAnalysisResult.Invalid;
+            }
+
             var root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
             var token = root.FindToken(position);

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.LanguageServices;
-using System.Text;
 using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.MoveToNamespace
@@ -40,7 +39,7 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
 
         protected AbstractMoveToNamespaceService(IMoveToNamespaceOptionsService moveToNamespaceOptionsService)
         {
-            OptionsService = moveToNamespaceOptionsService ?? throw new ArgumentNullException(nameof(moveToNamespaceOptionsService));
+            OptionsService = moveToNamespaceOptionsService;
         }
 
         public async Task<ImmutableArray<AbstractMoveToNamespaceCodeAction>> GetCodeActionsAsync(
@@ -48,11 +47,16 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
             TextSpan span,
             CancellationToken cancellationToken)
         {
-            var typeAnalysisResult = await AnalyzeTypeAtPositionAsync(document, span.Start, cancellationToken).ConfigureAwait(false);
-
-            if (typeAnalysisResult.CanPerform)
+            // Code actions cannot be completed without the options needed
+            // to fill in missing information.
+            if (OptionsService != null)
             {
-                return ImmutableArray.Create(AbstractMoveToNamespaceCodeAction.Generate(this, typeAnalysisResult));
+                var typeAnalysisResult = await AnalyzeTypeAtPositionAsync(document, span.Start, cancellationToken).ConfigureAwait(false);
+
+                if (typeAnalysisResult.CanPerform)
+                {
+                    return ImmutableArray.Create(AbstractMoveToNamespaceCodeAction.Generate(this, typeAnalysisResult));
+                }
             }
 
             return ImmutableArray<AbstractMoveToNamespaceCodeAction>.Empty;

--- a/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/AbstractMoveToNamespaceService.cs
@@ -35,6 +35,13 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         protected abstract string GetNamespaceName(TNamedTypeDeclarationSyntax namedTypeSyntax);
         protected abstract bool IsContainedInNamespaceDeclaration(TNamespaceDeclarationSyntax namespaceSyntax, int position);
 
+        private readonly IMoveToNamespaceOptionsService _optionsService;
+
+        protected AbstractMoveToNamespaceService(IMoveToNamespaceOptionsService moveToNamespaceOptionsService)
+        {
+            _optionsService = moveToNamespaceOptionsService ?? throw new ArgumentNullException(nameof(moveToNamespaceOptionsService));
+        }
+
         public async Task<ImmutableArray<AbstractMoveToNamespaceCodeAction>> GetCodeActionsAsync(
             Document document,
             TextSpan span,
@@ -245,14 +252,8 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
             ImmutableArray<string> namespaces)
         {
             var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
-            var moveToNamespaceOptionsService = document.Project.Solution.Workspace.Services.GetService<IMoveToNamespaceOptionsService>();
 
-            if (moveToNamespaceOptionsService == null)
-            {
-                return MoveToNamespaceOptionsResult.Cancelled;
-            }
-
-            return moveToNamespaceOptionsService.GetChangeNamespaceOptions(
+            return _optionsService.GetChangeNamespaceOptions(
                 defaultNamespace,
                 namespaces,
                 syntaxFactsService);

--- a/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceCodeActionProvider.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceCodeActionProvider.cs
@@ -3,7 +3,6 @@
 using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.MoveToNamespace
 {
@@ -12,15 +11,17 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.MoveTypeToFile)]
     internal class MoveToNamespaceCodeActionProvider : CodeRefactoringProvider
     {
+        private readonly IMoveToNamespaceService _moveToNamespaceService;
+
         [ImportingConstructor]
-        public MoveToNamespaceCodeActionProvider()
+        public MoveToNamespaceCodeActionProvider(IMoveToNamespaceService moveToNamespaceService)
         {
+            _moveToNamespaceService = moveToNamespaceService;
         }
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
-            var service = context.Document.GetLanguageService<IMoveToNamespaceService>();
-            var actions = await service.GetCodeActionsAsync(context.Document, context.Span, context.CancellationToken).ConfigureAwait(false);
+            var actions = await _moveToNamespaceService.GetCodeActionsAsync(context.Document, context.Span, context.CancellationToken).ConfigureAwait(false);
             context.RegisterRefactorings(actions);
         }
     }

--- a/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceCodeActionProvider.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceCodeActionProvider.cs
@@ -3,6 +3,7 @@
 using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.MoveToNamespace
 {
@@ -11,17 +12,20 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
     [ExtensionOrder(After = PredefinedCodeRefactoringProviderNames.MoveTypeToFile)]
     internal class MoveToNamespaceCodeActionProvider : CodeRefactoringProvider
     {
-        private readonly IMoveToNamespaceService _moveToNamespaceService;
-
         [ImportingConstructor]
-        public MoveToNamespaceCodeActionProvider(IMoveToNamespaceService moveToNamespaceService)
+        public MoveToNamespaceCodeActionProvider()
         {
-            _moveToNamespaceService = moveToNamespaceService;
         }
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
-            var actions = await _moveToNamespaceService.GetCodeActionsAsync(context.Document, context.Span, context.CancellationToken).ConfigureAwait(false);
+            var moveToNamespaceService = context.Document.GetLanguageService<IMoveToNamespaceService>();
+            if (moveToNamespaceService == null)
+            {
+                return;
+            }
+
+            var actions = await moveToNamespaceService.GetCodeActionsAsync(context.Document, context.Span, context.CancellationToken).ConfigureAwait(false);
             context.RegisterRefactorings(actions);
         }
     }

--- a/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceCodeActionProvider.cs
+++ b/src/Features/Core/Portable/MoveToNamespace/MoveToNamespaceCodeActionProvider.cs
@@ -20,11 +20,6 @@ namespace Microsoft.CodeAnalysis.MoveToNamespace
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
             var moveToNamespaceService = context.Document.GetLanguageService<IMoveToNamespaceService>();
-            if (moveToNamespaceService == null)
-            {
-                return;
-            }
-
             var actions = await moveToNamespaceService.GetCodeActionsAsync(context.Document, context.Span, context.CancellationToken).ConfigureAwait(false);
             context.RegisterRefactorings(actions);
         }

--- a/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/MoveToNamespace/VisualStudioMoveToNamespaceOptionsService.cs
@@ -2,13 +2,12 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.MoveToNamespace;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.MoveToNamespace
 {
-    [ExportWorkspaceService(typeof(IMoveToNamespaceOptionsService), layer: ServiceLayer.Host), Shared]
+    [Export(typeof(IMoveToNamespaceOptionsService)), Shared]
     internal class VisualStudioMoveToNamespaceOptionsService : IMoveToNamespaceOptionsService
     {
         [ImportingConstructor]


### PR DESCRIPTION
Fixes #35577 