### PR TITLE
Use the arcade toolset project to build in determinism

### DIFF
--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -53,7 +53,7 @@ function Run-Build([string]$rootDir, [string]$logFileName) {
      /p:DebugDeterminism=true `
      /p:Features="debug-determinism" `
      /p:DeployExtension=false `
-     /p:RepoRoot=$RepoRoot `
+     /p:RepoRoot=$rootDir `
      /p:TreatWarningsAsErrors=true `
      /bl:$logFilePath
 }

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -37,11 +37,25 @@ function Run-Build([string]$rootDir, [string]$logFileName) {
 
   $solution = Join-Path $rootDir "Roslyn.sln"
 
-  Write-Host "Restoring $solution"
-  Run-MSBuild $solution "/t:Restore" -logFileName:"Restore-$logFileName"
+  $toolsetBuildProj = InitializeToolset
+
+  if ($logFileName -eq "") {
+    $logFileName = [IO.Path]::GetFileNameWithoutExtension($projectFilePath)
+  }
+  $logFileName = [IO.Path]::ChangeExtension($logFileName, ".binlog")
+  $logFilePath = Join-Path $LogDir $logFileName
 
   Write-Host "Building $solution"
-  Run-MSBuild $solution "/p:DebugDeterminism=true /p:Features=`"debug-determinism`" /p:DeployExtension=false" -logFileName:$logFileName
+  MSBuild $toolsetBuildProj `
+     /p:Projects=$solution `
+     /p:Restore=true `
+     /p:Build=true `
+     /p:DebugDeterminism=true `
+     /p:Features="debug-determinism" `
+     /p:DeployExtension=false `
+     /p:RepoRoot=$RepoRoot `
+     /p:TreatWarningsAsErrors=true `
+     /bl:$logFilePath
 }
 
 function Get-ObjDir([string]$rootDir) { 
@@ -239,8 +253,9 @@ try {
   $binaryLog = $true
   $officialBuildId = ""
   $ci = $true
+  $nodeReuse = $false
   $properties = @()
-  
+
   if ($bootstrapDir -eq "") {
     $bootstrapDir = Make-BootstrapBuild
   } elseif (![IO.Path]::IsPathRooted($script:bootstrapDir)) {


### PR DESCRIPTION
The previous version didn't restore the toolset fully, so if anything in the build needs toolset imports, that will fail.