### PR TITLE
Delete unused experiment names added in merge.

### DIFF
--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -30,8 +30,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string PartialLoadMode = "Roslyn.PartialLoadMode";
         public const string TypeImportCompletion = "Roslyn.TypeImportCompletion";
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
-        public const string RoslynToggleBlockComment = "Roslyn.ToggleBlockComment";
-        public const string RoslynToggleLineComment = "Roslyn.ToggleLineComment";
         public const string NativeEditorConfigSupport = "Roslyn.NativeEditorConfigSupport";
         public const string RoslynInlineRenameFile = "Roslyn.FileRename";
     }


### PR DESCRIPTION
@sandyarmstrong pointed out these experiment names accidentally got added back in a merge somewhere.  They were removed in https://github.com/dotnet/roslyn/pull/35271