### PR TITLE
Guard against runaway parsing of the switch expression arms.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -661,7 +661,8 @@ tryAgain:
         {
             var arms = _pool.AllocateSeparated<SwitchExpressionArmSyntax>();
 
-            while (this.CurrentToken.Kind != SyntaxKind.CloseBraceToken)
+            int lastTokenPosition = -1;
+            while (IsMakingProgress(ref lastTokenPosition) && this.CurrentToken.Kind != SyntaxKind.CloseBraceToken)
             {
                 // We use a precedence that excludes lambdas, assignments, and a conditional which could have a
                 // lambda on the right, because we need the parser to leave the EqualsGreaterThanToken


### PR DESCRIPTION
Fixes #36427
In DEBUG builds it will fail an assertion in offending scenarios allowing us to diagnose the underlying issue.
There are no tests as I do not know how to reproduce the customer-reported issue.
But the stack trace suggests that this change is likely to paper over the symptoms until diagnosed.