### PR TITLE
recognize @code as code block

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -51,6 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         private const string HelperRazor = "helper";
         private const string FunctionsRazor = "functions";
+        private const string CodeRazor = "code";
 
         private static readonly EditOptions s_venusEditOptions = new EditOptions(new StringDifferenceOptions
         {
@@ -1057,7 +1058,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             if (_project.Language == LanguageNames.CSharp)
             {
                 return CheckCode(surfaceSnapshot, position, ch, CSharpRazorBlock) ||
-                       CheckCode(surfaceSnapshot, position, ch, FunctionsRazor, CSharpRazorBlock);
+                       CheckCode(surfaceSnapshot, position, ch, FunctionsRazor, CSharpRazorBlock) ||
+                       CheckCode(surfaceSnapshot, position, ch, CodeRazor, CSharpRazorBlock);
             }
 
             if (_project.Language == LanguageNames.VisualBasic)


### PR DESCRIPTION
razor added new @code block. add support for new code block in roslyn.

for old razor version, IsCodeBlock won't get called since razor will not treat code in @code as C# code block, in new razor version where @code is added, razor will recognize it as C# code block and call us which we will in turn check new @code along with existing @ tags for code blocks.

addressing https://github.com/aspnet/AspNetCore/issues/10942