### PR TITLE
Fix #33560 Handle equal tokens where Text is not available.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -288,6 +288,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         public static bool AreTwoTokensOnSameLine(SyntaxToken token1, SyntaxToken token2)
         {
+            if (token1 == token2) return true;
+
             var tree = token1.SyntaxTree;
             if (tree != null && tree.TryGetText(out var text))
             {

--- a/src/Workspaces/CoreTest/UtilityTest/FormattingRangeHelperTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FormattingRangeHelperTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.UtilityTest
+{
+    public class FormattingRangeHelperTests
+    {
+        [Fact]
+        public void TestAreTwoTokensOnSameLineTrue()
+        {
+            var root = SyntaxFactory.ParseSyntaxTree("{Foo();}").GetRoot();
+            var token1 = root.GetFirstToken();
+            var token2 = root.GetLastToken();
+
+            Assert.True(FormattingRangeHelper.AreTwoTokensOnSameLine(token1, token2));
+        }
+
+        [Fact]
+        public void TestAreTwoTokensOnSameLineFalse()
+        {
+            var root = SyntaxFactory.ParseSyntaxTree("{Fizz();\nBuzz();}").GetRoot();
+            var token1 = root.GetFirstToken();
+            var token2 = root.GetLastToken();
+
+            Assert.False(FormattingRangeHelper.AreTwoTokensOnSameLine(token1, token2));
+        }
+
+        [Fact]
+        public void TestAreTwoTokensOnSameLineWithEqualTokens()
+        {
+            var token = SyntaxFactory.ParseSyntaxTree("else\nFoo();").GetRoot().GetFirstToken();
+
+            Assert.True(FormattingRangeHelper.AreTwoTokensOnSameLine(token, token));
+        }
+
+        [Fact]
+        public void TestAreTwoTokensOnSameLineWithEqualTokensWithoutSyntaxTree()
+        {
+            var token = SyntaxFactory.ParseToken("else");
+
+            Assert.True(FormattingRangeHelper.AreTwoTokensOnSameLine(token, token));
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/UtilityTest/FormattingRangeHelperTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/FormattingRangeHelperTests.cs
@@ -2,12 +2,14 @@
 
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.UtilityTest
 {
     public class FormattingRangeHelperTests
     {
+        [WorkItem(33560, "https://github.com/dotnet/roslyn/issues/33560")]
         [Fact]
         public void TestAreTwoTokensOnSameLineTrue()
         {
@@ -18,6 +20,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.UtilityTest
             Assert.True(FormattingRangeHelper.AreTwoTokensOnSameLine(token1, token2));
         }
 
+        [WorkItem(33560, "https://github.com/dotnet/roslyn/issues/33560")]
         [Fact]
         public void TestAreTwoTokensOnSameLineFalse()
         {
@@ -28,6 +31,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.UtilityTest
             Assert.False(FormattingRangeHelper.AreTwoTokensOnSameLine(token1, token2));
         }
 
+        [WorkItem(33560, "https://github.com/dotnet/roslyn/issues/33560")]
         [Fact]
         public void TestAreTwoTokensOnSameLineWithEqualTokens()
         {
@@ -36,6 +40,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.UtilityTest
             Assert.True(FormattingRangeHelper.AreTwoTokensOnSameLine(token, token));
         }
 
+        [WorkItem(33560, "https://github.com/dotnet/roslyn/issues/33560")]
         [Fact]
         public void TestAreTwoTokensOnSameLineWithEqualTokensWithoutSyntaxTree()
         {


### PR DESCRIPTION
Fixes #33560
I updated the helper method `AreTwoTokensOnSameLine` to exit early when the provided tokens are equal. This prevents an exception from being thrown when equal tokens are provided and the `SyntaxTree` is null or the `SyntaxTree.TryGetText()` call fails. I added unit tests to cover basic regressions as well as the erroneous case above.