### PR TITLE
Preserve local function preceding whitespace for Issue #35489

### DIFF
--- a/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
@@ -359,5 +359,40 @@ class C
 }}",
 parseOptions: CSharp8ParseOptions);
         }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task TestLeadingTriviaBeforeComment(string leadingTrivia)
+        {
+            await TestInRegularAndScriptAsync(
+$@"using System;
+
+class C
+{{
+    void M()
+    {{{leadingTrivia}
+        //Local function comment
+        int [||]fibonacci(int n)
+        {{
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }}
+    }}
+}}",
+$@"using System;
+
+class C
+{{
+    void M()
+    {{{leadingTrivia}
+        //Local function comment
+        static int fibonacci(int n)
+        {{
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }}
+    }}
+}}",
+parseOptions: CSharp8ParseOptions);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
@@ -179,24 +179,26 @@ class C
 parseOptions: CSharp8ParseOptions);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
-        public async Task TestLeadingTriviaAfterSemicolon()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task TestLeadingTriviaAfterSemicolon(string leadingTrivia)
         {
             await TestInRegularAndScriptAsync(
-@"using System;
+$@"using System;
 
 class C
-{
+{{
     void M()
-    {
-        int x;
-
+    {{
+        int x;{leadingTrivia}
         int [||]fibonacci(int n)
-        {
+        {{
             return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
-        }
-    }
-}",
+        }}
+    }}
+}}",
 @"using System;
 
 class C
@@ -211,6 +213,150 @@ class C
         }
     }
 }",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task TestLeadingTriviaAfterOpenBrace(string leadingTrivia)
+        {
+            await TestInRegularAndScriptAsync(
+$@"using System;
+
+class C
+{{
+    void M()
+    {{{leadingTrivia}
+        int [||]fibonacci(int n)
+        {{
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }}
+    }}
+}}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        static int fibonacci(int n)
+        {
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task TestLeadingTriviaAfterLocalFunction(string leadingTrivia)
+        {
+            await TestInRegularAndScriptAsync(
+$@"using System;
+
+class C
+{{
+    void M()
+    {{
+        bool otherFunction()
+        {{
+            return true;
+        }}{leadingTrivia}
+        int [||]fibonacci(int n)
+        {{
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }}
+    }}
+}}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        bool otherFunction()
+        {
+            return true;
+        }
+
+        static int fibonacci(int n)
+        {
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task TestLeadingTriviaAfterExpressionBodyLocalFunction(string leadingTrivia)
+        {
+            await TestInRegularAndScriptAsync(
+$@"using System;
+
+class C
+{{
+    void M()
+    {{
+        bool otherFunction() => true;{leadingTrivia}
+        int [||]fibonacci(int n) => n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+    }}
+}}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        bool otherFunction() => true;
+
+        static int fibonacci(int n) => n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task TestLeadingTriviaAfterComment(string leadingTrivia)
+        {
+            await TestInRegularAndScriptAsync(
+$@"using System;
+
+class C
+{{
+    void M()
+    {{
+        //Local function comment{leadingTrivia}
+        int [||]fibonacci(int n)
+        {{
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }}
+    }}
+}}",
+$@"using System;
+
+class C
+{{
+    void M()
+    {{
+        //Local function comment{leadingTrivia}
+        static int fibonacci(int n)
+        {{
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }}
+    }}
+}}",
 parseOptions: CSharp8ParseOptions);
         }
     }

--- a/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
@@ -178,5 +178,40 @@ class C
 }",
 parseOptions: CSharp8ParseOptions);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
+        public async Task TestSurroundingTrivia()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+
+        int [||]fibonacci(int n)
+        {
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }
+
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+
+        static int fibonacci(int n)
+        {
+            return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+        }
+
+    }
+}",
+parseOptions: CSharp8ParseOptions);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeLocalFunctionStatic/MakeLocalFunctionStaticTests.cs
@@ -180,7 +180,7 @@ parseOptions: CSharp8ParseOptions);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeLocalFunctionStatic)]
-        public async Task TestSurroundingTrivia()
+        public async Task TestLeadingTriviaAfterSemicolon()
         {
             await TestInRegularAndScriptAsync(
 @"using System;
@@ -189,12 +189,12 @@ class C
 {
     void M()
     {
+        int x;
 
         int [||]fibonacci(int n)
         {
             return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
         }
-
     }
 }",
 @"using System;
@@ -203,12 +203,12 @@ class C
 {
     void M()
     {
+        int x;
 
         static int fibonacci(int n)
         {
             return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
         }
-
     }
 }",
 parseOptions: CSharp8ParseOptions);

--- a/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticCodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
                     localFunction,
                     (current, generator) => generator.WithModifiers(
                         current,
-                        generator.GetModifiers(current).WithIsStatic(true)).WithTriviaFrom(localFunction));
+                        generator.GetModifiers(current).WithIsStatic(true)));
             }
 
             return Task.CompletedTask;

--- a/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticCodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
                     localFunction,
                     (current, generator) => generator.WithModifiers(
                         current,
-                        generator.GetModifiers(current).WithIsStatic(true)));
+                        generator.GetModifiers(current).WithIsStatic(true)).WithTriviaFrom(localFunction));
             }
 
             return Task.CompletedTask;

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -424,6 +424,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 return currentToken.Parent is ExternAliasDirectiveSyntax ? 1 : 2;
             }
+            else if (currentToken.Parent is LocalFunctionStatementSyntax)
+            {
+                return 2;
+            }
             else
             {
                 return 1;


### PR DESCRIPTION
This resolves #35489 by preserving the original trivia in the 'Make local function static' code fix. 