### PR TITLE
[WIP] Lower foreach over List<T> to for-loop

### DIFF
--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -497,6 +497,11 @@ namespace Microsoft.CodeAnalysis
         System_Threading_CancellationTokenSource__Token,
         System_Threading_CancellationTokenSource__Dispose,
 
+        System_Collections_Generic_List_T__get_Count,
+        System_Collections_Generic_List_T__get_Item,
+        // Replace with System_Collections_Generic_List_T__get_Version
+        System_Collections_Generic_List_T__get_Capacity,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3426,6 +3426,29 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+
+                 // System_Collections_Generic_List_T__get_Count
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)(WellKnownType.System_Collections_Generic_List_T),                                                   // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    0,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32, // Return Type
+
+                 // System_Collections_Generic_List_T__get_Item
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)(WellKnownType.System_Collections_Generic_List_T),                                                   // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    1,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                 // System_Collections_Generic_List_T__get_Capacity
+                 // Replace with System_Collections_Generic_List_T__get_Version
+                 (byte)(MemberFlags.PropertyGet),                                                                                                               // Flags
+                 (byte)(WellKnownType.System_Collections_Generic_List_T),                                                   // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                    0,                                                                                                                                          // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32, // Return Type
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3857,6 +3880,10 @@ namespace Microsoft.CodeAnalysis
                 "CreateLinkedTokenSource",                  // System_Threading_CancellationTokenSource__CreateLinkedTokenSource
                 "Token",                                    // System_Threading_CancellationTokenSource__Token
                 "Dispose",                                  // System_Threading_CancellationTokenSource__Dispose
+                "get_Count",                                // System_Collections_Generic_List_T__get_Count
+                "get_Item",                                 // System_Collections_Generic_List_T__get_Item
+                // get_Version
+                "get_Capacity",                             // System_Collections_Generic_List_T__get_Capacity
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);


### PR DESCRIPTION
# General

Lowering foreach iteration over List<T> to for loop, when applicable.

It came to me as quite the surprise when I found out that roslyn doesn't actually lower foreach loops to for
when iterating through a List<T>.  
Upon looking at the List<T> implementation I found out, that the reason why this isn't as trivial as for T[] is because List<T> keeps track of an internal version, which changes each time the list is modified.
As that internal version is not exposed publically this optimization would require a change in the List<T> API to allow the said version to be accessed.

By moving all the List<T>.Enumerator logic onto the callsite itself it would drastically increase performance in certain scenarios.
I would still need some further confirmation that this is actually a side-effect less optimization, I myself couldn't think of 
any possible things that could go wrong, but I may be completely missing something.

Currently using the Capacity property as a placeholder until the internal version of List<T> is exposed.

# Demonstration

## Initial C# code

```csharp
foreach (var x in some_list)
{
    // Do something with x
}
```

## Previous Roslyn translation 

```csharp
var enumerator = some_list.GetEnumerator();
try
{
    while (enumerator.MoveNext())
    {
        // Do something with enumerator.Current
    }
}
finally
{
    enumerator.Dispose();
}
```

## New roslyn translation

```csharp
int version = some_list.Version; // Version property does not currently exist
int i = 0;
while (i < some_list.Count)
{
    // Do something with some_list[i]
    if (version != some_list.Version)
    {
        throw new InvalidOperationException(); // Matching Exception message still needs to be passed to .ctor
    }
    i++;
}
```

# Benefits

Pro:
- Massive performance benefits when body of loop performs little work
    - In case of summing the length of all strings in List\<string\> up to 2.5x better performance
    - However, as the body of the loop does more work the benefits start to disintegrate
- ~~No allocation of Enumerator object~~ (Actually it shouldn't allocate as it is a struct Enumerator)

Con:
- Increased IL size (6 bytes per loop)
- Necessity of modifying the List\<T\> API in order to expose internal version 

## Benchmarks

This benchmark just sums up a list of integers for the first three results and the lengths of a list of strings for the last three.

![](https://media.discordapp.net/attachments/406551726896709632/590884755126353943/unknown.png)

# Considerations

There are a couple more things that have to be considered:

- Would this cause any side-effects?
- Would it cause issues when allowing lowering of types that derive from List\<T\>?
- Is it a good idea to expose the internal version field of List\<T\>?
    - If not, maybe a hashed version?
- Could/Should this be implemented in RyuJit to do runtime checking for List\<T\>, as e.g. IList\<T\> would not be lowered?

# Todo

Things that are yet to be completed, assuming aforementioned considerations are not going to be an issue:
- Add Tests
- Investigate/Implement possibility of allowing lowering of types that derive from List\<T\>
- Add API to expose internal version of List\<T\>
- Modify invoking InvalidOperationException constructor to take correct string argument
    - I am actually not quite sure how to do this as the no parameter constructor is already added as a WellKnownMember,
        so I can't add another one in WellKnownMembers.cs that takes one parameter, any help is appreciated!
- Modify PR to change WellKnownMember from System_Collections_Generic_List_T__get_Capacity to System_Collections_Generic_List_T__get_Version,
    once the Version API has been added