### PR TITLE
Improve integration test logging

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <summary>
         /// Get the WER entries for VS and VS related EXEs from the Event Log and write them to a file
         /// </summary>
-        internal static void TryWriteWatsonEntriesToFile(string filePath)
+        internal static void AppendWatsonEntriesToFile(string filePath)
         {
             try
             {
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                     ReverseDirection = true
                 };
 
-                var eventLogReader = new EventLogReader(eventLogQuery);
+                using var eventLogReader = new EventLogReader(eventLogQuery);
                 EventRecord eventLogRecord;
                 var watsonEntriesCount = 0;
                 while ((eventLogRecord = eventLogReader.ReadEvent()) != null)
@@ -157,35 +157,39 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 if (watsonEntries.Any())
                 {
-                    var watsonEntriesStringBuilder = new StringBuilder();
+                    var builder = new StringBuilder();
+                    builder.AppendLine();
+                    builder.AppendLine("--- Watson event log entries -------------");
+                    builder.AppendLine();
+
                     foreach (var entry in watsonEntries)
                     {
-                        watsonEntriesStringBuilder.AppendLine($"Event Time (UTC): {entry.EventTime}");
-                        watsonEntriesStringBuilder.AppendLine($"Application Name: {entry.ApplicationName}");
-                        watsonEntriesStringBuilder.AppendLine($"Application Version: {entry.ApplicationVersion}");
-                        watsonEntriesStringBuilder.AppendLine($"Faulting Module: {entry.FaultingModule}");
-                        watsonEntriesStringBuilder.AppendLine($"Faulting Module Version: {entry.FaultingModuleVersion}");
-                        watsonEntriesStringBuilder.AppendLine($"Event Name: {entry.EventName}");
-                        watsonEntriesStringBuilder.AppendLine($"Cab Id: {entry.CabId}");
-                        watsonEntriesStringBuilder.AppendLine($"Fault Bucket: {entry.FaultBucket}");
-                        watsonEntriesStringBuilder.AppendLine($"Hashed Bucket: {entry.HashedBucket}");
-                        watsonEntriesStringBuilder.AppendLine($"Watson Report Id: {entry.WatsonReportId}");
-                        watsonEntriesStringBuilder.AppendLine();
+                        builder.AppendLine($"Event Time (UTC): {entry.EventTime}");
+                        builder.AppendLine($"Application Name: {entry.ApplicationName}");
+                        builder.AppendLine($"Application Version: {entry.ApplicationVersion}");
+                        builder.AppendLine($"Faulting Module: {entry.FaultingModule}");
+                        builder.AppendLine($"Faulting Module Version: {entry.FaultingModuleVersion}");
+                        builder.AppendLine($"Event Name: {entry.EventName}");
+                        builder.AppendLine($"Cab Id: {entry.CabId}");
+                        builder.AppendLine($"Fault Bucket: {entry.FaultBucket}");
+                        builder.AppendLine($"Hashed Bucket: {entry.HashedBucket}");
+                        builder.AppendLine($"Watson Report Id: {entry.WatsonReportId}");
+                        builder.AppendLine();
                     }
 
-                    File.WriteAllText(filePath, watsonEntriesStringBuilder.ToString());
+                    File.AppendAllText(filePath, builder.ToString());
                 }
             }
             catch (Exception ex)
             {
-                File.WriteAllText(filePath, ex.ToString());
+                File.AppendAllText(filePath, $"Exception thrown while reading event log: {ex}");
             }
         }
 
         /// <summary>
         /// Get the .NetRuntime entries from the Event Log and write them to a file
         /// </summary>
-        internal static void TryWriteDotNetEntriesToFile(string filePath)
+        internal static void AppendDotNetEntriesToFile(string filePath)
         {
             try
             {
@@ -198,7 +202,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                     ReverseDirection = true
                 };
 
-                var eventLogReader = new EventLogReader(eventLogQuery);
+                using var eventLogReader = new EventLogReader(eventLogQuery);
                 EventRecord eventLogRecord;
                 while ((eventLogRecord = eventLogReader.ReadEvent()) != null)
                 {
@@ -220,21 +224,25 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 if (dotNetEntries.Any())
                 {
-                    var dotNetEntriesStringBuilder = new StringBuilder();
+                    var builder = new StringBuilder();
+                    builder.AppendLine();
+                    builder.AppendLine("--- .NET Runtime event log entries -------");
+                    builder.AppendLine();
+
                     foreach (var entry in dotNetEntries)
                     {
-                        dotNetEntriesStringBuilder.AppendLine($"Event Time (UTC): {entry.EventTime}");
-                        dotNetEntriesStringBuilder.AppendLine($"Event ID: {entry.EventId}");
-                        dotNetEntriesStringBuilder.AppendLine($"Data: {entry.Data.Replace("\n", "\r\n")}");
-                        dotNetEntriesStringBuilder.AppendLine();
+                        builder.AppendLine($"Event Time (UTC): {entry.EventTime}");
+                        builder.AppendLine($"Event ID: {entry.EventId}");
+                        builder.AppendLine($"Data: {entry.Data.Replace("\n", "\r\n")}");
+                        builder.AppendLine();
                     }
 
-                    File.WriteAllText(filePath, dotNetEntriesStringBuilder.ToString());
+                    File.AppendAllText(filePath, builder.ToString());
                 }
             }
             catch (Exception ex)
             {
-                File.WriteAllText(filePath, ex.ToString());
+                File.AppendAllText(filePath, $"Exception thrown while reading event log: {ex}");
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/EventLogCollector.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <summary>
         /// Get the WER entries for VS and VS related EXEs from the Event Log and write them to a file
         /// </summary>
-        internal static void AppendWatsonEntriesToFile(string filePath)
+        internal static void AppendWatsonEntries(StringBuilder builder)
         {
             try
             {
@@ -157,7 +157,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 if (watsonEntries.Any())
                 {
-                    var builder = new StringBuilder();
                     builder.AppendLine();
                     builder.AppendLine("--- Watson event log entries -------------");
                     builder.AppendLine();
@@ -176,20 +175,18 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                         builder.AppendLine($"Watson Report Id: {entry.WatsonReportId}");
                         builder.AppendLine();
                     }
-
-                    File.AppendAllText(filePath, builder.ToString());
                 }
             }
             catch (Exception ex)
             {
-                File.AppendAllText(filePath, $"Exception thrown while reading event log: {ex}");
+                builder.AppendLine($"Exception thrown while reading event log: {ex}");
             }
         }
 
         /// <summary>
         /// Get the .NetRuntime entries from the Event Log and write them to a file
         /// </summary>
-        internal static void AppendDotNetEntriesToFile(string filePath)
+        internal static void AppendDotNetEntries(StringBuilder builder)
         {
             try
             {
@@ -224,7 +221,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 if (dotNetEntries.Any())
                 {
-                    var builder = new StringBuilder();
                     builder.AppendLine();
                     builder.AppendLine("--- .NET Runtime event log entries -------");
                     builder.AppendLine();
@@ -236,13 +232,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                         builder.AppendLine($"Data: {entry.Data.Replace("\n", "\r\n")}");
                         builder.AppendLine();
                     }
-
-                    File.AppendAllText(filePath, builder.ToString());
                 }
             }
             catch (Exception ex)
             {
-                File.AppendAllText(filePath, $"Exception thrown while reading event log: {ex}");
+                builder.AppendLine($"Exception thrown while reading event log: {ex}");
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.VisualStudio.Setup.Configuration;
@@ -79,10 +80,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 Directory.CreateDirectory(logDir);
 
                 var exception = eventArgs.Exception;
-                File.WriteAllText(logPath, $"First chance exception {exception.GetType().Name}:{Environment.NewLine}{exception.StackTrace}");
+                var builder = new StringBuilder();
 
-                EventLogCollector.AppendDotNetEntriesToFile(logPath);
-                EventLogCollector.AppendWatsonEntriesToFile(logPath);
+                builder.AppendLine($"First chance exception {exception.GetType().Name}:");
+                builder.AppendLine(exception.StackTrace);
+
+                EventLogCollector.AppendDotNetEntries(builder);
+                EventLogCollector.AppendWatsonEntries(builder);
+                File.WriteAllText(logPath, builder.ToString());
 
                 ScreenshotService.TakeScreenshot(Path.ChangeExtension(logPath, ".png"));
             }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -79,10 +79,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 Directory.CreateDirectory(logDir);
 
+                var currentProcess = Process.GetCurrentProcess();
                 var exception = eventArgs.Exception;
                 var builder = new StringBuilder();
 
-                builder.AppendLine($"First chance exception {exception.GetType().Name}:");
+                builder.AppendLine($"First chance exception {exception.GetType().Name} thrown in process {currentProcess.ProcessName} ({currentProcess.Id}):");
                 builder.AppendLine(exception.StackTrace);
 
                 EventLogCollector.AppendDotNetEntries(builder);


### PR DESCRIPTION
Write all log information for each first chance exception to a single file (as opposed to multiple log files per exception).