### PR TITLE
Rename IsNotNullableIfReferenceType to IsNotNullable

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.TypeParameterSymbol.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override bool HasNotNullConstraint => false;
 
-            internal override bool? IsNotNullableIfReferenceType => null;
+            internal override bool? IsNotNullable => null;
 
             public override bool HasValueTypeConstraint
             {

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -913,7 +913,7 @@ hasRelatedInterfaces:
                     {
                         if (!SatisfiesConstraintType(conversions.WithNullability(true), typeArgument, constraintType, ref useSiteDiagnostics) ||
                             (typeArgument.GetValueNullableAnnotation().IsAnnotated() && !typeArgument.Type.IsNonNullableValueType() &&
-                             TypeParameterSymbol.IsNotNullableIfReferenceTypeFromConstraintType(constraintType, out _) == true))
+                             TypeParameterSymbol.IsNotNullableFromConstraintType(constraintType, out _) == true))
                         {
                             var diagnostic = new CSDiagnosticInfo(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint, containingSymbol.ConstructedFrom(), constraintType, typeParameter, typeArgument);
                             nullabilityDiagnosticsBuilderOpt.Add(new TypeParameterDiagnosticInfo(typeParameter, diagnostic));

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public override bool HasNotNullConstraint => false;
 
-            internal override bool? IsNotNullableIfReferenceType => null;
+            internal override bool? IsNotNullable => null;
 
             public override bool HasValueTypeConstraint
             {

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -599,10 +599,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (!typeParameter1.IsValueType)
             {
-                bool? isNotNullableIfReferenceType1 = typeParameter1.IsNotNullableIfReferenceType;
-                bool? isNotNullableIfReferenceType2 = typeParameter2.IsNotNullableIfReferenceType;
-                if (isNotNullableIfReferenceType1.HasValue && isNotNullableIfReferenceType2.HasValue &&
-                    isNotNullableIfReferenceType1.GetValueOrDefault() != isNotNullableIfReferenceType2.GetValueOrDefault())
+                bool? isNotNullable1 = typeParameter1.IsNotNullable;
+                bool? isNotNullable2 = typeParameter2.IsNotNullable;
+                if (isNotNullable1.HasValue && isNotNullable2.HasValue &&
+                    isNotNullable1.GetValueOrDefault() != isNotNullable2.GetValueOrDefault())
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                                 inProgress = inProgress.Prepend(this);
                                 foreach (TypeWithAnnotations constraintType in symbolsBuilder)
                                 {
-                                    if (!ConstraintsHelper.IsObjectConstraintSignificant(IsNotNullableIfReferenceTypeFromConstraintType(constraintType, inProgress, out _), bestObjectConstraint))
+                                    if (!ConstraintsHelper.IsObjectConstraintSignificant(IsNotNullableFromConstraintType(constraintType, inProgress, out _), bestObjectConstraint))
                                     {
                                         bestObjectConstraint = default;
                                         break;
@@ -277,28 +277,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return type;
         }
 
-        private static bool? IsNotNullableIfReferenceTypeFromConstraintType(TypeWithAnnotations constraintType, ConsList<PETypeParameterSymbol> inProgress, out bool isNonNullableValueType)
+        private static bool? IsNotNullableFromConstraintType(TypeWithAnnotations constraintType, ConsList<PETypeParameterSymbol> inProgress, out bool isNonNullableValueType)
         {
             if (!(constraintType.Type is PETypeParameterSymbol typeParameter) ||
                 (object)typeParameter.ContainingSymbol != inProgress.Head.ContainingSymbol ||
                 typeParameter.GetConstraintHandleCollection().Count == 0)
             {
-                return IsNotNullableIfReferenceTypeFromConstraintType(constraintType, out isNonNullableValueType);
+                return IsNotNullableFromConstraintType(constraintType, out isNonNullableValueType);
             }
 
-            bool? isNotNullableIfReferenceType = typeParameter.CalculateIsNotNullableIfReferenceType(inProgress, out isNonNullableValueType);
+            bool? isNotNullable = typeParameter.CalculateIsNotNullable(inProgress, out isNonNullableValueType);
 
             if (isNonNullableValueType)
             {
-                Debug.Assert(isNotNullableIfReferenceType == true);
+                Debug.Assert(isNotNullable == true);
                 return true;
             }
 
-            if (constraintType.NullableAnnotation.IsAnnotated() || isNotNullableIfReferenceType == false)
+            if (constraintType.NullableAnnotation.IsAnnotated() || isNotNullable == false)
             {
                 return false;
             }
-            else if (constraintType.NullableAnnotation.IsOblivious() || isNotNullableIfReferenceType == null)
+            else if (constraintType.NullableAnnotation.IsOblivious() || isNotNullable == null)
             {
                 return null;
             }
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return true;
         }
 
-        private bool? CalculateIsNotNullableIfReferenceType(ConsList<PETypeParameterSymbol> inProgress, out bool isNonNullableValueType)
+        private bool? CalculateIsNotNullable(ConsList<PETypeParameterSymbol> inProgress, out bool isNonNullableValueType)
         {
             if (inProgress.ContainsReference(this))
             {
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return fromNonTypeConstraints;
             }
 
-            bool? fromTypes = IsNotNullableIfReferenceTypeFromConstraintTypes(constraintTypes, inProgress, out isNonNullableValueType);
+            bool? fromTypes = IsNotNullableFromConstraintTypes(constraintTypes, inProgress, out isNonNullableValueType);
 
             if (isNonNullableValueType)
             {
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return fromNonTypeConstraints;
         }
 
-        private static bool? IsNotNullableIfReferenceTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes, ConsList<PETypeParameterSymbol> inProgress, out bool isNonNullableValueType)
+        private static bool? IsNotNullableFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes, ConsList<PETypeParameterSymbol> inProgress, out bool isNonNullableValueType)
         {
             Debug.Assert(!constraintTypes.IsDefaultOrEmpty);
 
@@ -356,7 +356,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             bool? result = false;
             foreach (TypeWithAnnotations constraintType in constraintTypes)
             {
-                bool? fromType = IsNotNullableIfReferenceTypeFromConstraintType(constraintType, inProgress, out isNonNullableValueType);
+                bool? fromType = IsNotNullableFromConstraintType(constraintType, inProgress, out isNonNullableValueType);
 
                 if (isNonNullableValueType)
                 {
@@ -466,7 +466,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
@@ -507,11 +507,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                             symbolsBuilder.Add(type);
                         }
 
-                        return IsNotNullableIfReferenceTypeFromConstraintTypes(symbolsBuilder.ToImmutableAndFree());
+                        return IsNotNullableFromConstraintTypes(symbolsBuilder.ToImmutableAndFree());
                     }
                 }
 
-                return CalculateIsNotNullableIfReferenceType();
+                return CalculateIsNotNullable();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingTypeParameterSymbol.cs
@@ -82,11 +82,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return this.RetargetingTranslator.Retarget(_underlyingTypeParameter.GetConstraintTypes(inProgress));
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
-                return _underlyingTypeParameter.IsNotNullableIfReferenceType;
+                return _underlyingTypeParameter.IsNotNullable;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool HasNotNullConstraint => false;
 
-        internal override bool? IsNotNullableIfReferenceType => null;
+        internal override bool? IsNotNullable => null;
 
         public override bool HasUnmanagedTypeConstraint
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool HasNotNullConstraint => false;
 
-        internal override bool? IsNotNullableIfReferenceType => null;
+        internal override bool? IsNotNullable => null;
 
         public override bool HasUnmanagedTypeConstraint
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -328,7 +328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return !this.HasReferenceTypeConstraint &&
                 !this.HasValueTypeConstraint &&
                 this.ConstraintTypesNoUseSiteDiagnostics.IsEmpty &&
-                this.IsNotNullableIfReferenceType == false;
+                this.IsNotNullable == false;
         }
 
         private NamedTypeSymbol GetDefaultBaseType()
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return NullableAnnotationExtensions.NotAnnotatedAttributeValue;
             }
-            else if (!this.HasValueTypeConstraint && this.ConstraintTypesNoUseSiteDiagnostics.IsEmpty && this.IsNotNullableIfReferenceType == false)
+            else if (!this.HasValueTypeConstraint && this.ConstraintTypesNoUseSiteDiagnostics.IsEmpty && this.IsNotNullable == false)
             {
                 return NullableAnnotationExtensions.AnnotatedAttributeValue;
             }
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
@@ -540,7 +540,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return null;
                 }
 
-                return CalculateIsNotNullableIfReferenceType();
+                return CalculateIsNotNullable();
             }
         }
 
@@ -652,7 +652,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return null;
                 }
 
-                return CalculateIsNotNullableIfReferenceType();
+                return CalculateIsNotNullable();
             }
         }
 
@@ -892,11 +892,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
-                return this.OverriddenTypeParameter?.IsNotNullableIfReferenceType;
+                return this.OverriddenTypeParameter?.IsNotNullable;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         foreach (TypeWithAnnotations constraintType in constraintTypes)
                         {
-                            if (!ConstraintsHelper.IsObjectConstraintSignificant(IsNotNullableIfReferenceTypeFromConstraintType(constraintType, out _), bestObjectConstraint))
+                            if (!ConstraintsHelper.IsObjectConstraintSignificant(IsNotNullableFromConstraintType(constraintType, out _), bestObjectConstraint))
                             {
                                 bestObjectConstraint = default;
                                 break;
@@ -149,22 +149,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return constraintTypes.ToImmutableAndFree();
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
                 if (_underlyingTypeParameter.ConstraintTypesNoUseSiteDiagnostics.IsEmpty)
                 {
-                    return _underlyingTypeParameter.IsNotNullableIfReferenceType;
+                    return _underlyingTypeParameter.IsNotNullable;
                 }
                 else if (!HasNotNullConstraint && !HasValueTypeConstraint && !HasReferenceTypeConstraint)
                 {
                     var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();
                     _map.SubstituteConstraintTypesDistinctWithoutModifiers(_underlyingTypeParameter, _underlyingTypeParameter.GetConstraintTypes(ConsList<TypeParameterSymbol>.Empty), constraintTypes, null);
-                    return IsNotNullableIfReferenceTypeFromConstraintTypes(constraintTypes.ToImmutableAndFree());
+                    return IsNotNullableFromConstraintTypes(constraintTypes.ToImmutableAndFree());
                 }
 
-                return CalculateIsNotNullableIfReferenceType();
+                return CalculateIsNotNullable();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -430,14 +430,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal static bool? IsNotNullableIfReferenceTypeFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes)
+        internal static bool? IsNotNullableFromConstraintTypes(ImmutableArray<TypeWithAnnotations> constraintTypes)
         {
             Debug.Assert(!constraintTypes.IsDefaultOrEmpty);
 
             bool? result = false;
             foreach (TypeWithAnnotations constraintType in constraintTypes)
             {
-                bool? fromType = IsNotNullableIfReferenceTypeFromConstraintType(constraintType, out _);
+                bool? fromType = IsNotNullableFromConstraintType(constraintType, out _);
                 if (fromType == true)
                 {
                     return true;
@@ -451,7 +451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        internal static bool? IsNotNullableIfReferenceTypeFromConstraintType(TypeWithAnnotations constraintType, out bool isNonNullableValueType)
+        internal static bool? IsNotNullableFromConstraintType(TypeWithAnnotations constraintType, out bool isNonNullableValueType)
         {
             if (constraintType.Type.IsNonNullableValueType())
             {
@@ -468,13 +468,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (constraintType.TypeKind == TypeKind.TypeParameter)
             {
-                bool? isNotNullableIfReferenceType = ((TypeParameterSymbol)constraintType.Type).IsNotNullableIfReferenceType;
+                bool? isNotNullable = ((TypeParameterSymbol)constraintType.Type).IsNotNullable;
 
-                if (isNotNullableIfReferenceType == false)
+                if (isNotNullable == false)
                 {
                     return false;
                 }
-                else if (isNotNullableIfReferenceType == null)
+                else if (isNotNullable == null)
                 {
                     return null;
                 }
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        protected bool? CalculateIsNotNullableIfReferenceType()
+        protected bool? CalculateIsNotNullable()
         {
             bool? fromNonTypeConstraints = CalculateIsNotNullableFromNonTypeConstraints();
 
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return fromNonTypeConstraints;
             }
 
-            bool? fromTypes = IsNotNullableIfReferenceTypeFromConstraintTypes(constraintTypes);
+            bool? fromTypes = IsNotNullableFromConstraintTypes(constraintTypes);
 
             if (fromTypes == true || fromNonTypeConstraints == false)
             {
@@ -557,7 +557,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         // https://github.com/dotnet/roslyn/issues/26198 Should this API be exposed through ITypeParameterSymbol?
-        internal abstract bool? IsNotNullableIfReferenceType { get; }
+        internal abstract bool? IsNotNullable { get; }
 
         public sealed override bool IsValueType
         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeParameter = (TypeParameterSymbol)type;
             // https://github.com/dotnet/roslyn/issues/30056: Test `where T : unmanaged`. See
             // UninitializedNonNullableFieldTests.TypeParameterConstraints for instance.
-            return !typeParameter.IsValueType && !(typeParameter.IsReferenceType && typeParameter.IsNotNullableIfReferenceType == true);
+            return !typeParameter.IsValueType && !(typeParameter.IsReferenceType && typeParameter.IsNotNullable == true);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public static bool IsPossiblyNullableReferenceTypeTypeParameter(this TypeSymbol type)
         {
-            return type is TypeParameterSymbol { IsValueType: false, IsNotNullableIfReferenceType: false };
+            return type is TypeParameterSymbol { IsValueType: false, IsNotNullable: false };
         }
 
         public static bool IsNonNullableValueType(this TypeSymbol typeArgument)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EETypeParameterSymbol.cs
@@ -65,16 +65,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return _sourceTypeParameter.HasNotNullConstraint; }
         }
 
-        internal override bool? IsNotNullableIfReferenceType
+        internal override bool? IsNotNullable
         {
             get
             {
                 if (_sourceTypeParameter.ConstraintTypesNoUseSiteDiagnostics.IsEmpty)
                 {
-                    return _sourceTypeParameter.IsNotNullableIfReferenceType;
+                    return _sourceTypeParameter.IsNotNullable;
                 }
 
-                return CalculateIsNotNullableIfReferenceType();
+                return CalculateIsNotNullable();
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/SimpleTypeParameterSymbol.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override bool HasNotNullConstraint => false;
 
-        internal override bool? IsNotNullableIfReferenceType => null;
+        internal override bool? IsNotNullable => null;
 
         public override bool HasValueTypeConstraint
         {


### PR DESCRIPTION
All the affected APIs are also covering nullable value types now.