### PR TITLE
Nullable Analysis Pay-for-play

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     useSiteDiagnostics.Add(info);
                 }
             }
-            if (nullableState == null)
+            if (nullableState == null || !Binder.Compilation.RunNullableWalker)
             {
                 return InferredReturnType.TypeWithAnnotations;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -101,13 +101,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     useSiteDiagnostics.Add(info);
                 }
             }
-            if (nullableState == null || !Binder.Compilation.RunNullableWalker)
+            if (nullableState == null)
             {
                 return InferredReturnType.TypeWithAnnotations;
             }
             else
             {
                 Debug.Assert(conversions != null);
+                Debug.Assert(Binder.Compilation.ShouldRunNullableWalker);
                 // Diagnostics from NullableWalker.Analyze can be dropped here since Analyze
                 // will be called again from NullableWalker.ApplyConversion when the
                 // BoundLambda is converted to an anonymous function.

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -108,7 +108,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 Debug.Assert(conversions != null);
-                Debug.Assert(Binder.Compilation.ShouldRunNullableWalker);
                 // Diagnostics from NullableWalker.Analyze can be dropped here since Analyze
                 // will be called again from NullableWalker.ApplyConversion when the
                 // BoundLambda is converted to an anonymous function.

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -120,6 +120,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private HashSet<SyntaxTree> _lazyCompilationUnitCompletedTrees;
 
+        /// <summary>
+        /// Run the nullable walker during the flow analysis passes. True if the project-level nullable
+        /// context option is set, or if any file file enables nullable or just the nullable warnings.
+        /// </summary>
+        private ThreeState _lazyRunNullableWalker;
+
         public override string Language
         {
             get
@@ -171,9 +177,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool FeatureStrictEnabled => Feature("strict") != null;
 
         /// <summary>
-        /// True if we should enable nullable analysis in this compilation.
+        /// True if we should enable nullable semantic analysis in this compilation.
         /// </summary>
-        internal bool NullableAnalysisEnabled => Feature("run-nullable-analysis") is "true";
+        // Note that this is intentionally not conditioned off RunNullableWalker currently. Once we fully enable
+        // the nullable analysis semantic model feature and feel confident in it, we only run the analysis if
+        // the feature flag is set.
+        internal bool NullableSemanticAnalysisEnabled => Feature("run-nullable-analysis") is "true";
 
         /// <summary>
         /// True when the "peverify-compat" feature flag is set or the language version is below C# 7.2.
@@ -182,6 +191,34 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// The flag is only to be used if PEVerify pass is extremely important.
         /// </summary>
         internal bool IsPeVerifyCompatEnabled => LanguageVersion < LanguageVersion.CSharp7_2 || Feature("peverify-compat") != null;
+
+        internal bool RunNullableWalker
+        {
+            get
+            {
+                if (!_lazyRunNullableWalker.HasValue())
+                {
+                    if (Options.NullableContextOptions != NullableContextOptions.Disable)
+                    {
+                        _lazyRunNullableWalker = ThreeState.True;
+                        return true;
+                    }
+
+                    foreach (var syntaxTree in SyntaxTrees)
+                    {
+                        if (((CSharpSyntaxTree)syntaxTree).HasNullableEnables())
+                        {
+                            _lazyRunNullableWalker = ThreeState.True;
+                            return true;
+                        }
+                    }
+
+                    _lazyRunNullableWalker = ThreeState.False;
+                }
+
+                return _lazyRunNullableWalker.Value();
+            }
+        }
 
         /// <summary>
         /// The language version that was used to parse the syntax trees of this compilation.

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -122,9 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Run the nullable walker during the flow analysis passes. True if the project-level nullable
-        /// context option is set, or if any file file enables nullable or just the nullable warnings.
+        /// context option is set, or if any file enables nullable or just the nullable warnings.
         /// </summary>
-        private ThreeState _lazyRunNullableWalker;
+        private ThreeState _lazyShouldRunNullableWalker;
 
         public override string Language
         {
@@ -192,15 +192,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool IsPeVerifyCompatEnabled => LanguageVersion < LanguageVersion.CSharp7_2 || Feature("peverify-compat") != null;
 
-        internal bool RunNullableWalker
+        internal bool ShouldRunNullableWalker
         {
             get
             {
-                if (!_lazyRunNullableWalker.HasValue())
+                if (!_lazyShouldRunNullableWalker.HasValue())
                 {
                     if (Options.NullableContextOptions != NullableContextOptions.Disable)
                     {
-                        _lazyRunNullableWalker = ThreeState.True;
+                        _lazyShouldRunNullableWalker = ThreeState.True;
                         return true;
                     }
 
@@ -208,15 +208,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (((CSharpSyntaxTree)syntaxTree).HasNullableEnables())
                         {
-                            _lazyRunNullableWalker = ThreeState.True;
+                            _lazyShouldRunNullableWalker = ThreeState.True;
                             return true;
                         }
                     }
 
-                    _lazyRunNullableWalker = ThreeState.False;
+                    _lazyShouldRunNullableWalker = ThreeState.False;
                 }
 
-                return _lazyRunNullableWalker.Value();
+                return _lazyShouldRunNullableWalker.Value();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1443,8 +1443,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //    cached nodes for the root syntax node, and the existing snapshot manager must be null.
                 Debug.Assert((IsSpeculativeSemanticModel && manager is null) ||
                              (!IsSpeculativeSemanticModel &&
-                              (manager is null && (!Compilation.NullableAnalysisEnabled || syntax != Root)) ||
-                              (manager is object && syntax == Root && Compilation.NullableAnalysisEnabled && _lazySnapshotManager is null)));
+                              (manager is null && (!Compilation.NullableSemanticAnalysisEnabled || syntax != Root)) ||
+                              (manager is object && syntax == Root && Compilation.NullableSemanticAnalysisEnabled && _lazySnapshotManager is null)));
                 if (!IsSpeculativeSemanticModel && manager is object)
                 {
                     _lazySnapshotManager = manager;
@@ -1846,7 +1846,7 @@ done:
             DiagnosticBag diagnostics = _ignoredDiagnostics;
 
             // If we're in DEBUG mode, always enable the analysis, but throw away the results
-            if (!Compilation.NullableAnalysisEnabled)
+            if (!Compilation.NullableSemanticAnalysisEnabled)
             {
 #if DEBUG
                 diagnostics = new DiagnosticBag();
@@ -1871,7 +1871,7 @@ done:
                 // In DEBUG mode, we don't want to increase test run times, so if
                 // nullable analysis isn't enabled and some node has already been bound
                 // we assume we've already done this test binding and just return
-                || (!Compilation.NullableAnalysisEnabled && _guardedNodeMap.Count > 0)
+                || (!Compilation.NullableSemanticAnalysisEnabled && _guardedNodeMap.Count > 0)
 #endif
                 )
             {
@@ -1914,7 +1914,7 @@ done:
                 boundRoot = RewriteNullableBoundNodesWithSnapshots(boundRoot, binder, diagnostics, takeSnapshots, out var snapshotManager);
 #if DEBUG
                 // Don't actually cache the results if the nullable analysis is not enabled in debug mode.
-                if (!Compilation.NullableAnalysisEnabled) return;
+                if (!Compilation.NullableSemanticAnalysisEnabled) return;
 #endif
                 GuardedAddBoundTreeForStandaloneSyntax(bindableRoot, boundRoot, snapshotManager);
             }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1651,7 +1651,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     bodyBinder.ValidateIteratorMethods(diagnostics);
 
                     BoundNode methodBody = bodyBinder.BindMethodBody(syntaxNode, diagnostics);
-                    if (bodyBinder.Compilation.NullableAnalysisEnabled)
+                    if (bodyBinder.Compilation.NullableSemanticAnalysisEnabled)
                     {
                         // Currently, we're passing an empty DiagnosticBag here because the flow analysis pass later will
                         // also run the nullable walker, and issue duplicate warnings. We should try to only run the pass

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 walker.Free();
             }
 
-            if (compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() && compilation.RunNullableWalker)
+            if (compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() && compilation.ShouldRunNullableWalker)
             {
                 NullableWalker.Analyze(compilation, member, node, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 walker.Free();
             }
 
-            if (compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion())
+            if (compilation.LanguageVersion >= MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() && compilation.RunNullableWalker)
             {
                 NullableWalker.Analyze(compilation, member, node, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
-            if (compilation.NullableAnalysisEnabled)
+            if (compilation.NullableSemanticAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
@@ -496,7 +496,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var analyzedNullabilitiesMap = analyzedNullabilities.ToImmutable();
 
 #if DEBUG
-            if (binder.Compilation.NullableAnalysisEnabled)
+            if (binder.Compilation.NullableSemanticAnalysisEnabled)
             {
                 DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManagerOpt: null, node);
             }
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics)
         {
             var compilation = binder.Compilation;
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion())
+            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.RunNullableWalker)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics)
         {
             var compilation = binder.Compilation;
-            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.RunNullableWalker)
+            if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -619,15 +619,29 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _lazyPragmaWarningStateMap.GetWarningState(id, position);
         }
 
-        internal NullableContextState GetNullableContextState(int position)
+        private void EnsureNullableContextMapInitialized()
         {
             if (_lazyNullableContextStateMap == null)
             {
                 // Create the #nullable directive map on demand.
                 Interlocked.CompareExchange(ref _lazyNullableContextStateMap, NullableContextStateMap.Create(this, IsGeneratedCode()), null);
             }
+        }
 
+        internal NullableContextState GetNullableContextState(int position)
+        {
+            EnsureNullableContextMapInitialized();
             return _lazyNullableContextStateMap.GetContextState(position);
+        }
+
+        /// <summary>
+        /// Returns true if there are any nullable directives that enable annotations, warnings, or both.
+        /// This does not include any restore directives.
+        /// </summary>
+        internal bool HasNullableEnables()
+        {
+            EnsureNullableContextMapInitialized();
+            return _lazyNullableContextStateMap.HasNullableEnables();
         }
 
         internal bool IsGeneratedCode()

--- a/src/Compilers/CSharp/Portable/Syntax/NullableContextStateMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/NullableContextStateMap.cs
@@ -89,6 +89,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return context;
         }
 
+        /// <summary>
+        /// Returns true if any of the NullableContexts in this map enable annotations, warnings, or both.
+        /// This does not include any restore directives.
+        /// </summary>
+        internal bool HasNullableEnables()
+        {
+            foreach (var context in _contexts)
+            {
+                if (context.AnnotationsState == true || context.WarningsState == true)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static ImmutableArray<NullableContextState> GetContexts(SyntaxTree tree, bool isGeneratedCode)
         {
             var previousContext = GetContextForFileStart(position: 0, isGeneratedCode: isGeneratedCode);


### PR DESCRIPTION
Make nullable analysis conditional on whether the user enabled the nullable feature, either on the command line or via a nullable enable directive.

Fixes https://github.com/dotnet/roslyn/issues/36131. This makes the condition global, so if there are any nullable enables in the entire project it'll turn on the NullableWalker for the whole project. If we want to make this more fine-grained, we can do that in a follow-up. @dotnet/roslyn-compiler for review.