### PR TITLE
Revert "use the source instead of the name to find nuget packages"

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
@@ -24,8 +24,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
 
     public class AddUsingNuGetTests : AbstractAddUsingTests
     {
+        const string NugetOrgSource = "nuget.org";
+
         private static readonly ImmutableArray<PackageSource> NugetPackageSources =
-            ImmutableArray.Create(new PackageSource(SymbolSearchUpdateEngine.NugetOrgSourceName, SymbolSearchUpdateEngine.NugetOrgSourceUri));
+            ImmutableArray.Create(new PackageSource(NugetOrgSource, "http://nuget.org/"));
 
         protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
         {
@@ -61,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-                SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+                NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
             await TestInRegularAndScriptAsync(
@@ -92,7 +94,7 @@ class C
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-                SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+                NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
             await TestInRegularAndScriptAsync(
@@ -121,7 +123,7 @@ class C
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-                SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+                NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
             await TestMissingInRegularAndScriptAsync(
@@ -147,7 +149,7 @@ class C
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-                SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+                NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NS1", "NS2")));
 
             var data = new FixProviderData(installerServiceMock.Object, packageServiceMock.Object);
@@ -191,7 +193,7 @@ parameters: new TestParameters(index: 2, fixProviderData: data));
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
             packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(
-                SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+                NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
             await TestInRegularAndScriptAsync(
@@ -224,7 +226,7 @@ class C
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
-            packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+            packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
             await TestInRegularAndScriptAsync(
@@ -258,7 +260,7 @@ class C
             var packageServiceMock = new Mock<ISymbolSearchService>(MockBehavior.Strict);
             packageServiceMock.Setup(s => s.FindReferenceAssembliesWithTypeAsync("NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IList<ReferenceAssemblyWithTypeResult>>(new List<ReferenceAssemblyWithTypeResult>()));
-            packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "NuGetType", 0, It.IsAny<CancellationToken>()))
+            packageServiceMock.Setup(s => s.FindPackagesWithTypeAsync(NugetOrgSource, "NuGetType", 0, It.IsAny<CancellationToken>()))
                 .Returns(CreateSearchResult("NuGetPackage", "NuGetType", CreateNameParts("NuGetNamespace")));
 
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.Update.cs
+++ b/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.Update.cs
@@ -34,8 +34,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         internal const string ChecksumAttributeName = "checksum";
         internal const string UpToDateAttributeName = "upToDate";
         internal const string TooOldAttributeName = "tooOld";
-        internal const string NugetOrgSourceName = "nuget.org";
-        internal const string NugetOrgSourceUri = "https://api.nuget.org/v3/index.json";
+        internal const string NugetOrgSource = "nuget.org";
 
         public const string HostId = "RoslynNuGetSearch";
         private const string MicrosoftAssemblyReferencesName = "MicrosoftAssemblyReferences";
@@ -107,7 +106,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             internal async Task UpdateInBackgroundAsync()
             {
                 // We only support this single source currently.
-                if (_source != NugetOrgSourceUri)
+                if (_source != NugetOrgSource)
                 {
                     return;
                 }

--- a/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/EditorFeatures/Core.Wpf/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             string name, int arity, CancellationToken cancellationToken)
         {
             // Our reference assembly data is stored in the nuget.org DB.
-            if (!_sourceToDatabase.TryGetValue(NugetOrgSourceName, out var databaseWrapper))
+            if (!_sourceToDatabase.TryGetValue(NugetOrgSource, out var databaseWrapper))
             {
                 // Don't have a database to search.  
                 return SpecializedTasks.EmptyImmutableArray<ReferenceAssemblyWithTypeResult>();

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         {
             // Always pull down the nuget.org index.  It contains the MS reference assembly index
             // inside of it.
-            Task.Run(() => UpdateSourceInBackgroundAsync(SymbolSearchUpdateEngine.NugetOrgSourceUri));
+            Task.Run(() => UpdateSourceInBackgroundAsync(SymbolSearchUpdateEngine.NugetOrgSource));
         }
 
         private async Task<ISymbolSearchUpdateEngine> GetEngineAsync(CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
+++ b/src/VisualStudio/Core/Test/SymbolSearch/SymbolSearchUpdateEngineTests.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await service.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await service.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlService.Verify()
             End Using
@@ -77,7 +77,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await service.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await service.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlService.Verify()
             End Using
@@ -115,7 +115,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 serviceMock.Verify()
                 clientMock.Verify()
@@ -159,7 +159,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 serviceMock.Verify()
                 clientMock.Verify()
@@ -195,7 +195,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 serviceMock.Verify()
                 clientMock.Verify()
@@ -244,7 +244,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -288,7 +288,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -336,7 +336,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -395,7 +395,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -441,7 +441,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -495,7 +495,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -555,7 +555,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()
@@ -611,7 +611,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SymbolSearch
                     reportAndSwallowException:=s_allButMoqExceptions,
                     updateCancellationToken:=cancellationTokenSource.Token)
 
-                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSourceName, "TestDirectory")
+                Await searchService.UpdateContinuouslyAsync(SymbolSearchUpdateEngine.NugetOrgSource, "TestDirectory")
                 ioMock.Verify()
                 remoteControlMock.Verify()
                 clientMock.Verify()


### PR DESCRIPTION
reverts https://github.com/dotnet/roslyn/pull/35397

CC: @RikkiGibson 	@jinujoseph 	@heejaechang 	