### PR TITLE
Fix parsing bug in invalid using statements

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8289,6 +8289,7 @@ tryAgain:
             {
                 usingKeyword = CheckFeatureAvailability(usingKeyword, MessageID.IDS_FeatureUsingDeclarations);
             }
+            bool canParseAsLocalFunction = usingKeyword == default;
 
             var mods = _pool.Allocate();
             this.ParseDeclarationModifiers(mods);
@@ -8299,7 +8300,7 @@ tryAgain:
                 TypeSyntax type;
                 LocalFunctionStatementSyntax localFunction;
                 this.ParseLocalDeclaration(variables,
-                    allowLocalFunctions: usingKeyword == default,
+                    allowLocalFunctions: canParseAsLocalFunction,
                     mods: mods.ToList(),
                     type: out type,
                     localFunction: out localFunction);
@@ -8312,7 +8313,8 @@ tryAgain:
 
                 // If we find an accessibility modifier but no local function it's likely
                 // the user forgot a closing brace. Let's back out of statement parsing.
-                if (mods.Count > 0 &&
+                if (canParseAsLocalFunction &&
+                    mods.Count > 0 &&
                     IsAccessibilityModifier(((SyntaxToken)mods[0]).ContextualKind))
                 {
                     return null;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
@@ -767,6 +768,30 @@ class C4
                 // (40,15): warning CS0612: 'S3.Dispose()' is obsolete
                 //         using S3 S3 = new S3();
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "using S3 S3 = new S3();").WithArguments("S3.Dispose()").WithLocation(40, 9)
+                );
+        }
+
+        [Fact]
+        [WorkItem(36413, "https://github.com/dotnet/roslyn/issues/36413")]
+        public void UsingDeclarationsWithInvalidModifiers()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main()
+    {
+        using public readonly var x = (IDisposable)null;
+    }
+}
+";
+            CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+                // (7,15): error CS0106: The modifier 'public' is not valid for this item
+                //         using public readonly var x = (IDisposable)null;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "public").WithArguments("public").WithLocation(7, 15),
+                // (7,22): error CS0106: The modifier 'readonly' is not valid for this item
+                //         using public readonly var x = (IDisposable)null;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "readonly").WithArguments("readonly").WithLocation(7, 22)
                 );
         }
     }


### PR DESCRIPTION
Don't exit early when parsing invalid local declarations if we know that it couldn't be a local function

Fixes https://github.com/dotnet/roslyn/issues/36413