### PR TITLE
Add a bunch of nullability support to some code generation helpers

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/EventGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/EventGenerator.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         AttributeGenerator.GenerateAttributeLists(@event.GetAttributes(), options),
                         GenerateModifiers(@event, destination, options),
                         SyntaxFactory.VariableDeclaration(
-                            @event.Type.GenerateTypeSyntax(),
+                            @event.Type.WithNullability(@event.NullableAnnotation).GenerateTypeSyntax(),
                             SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(@event.Name.ToIdentifierToken()))))));
         }
 
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return AddFormatterAndCodeGeneratorAnnotationsTo(SyntaxFactory.EventDeclaration(
                 attributeLists: AttributeGenerator.GenerateAttributeLists(@event.GetAttributes(), options),
                 modifiers: GenerateModifiers(@event, destination, options),
-                type: @event.Type.GenerateTypeSyntax(),
+                type: @event.Type.WithNullability(@event.NullableAnnotation).GenerateTypeSyntax(),
                 explicitInterfaceSpecifier: explicitInterfaceSpecifier,
                 identifier: @event.Name.ToIdentifierToken(),
                 accessorList: GenerateAccessorList(@event, destination, options)));

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/FieldGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/FieldGenerator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 AttributeGenerator.GenerateAttributeLists(field.GetAttributes(), options),
                 GenerateModifiers(field, options),
                 SyntaxFactory.VariableDeclaration(
-                    field.Type.GenerateTypeSyntax(),
+                    field.Type.WithNullability(field.NullableAnnotation).GenerateTypeSyntax(),
                     SyntaxFactory.SingletonSeparatedList(
                         AddAnnotationsTo(field, SyntaxFactory.VariableDeclarator(field.Name.ToIdentifierToken(), null, initializer)))));
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/ParameterGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/ParameterGenerator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return SyntaxFactory.Parameter(p.Name.ToIdentifierToken())
                     .WithAttributeLists(GenerateAttributes(p, isExplicit, options))
                     .WithModifiers(GenerateModifiers(p, isFirstParam))
-                    .WithType(p.Type.GenerateTypeSyntax())
+                    .WithType(p.Type.WithNullability(p.NullableAnnotation).GenerateTypeSyntax())
                     .WithDefault(GenerateEqualsValueClause(p, isExplicit, seenOptional));
         }
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var declaration = SyntaxFactory.IndexerDeclaration(
                     attributeLists: AttributeGenerator.GenerateAttributeLists(property.GetAttributes(), options),
                     modifiers: GenerateModifiers(property, destination, options),
-                    type: property.GenerateTypeSyntax(),
+                    type: GenerateTypeSyntax(property),
                     explicitInterfaceSpecifier: explicitInterfaceSpecifier,
                     parameterList: ParameterGenerator.GenerateBracketedParameterList(property.Parameters, explicitInterfaceSpecifier != null, options),
                     accessorList: GenerateAccessorList(property, destination, workspace, options, parseOptions));
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var propertyDeclaration = SyntaxFactory.PropertyDeclaration(
                 attributeLists: AttributeGenerator.GenerateAttributeLists(property.GetAttributes(), options),
                 modifiers: GenerateModifiers(property, destination, options),
-                type: property.GenerateTypeSyntax(),
+                type: GenerateTypeSyntax(property),
                 explicitInterfaceSpecifier: explicitInterfaceSpecifier,
                 identifier: property.Name.ToIdentifierToken(),
                 accessorList: accessorList,
@@ -138,6 +138,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return AddFormatterAndCodeGeneratorAnnotationsTo(
                 AddAnnotationsTo(property, propertyDeclaration));
         }
+
+        private static TypeSyntax GenerateTypeSyntax(IPropertySymbol property)
+        {
+            var returnType = property.Type.WithNullability(property.NullableAnnotation);
+
+            if (property.ReturnsByRef)
+            {
+                return returnType.GenerateRefTypeSyntax();
+            }
+            else if (property.ReturnsByRefReadonly)
+            {
+                return returnType.GenerateRefReadOnlyTypeSyntax();
+            }
+            else
+            {
+                return returnType.GenerateTypeSyntax();
+            }
+        }
+
 
         private static bool TryGetExpressionBody(
             BasePropertyDeclarationSyntax baseProperty, ParseOptions options, ExpressionBodyPreference preference,

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
@@ -109,22 +109,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
         }
 
-        public static TypeSyntax GenerateTypeSyntax(this IPropertySymbol property)
-        {
-            if (property.ReturnsByRef)
-            {
-                return property.Type.GenerateRefTypeSyntax();
-            }
-            else if (property.ReturnsByRefReadonly)
-            {
-                return property.Type.GenerateRefReadOnlyTypeSyntax();
-            }
-            else
-            {
-                return property.Type.GenerateTypeSyntax();
-            }
-        }
-
         public static TypeSyntax StripRefIfNeeded(this TypeSyntax type)
             => type is RefTypeSyntax refType ? refType.Type : type;
     }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public NullableAnnotation ElementNullableAnnotation => throw new System.NotImplementedException();
+        public NullableAnnotation ElementNullableAnnotation => ElementType.GetNullability();
 
         public bool Equals(IArrayTypeSymbol other)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     internal class CodeGenerationEventSymbol : CodeGenerationSymbol, IEventSymbol
     {
         public ITypeSymbol Type { get; }
-        public NullableAnnotation NullableAnnotation => throw new NotImplementedException();
+        public NullableAnnotation NullableAnnotation => Type.GetNullability();
 
         public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations { get; }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     internal class CodeGenerationFieldSymbol : CodeGenerationSymbol, IFieldSymbol
     {
         public ITypeSymbol Type { get; }
-        public NullableAnnotation NullableAnnotation => throw new NotImplementedException();
+        public NullableAnnotation NullableAnnotation => Type.GetNullability();
         public object ConstantValue { get; }
         public bool HasConstantValue { get; }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public RefKind RefKind { get; }
         public bool IsParams { get; }
         public ITypeSymbol Type { get; }
-        public NullableAnnotation NullableAnnotation => throw new NotImplementedException();
+        public NullableAnnotation NullableAnnotation => Type.GetNullability();
         public bool IsOptional { get; }
         public int Ordinal { get; }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     {
         private RefKind _refKind;
         public ITypeSymbol Type { get; }
-        public NullableAnnotation NullableAnnotation { get; }
+        public NullableAnnotation NullableAnnotation => Type.GetNullability();
         public bool IsIndexer { get; }
 
         public ImmutableArray<IParameterSymbol> Parameters { get; }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -92,6 +92,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public NullableAnnotation ReferenceTypeConstraintNullableAnnotation => throw new System.NotImplementedException();
 
-        public ImmutableArray<NullableAnnotation> ConstraintNullableAnnotations => throw new System.NotImplementedException();
+        public ImmutableArray<NullableAnnotation> ConstraintNullableAnnotations => ConstraintTypes.SelectAsArray(t => t.GetNullability());
     }
 }


### PR DESCRIPTION
This adds more generic plumbing for nullability support to some common helpers. This will ultimately be tested by the code that calls these helpers (which is probably going to be metadata as source which should come very soonish.)