### PR TITLE
EE formatters for IntPtr and UIntPtr

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/CSharpResultProviderTestBase.cs
@@ -50,5 +50,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 return string.Format("0x{0:x8}", pointer.ToInt32());
             }
         }
+
+        protected static string PointerToString(UIntPtr pointer)
+        {
+            if (Environment.Is64BitProcess)
+            {
+                return string.Format("0x{0:x16}", pointer.ToUInt64());
+            }
+            else
+            {
+                return string.Format("0x{0:x8}", pointer.ToUInt32());
+            }
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -743,7 +743,7 @@ unsafe class C
                 string fullName = string.Format("*({0}).p", rootExpr);
                 children = GetChildren(children[0]);
                 Verify(children,
-                    EvalResult(fullName, "0x00000004", "System.IntPtr", fullName, DkmEvaluationResultFlags.None));
+                    EvalResult(fullName, IntPtr.Size == 8 ? "0x0000000000000004" : "0x00000004", "System.IntPtr", fullName, DkmEvaluationResultFlags.None));
             }
         }
 
@@ -783,7 +783,7 @@ unsafe class C
                 string fullName = string.Format("*({0}).p", rootExpr);
                 children = GetChildren(children[0]);
                 Verify(children,
-                    EvalResult(fullName, "0x00000004", "System.UIntPtr", fullName, DkmEvaluationResultFlags.None));
+                    EvalResult(fullName, UIntPtr.Size == 8 ? "0x0000000000000004" : "0x00000004", "System.UIntPtr", fullName, DkmEvaluationResultFlags.None));
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -743,11 +743,47 @@ unsafe class C
                 string fullName = string.Format("*({0}).p", rootExpr);
                 children = GetChildren(children[0]);
                 Verify(children,
-                    EvalResult(fullName, "{4}", "System.IntPtr", fullName, DkmEvaluationResultFlags.Expandable));
+                    EvalResult(fullName, "0x00000004", "System.IntPtr", fullName, DkmEvaluationResultFlags.None));
+            }
+        }
+
+        [Fact]
+        public void UIntPtrPointer()
+        {
+            var source = @"
+using System;
+
+unsafe class C
+{
+    internal C(ulong p)
+    {
+        this.p = (UIntPtr*)p;
+    }
+    UIntPtr* p;
+    UIntPtr* q;
+}";
+            var assembly = GetUnsafeAssembly(source);
+            unsafe
+            {
+                // NOTE: We're depending on endian-ness to put
+                // the interesting bytes first when we run this
+                // test as 32-bit.
+                ulong i = 4;
+                ulong p = (ulong)&i;
+                var type = assembly.GetType("C");
+                var rootExpr = string.Format("new C({0})", p);
+                var value = CreateDkmClrValue(type.Instantiate(p));
+                var evalResult = FormatResult(rootExpr, value);
+                Verify(evalResult,
+                    EvalResult(rootExpr, "{C}", "C", rootExpr, DkmEvaluationResultFlags.Expandable));
+                var children = GetChildren(evalResult);
+                Verify(children,
+                    EvalResult("p", PointerToString(new UIntPtr(p)), "System.UIntPtr*", string.Format("({0}).p", rootExpr), DkmEvaluationResultFlags.Expandable),
+                    EvalResult("q", PointerToString(UIntPtr.Zero), "System.UIntPtr*", string.Format("({0}).q", rootExpr)));
+                string fullName = string.Format("*({0}).p", rootExpr);
                 children = GetChildren(children[0]);
                 Verify(children,
-                    EvalResult("m_value", PointerToString(new IntPtr(i)), "void*", string.Format("({0}).m_value", fullName)),
-                    EvalResult("Static members", null, "", "System.IntPtr", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Class));
+                    EvalResult(fullName, "0x00000004", "System.UIntPtr", fullName, DkmEvaluationResultFlags.None));
             }
         }
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -32,17 +32,18 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // For members of type DynamicProperty (part of Dynamic View expansion), we want
             // to expand the underlying value (not the members of the DynamicProperty type).
             var type = value.Type;
-            var isDynamicProperty = type.GetLmrType().IsDynamicProperty();
+            var runtimeType = type.GetLmrType();
+            var isDynamicProperty = runtimeType.IsDynamicProperty();
             if (isDynamicProperty)
             {
                 Debug.Assert(!value.IsNull);
                 value = value.GetFieldValue("value", inspectionContext);
             }
 
-            var runtimeType = type.GetLmrType();
-            // Primitives, enums, function pointers, and null values with a declared type that is an interface have no visible members.
+            // Primitives, enums, function pointers, IntPtr, UIntPtr and null values with a declared type that is an interface have no visible members.
             Debug.Assert(!runtimeType.IsInterface || value.IsNull);
-            if (resultProvider.IsPrimitiveType(runtimeType) || runtimeType.IsEnum || runtimeType.IsInterface || runtimeType.IsFunctionPointer())
+            if (resultProvider.IsPrimitiveType(runtimeType) || runtimeType.IsEnum || runtimeType.IsInterface || runtimeType.IsFunctionPointer() ||
+                runtimeType.IsIntPtr() || runtimeType.IsUIntPtr())
             {
                 return null;
             }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -100,10 +100,31 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     ? _nullString
                     : GetValueString(nullableValue, inspectionContext, ObjectDisplayOptions.None, GetValueFlags.IncludeTypeName);
             }
-            else if (lmrType.IsIntPtr() || lmrType.IsUIntPtr())
+            else if (lmrType.IsIntPtr())
             {
-                var fieldValue = value.GetFieldValue(InternalWellKnownMemberNames.IntPtrAndUIntPtrStringValue, inspectionContext);
-                return FormatPrimitive(fieldValue, ObjectDisplayOptions.UseHexadecimalNumbers, inspectionContext);
+                if (IntPtr.Size == 8)
+                {
+                    var intPtr = ((IntPtr)value.HostObjectValue).ToInt64();
+                    return FormatPrimitiveObject(intPtr, ObjectDisplayOptions.UseHexadecimalNumbers);
+                }
+                else
+                {
+                    var intPtr = ((IntPtr)value.HostObjectValue).ToInt32();
+                    return FormatPrimitiveObject(intPtr, ObjectDisplayOptions.UseHexadecimalNumbers);
+                }
+            }
+            else if (lmrType.IsUIntPtr())
+            {
+                if (UIntPtr.Size == 8)
+                {
+                    var uIntPtr = ((UIntPtr)value.HostObjectValue).ToUInt64();
+                    return FormatPrimitiveObject(uIntPtr, ObjectDisplayOptions.UseHexadecimalNumbers);
+                }
+                else
+                {
+                    var uIntPtr = ((UIntPtr)value.HostObjectValue).ToUInt32();
+                    return FormatPrimitiveObject(uIntPtr, ObjectDisplayOptions.UseHexadecimalNumbers);
+                }
             }
             else
             {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -100,6 +100,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     ? _nullString
                     : GetValueString(nullableValue, inspectionContext, ObjectDisplayOptions.None, GetValueFlags.IncludeTypeName);
             }
+            else if (lmrType.IsIntPtr() || lmrType.IsUIntPtr())
+            {
+                var fieldValue = value.GetFieldValue(InternalWellKnownMemberNames.IntPtrAndUIntPtrStringValue, inspectionContext);
+                return FormatPrimitive(fieldValue, ObjectDisplayOptions.UseHexadecimalNumbers, inspectionContext);
+            }
             else
             {
                 int cardinality;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/InternalWellKnownMemberNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/InternalWellKnownMemberNames.cs
@@ -7,5 +7,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         public const string NullableHasValue = "hasValue";
         public const string NullableValue = "value";
         public const string SqlStringValue = "m_value";
+        public const string IntPtrAndUIntPtrStringValue = "m_value";
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/InternalWellKnownMemberNames.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/InternalWellKnownMemberNames.cs
@@ -7,6 +7,5 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         public const string NullableHasValue = "hasValue";
         public const string NullableValue = "value";
         public const string SqlStringValue = "m_value";
-        public const string IntPtrAndUIntPtrStringValue = "m_value";
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -272,6 +272,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             return type.IsMscorlibType("System.Collections", "IEnumerable");
         }
 
+        internal static bool IsIntPtr(this Type type)
+            => type.IsMscorlibType("System", "IntPtr");
+
+        internal static bool IsUIntPtr(this Type type)
+            => type.IsMscorlibType("System", "UIntPtr");
+
         internal static bool IsIEnumerableOfT(this Type type)
         {
             return type.IsMscorlibType("System.Collections.Generic", "IEnumerable`1");

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ExpansionTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ExpansionTests.vb
@@ -130,7 +130,7 @@ End Class"
                     EvalResult("q", PointerToString(IntPtr.Zero), "Integer*", String.Format("({0}).q", rootExpr)))
             Dim fullName = String.Format("*({0}).p", rootExpr)
             Verify(GetChildren(children(0)),
-                    EvalResult(fullName, "4", "Integer", fullName))
+                    EvalResult(fullName, "4", "Integer", fullName, DkmEvaluationResultFlags.None))
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes Roslyn part of https://developercommunity.visualstudio.com/content/problem/491378/vb-intptr-error-bc30657-topointer-has-a-return-typ.html