### PR TITLE
Pass feature flags to the remote workspace

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -26,8 +26,9 @@ namespace Roslyn.Test.Utilities.Remote
         {
             var inprocServices = new InProcRemoteServices(runCacheCleanup);
 
-            var remoteHostStream = await inprocServices.RequestServiceAsync(WellKnownRemoteHostServices.RemoteHostService, cancellationToken).ConfigureAwait(false);
+            // Create the RemotableDataJsonRpc before we create the remote host: this call implicitly sets up the remote IExperimentationService so that will be available for later calls
             var remotableDataRpc = new RemotableDataJsonRpc(workspace, inprocServices.Logger, await inprocServices.RequestServiceAsync(WellKnownServiceHubServices.SnapshotService, cancellationToken).ConfigureAwait(false));
+            var remoteHostStream = await inprocServices.RequestServiceAsync(WellKnownRemoteHostServices.RemoteHostService, cancellationToken).ConfigureAwait(false);
 
             var current = CreateClientId(Process.GetCurrentProcess().Id.ToString());
             var instance = new InProcRemoteHostClient(current, workspace, inprocServices, new ReferenceCountedDisposable<RemotableDataJsonRpc>(remotableDataRpc), remoteHostStream);

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemotableDataJsonRpcEx.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemotableDataJsonRpcEx.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Execution;
+using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.VisualStudio.Threading;
@@ -65,6 +66,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 // only expected exception will be catched. otherwise, NFW and let it propagate
                 Debug.Assert(cancellationToken.IsCancellationRequested || ex is IOException);
             }
+        }
+
+        public Task<bool> IsExperimentEnabledAsync(string experimentName, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Workspace.Services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(experimentName));
         }
 
         private bool ReportUnlessCanceled(Exception ex, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -87,11 +87,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 var current = CreateClientId(Process.GetCurrentProcess().Id.ToString());
 
                 var hostGroup = new HostGroup(current);
-                var remoteHostStream = await Connections.RequestServiceAsync(workspace, primary, WellKnownRemoteHostServices.RemoteHostService, hostGroup, timeout, cancellationToken).ConfigureAwait(false);
 
+                // Create the RemotableDataJsonRpc before we create the remote host: this call implicitly sets up the remote IExperimentationService so that will be available for later calls
                 var remotableDataRpc = new RemotableDataJsonRpc(
                                           workspace, primary.Logger,
                                           await Connections.RequestServiceAsync(workspace, primary, WellKnownServiceHubServices.SnapshotService, hostGroup, timeout, cancellationToken).ConfigureAwait(false));
+
+                var remoteHostStream = await Connections.RequestServiceAsync(workspace, primary, WellKnownRemoteHostServices.RemoteHostService, hostGroup, timeout, cancellationToken).ConfigureAwait(false);
 
                 var enableConnectionPool = workspace.Options.GetOption(RemoteHostOptions.EnableConnectionPool);
                 var maxConnection = workspace.Options.GetOption(RemoteHostOptions.MaxPoolConnection);

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -456,5 +456,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         Intellisense_AsyncCompletion_Data,
         Intellisense_CompletionProviders_Data,
+
+        SnapshotService_IsExperimentEnabledAsync,
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/WellKnownServiceHubServices.cs
+++ b/src/Workspaces/Core/Portable/Remote/WellKnownServiceHubServices.cs
@@ -20,5 +20,6 @@ namespace Microsoft.CodeAnalysis.Remote
         // these are OOP implementation itself should care. not features that consume OOP care
         public const string ServiceHubServiceBase_Initialize = "Initialize";
         public const string AssetService_RequestAssetAsync = "RequestAssetAsync";
+        public const string AssetService_IsExperimentEnabledAsync = "IsExperimentEnabledAsync";
     }
 }

--- a/src/Workspaces/Remote/Core/Services/AssetSource.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetSource.cs
@@ -23,5 +23,6 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         public abstract Task<IList<(Checksum, object)>> RequestAssetsAsync(int scopeId, ISet<Checksum> checksums, ISerializerService serializerService, CancellationToken cancellationToken);
+        public abstract Task<bool> IsExperimentEnabledAsync(string experimentName, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/Core/Services/RemoteExperimentationService.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteExperimentationService.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Threading;
+using Microsoft.CodeAnalysis.Experiments;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Remote.Services
+{
+    [ExportWorkspaceService(typeof(IExperimentationService), ServiceLayer.Host), Shared]
+    internal sealed class RemoteExperimentationService : IExperimentationService
+    {
+        public bool IsExperimentEnabled(string experimentName)
+        {
+            var assetSource = AssetStorage.Default.AssetSource;
+            return assetSource?.IsExperimentEnabledAsync(experimentName, CancellationToken.None).Result ?? false; 
+        }
+    }
+}

--- a/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
+++ b/src/Workspaces/Remote/Core/Shared/SimpleAssetSource.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Serialization;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote.Shared
 {
@@ -40,6 +41,11 @@ namespace Microsoft.CodeAnalysis.Remote.Shared
             }
 
             return Task.FromResult<IList<(Checksum, object)>>(list);
+        }
+
+        public override Task<bool> IsExperimentEnabledAsync(string experimentName, CancellationToken cancellationToken)
+        {
+            return SpecializedTasks.False;
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -34,6 +34,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (RoslynLogger.LogBlock(FunctionId.SnapshotService_RequestAssetAsync, GetRequestLogInfo, scopeId, checksums, cancellationToken))
                 {
+                    // Surround this with a try/catch to report exceptions because we want to report any crashes here.
                     try
                     {
                         return await _owner.RunServiceAsync(() =>
@@ -47,6 +48,18 @@ namespace Microsoft.CodeAnalysis.Remote
                     {
                         throw ExceptionUtilities.Unreachable;
                     }
+                }
+            }
+
+            public override async Task<bool> IsExperimentEnabledAsync(string experimentName, CancellationToken cancellationToken)
+            {
+                using (RoslynLogger.LogBlock(FunctionId.SnapshotService_IsExperimentEnabledAsync, experimentName, cancellationToken))
+                {
+                    return await _owner.RunServiceAsync(() =>
+                    {
+                        return _owner.InvokeAsync<bool>(WellKnownServiceHubServices.AssetService_IsExperimentEnabledAsync,
+                            new object[] { experimentName }, cancellationToken);
+                    }, cancellationToken).ConfigureAwait(false);
                 }
             }
 


### PR DESCRIPTION
This implements IExperimentationService in the remote workspace; any request for feature flags is forwarded to the main Visual Studio process and the feature flag is queried there.