### PR TITLE
Make Dispose analyzers (IDE0067 and IDE0069) more conservative

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,7 @@
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.17</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>
-    <MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>2.9.3-beta1.19301.2+4c8365b9</MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>
+    <MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>2.9.4-beta1.19321.5+ffe2b1b5</MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>
     <MicrosoftCodeQualityAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeQualityAnalyzersVersion>
     <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>

--- a/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.cs
@@ -5041,5 +5041,24 @@ class C : IDisposable
 }",
             Diagnostic(IDEDiagnosticIds.DisposeObjectsBeforeLosingScopeDiagnosticId));
         }
+
+        [Fact, WorkItem(36498, "https://github.com/dotnet/roslyn/issues/36498")]
+        public async Task DisposableObjectPushedToStackIsNotFlagged()
+        {
+            await TestDiagnosticMissingAsync(@"
+using System;
+using System.Collections.Generic;
+
+class C : IDisposable
+{
+    public void Dispose() { }
+
+    public void M1(Stack<object> stack)
+    {
+        var c = [|new C()|];
+        stack.Push(c);
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
             private readonly ConcurrentDictionary<IFieldSymbol, /*disposed*/bool> _fieldDisposeValueMap;
             private readonly DisposeAnalysisHelper _disposeAnalysisHelper;
             private bool _hasErrors;
+            private bool _hasDisposeMethod;
 
             public SymbolAnalyzer(ImmutableHashSet<IFieldSymbol> disposableFields, DisposeAnalysisHelper disposeAnalysisHelper)
             {
@@ -111,7 +112,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
             private void OnSymbolEnd(SymbolAnalysisContext symbolEndContext)
             {
-                if (_hasErrors)
+                if (_hasErrors || !_hasDisposeMethod)
                 {
                     return;
                 }
@@ -244,6 +245,8 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
                 void AnalyzeDisposeMethod()
                 {
+                    _hasDisposeMethod = true;
+
                     if (_hasErrors)
                     {
                         return;

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeAnalysisHelper.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeAnalysisHelper.cs
@@ -113,7 +113,8 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                         context.Options, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
                         exceptionPathsAnalysis: false, context.CancellationToken, out pointsToAnalysisResult,
                         interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
-                        defaultDisposeOwnershipTransferAtConstructor: true);
+                        defaultDisposeOwnershipTransferAtConstructor: true,
+                        defaultDisposeOwnershipTransferAtMethodCall: true);
                     if (disposeAnalysisResult != null)
                     {
                         return true;
@@ -147,7 +148,8 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                         context.Options, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
                         exceptionPathsAnalysis: false, context.CancellationToken, out pointsToAnalysisResult,
                         interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
-                        defaultDisposeOwnershipTransferAtConstructor: true);
+                        defaultDisposeOwnershipTransferAtConstructor: true,
+                        defaultDisposeOwnershipTransferAtMethodCall: true);
                     if (disposeAnalysisResult != null)
                     {
                         return true;


### PR DESCRIPTION
1. Make IDE0069 (DisposableFieldsShouldBeDisposed) conservative by bailing out on disposable types that don't have the Dispose implementation, but rely on base type implementing it and having virtual helper methods for dispose functionality

2. Make IDE0067 (DisposeObjectsBeforeLosingScope) conservative by bailing out on disposable objects that are passed as arguments to methods in metadata.

Requires updating to a new FlowAnalysisUtilities version.
Fixes #36498