### PR TITLE
Don't treat zero-length deconstruction as an error when binding patterns.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -908,7 +908,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             deconstructMethod = deconstruct.ExpressionSymbol as MethodSymbol;
                             if (!hasErrors)
-                                hasErrors = outPlaceholders.IsDefaultOrEmpty || tupleDesignation.Variables.Count != outPlaceholders.Length;
+                                hasErrors = outPlaceholders.IsDefault || tupleDesignation.Variables.Count != outPlaceholders.Length;
 
                             for (int i = 0; i < tupleDesignation.Variables.Count; i++)
                             {


### PR DESCRIPTION
Fixes #36496

This is a tiny bug fix for a compiler "crash".
@dotnet/roslyn-compiler Please review.
