### PR TITLE
Unwrap nullability-wrapped symbols in object initializer completion 

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -27,13 +27,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         public async Task NothingToInitialize()
         {
             var markup = @"
-class c { }
+class C { }
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { $$
+       C goo = new C { $$
     }
 }";
 
@@ -45,13 +45,13 @@ class d
         public async Task OneItem1()
         {
             var markup = @"
-class c { public int value {set; get; }}
+class C { public int value {set; get; }}
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { v$$
+       C goo = new C { v$$
     }
 }";
 
@@ -64,13 +64,13 @@ class d
         public async Task ShowWithEqualsSign()
         {
             var markup = @"
-class c { public int value {set; get; }}
+class C { public int value {set; get; }}
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { v$$=
+       C goo = new C { v$$=
     }
 }";
 
@@ -83,13 +83,13 @@ class d
         public async Task OneItem2()
         {
             var markup = @"
-class c
+class C
 {
     public int value {set; get; }
 
     void goo()
     {
-       c goo = new c { v$$
+       C goo = new C { v$$
     }
 }";
 
@@ -102,17 +102,17 @@ class c
         public async Task FieldAndProperty()
         {
             var markup = @"
-class c 
+class C 
 { 
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { v$$
+       C goo = new C { v$$
     }
 }";
 
@@ -125,17 +125,17 @@ class d
         public async Task HidePreviouslyTyped()
         {
             var markup = @"
-class c 
+class C 
 { 
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { value = 3, o$$
+       C goo = new C { value = 3, o$$
     }
 }";
 
@@ -148,17 +148,17 @@ class d
         public async Task NotInEqualsValue()
         {
             var markup = @"
-class c 
+class C 
 { 
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { value = v$$
+       C goo = new C { value = v$$
     }
 }";
 
@@ -169,17 +169,17 @@ class d
         public async Task NothingLeftToShow()
         {
             var markup = @"
-class c 
+class C 
 { 
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { value = 3, otherValue = 4, $$
+       C goo = new C { value = 3, otherValue = 4, $$
     }
 }";
 
@@ -191,22 +191,22 @@ class d
         public async Task NestedObjectInitializers()
         {
             var markup = @"
-class c 
+class C 
 { 
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
-    public c myValue {set; get;}
+    public C myValue {set; get;}
 }
 
-class e
+class E
 {
     void goo()
     {
-       d bar = new d { myValue = new c { $$
+       D bar = new D { myValue = new C { $$
     }
 }";
             await VerifyItemIsAbsentAsync(markup, "myValue");
@@ -219,18 +219,18 @@ class e
         public async Task NotExclusive1()
         {
             var markup = @"using System.Collections.Generic;
-class c : IEnumerable<int>
+class C : IEnumerable<int>
 { 
     public void Add(int a) { }
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
     void goo()
     {
-       c bar = new c { v$$
+       C bar = new C { v$$
     }
 }";
             await VerifyExclusiveAsync(markup, false);
@@ -240,18 +240,18 @@ class d
         public async Task NotExclusive2()
         {
             var markup = @"using System.Collections;
-class c : IEnumerable
+class C : IEnumerable
 { 
     public void Add(object a) { }
     public int value {set; get; }
     public int otherValue;
 }
 
-class d
+class D
 {
     void goo()
     {
-       c bar = new c { v$$
+       C bar = new C { v$$
     }
 }";
             await VerifyExclusiveAsync(markup, false);
@@ -346,8 +346,8 @@ class C
         {
             var markup = @"using System.Collections.Generic;
 
-class b {}
-class d : b
+class B {}
+class D : B
 {
     public int goo;
 }
@@ -356,7 +356,7 @@ class C
 {
     void stuff()
     {
-        b a = new d { $$
+        B a = new D { $$
     }
 }
 ";
@@ -543,13 +543,13 @@ public class Goo
         public async Task TestCommitCharacter()
         {
             const string markup = @"
-class c { public int value {set; get; }}
+class C { public int value {set; get; }}
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { v$$
+       C goo = new C { v$$
     }
 }";
 
@@ -560,13 +560,13 @@ class d
         public async Task TestEnter()
         {
             const string markup = @"
-class c { public int value {set; get; }}
+class C { public int value {set; get; }}
 
-class d
+class D
 {
     void goo()
     {
-       c goo = new c { v$$
+       C goo = new C { v$$
     }
 }";
 
@@ -914,7 +914,7 @@ internal class Example
         public async Task ObjectInitializerEscapeKeywords()
         {
             var markup = @"
-class c
+class C
 {
     public int @new { get; set; }
 
@@ -923,11 +923,11 @@ class c
     public int now { get; set; }
 }
 
-class d
+class D
 {
     static void Main(string[] args)
     {
-        var t = new c() { $$ };
+        var t = new C() { $$ };
     }
 }";
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -1107,6 +1107,37 @@ class Program
             await VerifyItemExistsAsync(markup, "PropB");
         }
 
+        [WorkItem(36702, "https://github.com/dotnet/roslyn/issues/36702")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NestedPropertyInitializers6()
+        {
+            var markup = @"
+class A
+{
+    public B PropB { get; }
+}
+
+class B
+{
+    public C PropC { get; }
+}
+
+class C
+{
+    public int P { get; }
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new A { PropB = { $$ } }
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "PropC");
+        }
+
         private async Task VerifyExclusiveAsync(string markup, bool exclusive)
         {
             using (var workspace = TestWorkspace.CreateCSharp(markup))

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var enclosing = semanticModel.GetEnclosingNamedType(position, cancellationToken);
 
             // Find the members that can be initialized. If we have a NamedTypeSymbol, also get the overridden members.
-            IEnumerable<ISymbol> members = semanticModel.LookupSymbols(position, initializedType);
+            IEnumerable<ISymbol> members = semanticModel.LookupSymbols(position, initializedType.WithoutNullability());
             members = members.Where(m => IsInitializable(m, enclosing) &&
                                          m.CanBeReferencedByName &&
                                          IsLegalFieldOrProperty(m, enclosing) &&


### PR DESCRIPTION
This slipped through because we didn't have any tests at all for the case where we are using the type-inferrer to infer the case like:

    a = new A { B = { } }

where the inner one doesn't have a `new B` before it. The scenario wasn't new but just happened to be the precise case that was broken.

Fixes #36702