### PR TITLE
Re-enable MSBuildWorkspaceTests.TestEditorConfigDiscovery

### DIFF
--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3638,12 +3638,17 @@ class C { }";
 
             CreateFiles(files);
 
+            string expectedEditorConfigPath = SolutionDirectory.CreateOrOpenFile(".editorconfig").Path;
+
             using (var workspace = CreateMSBuildWorkspace())
             {
                 var projectFullPath = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
 
                 var project = await workspace.OpenProjectAsync(projectFullPath);
-                var analyzerConfigDocument = Assert.Single(project.AnalyzerConfigDocuments);
+
+                // We should have exactly one .editorconfig corresponding to the file we had. We may also
+                // have other files if there is a .editorconfig floating around somewhere higher on the disk.
+                var analyzerConfigDocument = Assert.Single(project.AnalyzerConfigDocuments.Where(d => d.FilePath == expectedEditorConfigPath));
                 Assert.Equal(".editorconfig", analyzerConfigDocument.Name);
                 var text = await analyzerConfigDocument.GetTextAsync();
                 Assert.Equal("root = true", text.ToString());

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -25,6 +25,7 @@ using static Microsoft.CodeAnalysis.MSBuild.UnitTests.SolutionGeneration;
 using static Microsoft.CodeAnalysis.CSharp.LanguageVersionFacts;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
 {
@@ -3628,7 +3629,7 @@ class C { }";
             }
         }
 
-        [ConditionalFact(typeof(VisualStudioMSBuildInstalled), AlwaysSkip = "https://github.com/dotnet/core-eng/issues/6424"), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [ConditionalFact(typeof(VisualStudio16_2OrHigherMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         public async Task TestEditorConfigDiscovery()
         {
             var files = GetSimpleCSharpSolutionFiles()
@@ -3649,7 +3650,7 @@ class C { }";
             }
         }
 
-        [ConditionalFact(typeof(VisualStudioMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
+        [ConditionalFact(typeof(VisualStudio16_2OrHigherMSBuildInstalled)), Trait(Traits.Feature, Traits.Features.MSBuildWorkspace)]
         public async Task TestEditorConfigDiscoveryDisabled()
         {
             var files = GetSimpleCSharpSolutionFiles()


### PR DESCRIPTION
Besides unskipping the test, we also had to update our test harness. We have to locate an MSBuild on the machine which is suitable for our use, once we found one we just used that. On our machines we have both 15.9 and 16.2 (as of this writing), but we always picked 15.9. Now, we look for the highest version and will add binding redirects to that one; we can also filter tests to a specific minimum version if necessary. It's critical we always find the highest version when first setting up -- we have to add binding logic to make sure we load that; if we loaded a lower version for a test that had a lower minimum version, we wouldn't be able to run another test later.