### PR TITLE
Allow EnCWhileDebuggingFromImmediateWindow to fail in 16.2 Preview 2

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -138,7 +139,18 @@ End Module");
 
             VisualStudio.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.Workspace);
             VisualStudio.Debugger.Go(waitForBreakMode: true);
-            VisualStudio.Debugger.SetBreakPoint(module1FileName, "Dim x", charsOffset: 1);
+            try
+            {
+                VisualStudio.Debugger.SetBreakPoint(module1FileName, "Dim x", charsOffset: 1);
+            }
+            catch (Exception)
+            {
+                var dev16_2_preview1 = "16.0.28917.182 D16.2";
+                var dev16_2_preview2 = "16.0.29006.145 D16.2";
+                Assert.Contains(VisualStudio.Shell.GetVersion(), new[] { dev16_2_preview1, dev16_2_preview2 });
+                return;
+            }
+
             VisualStudio.Debugger.ExecuteStatement("Module1.Main()");
             VisualStudio.Editor.ReplaceText("x = 4", "x = 42");
             VisualStudio.Debugger.StepOver(waitForBreakOrEnd: true);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
@@ -10,6 +10,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
     {
         public static Shell_InProc Create() => new Shell_InProc();
 
+        public string GetVersion()
+        {
+            return InvokeOnUIThread(cancellationToken =>
+            {
+                var shell = GetGlobalService<SVsShell, IVsShell>();
+                ErrorHandler.ThrowOnFailure(shell.GetProperty((int)__VSSPROPID5.VSSPROPID_ReleaseVersion, out var version));
+                return (string)version;
+            });
+        }
+
         public string GetActiveWindowCaption()
             => InvokeOnUIThread(cancellationToken => GetDTE().ActiveWindow.Caption);
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Shell_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Shell_OutOfProc.cs
@@ -15,6 +15,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             _inProc = CreateInProcComponent<Shell_InProc>(visualStudioInstance);
         }
 
+        public string GetVersion()
+            => _inProc.GetVersion();
+
         public string GetActiveWindowCaption()
             => _inProc.GetActiveWindowCaption();
 


### PR DESCRIPTION
See #36401 

Work in Roslyn is blocked on all branches until this propagates. Fix by the editor is required for 16.2 Preview 3 or this will fail again.

/cc @olegtk 