### PR TITLE
Semantic model tuple types

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     TupleTypeSymbol.ReportNamesMismatchesIfAny(destination, sourceTuple, diagnostics);
                     source = new BoundConvertedTupleLiteral(
                         sourceTuple.Syntax,
-                        sourceTuple.Type,
+                        sourceTuple,
                         sourceTuple.Arguments,
                         sourceTuple.Type, // same type to keep original element names 
                         sourceTuple.HasErrors).WithSuppression(sourceTuple.IsSuppressed);
@@ -429,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression result = new BoundConvertedTupleLiteral(
                 sourceTuple.Syntax,
-                sourceTuple.Type,
+                sourceTuple,
                 convertedArguments.ToImmutableAndFree(),
                 targetType).WithSuppression(sourceTuple.IsSuppressed);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1528,7 +1528,7 @@
     <!-- Converted tuple must have a type -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <!-- Original tuple is preserved for the purpose of semantic model -->
-    <Field Name="SourceTuple" Type="BoundTupleLiteral" SkipInVisitor="true" ForceInNullabilityRewriter="true" />
+    <Field Name="SourceTuple" Type="BoundTupleLiteral" SkipInVisitor="ExceptNullabilityRewriter" />
   </Node>
   
   <Node Name="BoundDynamicObjectCreationExpression" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1527,8 +1527,8 @@
   <Node Name="BoundConvertedTupleLiteral" Base="BoundTupleExpression">
     <!-- Converted tuple must have a type -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <!-- Natural type is preserved for the purpose of semantic model. Can be null -->
-    <Field Name="NaturalTypeOpt" Type="TypeSymbol" Null="allow"/>
+    <!-- Original tuple is preserved for the purpose of semantic model -->
+    <Field Name="SourceTuple" Type="BoundTupleLiteral" SkipInVisitor="true" ForceInNullabilityRewriter="true" />
   </Node>
   
   <Node Name="BoundDynamicObjectCreationExpression" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1955,7 +1955,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // The bound tree always fully binds tuple literals. From the language point of
                                 // view, however, converted tuple literals represent tuple conversions
                                 // from tuple literal expressions which may or may not have types
-                                type = tupleLiteral.NaturalTypeOpt;
+                                type = tupleLiteral.SourceTuple.Type;
                                 break;
                             }
                     }
@@ -1987,7 +1987,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (tupleLiteralConversion.Operand.Kind == BoundKind.ConvertedTupleLiteral)
                     {
                         var convertedTuple = (BoundConvertedTupleLiteral)tupleLiteralConversion.Operand;
-                        type = convertedTuple.NaturalTypeOpt;
+                        type = convertedTuple.SourceTuple.Type;
                         nullability = convertedTuple.TopLevelNullability;
                     }
                     else

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -165,6 +165,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     node = child;
                 }
             }
+
+            public override BoundNode VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
+            {
+                Visit(node.SourceTuple);
+                return base.VisitConvertedTupleLiteral(node);
+            }
         }
 #endif
     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4047,6 +4047,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
         {
+            // Visit the source tuple so that the semantic model can correctly report nullability for it
+            // Disable diagnostics, as we don't want to duplicate any that are produced by visiting the actual literal below
+            var previousDisableDiagnostics = _disableDiagnostics;
+            _disableDiagnostics = true;
+            VisitTupleExpression(node.SourceTuple);
+            _disableDiagnostics = previousDisableDiagnostics;
+
             VisitTupleExpression(node);
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4048,11 +4048,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
         {
             // Visit the source tuple so that the semantic model can correctly report nullability for it
-            // Disable diagnostics, as we don't want to duplicate any that are produced by visiting the actual literal below
-            var previousDisableDiagnostics = _disableDiagnostics;
-            _disableDiagnostics = true;
-            VisitTupleExpression(node.SourceTuple);
-            _disableDiagnostics = previousDisableDiagnostics;
+            // Disable diagnostics, as we don't want to duplicate any that are produced by visiting the converted literal below
+            VisitWithoutDiagnostics(node.SourceTuple);
 
             VisitTupleExpression(node);
             return null;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1797,7 +1797,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         internal IOperation CreateBoundConvertedTupleLiteralOperation(BoundConvertedTupleLiteral boundConvertedTupleLiteral, bool createDeclaration = true)
         {
-            return CreateTupleOperation(boundConvertedTupleLiteral, boundConvertedTupleLiteral.NaturalTypeOpt, createDeclaration);
+            return CreateTupleOperation(boundConvertedTupleLiteral, boundConvertedTupleLiteral.SourceTuple.Type, createDeclaration);
         }
 
         internal IOperation CreateTupleOperation(BoundTupleExpression boundTupleExpression, ITypeSymbol naturalType, bool createDeclaration)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleEqualityTests.cs
@@ -2191,7 +2191,6 @@ public class C
 Operator '!=' cannot be applied to operands of type 'System.ValueTuple<int,int,int>' and 'System.ValueTuple<int,int,int>'");
         }
 
-        // https://github.com/dotnet/roslyn/issues/35010 Support deconstruction assignment
         [Fact]
         public void TestComparisonWithDeconstructionResult()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -2882,7 +2882,6 @@ static class Program
 }");
         }
 
-        // https://github.com/dotnet/roslyn/issues/35010 Support deconstruction assignment
         [Fact]
         public void DoNotShareInputForMutatingWhenClause()
         {

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -324,15 +324,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         Assert.NotEqual(CodeAnalysis.NullableAnnotation.NotApplicable, typeInfo.Nullability.Annotation);
                         Assert.NotEqual(CodeAnalysis.NullableFlowState.NotApplicable, typeInfo.Nullability.FlowState);
                         // https://github.com/dotnet/roslyn/issues/35035: After refactoring symboldisplay, we should be able to just call something like typeInfo.Type.ToDisplayString(typeInfo.Nullability.FlowState, TypeWithState.TestDisplayFormat)
-                        return TypeWithState.Create((TypeSymbol)typeInfo.Type, typeInfo.Nullability.FlowState.ToInternalFlowState()).ToTypeWithAnnotations().ToDisplayString(TypeWithAnnotations.TestDisplayFormat);
+                        if (annotation.IsConverted)
+                        {
+                            return TypeWithState.Create((TypeSymbol)typeInfo.ConvertedType, typeInfo.ConvertedNullability.FlowState.ToInternalFlowState()).ToTypeWithAnnotations().ToDisplayString(TypeWithAnnotations.TestDisplayFormat);
+                        }
+                        else
+                        {
+                            return TypeWithState.Create((TypeSymbol)typeInfo.Type, typeInfo.Nullability.FlowState.ToInternalFlowState()).ToTypeWithAnnotations().ToDisplayString(TypeWithAnnotations.TestDisplayFormat);
+                        }
                     });
                 // Consider reporting the correct source with annotations on mismatch.
                 AssertEx.Equal(expectedTypes, actualTypes, message: method.ToTestDisplayString());
             }
 
-            ImmutableArray<(ExpressionSyntax Expression, string Text)> getAnnotations()
+            ImmutableArray<(ExpressionSyntax Expression, string Text, bool IsConverted)> getAnnotations()
             {
-                var builder = ArrayBuilder<(ExpressionSyntax, string)>.GetInstance();
+                var builder = ArrayBuilder<(ExpressionSyntax, string, bool)>.GetInstance();
                 foreach (var token in root.DescendantTokens())
                 {
                     foreach (var trivia in token.TrailingTrivia)
@@ -340,15 +347,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         if (trivia.Kind() == SyntaxKind.MultiLineCommentTrivia)
                         {
                             var text = trivia.ToFullString();
-                            const string prefix = "/*T:";
+                            const string typePrefix = "/*T:";
+                            const string convertedPrefix = "/*CT:";
                             const string suffix = "*/";
-                            if (text.StartsWith(prefix) && text.EndsWith(suffix))
+                            bool startsWithTypePrefix = text.StartsWith(typePrefix);
+                            if (text.EndsWith(suffix) && (startsWithTypePrefix || text.StartsWith(convertedPrefix)))
                             {
+                                var prefix = startsWithTypePrefix ? typePrefix : convertedPrefix;
                                 var expr = getEnclosingExpression(token);
                                 Assert.True(expr != null, $"VerifyTypes could not find a matching expression for annotation '{text}'.");
 
                                 var content = text.Substring(prefix.Length, text.Length - prefix.Length - suffix.Length);
-                                builder.Add((expr, content));
+                                builder.Add((expr, content, !startsWithTypePrefix));
                             }
                         }
                     }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1493,7 +1493,7 @@ namespace BoundTreeGenerator
                             foreach (var field in AllNodeOrNodeListFields(node))
                             {
                                 hadField = true;
-                                WriteNodeVisitCall(field);
+                                WriteNodeVisitCall(field, forceVisit: ForceInNullabilityRewriter(field));
                             }
 
                             if (hadField)
@@ -1708,6 +1708,11 @@ namespace BoundTreeGenerator
             return string.Compare(f.SkipInVisitor, "true", true) == 0;
         }
 
+        private static bool ForceInNullabilityRewriter(Field f)
+        {
+            return string.Compare(f.ForceInNullabilityRewriter, "true", true) == 0;
+        }
+
         private static bool SkipInNullabilityRewriter(Node n)
         {
             return string.Compare(n.SkipInNullabilityRewriter, "true", true) == 0;
@@ -1777,12 +1782,12 @@ namespace BoundTreeGenerator
             }
         }
 
-        private void WriteNodeVisitCall(Field field)
+        private void WriteNodeVisitCall(Field field, bool forceVisit = false)
         {
             switch (_targetLang)
             {
                 case TargetLanguage.CSharp:
-                    if (SkipInVisitor(field))
+                    if (SkipInVisitor(field) && !forceVisit)
                     {
                         WriteLine($"{field.Type} {ToCamelCase(field.Name)} = node.{field.Name};");
                     }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1493,7 +1493,7 @@ namespace BoundTreeGenerator
                             foreach (var field in AllNodeOrNodeListFields(node))
                             {
                                 hadField = true;
-                                WriteNodeVisitCall(field, forceVisit: ForceInNullabilityRewriter(field));
+                                WriteNodeVisitCall(field, forceVisit: VisitFieldOnlyInNullabilityRewriter(field));
                             }
 
                             if (hadField)
@@ -1705,12 +1705,13 @@ namespace BoundTreeGenerator
 
         private static bool SkipInVisitor(Field f)
         {
-            return string.Compare(f.SkipInVisitor, "true", true) == 0;
+            return string.Compare(f.SkipInVisitor, "true", true) == 0
+                || VisitFieldOnlyInNullabilityRewriter(f);
         }
 
-        private static bool ForceInNullabilityRewriter(Field f)
+        private static bool VisitFieldOnlyInNullabilityRewriter(Field f)
         {
-            return string.Compare(f.ForceInNullabilityRewriter, "true", true) == 0;
+            return string.Compare(f.SkipInVisitor, "ExceptNullabilityRewriter", true) == 0;
         }
 
         private static bool SkipInNullabilityRewriter(Node n)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Model.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Model.cs
@@ -98,9 +98,6 @@ namespace BoundTreeGenerator
 
         [XmlAttribute]
         public string SkipInVisitor;
-
-        [XmlAttribute]
-        public string ForceInNullabilityRewriter;
     }
 
     public class EnumType : TreeType

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Model.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/Model.cs
@@ -98,6 +98,9 @@ namespace BoundTreeGenerator
 
         [XmlAttribute]
         public string SkipInVisitor;
+
+        [XmlAttribute]
+        public string ForceInNullabilityRewriter;
     }
 
     public class EnumType : TreeType


### PR DESCRIPTION
Correctly report nullability of tuples in the semantic model: 
- Store the original tuple literal rather than just its type
- Visit the original literal without diagnostics only in the nullability walker to understand its type
- Update the generator to allow force visiting fields in the nullable re-writer
- Update various tuple tests to be correct

Related: #35010
