### PR TITLE
Revert "Revert RestrictedIVTs in M.VS.LanguageServices.csproj"

### DIFF
--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -118,9 +118,9 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" Key="$(TypeScriptKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35077" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.TypeScript" Key="$(TypeScriptKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35077" />
     <InternalsVisibleTo Include="Roslyn.Services.Editor.TypeScript.UnitTests" Key="$(TypeScriptKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35077" />
-    <InternalsVisibleTo Include="ManagedSourceCodeAnalysis" Key="$(TypeScriptKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35080" />
-    <InternalsVisibleTo Include="CodeAnalysis" Key="$(TypeScriptKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35080" />
-    <InternalsVisibleTo Include="StanCore" Key="$(TypeScriptKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35080" />
+    <RestrictedInternalsVisibleTo Include="ManagedSourceCodeAnalysis" Key="$(TypeScriptKey)" Partner="LegacyCodeAnalysis" />
+    <RestrictedInternalsVisibleTo Include="CodeAnalysis" Key="$(TypeScriptKey)" Partner="LegacyCodeAnalysis" />
+    <RestrictedInternalsVisibleTo Include="StanCore" Key="$(TypeScriptKey)" Partner="LegacyCodeAnalysis" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote" Key="$(RemoteLanguageServiceKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35074" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote.15.7" Key="$(RemoteLanguageServiceKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35074" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Remote.15.8" Key="$(RemoteLanguageServiceKey)" WorkItem="https://github.com/dotnet/roslyn/issues/35074" />


### PR DESCRIPTION
Reverts dotnet/roslyn#36445

The underlying issue was a XAML project (StanCore) not referencing Microsoft.CodeAnalysis.Workspaces, the assembly where `RestrictedInternalsVisibleToAttribute` is defined. The XAML compiler examines assembly attributes, and the lack of this reference meant an exception was thrown when the restricted IVT attribute usage was reached.