### PR TITLE
Fix build errors in Microsoft.CodeAnalysis.dll

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticSuppressor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticSuppressor.cs
@@ -12,7 +12,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         // Disallow suppressors from reporting diagnostics or registering analysis actions.
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
 
-        public sealed override void Initialize(AnalysisContext context) { }
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        }
 
         /// <summary>
         /// Returns a set of descriptors for the suppressions that this suppressor is capable of producing.


### PR DESCRIPTION
The dev16.3-preview1 build is broken. I think some sync issue came up that prevented these diagnostics from occurring until after both PRs got merged. Here are the diagnostics I'm seeing:

```
F:\src\roslyn\src\Compilers\Core\Portable\DiagnosticAnalyzer\DiagnosticSuppressor.cs(15,64): error RS1026: Enable concurrent execution [F:\src\roslyn\src\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj]
F:\src\roslyn\src\Compilers\Core\Portable\DiagnosticAnalyzer\DiagnosticSuppressor.cs(15,64): error RS1025: Configure generated code analysis [F:\src\roslyn\src\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj]
```

This PR fixes the problem by applying the code fixes for these diagnostics.