### PR TITLE
Update  xUnit2018 diagnostic severity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,7 +37,7 @@ indent_size = 2
 
 # Dotnet diagnostic settings
 [*.{cs,vb}]
-dotnet_diagnostic.xUnit2018.severity = suppress # "do not compare an object's exact type to the abstract class" is a valid assert, but very noisy right now
+dotnet_diagnostic.xUnit2018.severity = none # "do not compare an object's exact type to the abstract class" is a valid assert, but very noisy right now
 
 # Dotnet code style settings:
 [*.{cs,vb}]


### PR DESCRIPTION
Since we merged https://github.com/dotnet/roslyn/pull/36566, we've been seeing the following error in CI builds - "The diagnostic 'xunit2018' was given an invalid severity 'suppress' in the analyzer config file"

This updated the editorconfig to use `none` instead of `suppress`