### PR TITLE
Set a non-fatal error handler that rethrows exceptions

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -59,14 +59,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             }
         }
 
-        // Same as setting the Handler property except that it avoids the assert.  This is useful in 
-        // test code which needs to verify the handler is called in specific cases and will continually
-        // overwrite this value.
-        public static void OverwriteHandler(Action<Exception> value)
-        {
-            s_fatalHandler = value;
-        }
-
         /// <summary>
         /// Use in an exception filter to report a fatal error. 
         /// Unless the exception is <see cref="OperationCanceledException"/> 

--- a/src/Workspaces/CoreTestUtilities/MEF/UseExportProviderAttribute.cs
+++ b/src/Workspaces/CoreTestUtilities/MEF/UseExportProviderAttribute.cs
@@ -5,11 +5,13 @@ using System.Collections.Generic;
 using System.Composition.Hosting;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Remote;
@@ -61,6 +63,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             CreateRemoteHostServices,
             LazyThreadSafetyMode.ExecutionAndPublication);
 
+        private static readonly Action<Exception> s_NonFatalErrorHandler =
+            e => ExceptionDispatchInfo.Capture(e).Throw();
+
         private MefHostServices _hostServices;
 
         public override void Before(MethodInfo methodUnderTest)
@@ -71,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             // make sure we enable this for all unit tests
             AsynchronousOperationListenerProvider.Enable(enable: true, diagnostics: true);
             ExportProviderCache.SetEnabled_OnlyUseExportProviderAttributeCanCall(true);
+            FatalError.NonFatalHandler = s_NonFatalErrorHandler;
         }
 
         /// <summary>


### PR DESCRIPTION
Without this our unit tests will throw non-fatal exceptions and just march on silently, making us unaware of bad things happening.