### PR TITLE
Change dotnet_diagnostic.*.severity settings to match code style

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -154,7 +154,7 @@ class C
 }");
             var analyzerConfig = dir.CreateFile(".editorconfig").WriteAllText(@"
 [*.cs]
-dotnet_diagnostic.cs0169.severity = suppress");
+dotnet_diagnostic.cs0169.severity = none");
             var cmd = CreateCSharpCompiler(null, dir.Path, new[] {
                 "/nologo",
                 "/t:library",
@@ -184,12 +184,12 @@ class C
             var additionalFile = dir.CreateFile("file.txt");
             var analyzerConfig = dir.CreateFile(".editorconfig").WriteAllText(@"
 [*.cs]
-dotnet_diagnostic.cs0169.severity = suppress
-dotnet_diagnostic.Warning01.severity = suppress
+dotnet_diagnostic.cs0169.severity = none
+dotnet_diagnostic.Warning01.severity = none
 my_option = my_val
 
 [*.txt]
-dotnet_diagnostic.cs0169.severity = suppress
+dotnet_diagnostic.cs0169.severity = none
 my_option2 = my_val2");
             var cmd = CreateCSharpCompiler(null, dir.Path, new[] {
                 "/nologo",

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -853,7 +853,7 @@ RoOt = TruE");
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic.cs000.severity = suppress
+dotnet_diagnostic.cs000.severity = none
 
 [*.vb]
 dotnet_diagnostic.cs000.severity = error", "/.editorconfig"));
@@ -876,7 +876,7 @@ dotnet_diagnostic.cs000.severity = error", "/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic.cs000.severity = suppress
+dotnet_diagnostic.cs000.severity = none
 
 [test.*]
 dotnet_diagnostic.cs000.severity = error", "/.editorconfig"));
@@ -899,13 +899,13 @@ dotnet_diagnostic.cs000.severity = error", "/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic.cs000.severity = suppress
+dotnet_diagnostic.cs000.severity = none
 
 [*.vb]
 dotnet_diagnostic.cs000.severity = error
 
 [{test.*]
-dotnet_diagnostic.cs000.severity = info"
+dotnet_diagnostic.cs000.severity = suggestion"
 , "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
@@ -926,8 +926,8 @@ dotnet_diagnostic.cs000.severity = info"
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic.cs000.severity = suppress
-dotnet_diagnostic.cs001.severity = info", "/.editorconfig"));
+dotnet_diagnostic.cs000.severity = none
+dotnet_diagnostic.cs001.severity = suggestion", "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
                 new[] { "/test.cs" },
@@ -943,15 +943,37 @@ dotnet_diagnostic.cs001.severity = info", "/.editorconfig"));
         }
 
         [Fact]
+        public void TwoTermsForHidden()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.severity = silent
+dotnet_diagnostic.cs001.severity = refactoring", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/test.cs" },
+                configs);
+            configs.Free();
+
+            Assert.Equal(new[]
+            {
+                CreateImmutableDictionary(
+                    ("cs000", ReportDiagnostic.Hidden),
+                    ("cs001", ReportDiagnostic.Hidden)),
+            }, options.Select(o => o.TreeOptions).ToArray());
+        }
+
+        [Fact]
         public void TwoSettingsDifferentSections()
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic.cs000.severity = suppress
+dotnet_diagnostic.cs000.severity = none
 
 [test.*]
-dotnet_diagnostic.cs001.severity = info", "/.editorconfig"));
+dotnet_diagnostic.cs001.severity = suggestion", "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
                 new[] { "/test.cs" },
@@ -972,13 +994,13 @@ dotnet_diagnostic.cs001.severity = info", "/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [**/*]
-dotnet_diagnostic.cs000.severity = suppress
+dotnet_diagnostic.cs000.severity = none
 
 [**test.*]
-dotnet_diagnostic.cs001.severity = info", "/.editorconfig"));
+dotnet_diagnostic.cs001.severity = suggestion", "/.editorconfig"));
             configs.Add(Parse(@"
 [**]
-dotnet_diagnostic.cs000.severity = warn
+dotnet_diagnostic.cs000.severity = warning
 
 [test.cs]
 dotnet_diagnostic.cs001.severity = error", "/subdir/.editorconfig"));
@@ -1005,10 +1027,10 @@ dotnet_diagnostic.cs001.severity = error", "/subdir/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [**/*]
-dotnet_diagnostic.cs000.severity = suppress
+dotnet_diagnostic.cs000.severity = none
 
 [**test.cs]
-dotnet_diagnostic.cs001.severity = info", "/.editorconfig"));
+dotnet_diagnostic.cs001.severity = suggestion", "/.editorconfig"));
             configs.Add(Parse(@"
 [test.cs]
 dotnet_diagnostic.cs001.severity = error", "/subdir/.editorconfig"));
@@ -1036,7 +1058,7 @@ dotnet_diagnostic.cs001.severity = error", "/subdir/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic.cs000.severity = suppress", "Z:\\.editorconfig"));
+dotnet_diagnostic.cs000.severity = none", "Z:\\.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
                 new[] { "Z:\\test.cs" },
@@ -1187,7 +1209,7 @@ dotnet_diagnostic.cs000.some_key = some_other_val", "/subdir/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [*.cs]
-dotnet_diagnostic..severity = warn
+dotnet_diagnostic..severity = warning
 dotnet_diagnostic..some_key = some_val", "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
@@ -1247,7 +1269,7 @@ dotnet_diagnostic.some_key = some_val", "/.editorconfig"));
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
             configs.Add(Parse(@"
 [a{-10..0}b{0..10}.cs]
-dotnet_diagnostic.cs000.severity = warn", "/.editorconfig"));
+dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
 
             var options = GetAnalyzerConfigOptions(
                 new[] { "/a0b0.cs", "/test/a-5b5.cs", "/a0b0.vb" },

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -165,19 +165,19 @@ namespace Microsoft.CodeAnalysis
                         {
                             severity = ReportDiagnostic.Error;
                         }
-                        else if (comparer.Equals(value, "warn"))
+                        else if (comparer.Equals(value, "warning"))
                         {
                             severity = ReportDiagnostic.Warn;
                         }
-                        else if (comparer.Equals(value, "info"))
+                        else if (comparer.Equals(value, "suggestion"))
                         {
                             severity = ReportDiagnostic.Info;
                         }
-                        else if (comparer.Equals(value, "hidden"))
+                        else if (comparer.Equals(value, "silent") || comparer.Equals(value, "refactoring"))
                         {
                             severity = ReportDiagnostic.Hidden;
                         }
-                        else if (comparer.Equals(value, "suppress"))
+                        else if (comparer.Equals(value, "none"))
                         {
                             severity = ReportDiagnostic.Suppress;
                         }

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -66,7 +66,7 @@ End Class")
             Dim additionalFile = dir.CreateFile("file.txt")
             Dim analyzerConfig = dir.CreateFile(".editorconfig").WriteAllText("
 [*.vb]
-dotnet_diagnostic.bc42024.severity = suppress")
+dotnet_diagnostic.bc42024.severity = none")
             Dim cmd = New MockVisualBasicCompiler(Nothing, dir.Path, {
                 "/nologo",
                 "/t:library",
@@ -96,13 +96,13 @@ End Class")
             Dim additionalFile = dir.CreateFile("file.txt")
             Dim analyzerConfig = dir.CreateFile(".editorconfig").WriteAllText("
 [*.vb]
-dotnet_diagnostic.bc42024.severity = suppress
-dotnet_diagnostic.warning01.severity = suppress
-dotnet_diagnostic.Warning03.severity = suppress
+dotnet_diagnostic.bc42024.severity = none
+dotnet_diagnostic.warning01.severity = none
+dotnet_diagnostic.Warning03.severity = none
 my_option = my_val
 
 [*.txt]
-dotnet_diagnostic.bc42024.severity = suppress
+dotnet_diagnostic.bc42024.severity = none
 my_option2 = my_val2")
             Dim cmd = New MockVisualBasicCompiler(Nothing, dir.Path, {
                 "/nologo",


### PR DESCRIPTION
The code style settings we already had in a .editorconfig file supplied a set of terms to set different diagnostic severities. The terms don't match the underlying compiler enum, but we will adopt them for setting compiler diagnostic settings as well to keep the values consistent inside a .editorconfig file.

Fixes https://github.com/dotnet/roslyn/issues/35690