### PR TITLE
Couple of AD0001 fixes for unused parameter analyzer

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1213,5 +1213,68 @@ internal sealed class CustomSerializingType : ISerializable
 }",
     Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId));
         }
+
+        [WorkItem(36715, "https://github.com/dotnet/roslyn/issues/36715")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task GenericLocalFunction_02()
+        {
+            await TestDiagnosticsAsync(
+@"using System.Collections.Generic;
+
+class C
+{
+    void M(object [|value|])
+    {
+        try
+        {
+            value = LocalFunc(0);
+        }
+        finally
+        {
+            value = LocalFunc(0);
+        }
+
+        return;
+
+        IEnumerable<T> LocalFunc<T>(T value)
+        {
+            yield return value;
+        }
+    }
+}",
+    Diagnostic(IDEDiagnosticIds.UnusedParameterDiagnosticId));
+        }
+
+        [WorkItem(36715, "https://github.com/dotnet/roslyn/issues/36715")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task GenericLocalFunction_03()
+        {
+            await TestDiagnosticsAsync(
+@"using System;
+using System.Collections.Generic;
+
+class C
+{
+    void M(object [|value|])
+    {
+        Func<object, IEnumerable<object>> myDel = LocalFunc;
+        try
+        {
+            value = myDel(value);
+        }
+        finally
+        {
+            value = myDel(value);
+        }
+
+        return;
+
+        IEnumerable<T> LocalFunc<T>(T value)
+        {
+            yield return value;
+        }
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1276,5 +1276,34 @@ class C
     }
 }");
         }
+
+        [WorkItem(34830, "https://github.com/dotnet/roslyn/issues/34830")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task RegressionTest_ShouldReportUnusedParameter()
+        {
+            var options = Option(CodeStyleOptions.UnusedParameters,
+                new CodeStyleOption<UnusedParametersPreference>(default, NotificationOption.Suggestion));
+
+            await TestDiagnosticMissingAsync(
+@"using System;
+using System.Threading.Tasks;
+
+public interface IFoo { event Action Fooed; }
+
+public sealed class C : IDisposable
+{
+    private readonly Task<IFoo> foo;
+
+    public C(Task<IFoo> [|foo|])
+    {
+        this.foo = foo;
+        Task.Run(async () => (await foo).Fooed += fooed);
+    }
+
+    private void fooed() { }
+
+    public void Dispose() => foo.Result.Fooed -= fooed;
+}", options);
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeStyle/UnusedParametersPreference.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/UnusedParametersPreference.cs
@@ -8,9 +8,9 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     internal enum UnusedParametersPreference
     {
         // Ununsed parameters of non-public methods are flagged.
-        NonPublicMethods = 1,
+        NonPublicMethods = 0,
 
         // Unused parameters of methods with any accessibility (private/public/protected/internal) are flagged.
-        AllMethods = 2,
+        AllMethods = 1,
     }
 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.FlowGraphAnalysisData.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.FlowGraphAnalysisData.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                                 }
                                 else if (invocation.TargetMethod.IsLocalFunction())
                                 {
-                                    var localFunctionGraph = cfg.GetLocalFunctionControlFlowGraphInScope(invocation.TargetMethod);
+                                    var localFunctionGraph = cfg.GetLocalFunctionControlFlowGraphInScope(invocation.TargetMethod.OriginalDefinition);
                                     if (localFunctionGraph != null)
                                     {
                                         AddDescendantOperationsInLambdaOrLocalFunctionGraph(localFunctionGraph);
@@ -275,6 +275,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     ControlFlowGraph TryGetLocalFunctionControlFlowGraphInScope(IMethodSymbol localFunction)
                     {
                         Debug.Assert(localFunction.IsLocalFunction());
+
+                        // Use the original definition of the local function for flow analysis.
+                        localFunction = localFunction.OriginalDefinition;
+
                         if (_localFunctionTargetsToAccessingCfgMap.TryGetValue(localFunction, out var localFunctionAccessingCfg))
                         {
                             var localFunctionCfg = localFunctionAccessingCfg.GetLocalFunctionControlFlowGraphInScope(localFunction);
@@ -514,7 +518,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                     //
                     Debug.Assert(localFunctionTarget.Method.IsLocalFunction());
                     SetReachingDelegateTargetCore(write, localFunctionTarget);
-                    _localFunctionTargetsToAccessingCfgMap[localFunctionTarget.Method] = ControlFlowGraph;
+                    _localFunctionTargetsToAccessingCfgMap[localFunctionTarget.Method.OriginalDefinition] = ControlFlowGraph;
                 }
 
                 public override void SetEmptyInvocationTargetsForDelegate(IOperation write)


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn/commit/3146d928ef5eeb0244e34ea6536ade1069e8f844: Handle generic local function usages in finally region in symbol usage analysis. Fixes #36715

2. https://github.com/dotnet/roslyn/commit/ee61cc53ff02b55df8c9d756235c0e1085dafa4b: Fix AD0001 from unhandled UnusedParametersPreference. Fixes #34830