### PR TITLE
Fix crash where type inference doing method inference needs to drop nullability

### DIFF
--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -3030,5 +3030,24 @@ class C
 
             await TestAsync(text, "global::Program", testNode: false);
         }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36046"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        public async Task TestInferringThroughGenericFunctionWithNullableReturn()
+        {
+            var text =
+@"#nullable enable
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        string? s = Identity([|input|]);
+    }
+
+    static T Identity<T>(T value) { return value; }
+}";
+
+            await TestAsync(text, "global::System.String?");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -618,7 +618,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return method;
                 }
 
-                var typeArguments = method.ConstructedFrom.TypeParameters.Select(tp => bestMap.GetValueOrDefault(tp) ?? tp).ToArray();
+                // TODO: pass nullability once https://github.com/dotnet/roslyn/issues/36046 is fixed
+                var typeArguments = method.ConstructedFrom.TypeParameters
+                    .Select(tp => (bestMap.GetValueOrDefault(tp) ?? tp).WithoutNullability()).ToArray();
                 return method.ConstructedFrom.Construct(typeArguments);
             }
 


### PR DESCRIPTION
I added a test to ensure the inferrer no longer crashes, but https://github.com/dotnet/roslyn/issues/36046 still blocks the ability for it to actually pass. The test is then added skipped until that works.