### PR TITLE
Add workarounds to IDE analyzers for missing IOperation/CFG support for using declarations

### DIFF
--- a/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.cs
@@ -5024,6 +5024,37 @@ class C : IDisposable
 }");
         }
 
+        [Fact, WorkItem(32100, "https://github.com/dotnet/roslyn/issues/32100")]
+        public async Task UsingDeclaration()
+        {
+            await TestDiagnosticsAsync(@"
+using System;
+class C : IDisposable
+{
+    public void Dispose() { }
+    void M1()
+    {
+        [|using var c = new C()|];
+    }
+}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        }
+
+        [Fact, WorkItem(32100, "https://github.com/dotnet/roslyn/issues/32100")]
+        public async Task UsingDeclarationWithInitializer()
+        {
+            await TestDiagnosticsAsync(@"
+using System;
+class C : IDisposable
+{
+    public int P { get; set; }
+    public void Dispose() { }
+    void M1()
+    {
+        [|using var c = new C() { P = 1 }|];
+    }
+}", parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        }
+
         [Fact]
         public async Task MissingDisposeInMethodWithAttributes()
         {

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -6999,5 +6999,48 @@ class C
     int M2() => 0;
 }", options: PreferUnusedLocal, parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [WorkItem(33464, "https://github.com/dotnet/roslyn/issues/33464")]
+        public async Task UsingDeclaration()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C : IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M()
+    {
+        using var [|x|] = new C();
+    }
+}", options: PreferDiscard,
+    parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [WorkItem(33464, "https://github.com/dotnet/roslyn/issues/33464")]
+        public async Task UsingDeclarationWithInitializer()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class C : IDisposable
+{
+    public int P { get; set; }
+    public void Dispose()
+    {
+    }
+
+    void M()
+    {
+        using var [|x|] = new C() { P = 1 };
+    }
+}", options: PreferDiscard,
+    parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        }
     }
 }

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
@@ -103,6 +103,13 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                     ComputeDiagnostics(disposeDataAtExit, notDisposedDiagnostics, mayBeNotDisposedDiagnostics,
                         disposeAnalysisResult, pointsToAnalysisResult);
 
+                    if (disposeAnalysisResult.ControlFlowGraph.OriginalOperation.HasAnyOperationDescendant(o => o.Kind == OperationKind.None))
+                    {
+                        // Workaround for https://github.com/dotnet/roslyn/issues/32100
+                        // Bail out in presence of OperationKind.None - not implemented IOperation.
+                        return;
+                    }
+
                     // Report diagnostics preferring *not* disposed diagnostics over may be not disposed diagnostics
                     // and avoiding duplicates.
                     foreach (var diagnostic in notDisposedDiagnostics.Concat(mayBeNotDisposedDiagnostics))

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -331,6 +331,16 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                             // Skip blocks from attributes (which have OperationKind.None) and parameter initializers.
                             // We don't have any unused values in such operation blocks.
                             return false;
+
+                        default:
+                            if (operationBlock.HasAnyOperationDescendant(o => o.Kind == OperationKind.None))
+                            {
+                                // Workaround for https://github.com/dotnet/roslyn/issues/32100
+                                // Bail out in presence of OperationKind.None - not implemented IOperation.
+                                return false;
+                            }
+
+                            break;
                     }
 
                     // We currently do not support points-to analysis, which is needed to accurately track locations of


### PR DESCRIPTION
Workaround for #32100
1. https://github.com/dotnet/roslyn/commit/a08f86e3d5ec1701fc6ccd3c0e3538341832c2ad: Workaround in dispose analyzer
2. https://github.com/dotnet/roslyn/commit/b0a9514603afde201b10caf990e035fc5d92a2f1: Workaround in unused parameter/value analyzer