### PR TITLE
Intellisense changes existing, correct variable to differently capitalized type of the same name

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringExtensions.cs
@@ -276,5 +276,17 @@ namespace Roslyn.Utilities
 
             return x;
         }
+
+        public static int GetCaseSensitivePrefixLength(this string string1, string string2)
+        {
+            int x = 0;
+            while (x < string1.Length && x < string2.Length &&
+                   string1[x] == string2[x])
+            {
+                x++;
+            }
+
+            return x;
+        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -544,11 +544,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // But only if it's an item that would have been hard selected.  We don't want
                 // to aggressively select an item that was only going to be softly offered.
                 var item1Priority = item1.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection
-                    ? item1.Rules.MatchPriority : MatchPriority.Default;
+                ? item1.Rules.MatchPriority : MatchPriority.Default;
                 var item2Priority = item2.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection
                     ? item2.Rules.MatchPriority : MatchPriority.Default;
 
                 if (item1Priority > item2Priority)
+                {
+                    return true;
+                }
+
+                prefixLength1 = item1.FilterText.GetCaseSensitivePrefixLength(result1.FilterText);
+                prefixLength2 = item2.FilterText.GetCaseSensitivePrefixLength(result2.FilterText);
+
+                // If there are "Abc" vs "abc", we should prefer the case typed by user.
+                if (prefixLength1 > prefixLength2)
                 {
                     return true;
                 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // But only if it's an item that would have been hard selected.  We don't want
                 // to aggressively select an item that was only going to be softly offered.
                 var item1Priority = item1.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection
-                ? item1.Rules.MatchPriority : MatchPriority.Default;
+                    ? item1.Rules.MatchPriority : MatchPriority.Default;
                 var item2Priority = item2.Rules.SelectionBehavior == CompletionItemSelectionBehavior.HardSelection
                     ? item2.Rules.MatchPriority : MatchPriority.Default;
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -2952,6 +2952,38 @@ class$$ C
             End Using
         End Function
 
+        <WorkItem(36515, "https://github.com/dotnet/roslyn/issues/36513")>
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TypingBackspaceShouldPreserveCase(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                <Document><![CDATA[
+class Program
+{
+    void M()
+    {
+        Structure structure;
+        structure.$$
+    }
+
+    struct Structure
+    {
+        public int A;
+    }
+}]]></Document>)
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Await state.AssertSelectedCompletionItem("structure")
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.AssertCompletionItemsContainAll({"A"})
+            End Using
+        End Function
+
         <WorkItem(1065600, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1065600")>
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36513

```
void M()
{
        Structure structure;
        structure.$$
}
```
Typing backspace at $$ starts completion for `structure`. It should prefer the one matches the case of the text already typed, i.e. `structure` rather than `Structure`. 

We have the issue in the old completion as well. Thank you, @mqudsi for pointing to this!