### PR TITLE
Fix header reading for Narrator on Pull Members Up dialog

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -147,11 +147,7 @@
                     <DataGrid.Columns>
                         <DataGridTemplateColumn Width="*">
                             <DataGridTemplateColumn.Header>
-                                <self:HeaderStackPanel
-                                    AutomationProperties.Name="Test Header"
-                                    AutomationProperties.IsColumnHeader="True"
-                                    AutomationProperties.LabeledBy="{Binding ElementName=MembersHeaderTextBlock}">
-                                    <self:SelectAllCheckBox
+                                <self:SelectAllCheckBox
                                             AutomationProperties.Name="{Binding SelectAllCheckBoxAutomationText}"
                                             Margin="0, 0, 4, 0"
                                             Checked="SelectAllCheckBox_Checked"
@@ -161,7 +157,6 @@
                                             DataContext="{Binding RelativeSource={RelativeSource AncestorType=DataGrid}, Path=DataContext}"
                                             IsThreeState="{Binding ThreeStateEnable, UpdateSourceTrigger=PropertyChanged}"
                                             IsChecked="{Binding SelectAllCheckBoxState, UpdateSourceTrigger=PropertyChanged}" />
-                                </self:HeaderStackPanel>
                             </DataGridTemplateColumn.Header>
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>

--- a/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PullMemberUp/MainDialog/PullMemberUpDialog.xaml
@@ -147,23 +147,21 @@
                     <DataGrid.Columns>
                         <DataGridTemplateColumn Width="*">
                             <DataGridTemplateColumn.Header>
-                                <StackPanel 
-                                    Orientation="Horizontal" 
-                                    Width="Auto">
+                                <self:HeaderStackPanel
+                                    AutomationProperties.Name="Test Header"
+                                    AutomationProperties.IsColumnHeader="True"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=MembersHeaderTextBlock}">
                                     <self:SelectAllCheckBox
-                                        AutomationProperties.Name="{Binding SelectAllCheckBoxAutomationText}"
-                                        Margin="0, 0, 4, 0"
-                                        Checked="SelectAllCheckBox_Checked"
-                                        Unchecked="SelectAllCheckBox_Unchecked"
-                                        Focusable="True"
-                                        DataContext="{Binding RelativeSource={RelativeSource AncestorType=DataGrid}, Path=DataContext}"
-                                        IsThreeState="{Binding ThreeStateEnable, UpdateSourceTrigger=PropertyChanged}"
-                                        IsChecked="{Binding SelectAllCheckBoxState, UpdateSourceTrigger=PropertyChanged}">
-                                    </self:SelectAllCheckBox>
-                                    <TextBlock
-                                        Width="Auto"
-                                        Text="{Binding RelativeSource={RelativeSource AncestorType=vs:DialogWindow}, Path=MembersHeader}" />
-                                </StackPanel>
+                                            AutomationProperties.Name="{Binding SelectAllCheckBoxAutomationText}"
+                                            Margin="0, 0, 4, 0"
+                                            Checked="SelectAllCheckBox_Checked"
+                                            Unchecked="SelectAllCheckBox_Unchecked"
+                                            Focusable="True"
+                                            Content="{Binding RelativeSource={RelativeSource AncestorType=vs:DialogWindow}, Path=MembersHeader}"
+                                            DataContext="{Binding RelativeSource={RelativeSource AncestorType=DataGrid}, Path=DataContext}"
+                                            IsThreeState="{Binding ThreeStateEnable, UpdateSourceTrigger=PropertyChanged}"
+                                            IsChecked="{Binding SelectAllCheckBoxState, UpdateSourceTrigger=PropertyChanged}" />
+                                </self:HeaderStackPanel>
                             </DataGridTemplateColumn.Header>
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>


### PR DESCRIPTION
With a StackPanel in the custom header, Narrator reads the StackPanel class name. We could implement [ITableItemProvider](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.automation.provider.itableitemprovider) with a custom user control to correctly handle this, or just use a `CheckBox.Content` property to display the text. Now Narrator correctly reads the checkbox content when the header value needs to be read. 