### PR TITLE
set "DeferUntilIntellisenseIsReady"=dword:00000000 for csharp and VB …

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackageRegistration.pkgdef
@@ -1,6 +1,7 @@
 ﻿[$RootKey$\Editors]
 
 [$RootKey$\Editors\{08467b34-b90f-4d91-bdca-eb8c8cf3033a}]
+"DeferUntilIntellisenseIsReady"=dword:00000000
 "CommonPhysicalViewAttributes"=dword:00000003
 "DisplayName"="#2359"
 "EditorTrustLevel"=dword:00000002
@@ -22,6 +23,7 @@
 "{7651a702-06e5-11d1-8ebd-00a0c90f26ea}"="Form"
 
 [$RootKey$\Editors\{A6C744A8-0E4A-4FC6-886A-064283054674}]
+"DeferUntilIntellisenseIsReady"=dword:00000000
 "CommonPhysicalViewAttributes"=dword:00000002
 "DisplayName"="#2358"
 "EditorTrustLevel"=dword:00000002

--- a/src/VisualStudio/VisualBasic/Impl/VisualBasicPackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/VisualBasicPackageRegistration.pkgdef
@@ -1,6 +1,7 @@
 ﻿[$RootKey$\Editors]
 
 [$RootKey$\Editors\{6C33E1AA-1401-4536-AB67-0E21E6E569DA}]
+"DeferUntilIntellisenseIsReady"=dword:00000000
 "Package"="{574FC912-F74F-4B4E-92C3-F695C208A2BB}"
 "DisplayName"="#1012"
 "CommonPhysicalViewAttributes"=dword:00000003
@@ -29,6 +30,7 @@
 "vb"=dword:00000027
 
 [$RootKey$\Editors\{2C015C70-C72C-11D0-88C3-00A0C9110049}]
+"DeferUntilIntellisenseIsReady"=dword:00000000
 "Package"="{574FC912-F74F-4B4E-92C3-F695C208A2BB}"
 "DisplayName"="#1013"
 "CommonPhysicalViewAttributes"=dword:00000002


### PR DESCRIPTION
…editor so that we opt out from C#/VB editors waiting for solution load to complete

this basically make csproj to behave same as cps where VS let users to open C# or VB code file before solution is fully loaded.