### PR TITLE
return Guid.Default if no Guid is present in the project

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
@@ -60,6 +60,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return guid;
         }
 
+        public static Guid GetProjectGuidOrDefault(this IVsHierarchy hierarchy)
+            => hierarchy.TryGetProjectGuid(out var guid) ? guid : Guid.Empty;
+
         public static bool TryGetProjectGuid(this IVsHierarchy hierarchy, out Guid guid)
             => ErrorHandler.Succeeded(hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ProjectIDGuid, out guid)) && guid != Guid.Empty;
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/IVsHierarchyExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return guid;
         }
 
-        public static Guid GetProjectGuidOrDefault(this IVsHierarchy hierarchy)
+        public static Guid GetProjectGuidOrEmpty(this IVsHierarchy hierarchy)
             => hierarchy.TryGetProjectGuid(out var guid) ? guid : Guid.Empty;
 
         public static bool TryGetProjectGuid(this IVsHierarchy hierarchy, out Guid guid)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                     // projectSystemName because they'll have a better one eventually.
                     AssemblyName = projectSystemName,
                     FilePath = projectFilePath,
-                    ProjectGuid = hierarchy.GetProjectGuidOrDefault(),
+                    ProjectGuid = hierarchy.GetProjectGuidOrEmpty(),
                 });
 
             ((VisualStudioWorkspaceImpl)Workspace).AddProjectRuleSetFileToInternalMaps(

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                     // projectSystemName because they'll have a better one eventually.
                     AssemblyName = projectSystemName,
                     FilePath = projectFilePath,
-                    ProjectGuid = hierarchy.GetProjectGuid(),
+                    ProjectGuid = hierarchy.GetProjectGuidOrDefault(),
                 });
 
             ((VisualStudioWorkspaceImpl)Workspace).AddProjectRuleSetFileToInternalMaps(


### PR DESCRIPTION
In [this PR](https://github.com/dotnet/roslyn/pull/35746) we inadvertently made a change that would cause the language service to fail to initialize if there was no project guid.

Unfortunately there are a lot of projects in the world that depend on this behavior and it is unlikely that we could ship this way.

fixes [AB#915798](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/915798)

CC: @jinujoseph 