### PR TITLE
Added null checks on F# external access services

### DIFF
--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public FSharpInlineRenameLocationSet(IFSharpInlineRenameLocationSet set)
         {
             _set = set;
-            _locations = set.Locations.Select(x => new InlineRenameLocation(x.Document, x.TextSpan)).ToList();
+            _locations = set.Locations?.Select(x => new InlineRenameLocation(x.Document, x.TextSpan)).ToList();
         }
 
         public IList<InlineRenameLocation> Locations => _locations;
@@ -90,7 +90,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public async Task<IInlineRenameReplacementInfo> GetReplacementsAsync(string replacementText, OptionSet optionSet, CancellationToken cancellationToken)
         {
             var info = await _set.GetReplacementsAsync(replacementText, optionSet, cancellationToken).ConfigureAwait(false);
-            return new FSharpInlineRenameReplacementInfo(info);
+            if (info != null)
+            {
+                return new FSharpInlineRenameReplacementInfo(info);
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 
@@ -122,7 +129,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public async Task<IInlineRenameLocationSet> FindRenameLocationsAsync(OptionSet optionSet, CancellationToken cancellationToken)
         {
             var set = await _info.FindRenameLocationsAsync(optionSet, cancellationToken).ConfigureAwait(false);
-            return new FSharpInlineRenameLocationSet(set);
+            if (set != null)
+            {
+                return new FSharpInlineRenameLocationSet(set);
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public TextSpan? GetConflictEditSpan(InlineRenameLocation location, string replacementText, CancellationToken cancellationToken)
@@ -167,7 +181,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public async Task<IInlineRenameInfo> GetRenameInfoAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var info = await _service.GetRenameInfoAsync(document, position, cancellationToken).ConfigureAwait(false);
-            return new FSharpInlineRenameInfo(info);
+            if (info != null)
+            {
+                return new FSharpInlineRenameInfo(info);
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpEditorInlineRenameService.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
 
         public IEnumerable<InlineRenameReplacement> GetReplacements(DocumentId documentId)
         {
-            return _info.GetReplacements(documentId).Select(x =>
+            return _info.GetReplacements(documentId)?.Select(x =>
                 new InlineRenameReplacement(FSharpInlineRenameReplacementKindHelpers.ConvertTo(x.Kind), x.OriginalSpan, x.NewSpan));
         }
     }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpGoToDefinitionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpGoToDefinitionService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public async Task<IEnumerable<INavigableItem>> FindDefinitionsAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var items = await _service.FindDefinitionsAsync(document, position, cancellationToken).ConfigureAwait(false);
-            return items.Select(x => new InternalFSharpNavigableItem(x));
+            return items?.Select(x => new InternalFSharpNavigableItem(x));
         }
 
         public bool TryGoToDefinition(Document document, int position, CancellationToken cancellationToken)

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
         public async Task<IList<NavigationBarItem>> GetItemsAsync(Document document, CancellationToken cancellationToken)
         {
             var items = await _service.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
-            return items.Select(x => ConvertToNavigationBarItem(x)).ToList();
+            return items?.Select(x => ConvertToNavigationBarItem(x)).ToList();
         }
 
         public void NavigateToItem(Document document, NavigationBarItem item, ITextView view, CancellationToken cancellationToken)

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/FSharpNavigationBarItemService.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor
                     item.Text,
                     FSharpGlyphHelpers.ConvertTo(item.Glyph),
                     item.Spans,
-                    item.ChildItems.Select(x => ConvertToNavigationBarItem(x)).ToList(),
+                    item.ChildItems?.Select(x => ConvertToNavigationBarItem(x)).ToList(),
                     item.Indent,
                     item.Bolded,
                     item.Grayed);

--- a/src/Tools/ExternalAccess/FSharp/Internal/Editor/Implementation/Debugging/FSharpBreakpointResolutionService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Editor/Implementation/Debugging/FSharpBreakpointResolutionService.cs
@@ -28,13 +28,20 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor.Implement
         public async Task<CodeAnalysis.Editor.Implementation.Debugging.BreakpointResolutionResult> ResolveBreakpointAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken = default)
         {
             var result = await _service.ResolveBreakpointAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
-            if (result.IsLineBreakpoint)
+            if (result != null)
             {
-                return CodeAnalysis.Editor.Implementation.Debugging.BreakpointResolutionResult.CreateLineResult(result.Document, result.LocationNameOpt);
+                if (result.IsLineBreakpoint)
+                {
+                    return CodeAnalysis.Editor.Implementation.Debugging.BreakpointResolutionResult.CreateLineResult(result.Document, result.LocationNameOpt);
+                }
+                else
+                {
+                    return CodeAnalysis.Editor.Implementation.Debugging.BreakpointResolutionResult.CreateSpanResult(result.Document, result.TextSpan, result.LocationNameOpt);
+                }
             }
             else
             {
-                return CodeAnalysis.Editor.Implementation.Debugging.BreakpointResolutionResult.CreateSpanResult(result.Document, result.TextSpan, result.LocationNameOpt);
+                return null;
             }
         }
 

--- a/src/Tools/ExternalAccess/FSharp/Internal/SignatureHelp/FSharpSignatureHelpProvider.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/SignatureHelp/FSharpSignatureHelpProvider.cs
@@ -30,29 +30,36 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.SignatureHelp
             var mappedTriggerInfo = new FSharpSignatureHelpTriggerInfo(mappedTriggerReason, triggerInfo.TriggerCharacter);
             var mappedSignatureHelpItems = await _provider.GetItemsAsync(document, position, mappedTriggerInfo, cancellationToken).ConfigureAwait(false);
 
-            return new SignatureHelpItems(
-                mappedSignatureHelpItems.Items.Select(x =>
-                    new SignatureHelpItem(
-                        x.IsVariadic,
-                        x.DocumentationFactory,
-                        x.PrefixDisplayParts,
-                        x.SeparatorDisplayParts,
-                        x.SuffixDisplayParts,
-                        x.Parameters.Select(y =>
-                            new SignatureHelpParameter(
-                                y.Name,
-                                y.IsOptional,
-                                y.DocumentationFactory,
-                                y.DisplayParts,
-                                y.PrefixDisplayParts,
-                                y.SuffixDisplayParts,
-                                y.SelectedDisplayParts)).ToList(),
-                        x.DescriptionParts)).ToList(),
-                mappedSignatureHelpItems.ApplicableSpan,
-                mappedSignatureHelpItems.ArgumentIndex,
-                mappedSignatureHelpItems.ArgumentCount,
-                mappedSignatureHelpItems.ArgumentName,
-                mappedSignatureHelpItems.SelectedItemIndex);
+            if (mappedSignatureHelpItems != null)
+            {
+                return new SignatureHelpItems(
+                    mappedSignatureHelpItems.Items?.Select(x =>
+                        new SignatureHelpItem(
+                            x.IsVariadic,
+                            x.DocumentationFactory,
+                            x.PrefixDisplayParts,
+                            x.SeparatorDisplayParts,
+                            x.SuffixDisplayParts,
+                            x.Parameters.Select(y =>
+                                new SignatureHelpParameter(
+                                    y.Name,
+                                    y.IsOptional,
+                                    y.DocumentationFactory,
+                                    y.DisplayParts,
+                                    y.PrefixDisplayParts,
+                                    y.SuffixDisplayParts,
+                                    y.SelectedDisplayParts)).ToList(),
+                            x.DescriptionParts)).ToList(),
+                    mappedSignatureHelpItems.ApplicableSpan,
+                    mappedSignatureHelpItems.ArgumentIndex,
+                    mappedSignatureHelpItems.ArgumentCount,
+                    mappedSignatureHelpItems.ArgumentName,
+                    mappedSignatureHelpItems.SelectedItemIndex);
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public bool IsRetriggerCharacter(char ch)

--- a/src/Tools/ExternalAccess/FSharp/Internal/Structure/FSharpBlockStructureService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Structure/FSharpBlockStructureService.cs
@@ -28,7 +28,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Structure
         public override async Task<BlockStructure> GetBlockStructureAsync(Document document, CancellationToken cancellationToken)
         {
             var blockStructure = await _service.GetBlockStructureAsync(document, cancellationToken).ConfigureAwait(false);
-            return new BlockStructure(blockStructure.Spans.SelectAsArray(x => new BlockSpan(x.Type, x.IsCollapsible, x.TextSpan, x.HintSpan, x.BannerText, x.AutoCollapse, x.IsDefaultCollapsed)));
+            if (blockStructure != null)
+            {
+                return new BlockStructure(blockStructure.Spans.SelectAsArray(x => new BlockSpan(x.Type, x.IsCollapsible, x.TextSpan, x.HintSpan, x.BannerText, x.AutoCollapse, x.IsDefaultCollapsed)));
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
We need to check for nulls when we map F# types to Roslyn types, vice versa, for the shim work. We got a crash in `FSharpSignatureHelpProvider` for this reason. I fixed the sig help provider, but I also put more null checks in the other places that potentially could need it.