### PR TITLE
Format this()/base() calls uniformly in the IDE.

### DIFF
--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -49,12 +49,12 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             _builder = ImmutableArray.CreateBuilder<T>(size);
         }
 
-        public ArrayBuilder() :
-            this(8)
+        public ArrayBuilder()
+            : this(8)
         { }
 
-        private ArrayBuilder(ObjectPool<ArrayBuilder<T>> pool) :
-            this()
+        private ArrayBuilder(ObjectPool<ArrayBuilder<T>> pool)
+            : this()
         {
             _pool = pool;
         }

--- a/src/EditorFeatures/CSharp/ExtractMethod/ExtractMethodCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/ExtractMethod/ExtractMethodCommandHandler.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.ExtractMethod
         public ExtractMethodCommandHandler(
             ITextBufferUndoManagerProvider undoManager,
             IEditorOperationsFactoryService editorOperationsFactoryService,
-            IInlineRenameService renameService) :
-            base(undoManager, editorOperationsFactoryService, renameService)
+            IInlineRenameService renameService)
+            : base(undoManager, editorOperationsFactoryService, renameService)
         {
         }
     }

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatterCommandHandler.cs
@@ -33,9 +33,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
         [ImportingConstructor]
         public SmartTokenFormatterCommandHandler(
             ITextUndoHistoryRegistry undoHistoryRegistry,
-            IEditorOperationsFactoryService editorOperationsFactoryService) :
-            base(undoHistoryRegistry,
-                 editorOperationsFactoryService)
+            IEditorOperationsFactoryService editorOperationsFactoryService)
+            : base(undoHistoryRegistry, editorOperationsFactoryService)
         {
         }
 

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewConflictViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewConflictViewTaggerProvider.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
         : AbstractPreviewTaggerProvider<ConflictTag>
     {
         [ImportingConstructor]
-        public PreviewConflictTaggerProvider() :
-            base(PredefinedPreviewTaggerKeys.ConflictSpansKey, ConflictTag.Instance)
+        public PreviewConflictTaggerProvider()
+            : base(PredefinedPreviewTaggerKeys.ConflictSpansKey, ConflictTag.Instance)
         {
         }
     }

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewReferenceHighlightingTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewReferenceHighlightingTaggerProvider.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
         : AbstractPreviewTaggerProvider<NavigableHighlightTag>
     {
         [ImportingConstructor]
-        public PreviewReferenceHighlightingTaggerProvider() :
-            base(PredefinedPreviewTaggerKeys.ReferenceHighlightingSpansKey, ReferenceHighlightTag.Instance)
+        public PreviewReferenceHighlightingTaggerProvider()
+            : base(PredefinedPreviewTaggerKeys.ReferenceHighlightingSpansKey, ReferenceHighlightTag.Instance)
         {
         }
     }
@@ -38,8 +38,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
         : AbstractPreviewTaggerProvider<NavigableHighlightTag>
     {
         [ImportingConstructor]
-        public PreviewWrittenReferenceHighlightingTaggerProvider() :
-            base(PredefinedPreviewTaggerKeys.WrittenReferenceHighlightingSpansKey, WrittenReferenceHighlightTag.Instance)
+        public PreviewWrittenReferenceHighlightingTaggerProvider()
+            : base(PredefinedPreviewTaggerKeys.WrittenReferenceHighlightingSpansKey, WrittenReferenceHighlightTag.Instance)
         {
         }
     }
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
         : AbstractPreviewTaggerProvider<NavigableHighlightTag>
     {
         [ImportingConstructor]
-        public PreviewDefinitionHighlightingTaggerProvider() :
-            base(PredefinedPreviewTaggerKeys.DefinitionHighlightingSpansKey, DefinitionHighlightTag.Instance)
+        public PreviewDefinitionHighlightingTaggerProvider()
+            : base(PredefinedPreviewTaggerKeys.DefinitionHighlightingSpansKey, DefinitionHighlightTag.Instance)
         {
         }
     }

--- a/src/EditorFeatures/Core.Wpf/Preview/PreviewWarningViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Preview/PreviewWarningViewTaggerProvider.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
         : AbstractPreviewTaggerProvider<PreviewWarningTag>
     {
         [ImportingConstructor]
-        public PreviewWarningTaggerProvider() :
-            base(PredefinedPreviewTaggerKeys.WarningSpansKey, PreviewWarningTag.Instance)
+        public PreviewWarningTaggerProvider()
+            : base(PredefinedPreviewTaggerKeys.WarningSpansKey, PreviewWarningTag.Instance)
         {
         }
     }

--- a/src/EditorFeatures/Core.Wpf/Structure/RoslynBlockTag.cs
+++ b/src/EditorFeatures/Core.Wpf/Structure/RoslynBlockTag.cs
@@ -26,8 +26,9 @@ namespace Microsoft.CodeAnalysis.Editor.Structure
             IEditorOptionsFactoryService editorOptionsFactoryService,
             IBlockTag parent,
             ITextSnapshot snapshot,
-            BlockSpan blockSpan) :
-            base(span: blockSpan.TextSpan.ToSnapshotSpan(snapshot),
+            BlockSpan blockSpan)
+            : base(
+                 span: blockSpan.TextSpan.ToSnapshotSpan(snapshot),
                  statementSpan: blockSpan.HintSpan.ToSnapshotSpan(snapshot),
                  parent: parent,
                  type: blockSpan.Type,

--- a/src/EditorFeatures/Core/Commands/CopyCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/CopyCommandArgs.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Editor.Commands
     [ExcludeFromCodeCoverage]
     internal class CopyCommandArgs : CommandArgs
     {
-        public CopyCommandArgs(ITextView textView, ITextBuffer subjectBuffer) :
-            base(textView, subjectBuffer)
+        public CopyCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
         {
         }
     }

--- a/src/EditorFeatures/Core/Commands/PasteCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/PasteCommandArgs.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.Editor.Commands
     [ExcludeFromCodeCoverage]
     internal class PasteCommandArgs : CommandArgs
     {
-        public PasteCommandArgs(ITextView textView, ITextBuffer subjectBuffer) :
-            base(textView, subjectBuffer)
+        public PasteCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
         {
         }
     }

--- a/src/EditorFeatures/Core/Extensibility/Commands/ExportCommandHandlerAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/ExportCommandHandlerAttribute.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor
         public string Name { get; }
         public IEnumerable<string> ContentTypes { get; }
 
-        public ExportCommandHandlerAttribute(string name, params string[] contentTypes) :
-            base(typeof(ICommandHandler))
+        public ExportCommandHandlerAttribute(string name, params string[] contentTypes)
+            : base(typeof(ICommandHandler))
         {
             this.Name = name;
             this.ContentTypes = contentTypes;

--- a/src/EditorFeatures/Core/Extensibility/Commands/ExportInteractiveCommandAttribute.cs
+++ b/src/EditorFeatures/Core/Extensibility/Commands/ExportInteractiveCommandAttribute.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Editor
     {
         public IEnumerable<string> ContentTypes { get; }
 
-        public ExportInteractiveAttribute(Type t, params string[] contentTypes) :
-            base(t)
+        public ExportInteractiveAttribute(Type t, params string[] contentTypes)
+            : base(t)
         {
             this.ContentTypes = contentTypes;
         }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.ParseOptionChangedEventSource.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             private readonly object _gate = new object();
 
-            public ParseOptionChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay) :
-                base(subjectBuffer, delay)
+            public ParseOptionChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
+                : base(subjectBuffer, delay)
             {
             }
 

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         {
             private readonly ISemanticChangeNotificationService _notificationService;
 
-            public SemanticChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay, ISemanticChangeNotificationService notificationService) :
-                base(subjectBuffer, delay)
+            public SemanticChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay, ISemanticChangeNotificationService notificationService)
+                : base(subjectBuffer, delay)
             {
                 _notificationService = notificationService;
             }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -251,8 +251,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             public NormalizedSnapshotSpanCollection Added { get; }
             public NormalizedSnapshotSpanCollection Removed { get; }
 
-            public DiffResult(List<SnapshotSpan> added, List<SnapshotSpan> removed) :
-                this(added?.Count == 0 ? null : (IEnumerable<SnapshotSpan>)added, removed?.Count == 0 ? null : (IEnumerable<SnapshotSpan>)removed)
+            public DiffResult(List<SnapshotSpan> added, List<SnapshotSpan> removed)
+                : this(added?.Count == 0 ? null : (IEnumerable<SnapshotSpan>)added, removed?.Count == 0 ? null : (IEnumerable<SnapshotSpan>)removed)
             {
             }
 

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -120,8 +120,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
 
         private sealed class TestTag : TextMarkerTag
         {
-            public TestTag() :
-                base("Test")
+            public TestTag()
+                : base("Test")
             {
             }
         }
@@ -173,8 +173,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
 
         private sealed class TestTaggerEventSource : AbstractTaggerEventSource
         {
-            public TestTaggerEventSource() :
-                base(delay: TaggerDelay.NearImmediate)
+            public TestTaggerEventSource()
+                : base(delay: TaggerDelay.NearImmediate)
             {
             }
 

--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -54,8 +54,8 @@ namespace Roslyn.Test.Utilities.Remote
             Workspace workspace,
             InProcRemoteServices inprocServices,
             ReferenceCountedDisposable<RemotableDataJsonRpc> remotableDataRpc,
-            Stream stream) :
-            base(workspace)
+            Stream stream)
+            : base(workspace)
         {
             Contract.ThrowIfNull(remotableDataRpc);
 

--- a/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesCodeFixProvider.cs
@@ -61,8 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
 
         private sealed class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(FeaturesResources.Add_braces, createChangedDocument, FeaturesResources.Add_braces)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Add_braces, createChangedDocument, FeaturesResources.Add_braces)
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeFixes/Iterator/CSharpAddYieldCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Iterator/CSharpAddYieldCodeFixProvider.cs
@@ -209,8 +209,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Iterator
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Document newDocument) :
-                base(title, c => Task.FromResult(newDocument))
+            public MyCodeAction(string title, Document newDocument)
+                : base(title, c => Task.FromResult(newDocument))
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeFixes/Iterator/CSharpChangeToIEnumerableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Iterator/CSharpChangeToIEnumerableCodeFixProvider.cs
@@ -126,8 +126,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.Iterator
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Document newDocument) :
-                base(title, c => Task.FromResult(newDocument))
+            public MyCodeAction(string title, Document newDocument)
+                : base(title, c => Task.FromResult(newDocument))
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeFixes/MakeStatementAsynchronous/CSharpMakeStatementAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/MakeStatementAsynchronous/CSharpMakeStatementAsynchronousCodeFixProvider.cs
@@ -113,10 +113,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.MakeStatementAsynchronous
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.Add_await,
-                     createChangedDocument,
-                     CSharpFeaturesResources.Add_await)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Add_await,
+                       createChangedDocument,
+                       CSharpFeaturesResources.Add_await)
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/Nullable/CSharpDeclareAsNullableCodeFixProvider.cs
@@ -193,10 +193,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.DeclareAsNullable
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.Declare_as_nullable,
-                     createChangedDocument,
-                     CSharpFeaturesResources.Declare_as_nullable)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Declare_as_nullable,
+                       createChangedDocument,
+                       CSharpFeaturesResources.Declare_as_nullable)
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.cs
@@ -86,8 +86,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryCast
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -589,8 +589,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeRefactorings/LambdaSimplifier/LambdaSimplifierCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/LambdaSimplifier/LambdaSimplifierCodeRefactoringProvider.cs
@@ -284,8 +284,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.LambdaSimplifier
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitOrImplicitType/AbstractUseTypeCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseExplicitOrImplicitType/AbstractUseTypeCodeRefactoringProvider.cs
@@ -105,8 +105,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseType
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsyncKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AsyncKeywordRecommender.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
     internal class AsyncKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
     {
-        public AsyncKeywordRecommender() :
-            base(SyntaxKind.AsyncKeyword, isValidInPreprocessorContext: false)
+        public AsyncKeywordRecommender()
+            : base(SyntaxKind.AsyncKeyword, isValidInPreprocessorContext: false)
         {
         }
 

--- a/src/Features/CSharp/Portable/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
 
         private sealed class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.Convert_switch_statement_to_expression, createChangedDocument)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Convert_switch_statement_to_expression, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.Analyzer.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.Analyzer.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 return analyzer.AnalyzeAsync();
             }
 
-            public CSharpAnalyzer(SelectionResult selectionResult, CancellationToken cancellationToken) :
-                base(selectionResult, cancellationToken)
+            public CSharpAnalyzer(SelectionResult selectionResult, CancellationToken cancellationToken)
+                : base(selectionResult, cancellationToken)
             {
             }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.ExpressionCodeGenerator.cs
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 public ExpressionCodeGenerator(
                     InsertionPoint insertionPoint,
                     SelectionResult selectionResult,
-                    AnalyzerResult analyzerResult) :
-                    base(insertionPoint, selectionResult, analyzerResult)
+                    AnalyzerResult analyzerResult)
+                    : base(insertionPoint, selectionResult, analyzerResult)
                 {
                 }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.MultipleStatementsCodeGenerator.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 public MultipleStatementsCodeGenerator(
                     InsertionPoint insertionPoint,
                     SelectionResult selectionResult,
-                    AnalyzerResult analyzerResult) :
-                    base(insertionPoint, selectionResult, analyzerResult)
+                    AnalyzerResult analyzerResult)
+                    : base(insertionPoint, selectionResult, analyzerResult)
                 {
                 }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.SingleStatementCodeGenerator.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 public SingleStatementCodeGenerator(
                     InsertionPoint insertionPoint,
                     SelectionResult selectionResult,
-                    AnalyzerResult analyzerResult) :
-                    base(insertionPoint, selectionResult, analyzerResult)
+                    AnalyzerResult analyzerResult)
+                    : base(insertionPoint, selectionResult, analyzerResult)
                 {
                 }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             protected CSharpCodeGenerator(
                 InsertionPoint insertionPoint,
                 SelectionResult selectionResult,
-                AnalyzerResult analyzerResult) :
-                base(insertionPoint, selectionResult, analyzerResult)
+                AnalyzerResult analyzerResult)
+                : base(insertionPoint, selectionResult, analyzerResult)
             {
                 Contract.ThrowIfFalse(this.SemanticDocument == selectionResult.SemanticDocument);
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.TriviaResult.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     result);
             }
 
-            private CSharpTriviaResult(SemanticDocument document, ITriviaSavedResult result) :
-                base(document, result, (int)SyntaxKind.EndOfLineTrivia, (int)SyntaxKind.WhitespaceTrivia)
+            private CSharpTriviaResult(SemanticDocument document, ITriviaSavedResult result)
+                : base(document, result, (int)SyntaxKind.EndOfLineTrivia, (int)SyntaxKind.WhitespaceTrivia)
             {
             }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
 {
     internal partial class CSharpMethodExtractor : MethodExtractor
     {
-        public CSharpMethodExtractor(CSharpSelectionResult result) :
-            base(result)
+        public CSharpMethodExtractor(CSharpSelectionResult result)
+            : base(result)
         {
         }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 bool selectionInExpression,
                 SemanticDocument document,
                 SyntaxAnnotation firstTokenAnnotation,
-                SyntaxAnnotation lastTokenAnnotation) :
-                base(status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation)
+                SyntaxAnnotation lastTokenAnnotation)
+                : base(status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation)
             {
             }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 bool selectionInExpression,
                 SemanticDocument document,
                 SyntaxAnnotation firstTokenAnnotation,
-                SyntaxAnnotation lastTokenAnnotation) :
-                base(status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation)
+                SyntaxAnnotation lastTokenAnnotation)
+                : base(status, originalSpan, finalSpan, options, selectionInExpression, document, firstTokenAnnotation, lastTokenAnnotation)
             {
             }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.cs
@@ -65,9 +65,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             bool selectionInExpression,
             SemanticDocument document,
             SyntaxAnnotation firstTokenAnnotation,
-            SyntaxAnnotation lastTokenAnnotation) :
-            base(status, originalSpan, finalSpan, options, selectionInExpression,
-                 document, firstTokenAnnotation, lastTokenAnnotation)
+            SyntaxAnnotation lastTokenAnnotation)
+            : base(status, originalSpan, finalSpan, options, selectionInExpression,
+                   document, firstTokenAnnotation, lastTokenAnnotation)
         {
         }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionValidator.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
         public CSharpSelectionValidator(
             SemanticDocument document,
             TextSpan textSpan,
-            OptionSet options) :
-            base(document, textSpan, options)
+            OptionSet options)
+            : base(document, textSpan, options)
         {
         }
 

--- a/src/Features/CSharp/Portable/MakeStructFieldsWritable/CSharpMakeStructFieldsWritableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeStructFieldsWritable/CSharpMakeStructFieldsWritableCodeFixProvider.cs
@@ -70,8 +70,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeStructFieldsWritable
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(FeaturesResources.Make_readonly_fields_writable, createChangedDocument)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Make_readonly_fields_writable, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/RemoveUnusedLocalFunction/CSharpRemoveUnusedLocalFunctionCodeFixProvider.cs
@@ -60,8 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedLocalFunction
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.Remove_unused_function, createChangedDocument, CSharpFeaturesResources.Remove_unused_function)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Remove_unused_function, createChangedDocument, CSharpFeaturesResources.Remove_unused_function)
             {
             }
         }

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -156,10 +156,10 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.Use_explicit_type_instead_of_var,
-                     createChangedDocument,
-                     CSharpFeaturesResources.Use_explicit_type_instead_of_var)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Use_explicit_type_instead_of_var,
+                       createChangedDocument,
+                       CSharpFeaturesResources.Use_explicit_type_instead_of_var)
             {
             }
         }

--- a/src/Features/CSharp/Portable/TypeStyle/UseImplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseImplicitTypeCodeFixProvider.cs
@@ -59,10 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.use_var_instead_of_explicit_type,
-                     createChangedDocument,
-                     CSharpFeaturesResources.use_var_instead_of_explicit_type)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.use_var_instead_of_explicit_type,
+                       createChangedDocument,
+                       CSharpFeaturesResources.use_var_instead_of_explicit_type)
             {
             }
         }

--- a/src/Features/CSharp/Portable/UseExplicitTypeForConst/UseExplicitTypeForConstCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseExplicitTypeForConst/UseExplicitTypeForConstCodeFixProvider.cs
@@ -64,9 +64,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExplicitTypeForConst
 
         private sealed class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(CSharpFeaturesResources.Use_explicit_type_instead_of_var,
-                     createChangedDocument)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(CSharpFeaturesResources.Use_explicit_type_instead_of_var,
+                       createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/AliasAmbiguousType/AbstractAliasAmbiguousTypeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AliasAmbiguousType/AbstractAliasAmbiguousTypeCodeFixProvider.cs
@@ -72,8 +72,8 @@ namespace Microsoft.CodeAnalysis.AliasAmbiguousType
 
         private class MyCodeAction : DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument, equivalenceKey: title)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument, equivalenceKey: title)
             {
             }
         }

--- a/src/Features/Core/Portable/CodeFixes/Async/AbstractAddAwaitCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Async/AbstractAddAwaitCodeFixProvider.cs
@@ -55,8 +55,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Async
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/CodeFixes/Async/AbstractChangeToAsyncCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Async/AbstractChangeToAsyncCodeFixProvider.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Async
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/CodeFixes/ImplementAbstractClass/AbstractImplementAbstractClassCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/ImplementAbstractClass/AbstractImplementAbstractClassCodeFixProvider.cs
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.ImplementAbstractClass
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument, string id) :
-                base(FeaturesResources.Implement_Abstract_Class, createChangedDocument, id)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument, string id)
+                : base(FeaturesResources.Implement_Abstract_Class, createChangedDocument, id)
             {
             }
         }

--- a/src/Features/Core/Portable/CodeRefactorings/AddAwait/AbstractAddAwaitCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddAwait/AbstractAddAwaitCodeRefactoringProvider.cs
@@ -123,8 +123,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.AddAwait
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
@@ -97,8 +97,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.ExtractMethod
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractSyncNamespaceCodeRefactoringProvider.cs
@@ -96,8 +96,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.SyncNamespace
 
         private class ChangeNamespaceCodeAction : SolutionChangeAction
         {
-            public ChangeNamespaceCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution) :
-                base(title, createChangedSolution)
+            public ChangeNamespaceCodeAction(string title, Func<CancellationToken, Task<Solution>> createChangedSolution)
+                : base(title, createChangedSolution)
             {
             }
         }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
@@ -259,8 +259,8 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
 
         private class ConvertToInterpolatedStringCodeAction : CodeAction.DocumentChangeAction
         {
-            public ConvertToInterpolatedStringCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public ConvertToInterpolatedStringCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -859,8 +859,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 public bool IsCompilationEndAnalyzer { get; private set; } = false;
 
-                public CollectNestedCompilationContext(Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken) :
-                    base(compilation, options, cancellationToken)
+                public CollectNestedCompilationContext(Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken)
+                    : base(compilation, options, cancellationToken)
                 {
                 }
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerUpdateArgsId.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerUpdateArgsId.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         public DiagnosticAnalyzer Analyzer => _Field1;
 
-        protected AnalyzerUpdateArgsId(DiagnosticAnalyzer analyzer) :
-            base(analyzer)
+        protected AnalyzerUpdateArgsId(DiagnosticAnalyzer analyzer)
+            : base(analyzer)
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -415,8 +415,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             public readonly object Id;
             public readonly ImmutableArray<DiagnosticData> Diagnostics;
 
-            public Data(UpdatedEventArgs args) :
-                this(args, ImmutableArray<DiagnosticData>.Empty)
+            public Data(UpdatedEventArgs args)
+                : this(args, ImmutableArray<DiagnosticData>.Empty)
             {
             }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 OldItems = default;
             }
 
-            public DocumentAnalysisData(VersionStamp version, ImmutableArray<DiagnosticData> oldItems, ImmutableArray<DiagnosticData> newItems) :
-                this(version, newItems)
+            public DocumentAnalysisData(VersionStamp version, ImmutableArray<DiagnosticData> oldItems, ImmutableArray<DiagnosticData> newItems)
+                : this(version, newItems)
             {
                 OldItems = oldItems;
             }
@@ -95,8 +95,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 ProjectId projectId,
                 VersionStamp version,
                 ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> oldResult,
-                ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> newResult) :
-                this(projectId, version, newResult)
+                ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> newResult)
+                : this(projectId, version, newResult)
             {
                 OldResult = oldResult;
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -233,13 +233,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         private class IDECachedDiagnosticGetter : DiagnosticGetter
         {
-            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, object id, bool includeSuppressedDiagnostics) :
-                base(owner, solution, projectId: null, documentId: null, id: id, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
+            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, object id, bool includeSuppressedDiagnostics)
+                : base(owner, solution, projectId: null, documentId: null, id: id, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
             {
             }
 
-            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics) :
-                base(owner, solution, projectId, documentId, id: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
+            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics)
+                : base(owner, solution, projectId, documentId, id: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
             {
             }
 
@@ -335,25 +335,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             private readonly ImmutableHashSet<string> _diagnosticIds;
 
-            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, object id, bool includeSuppressedDiagnostics) :
-                base(owner, solution, projectId: null, documentId: null, id: id, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, object id, bool includeSuppressedDiagnostics)
+                : base(owner, solution, projectId: null, documentId: null, id: id, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
             {
                 _diagnosticIds = null;
             }
 
-            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics) :
-                base(owner, solution, projectId, documentId, id: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics)
+                : base(owner, solution, projectId, documentId, id: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
             {
                 _diagnosticIds = null;
             }
 
-            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds, Solution solution, ProjectId projectId, bool includeSuppressedDiagnostics) :
-                this(owner, diagnosticIds, solution, projectId, documentId: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds, Solution solution, ProjectId projectId, bool includeSuppressedDiagnostics)
+                : this(owner, diagnosticIds, solution, projectId, documentId: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
             {
             }
 
-            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds, Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics) :
-                base(owner, solution, projectId, documentId, id: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds, Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics)
+                : base(owner, solution, projectId, documentId, id: null, includeSuppressedDiagnostics: includeSuppressedDiagnostics)
             {
                 _diagnosticIds = diagnosticIds;
             }

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -76,9 +76,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         private readonly ConditionalWeakTable<DiagnosticAnalyzer, IReadOnlyCollection<DiagnosticDescriptor>> _descriptorCache;
 
-        public HostAnalyzerManager(Lazy<ImmutableArray<HostDiagnosticAnalyzerPackage>> hostAnalyzerPackages, IAnalyzerAssemblyLoader hostAnalyzerAssemblyLoader, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource, PrimaryWorkspace primaryWorkspace) :
-            this(new Lazy<ImmutableArray<AnalyzerReference>>(() => CreateAnalyzerReferencesFromPackages(hostAnalyzerPackages.Value, new HostAnalyzerReferenceDiagnosticReporter(hostDiagnosticUpdateSource, primaryWorkspace), hostAnalyzerAssemblyLoader), isThreadSafe: true),
-                 hostAnalyzerPackages, hostDiagnosticUpdateSource)
+        public HostAnalyzerManager(Lazy<ImmutableArray<HostDiagnosticAnalyzerPackage>> hostAnalyzerPackages, IAnalyzerAssemblyLoader hostAnalyzerAssemblyLoader, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource, PrimaryWorkspace primaryWorkspace)
+            : this(new Lazy<ImmutableArray<AnalyzerReference>>(() => CreateAnalyzerReferencesFromPackages(hostAnalyzerPackages.Value, new HostAnalyzerReferenceDiagnosticReporter(hostDiagnosticUpdateSource, primaryWorkspace), hostAnalyzerAssemblyLoader), isThreadSafe: true),
+                   hostAnalyzerPackages, hostDiagnosticUpdateSource)
         {
         }
 
@@ -99,8 +99,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         // this is for testing
-        internal HostAnalyzerManager(ImmutableArray<AnalyzerReference> hostAnalyzerReferences, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource) :
-            this(new Lazy<ImmutableArray<AnalyzerReference>>(() => hostAnalyzerReferences), new Lazy<ImmutableArray<HostDiagnosticAnalyzerPackage>>(() => ImmutableArray<HostDiagnosticAnalyzerPackage>.Empty), hostDiagnosticUpdateSource)
+        internal HostAnalyzerManager(ImmutableArray<AnalyzerReference> hostAnalyzerReferences, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource)
+            : this(new Lazy<ImmutableArray<AnalyzerReference>>(() => hostAnalyzerReferences), new Lazy<ImmutableArray<HostDiagnosticAnalyzerPackage>>(() => ImmutableArray<HostDiagnosticAnalyzerPackage>.Empty), hostDiagnosticUpdateSource)
         {
         }
 

--- a/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
+++ b/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public readonly object Key;
         public readonly int Kind;
 
-        public LiveDiagnosticUpdateArgsId(DiagnosticAnalyzer analyzer, object key, int kind, string analyzerPackageName) :
-            base(analyzer)
+        public LiveDiagnosticUpdateArgsId(DiagnosticAnalyzer analyzer, object key, int kind, string analyzerPackageName)
+            : base(analyzer)
         {
             Contract.ThrowIfNull(key);
 

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -413,14 +413,14 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 Glyph = glyph;
             }
 
-            public Result(Solution solutionWithProperty, string name, Glyph glyph, List<IFieldSymbol> failedFieldSymbols) :
-                this(solutionWithProperty, name, glyph)
+            public Result(Solution solutionWithProperty, string name, Glyph glyph, List<IFieldSymbol> failedFieldSymbols)
+                : this(solutionWithProperty, name, glyph)
             {
                 FailedFields = failedFieldSymbols.ToImmutableArrayOrEmpty();
             }
 
-            public Result(Solution originalSolution, params IFieldSymbol[] fields) :
-                this(originalSolution, string.Empty, Glyph.Error)
+            public Result(Solution originalSolution, params IFieldSymbol[] fields)
+                : this(originalSolution, string.Empty, Glyph.Error)
             {
                 FailedFields = fields.ToImmutableArrayOrEmpty();
             }

--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
@@ -194,8 +194,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 bool readInside,
                 bool writtenInside,
                 bool readOutside,
-                bool writtenOutside) :
-                this()
+                bool writtenOutside)
+                : this()
             {
                 DataFlowIn = dataFlowIn;
                 DataFlowOut = dataFlowOut;

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -74,8 +74,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
         protected abstract class NotMovableVariableSymbol : VariableSymbol
         {
-            public NotMovableVariableSymbol(Compilation compilation, ITypeSymbol type) :
-                base(compilation, type)
+            public NotMovableVariableSymbol(Compilation compilation, ITypeSymbol type)
+                : base(compilation, type)
             {
             }
 
@@ -103,8 +103,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         {
             private readonly IParameterSymbol _parameterSymbol;
 
-            public ParameterVariableSymbol(Compilation compilation, IParameterSymbol parameterSymbol, ITypeSymbol type) :
-                base(compilation, type)
+            public ParameterVariableSymbol(Compilation compilation, IParameterSymbol parameterSymbol, ITypeSymbol type)
+                : base(compilation, type)
             {
                 Contract.ThrowIfNull(parameterSymbol);
                 _parameterSymbol = parameterSymbol;
@@ -182,8 +182,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             private readonly ILocalSymbol _localSymbol;
             private readonly HashSet<int> _nonNoisySet;
 
-            public LocalVariableSymbol(Compilation compilation, ILocalSymbol localSymbol, ITypeSymbol type, HashSet<int> nonNoisySet) :
-                base(compilation, type)
+            public LocalVariableSymbol(Compilation compilation, ILocalSymbol localSymbol, ITypeSymbol type, HashSet<int> nonNoisySet)
+                : base(compilation, type)
             {
                 Contract.ThrowIfNull(localSymbol);
                 Contract.ThrowIfNull(nonNoisySet);
@@ -299,8 +299,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         {
             private readonly IRangeVariableSymbol _symbol;
 
-            public QueryVariableSymbol(Compilation compilation, IRangeVariableSymbol symbol, ITypeSymbol type) :
-                base(compilation, type)
+            public QueryVariableSymbol(Compilation compilation, IRangeVariableSymbol symbol, ITypeSymbol type)
+                : base(compilation, type)
             {
                 Contract.ThrowIfNull(symbol);
                 _symbol = symbol;

--- a/src/Features/Core/Portable/ExtractMethod/SelectionValidator.NullSelectionResult.cs
+++ b/src/Features/Core/Portable/ExtractMethod/SelectionValidator.NullSelectionResult.cs
@@ -9,13 +9,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
         // null object
         protected class NullSelectionResult : SelectionResult
         {
-            public NullSelectionResult() :
-                this(OperationStatus.FailedWithUnknownReason)
+            public NullSelectionResult()
+                : this(OperationStatus.FailedWithUnknownReason)
             {
             }
 
-            protected NullSelectionResult(OperationStatus status) :
-                base(status)
+            protected NullSelectionResult(OperationStatus status)
+                : base(status)
             {
             }
 
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
         protected class ErrorSelectionResult : NullSelectionResult
         {
-            public ErrorSelectionResult(OperationStatus status) :
-                base(status.MakeFail())
+            public ErrorSelectionResult(OperationStatus status)
+                : base(status.MakeFail())
             {
             }
         }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -332,8 +332,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument, equivalenceKey: title)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument, equivalenceKey: title)
             {
             }
         }

--- a/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
@@ -94,8 +94,8 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(FeaturesResources.Add_readonly_modifier, createChangedDocument)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Add_readonly_modifier, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
+++ b/src/Features/Core/Portable/Organizing/Organizers/ExportSyntaxNodeOrganizerAttribute.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.Organizing.Organizers
     [AttributeUsage(AttributeTargets.Class)]
     internal class ExportSyntaxNodeOrganizerAttribute : ExportAttribute
     {
-        public ExportSyntaxNodeOrganizerAttribute(string languageName) :
-            base(typeof(ISyntaxOrganizer))
+        public ExportSyntaxNodeOrganizerAttribute(string languageName)
+            : base(typeof(ISyntaxOrganizer))
         {
             Language = languageName;
         }

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
@@ -228,8 +228,8 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsCodeFixProvider.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(title, createChangedDocument)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersCodeFixProvider.cs
@@ -121,8 +121,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(FeaturesResources.Remove_unused_member, createChangedDocument)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Remove_unused_member, createChangedDocument)
             {
             }
         }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedValuesCodeFixProvider.cs
@@ -840,8 +840,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
         private sealed class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey) :
-                base(title, createChangedDocument, equivalenceKey)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey)
+                : base(title, createChangedDocument, equivalenceKey)
             {
             }
         }

--- a/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveUnusedVariable/AbstractRemoveUnusedVariableCodeFixProvider.cs
@@ -181,8 +181,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedVariable
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(FeaturesResources.Remove_unused_variable, createChangedDocument, FeaturesResources.Remove_unused_variable)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Remove_unused_variable, createChangedDocument, FeaturesResources.Remove_unused_variable)
             {
             }
         }

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.SymbolKeySignatureHelpItem.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
                 IEnumerable<TaggedText> separatorParts,
                 IEnumerable<TaggedText> suffixParts,
                 IEnumerable<SignatureHelpParameter> parameters,
-                IEnumerable<TaggedText> descriptionParts) :
-                base(isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
+                IEnumerable<TaggedText> descriptionParts)
+                : base(isVariadic, documentationFactory, prefixParts, separatorParts, suffixParts, parameters, descriptionParts)
             {
                 SymbolKey = symbol?.GetSymbolKey();
             }

--- a/src/Features/Core/Portable/SolutionCrawler/GlobalOperationAwareIdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/GlobalOperationAwareIdleProcessor.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             IAsynchronousOperationListener listener,
             IGlobalOperationNotificationService globalOperationNotificationService,
             int backOffTimeSpanInMs,
-            CancellationToken shutdownToken) :
-            base(listener, backOffTimeSpanInMs, shutdownToken)
+            CancellationToken shutdownToken)
+            : base(listener, backOffTimeSpanInMs, shutdownToken)
         {
             _globalOperation = null;
             _globalOperationTask = Task.CompletedTask;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AbstractPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AbstractPriorityProcessor.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Lazy<ImmutableArray<IIncrementalAnalyzer>> lazyAnalyzers,
                         IGlobalOperationNotificationService globalOperationNotificationService,
                         int backOffTimeSpanInMs,
-                        CancellationToken shutdownToken) :
-                        base(listener, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
+                        CancellationToken shutdownToken)
+                        : base(listener, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
                     {
                         _gate = new object();
                         _lazyAnalyzers = lazyAnalyzers;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             {
                 private readonly Dictionary<ProjectId, Dictionary<DocumentId, WorkItem>> _documentWorkQueue = new Dictionary<ProjectId, Dictionary<DocumentId, WorkItem>>();
 
-                public AsyncDocumentWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace) :
-                    base(progressReporter, workspace)
+                public AsyncDocumentWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace)
+                    : base(progressReporter, workspace)
                 {
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             {
                 private readonly Dictionary<ProjectId, WorkItem> _projectWorkQueue = new Dictionary<ProjectId, WorkItem>();
 
-                public AsyncProjectWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace) :
-                    base(progressReporter, workspace)
+                public AsyncProjectWorkItemQueue(SolutionCrawlerProgressReporter progressReporter, Workspace workspace)
+                    : base(progressReporter, workspace)
                 {
                 }
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         IncrementalAnalyzerProcessor processor,
                         Lazy<ImmutableArray<IIncrementalAnalyzer>> lazyAnalyzers,
                         int backOffTimeSpanInMs,
-                        CancellationToken shutdownToken) :
-                        base(listener, backOffTimeSpanInMs, shutdownToken)
+                        CancellationToken shutdownToken)
+                        : base(listener, backOffTimeSpanInMs, shutdownToken)
                     {
                         _processor = processor;
                         _lazyAnalyzers = lazyAnalyzers;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Lazy<ImmutableArray<IIncrementalAnalyzer>> lazyAnalyzers,
                         IGlobalOperationNotificationService globalOperationNotificationService,
                         int backOffTimeSpanInMs,
-                        CancellationToken shutdownToken) :
-                        base(listener, processor, lazyAnalyzers, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
+                        CancellationToken shutdownToken)
+                        : base(listener, processor, lazyAnalyzers, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
                     {
                         _workItemQueue = new AsyncProjectWorkItemQueue(processor._registration.ProgressReporter, processor._registration.Workspace);
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Lazy<ImmutableArray<IIncrementalAnalyzer>> lazyAnalyzers,
                         IGlobalOperationNotificationService globalOperationNotificationService,
                         int backOffTimeSpanInMs,
-                        CancellationToken shutdownToken) :
-                        base(listener, processor, lazyAnalyzers, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
+                        CancellationToken shutdownToken)
+                        : base(listener, processor, lazyAnalyzers, globalOperationNotificationService, backOffTimeSpanInMs, shutdownToken)
                     {
                         _running = Task.CompletedTask;
                         _workItemQueue = new AsyncDocumentWorkItemQueue(processor._registration.ProgressReporter, processor._registration.Workspace);

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.SemanticChangeProcessor.cs
@@ -41,8 +41,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     IncrementalAnalyzerProcessor documentWorkerProcessor,
                     int backOffTimeSpanInMS,
                     int projectBackOffTimeSpanInMS,
-                    CancellationToken cancellationToken) :
-                    base(listener, backOffTimeSpanInMS, cancellationToken)
+                    CancellationToken cancellationToken)
+                    : base(listener, backOffTimeSpanInMS, cancellationToken)
                 {
                     _gate = new SemaphoreSlim(initialCount: 0);
 
@@ -355,8 +355,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Registration registration,
                         IncrementalAnalyzerProcessor processor,
                         int backOffTimeSpanInMS,
-                        CancellationToken cancellationToken) :
-                        base(listener, backOffTimeSpanInMS, cancellationToken)
+                        CancellationToken cancellationToken)
+                        : base(listener, backOffTimeSpanInMS, cancellationToken)
                     {
                         _registration = registration;
                         _processor = processor;

--- a/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/Features/Core/Portable/Workspace/ProjectCacheService.SimpleMRUCache.cs
@@ -91,10 +91,10 @@ namespace Microsoft.CodeAnalysis.Host
             private readonly ProjectCacheService _owner;
             private readonly SemaphoreSlim _gate;
 
-            public ImplicitCacheMonitor(ProjectCacheService owner, int backOffTimeSpanInMS) :
-                base(AsynchronousOperationListenerProvider.NullListener,
-                     backOffTimeSpanInMS,
-                     CancellationToken.None)
+            public ImplicitCacheMonitor(ProjectCacheService owner, int backOffTimeSpanInMS)
+                : base(AsynchronousOperationListenerProvider.NullListener,
+                       backOffTimeSpanInMS,
+                       CancellationToken.None)
             {
                 _owner = owner;
                 _gate = new SemaphoreSlim(0);

--- a/src/VisualStudio/CSharp/Impl/Progression/CSharpGraphProvider.cs
+++ b/src/VisualStudio/CSharp/Impl/Progression/CSharpGraphProvider.cs
@@ -22,8 +22,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Progression
             IGlyphService glyphService,
             SVsServiceProvider serviceProvider,
             IProgressionPrimaryWorkspaceProvider workspaceProvider,
-            IAsynchronousOperationListenerProvider listenerProvider) :
-            base(threadingContext, glyphService, serviceProvider, workspaceProvider.PrimaryWorkspace, listenerProvider)
+            IAsynchronousOperationListenerProvider listenerProvider)
+            : base(threadingContext, glyphService, serviceProvider, workspaceProvider.PrimaryWorkspace, listenerProvider)
         {
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewEngine.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewEngine.cs
@@ -41,8 +41,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
         public Solution FinalSolution { get; private set; }
         public bool ShowCheckBoxes { get; private set; }
 
-        public PreviewEngine(IThreadingContext threadingContext, string title, string helpString, string description, string topLevelItemName, Glyph topLevelGlyph, Solution newSolution, Solution oldSolution, IComponentModel componentModel, bool showCheckBoxes = true) :
-            this(threadingContext, title, helpString, description, topLevelItemName, topLevelGlyph, newSolution, oldSolution, componentModel, null, showCheckBoxes)
+        public PreviewEngine(IThreadingContext threadingContext, string title, string helpString, string description, string topLevelItemName, Glyph topLevelGlyph, Solution newSolution, Solution oldSolution, IComponentModel componentModel, bool showCheckBoxes = true)
+            : this(threadingContext, title, helpString, description, topLevelItemName, topLevelGlyph, newSolution, oldSolution, componentModel, null, showCheckBoxes)
         {
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -58,8 +58,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             IMetadataAsSourceFileService fileTrackingMetadataAsSourceService,
             SaveEventsService saveEventsService,
             VisualStudioWorkspace visualStudioWorkspace,
-            SVsServiceProvider serviceProvider) :
-            base(visualStudioWorkspace.Services.HostServices, WorkspaceKind.MiscellaneousFiles)
+            SVsServiceProvider serviceProvider)
+            : base(visualStudioWorkspace.Services.HostServices, WorkspaceKind.MiscellaneousFiles)
         {
             _foregroundThreadAffinitization = new ForegroundThreadAffinitizedObject(threadingContext, assertIsForeground: true);
 

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
@@ -26,10 +26,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             // hold last async token
             private IAsyncToken _lastToken;
 
-            public SolutionChecksumUpdater(RemoteHostClientService service, CancellationToken shutdownToken) :
-                base(service.Listener,
-                     service.Workspace.Services.GetService<IGlobalOperationNotificationService>(),
-                     service.Workspace.Options.GetOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS), shutdownToken)
+            public SolutionChecksumUpdater(RemoteHostClientService service, CancellationToken shutdownToken)
+                : base(service.Listener,
+                       service.Workspace.Services.GetService<IGlobalOperationNotificationService>(),
+                       service.Workspace.Options.GetOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS), shutdownToken)
             {
                 _service = service;
                 _textChangeQueue = new SimpleTaskQueue(TaskScheduler.Default);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousDiagnosticListTable.cs
@@ -20,15 +20,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         private readonly LiveTableDataSource _source;
 
         [ImportingConstructor]
-        public MiscellaneousDiagnosticListTable(MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
-            this((Workspace)workspace, diagnosticService, provider)
+        public MiscellaneousDiagnosticListTable(MiscellaneousFilesWorkspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
+            : this((Workspace)workspace, diagnosticService, provider)
         {
             ConnectWorkspaceEvents();
         }
 
         /// this is for test only
-        internal MiscellaneousDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
-            base(workspace, diagnosticService, provider)
+        internal MiscellaneousDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
+            : base(workspace, diagnosticService, provider)
         {
             _source = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);
             AddInitialTableSource(workspace.CurrentSolution, _source);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/MiscellaneousTodoListTable.cs
@@ -14,15 +14,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         internal const string IdentifierString = nameof(MiscellaneousTodoListTable);
 
         [ImportingConstructor]
-        public MiscellaneousTodoListTable(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
-            base(workspace, todoListProvider, IdentifierString, provider)
+        public MiscellaneousTodoListTable(MiscellaneousFilesWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider)
+            : base(workspace, todoListProvider, IdentifierString, provider)
         {
             ConnectWorkspaceEvents();
         }
 
         // only for test
-        public MiscellaneousTodoListTable(Microsoft.CodeAnalysis.Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
-            base(workspace, todoListProvider, IdentifierString, provider)
+        public MiscellaneousTodoListTable(Microsoft.CodeAnalysis.Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider)
+            : base(workspace, todoListProvider, IdentifierString, provider)
         {
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableEntriesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/TableEntriesFactory.cs
@@ -195,8 +195,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
             private class EmptySnapshot : AbstractTableEntriesSnapshot<TItem>
             {
-                public EmptySnapshot(int version) :
-                    base(version, ImmutableArray<TItem>.Empty, ImmutableArray<ITrackingPoint>.Empty)
+                public EmptySnapshot(int version)
+                    : base(version, ImmutableArray<TItem>.Empty, ImmutableArray<ITrackingPoint>.Empty)
                 {
                 }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -32,8 +32,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             private readonly Workspace _workspace;
             private readonly OpenDocumentTracker<DiagnosticTableItem> _tracker;
 
-            public LiveTableDataSource(Workspace workspace, IDiagnosticService diagnosticService, string identifier) :
-                base(workspace)
+            public LiveTableDataSource(Workspace workspace, IDiagnosticService diagnosticService, string identifier)
+                : base(workspace)
             {
                 _workspace = workspace;
                 _identifier = identifier;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             SuppressionStateColumnDefinition.ColumnName
         };
 
-        protected VisualStudioBaseDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
-            base(workspace, provider, StandardTables.ErrorsTable)
+        protected VisualStudioBaseDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
+            : base(workspace, provider, StandardTables.ErrorsTable)
         {
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -35,8 +35,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         private readonly TableDataSource _source;
 
-        protected VisualStudioBaseTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, string identifier, ITableManagerProvider provider) :
-            base(workspace, provider, StandardTables.TasksTable)
+        protected VisualStudioBaseTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, string identifier, ITableManagerProvider provider)
+            : base(workspace, provider, StandardTables.TasksTable)
         {
             _source = new TableDataSource(workspace, todoListProvider, identifier);
             AddInitialTableSource(workspace.CurrentSolution, _source);
@@ -75,8 +75,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             private readonly string _identifier;
             private readonly ITodoListProvider _todoListProvider;
 
-            public TableDataSource(Workspace workspace, ITodoListProvider todoListProvider, string identifier) :
-                base(workspace)
+            public TableDataSource(Workspace workspace, ITodoListProvider todoListProvider, string identifier)
+                : base(workspace)
             {
                 _workspace = workspace;
                 _identifier = identifier;

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -121,8 +121,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 private readonly DiagnosticTableEntriesSource _source;
 
                 public TableEntriesSnapshot(
-                    DiagnosticTableEntriesSource source, int version, ImmutableArray<DiagnosticTableItem> items) :
-                    base(version, items, ImmutableArray<ITrackingPoint>.Empty)
+                    DiagnosticTableEntriesSource source, int version, ImmutableArray<DiagnosticTableItem> items)
+                    : base(version, items, ImmutableArray<ITrackingPoint>.Empty)
                 {
                     _source = source;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             VisualStudioWorkspace workspace,
             IDiagnosticService diagnosticService,
             ExternalErrorDiagnosticUpdateSource errorSource,
-            ITableManagerProvider provider) :
-            this(workspace, diagnosticService, errorSource, provider)
+            ITableManagerProvider provider)
+            : this(workspace, diagnosticService, errorSource, provider)
         {
             ConnectWorkspaceEvents();
 
@@ -58,15 +58,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         }
 
         /// this is for test only
-        internal VisualStudioDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider) :
-            this(workspace, diagnosticService, errorSource: null, provider)
+        internal VisualStudioDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
+            : this(workspace, diagnosticService, errorSource: null, provider)
         {
             AddInitialTableSource(workspace.CurrentSolution, _liveTableSource);
         }
 
         /// this is for test only
-        internal VisualStudioDiagnosticListTable(Workspace workspace, ExternalErrorDiagnosticUpdateSource errorSource, ITableManagerProvider provider) :
-            this(workspace, diagnosticService: null, errorSource, provider)
+        internal VisualStudioDiagnosticListTable(Workspace workspace, ExternalErrorDiagnosticUpdateSource errorSource, ITableManagerProvider provider)
+            : this(workspace, diagnosticService: null, errorSource, provider)
         {
             AddInitialTableSource(workspace.CurrentSolution, _buildTableSource);
         }
@@ -75,8 +75,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             Workspace workspace,
             IDiagnosticService diagnosticService,
             ExternalErrorDiagnosticUpdateSource errorSource,
-            ITableManagerProvider provider) :
-            base(workspace, diagnosticService, provider)
+            ITableManagerProvider provider)
+            : base(workspace, diagnosticService, provider)
         {
             _liveTableSource = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);
             _buildTableSource = new BuildTableDataSource(workspace, errorSource);

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioTodoListTable.cs
@@ -15,15 +15,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         internal const string IdentifierString = nameof(VisualStudioTodoListTable);
 
         [ImportingConstructor]
-        public VisualStudioTodoListTable(VisualStudioWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
-            base(workspace, todoListProvider, IdentifierString, provider)
+        public VisualStudioTodoListTable(VisualStudioWorkspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider)
+            : base(workspace, todoListProvider, IdentifierString, provider)
         {
             ConnectWorkspaceEvents();
         }
 
         // only for test
-        public VisualStudioTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider) :
-            base(workspace, todoListProvider, IdentifierString, provider)
+        public VisualStudioTodoListTable(Workspace workspace, ITodoListProvider todoListProvider, ITableManagerProvider provider)
+            : base(workspace, todoListProvider, IdentifierString, provider)
         {
         }
     }

--- a/src/VisualStudio/Core/Test.Next/Mocks/TestAssetSource.cs
+++ b/src/VisualStudio/Core/Test.Next/Mocks/TestAssetSource.cs
@@ -9,18 +9,18 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Mocks
 {
     internal class TestAssetSource : SimpleAssetSource
     {
-        public TestAssetSource(AssetStorage assetStorage) :
-            this(assetStorage, new Dictionary<Checksum, object>())
+        public TestAssetSource(AssetStorage assetStorage)
+            : this(assetStorage, new Dictionary<Checksum, object>())
         {
         }
 
-        public TestAssetSource(AssetStorage assetStorage, Checksum checksum, object data) :
-            this(assetStorage, new Dictionary<Checksum, object>() { { checksum, data } })
+        public TestAssetSource(AssetStorage assetStorage, Checksum checksum, object data)
+            : this(assetStorage, new Dictionary<Checksum, object>() { { checksum, data } })
         {
         }
 
-        public TestAssetSource(AssetStorage assetStorage, Dictionary<Checksum, object> map) :
-            base(assetStorage, map)
+        public TestAssetSource(AssetStorage assetStorage, Dictionary<Checksum, object> map)
+            : base(assetStorage, map)
         {
         }
     }

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -254,8 +254,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
         private class TestService : ServiceHubServiceBase
         {
-            public TestService(Stream stream, IServiceProvider serviceProvider) :
-                base(serviceProvider, stream)
+            public TestService(Stream stream, IServiceProvider serviceProvider)
+                : base(serviceProvider, stream)
             {
                 Event = new ManualResetEvent(false);
 

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/DiagnosticsWindow.cs
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/DiagnosticsWindow.cs
@@ -18,8 +18,8 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow
         /// <summary>
         /// Standard constructor for the tool window.
         /// </summary>
-        public DiagnosticsWindow(object context) :
-            base(null)
+        public DiagnosticsWindow(object context)
+            : base(null)
         {
             // Set the window title reading it from the resources.
             this.Caption = Resources.ToolWindowTitle;

--- a/src/VisualStudio/Xaml/Impl/CodeFixes/RemoveUnnecessaryUsings/XamlRemoveUnnecessaryUsingsCodeFixProvider.cs
+++ b/src/VisualStudio/Xaml/Impl/CodeFixes/RemoveUnnecessaryUsings/XamlRemoveUnnecessaryUsingsCodeFixProvider.cs
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.CodeFixes.RemoveUnusedUsings
 
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument) :
-                base(Resources.RemoveUnnecessaryNamespaces, createChangedDocument)
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(Resources.RemoveUnnecessaryNamespaces, createChangedDocument)
             {
             }
         }

--- a/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.DirectiveWalker.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/DirectiveSyntaxExtensions.DirectiveWalker.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             public DirectiveWalker(
                 IDictionary<DirectiveTriviaSyntax, DirectiveTriviaSyntax> directiveMap,
                 IDictionary<DirectiveTriviaSyntax, IReadOnlyList<DirectiveTriviaSyntax>> conditionalMap,
-                CancellationToken cancellationToken) :
-                base(SyntaxWalkerDepth.Token)
+                CancellationToken cancellationToken)
+                : base(SyntaxWalkerDepth.Token)
             {
                 _directiveMap = directiveMap;
                 _conditionalMap = conditionalMap;

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/AggregatedFormattingResult.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/AggregatedFormattingResult.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
     internal class AggregatedFormattingResult : AbstractAggregatedFormattingResult
     {
-        public AggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, SimpleIntervalTree<TextSpan> formattingSpans) :
-            base(node, results, formattingSpans)
+        public AggregatedFormattingResult(SyntaxNode node, IList<AbstractFormattingResult> results, SimpleIntervalTree<TextSpan> formattingSpans)
+            : base(node, results, formattingSpans)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/CSharpFormatEngine.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             OptionSet optionSet,
             IEnumerable<AbstractFormattingRule> formattingRules,
             SyntaxToken token1,
-            SyntaxToken token2) :
-            base(TreeData.Create(node),
+            SyntaxToken token2)
+            : base(TreeData.Create(node),
                  optionSet,
                  formattingRules,
                  token1,

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
@@ -26,12 +26,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             OptionSet optionSet,
             ChainedFormattingRules formattingRules,
             SyntaxToken token1,
-            SyntaxToken token2) :
-            base(TreeData.Create(trivia, initialColumn),
-                 optionSet,
-                 formattingRules,
-                 token1,
-                 token2)
+            SyntaxToken token2)
+            : base(TreeData.Create(trivia, initialColumn),
+                   optionSet,
+                   formattingRules,
+                   token1,
+                   token2)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/FormattingResult.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/FormattingResult.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     /// </summary>
     internal class FormattingResult : AbstractFormattingResult
     {
-        internal FormattingResult(TreeData treeInfo, TokenStream tokenStream, TextSpan spanToFormat) :
-            base(treeInfo, tokenStream, spanToFormat)
+        internal FormattingResult(TreeData treeInfo, TokenStream tokenStream, TextSpan spanToFormat)
+            : base(treeInfo, tokenStream, spanToFormat)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             SyntaxToken token2,
             string originalString,
             int lineBreaks,
-            int spaces) :
-            base(context, formattingRules, token1, token2, originalString, lineBreaks, spaces)
+            int spaces)
+            : base(context, formattingRules, token1, token2, originalString, lineBreaks, spaces)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         /// </summary>
         private class ComplexTrivia : AbstractComplexTrivia
         {
-            public ComplexTrivia(OptionSet optionSet, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2) :
-                base(optionSet, treeInfo, token1, token2)
+            public ComplexTrivia(OptionSet optionSet, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
+                : base(optionSet, treeInfo, token1, token2)
             {
             }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.FormattedComplexTrivia.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 int lineBreaks,
                 int spaces,
                 string originalString,
-                CancellationToken cancellationToken) :
-                base(context.OptionSet, LanguageNames.CSharp)
+                CancellationToken cancellationToken)
+                : base(context.OptionSet, LanguageNames.CSharp)
             {
                 Contract.ThrowIfNull(context);
                 Contract.ThrowIfNull(formattingRules);

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     /// </summary>
     internal partial class TriviaDataFactory : AbstractTriviaDataFactory
     {
-        public TriviaDataFactory(TreeData treeInfo, OptionSet optionSet) :
-            base(treeInfo, optionSet)
+        public TriviaDataFactory(TreeData treeInfo, OptionSet optionSet)
+            : base(treeInfo, optionSet)
         {
         }
 

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.Indenter.cs
@@ -28,8 +28,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 IEnumerable<AbstractFormattingRule> rules,
                 OptionSet optionSet,
                 TextLine line,
-                CancellationToken cancellationToken) :
-                base(syntaxFacts, syntaxTree, rules, optionSet, line, cancellationToken)
+                CancellationToken cancellationToken)
+                : base(syntaxFacts, syntaxTree, rules, optionSet, line, cancellationToken)
             {
             }
 

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
             SemanticModel semanticModel,
             CancellationToken cancellationToken,
             bool skipVerificationForReplacedNode = false,
-            bool failOnOverloadResolutionFailuresInOriginalCode = false) :
-            base(expression, newExpression, semanticModel, cancellationToken, skipVerificationForReplacedNode, failOnOverloadResolutionFailuresInOriginalCode)
+            bool failOnOverloadResolutionFailuresInOriginalCode = false)
+            : base(expression, newExpression, semanticModel, cancellationToken, skipVerificationForReplacedNode, failOnOverloadResolutionFailuresInOriginalCode)
         {
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
@@ -14,18 +14,18 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ImmutableArray<AttributeData> attributes,
             Accessibility accessibility,
             DeclarationModifiers modifiers,
-            ImmutableArray<IParameterSymbol> parameters) :
-            base(containingType,
-                 attributes,
-                 accessibility,
-                 modifiers,
-                 returnType: null,
-                 refKind: RefKind.None,
-                 explicitInterfaceImplementations: default,
-                 name: string.Empty,
-                 typeParameters: ImmutableArray<ITypeParameterSymbol>.Empty,
-                 parameters: parameters,
-                 returnTypeAttributes: ImmutableArray<AttributeData>.Empty)
+            ImmutableArray<IParameterSymbol> parameters)
+            : base(containingType,
+                   attributes,
+                   accessibility,
+                   modifiers,
+                   returnType: null,
+                   refKind: RefKind.None,
+                   explicitInterfaceImplementations: default,
+                   name: string.Empty,
+                   typeParameters: ImmutableArray<ITypeParameterSymbol>.Empty,
+                   parameters: parameters,
+                   returnTypeAttributes: ImmutableArray<AttributeData>.Empty)
         {
         }
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
@@ -17,20 +17,20 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             ITypeSymbol toType,
             IParameterSymbol fromType,
             bool isImplicit,
-            ImmutableArray<AttributeData> toTypeAttributes) :
-            base(containingType,
-                attributes,
-                declaredAccessibility,
-                modifiers,
-                returnType: toType,
-                refKind: RefKind.None,
-                explicitInterfaceImplementations: default,
-                name: isImplicit ?
-                    WellKnownMemberNames.ImplicitConversionName :
-                    WellKnownMemberNames.ExplicitConversionName,
-                typeParameters: ImmutableArray<ITypeParameterSymbol>.Empty,
-                parameters: ImmutableArray.Create(fromType),
-                returnTypeAttributes: toTypeAttributes)
+            ImmutableArray<AttributeData> toTypeAttributes)
+            : base(containingType,
+                  attributes,
+                  declaredAccessibility,
+                  modifiers,
+                  returnType: toType,
+                  refKind: RefKind.None,
+                  explicitInterfaceImplementations: default,
+                  name: isImplicit ?
+                      WellKnownMemberNames.ImplicitConversionName :
+                      WellKnownMemberNames.ExplicitConversionName,
+                  typeParameters: ImmutableArray<ITypeParameterSymbol>.Empty,
+                  parameters: ImmutableArray.Create(fromType),
+                  returnTypeAttributes: toTypeAttributes)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -762,8 +762,8 @@ namespace Microsoft.CodeAnalysis.Execution
             private readonly DocumentationProvider _provider;
 
             public MissingMetadataReference(
-                MetadataReferenceProperties properties, string fullPath, DocumentationProvider initialDocumentation) :
-                base(properties, fullPath, initialDocumentation)
+                MetadataReferenceProperties properties, string fullPath, DocumentationProvider initialDocumentation)
+                : base(properties, fullPath, initialDocumentation)
             {
                 // TODO: doc comment provider is a bit wierd.
                 _provider = initialDocumentation;
@@ -801,8 +801,8 @@ namespace Microsoft.CodeAnalysis.Execution
 
             public SerializedMetadataReference(
                 MetadataReferenceProperties properties, string fullPath,
-                Metadata metadata, ImmutableArray<ITemporaryStreamStorage> storagesOpt, DocumentationProvider initialDocumentation) :
-                base(properties, fullPath, initialDocumentation)
+                Metadata metadata, ImmutableArray<ITemporaryStreamStorage> storagesOpt, DocumentationProvider initialDocumentation)
+                : base(properties, fullPath, initialDocumentation)
             {
                 _metadata = metadata;
                 _storagesOpt = storagesOpt;

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis.Execution
     {
         private readonly Action<ObjectWriter, CancellationToken> _writer;
 
-        public SimpleCustomAsset(WellKnownSynchronizationKind kind, Action<ObjectWriter, CancellationToken> writer) :
-            base(CreateChecksumFromStreamWriter(kind, writer), kind)
+        public SimpleCustomAsset(WellKnownSynchronizationKind kind, Action<ObjectWriter, CancellationToken> writer)
+            : base(CreateChecksumFromStreamWriter(kind, writer), kind)
         {
             // unlike SolutionAsset which gets checksum from solution states, this one build one by itself.
             _writer = writer;
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.Execution
             return new WorkspaceAnalyzerReferenceAsset(reference, serializer, checksum);
         }
 
-        private WorkspaceAnalyzerReferenceAsset(AnalyzerReference reference, ISerializerService serializer, Checksum checksum) :
-            base(checksum, WellKnownSynchronizationKind.AnalyzerReference)
+        private WorkspaceAnalyzerReferenceAsset(AnalyzerReference reference, ISerializerService serializer, Checksum checksum)
+            : base(checksum, WellKnownSynchronizationKind.AnalyzerReference)
         {
             _reference = reference;
             _serializer = serializer;

--- a/src/Workspaces/Core/Portable/Execution/Desktop/DesktopReferenceSerializationServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Execution/Desktop/DesktopReferenceSerializationServiceFactory.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.Execution
             // typical low number, high volumn data cache.
             private static readonly ConcurrentDictionary<Encoding, byte[]> s_encodingCache = new ConcurrentDictionary<Encoding, byte[]>(concurrencyLevel: 2, capacity: 5);
 
-            public Service(ITemporaryStorageService service, IDocumentationProviderService documentationService) :
-                base(service, documentationService)
+            public Service(ITemporaryStorageService service, IDocumentationProviderService documentationService)
+                : base(service, documentationService)
             {
             }
 

--- a/src/Workspaces/Core/Portable/Execution/ReferenceSerializationServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Execution/ReferenceSerializationServiceFactory.cs
@@ -30,8 +30,8 @@ namespace Microsoft.CodeAnalysis.Execution
 
         private sealed class Service : AbstractReferenceSerializationService
         {
-            public Service(ITemporaryStorageService2 service, IDocumentationProviderService documentationService) :
-                base(service, documentationService)
+            public Service(ITemporaryStorageService2 service, IDocumentationProviderService documentationService)
+                : base(service, documentationService)
             {
             }
 

--- a/src/Workspaces/Core/Portable/Execution/RemotableData.cs
+++ b/src/Workspaces/Core/Portable/Execution/RemotableData.cs
@@ -46,8 +46,8 @@ namespace Microsoft.CodeAnalysis.Execution
         /// </summary>
         private sealed class NullRemotableData : RemotableData
         {
-            public NullRemotableData() :
-                base(Checksum.Null, WellKnownSynchronizationKind.Null)
+            public NullRemotableData()
+                : base(Checksum.Null, WellKnownSynchronizationKind.Null)
             {
                 // null object has null kind and null checksum. 
                 // this null object is known to checksum framework and transportation framework to handle null case

--- a/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.Execution
             private readonly object _value;
             private readonly ISerializerService _serializer;
 
-            public SimpleSolutionAsset(Checksum checksum, object value, ISerializerService serializer) :
-                base(checksum, value.GetWellKnownSynchronizationKind())
+            public SimpleSolutionAsset(Checksum checksum, object value, ISerializerService serializer)
+                : base(checksum, value.GetWellKnownSynchronizationKind())
             {
                 _value = value;
                 _serializer = serializer;
@@ -63,8 +63,8 @@ namespace Microsoft.CodeAnalysis.Execution
             private readonly TextDocumentState _state;
             private readonly ISerializerService _serializer;
 
-            public SourceTextAsset(Checksum checksum, TextDocumentState state, ISerializerService serializer) :
-                base(checksum, WellKnownSynchronizationKind.SourceText)
+            public SourceTextAsset(Checksum checksum, TextDocumentState state, ISerializerService serializer)
+                : base(checksum, WellKnownSynchronizationKind.SourceText)
             {
                 _state = state;
                 _serializer = serializer;

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -27,9 +27,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsIndexerMemberCref,
                 bool containsDeconstruction,
                 bool containsAwait,
-                bool containsTupleExpressionOrTupleType) :
-                this(predefinedTypes, predefinedOperators,
-                     ConvertToContainingNodeFlag(
+                bool containsTupleExpressionOrTupleType)
+                : this(predefinedTypes, predefinedOperators,
+                       ConvertToContainingNodeFlag(
                          containsForEachStatement,
                          containsLockStatement,
                          containsUsingStatement,

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.AbstractComplexTrivia.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             private readonly bool _treatAsElastic;
 
-            public AbstractComplexTrivia(OptionSet optionSet, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2) :
-                base(optionSet, token1.Language)
+            public AbstractComplexTrivia(OptionSet optionSet, TreeData treeInfo, SyntaxToken token1, SyntaxToken token2)
+                : base(optionSet, token1.Language)
             {
                 Contract.ThrowIfNull(treeInfo);
 

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.FormattedWhitespace.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             private readonly string _newString;
 
-            public FormattedWhitespace(OptionSet optionSet, int lineBreaks, int indentation, string language) :
-                base(optionSet, language)
+            public FormattedWhitespace(OptionSet optionSet, int lineBreaks, int indentation, string language)
+                : base(optionSet, language)
             {
                 this.LineBreaks = Math.Max(0, lineBreaks);
                 this.Spaces = Math.Max(0, indentation);

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.ModifiedWhitespace.cs
@@ -13,14 +13,14 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             private readonly Whitespace _original;
 
-            public ModifiedWhitespace(OptionSet optionSet, int lineBreaks, int indentation, bool elastic, string language) :
-                base(optionSet, lineBreaks, indentation, elastic, language)
+            public ModifiedWhitespace(OptionSet optionSet, int lineBreaks, int indentation, bool elastic, string language)
+                : base(optionSet, lineBreaks, indentation, elastic, language)
             {
                 _original = null;
             }
 
-            public ModifiedWhitespace(OptionSet optionSet, Whitespace original, int lineBreaks, int indentation, bool elastic, string language) :
-                base(optionSet, lineBreaks, indentation, elastic, language)
+            public ModifiedWhitespace(OptionSet optionSet, Whitespace original, int lineBreaks, int indentation, bool elastic, string language)
+                : base(optionSet, lineBreaks, indentation, elastic, language)
             {
                 Contract.ThrowIfNull(original);
                 _original = original;

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             private readonly bool _elastic;
 
-            public Whitespace(OptionSet optionSet, int space, bool elastic, string language) :
-                this(optionSet, lineBreaks: 0, indentation: space, elastic: elastic, language: language)
+            public Whitespace(OptionSet optionSet, int space, bool elastic, string language)
+                : this(optionSet, lineBreaks: 0, indentation: space, elastic: elastic, language: language)
             {
                 Contract.ThrowIfFalse(space >= 0);
             }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenPairWithOperations.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenPairWithOperations.cs
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             TokenStream tokenStream,
             int tokenPairIndex,
             AdjustSpacesOperation spaceOperations,
-            AdjustNewLinesOperation lineOperations) :
-            this()
+            AdjustNewLinesOperation lineOperations)
+            : this()
         {
             Contract.ThrowIfNull(tokenStream);
 

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.Debug.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.Debug.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             private readonly TreeData _debugNodeData;
 
-            public Debug(SyntaxNode root, SourceText text) :
-                base(root, text)
+            public Debug(SyntaxNode root, SourceText text)
+                : base(root, text)
             {
                 _debugNodeData = new Node(root);
             }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.Node.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.Node.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         private class Node : TreeData
         {
-            public Node(SyntaxNode root) :
-                base(root)
+            public Node(SyntaxNode root)
+                : base(root)
             {
                 Contract.ThrowIfFalse(root.GetFirstToken(includeZeroWidth: true).RawKind != 0);
             }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.NodeAndText.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.NodeAndText.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Formatting
         {
             private readonly SourceText _text;
 
-            public NodeAndText(SyntaxNode root, SourceText text) :
-                base(root)
+            public NodeAndText(SyntaxNode root, SourceText text)
+                : base(root)
             {
                 Contract.ThrowIfNull(text);
                 _text = text;

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.StructuredTrivia.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.StructuredTrivia.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             private readonly SyntaxTrivia _trivia;
             private readonly TreeData _treeData;
 
-            public StructuredTrivia(SyntaxTrivia trivia, int initialColumn) :
-                base(trivia.GetStructure())
+            public StructuredTrivia(SyntaxTrivia trivia, int initialColumn)
+                : base(trivia.GetStructure())
             {
                 Contract.ThrowIfFalse(trivia.HasStructure);
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -83,8 +83,8 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public class NoOpClient : RemoteHostClient
         {
-            public NoOpClient(Workspace workspace) :
-                base(workspace)
+            public NoOpClient(Workspace workspace)
+                : base(workspace)
             {
             }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SourceTextExtensions.cs
@@ -253,8 +253,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return new ObjectReaderTextReader(builder.ToImmutable(), chunkSize, length);
             }
 
-            private ObjectReaderTextReader(ImmutableArray<char[]> chunks, int chunkSize, int length) :
-                base(length)
+            private ObjectReaderTextReader(ImmutableArray<char[]> chunks, int chunkSize, int length)
+                : base(length)
             {
                 _chunks = chunks;
                 _chunkSize = chunkSize;

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/AsynchronousOperationListener.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         private int _counter;
         private bool _trackActiveTokens;
 
-        public AsynchronousOperationListener() :
-            this(featureName: "noname", enableDiagnosticTokens: false)
+        public AsynchronousOperationListener()
+            : this(featureName: "noname", enableDiagnosticTokens: false)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SemanticMap.Walker.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SemanticMap.Walker.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             private readonly SemanticMap _map;
             private readonly CancellationToken _cancellationToken;
 
-            public Walker(SemanticModel semanticModel, SemanticMap map, CancellationToken cancellationToken) :
-                base(SyntaxWalkerDepth.Token)
+            public Walker(SemanticModel semanticModel, SemanticMap map, CancellationToken cancellationToken)
+                : base(SyntaxWalkerDepth.Token)
             {
                 _semanticModel = semanticModel;
                 _map = map;

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -415,8 +415,8 @@ namespace Microsoft.CodeAnalysis.Host
             private char* _position;
             private readonly char* _end;
 
-            public DirectMemoryAccessStreamReader(char* src, int length) :
-                base(length)
+            public DirectMemoryAccessStreamReader(char* src, int length)
+                : base(length)
             {
                 Debug.Assert(src != null);
                 Debug.Assert(length >= 0);

--- a/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
@@ -292,8 +292,8 @@ namespace Microsoft.CodeAnalysis
 
         private class ReadStream : PooledStream
         {
-            public ReadStream(long length, byte[][] chunks) :
-                base(length, new List<byte[]>(chunks))
+            public ReadStream(long length, byte[][] chunks)
+                : base(length, new List<byte[]>(chunks))
             {
 
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis
         private WeakReference<SemanticModel> _model;
         private Task<SyntaxTree> _syntaxTreeResultTask;
 
-        internal Document(Project project, DocumentState state) :
-            base(project, state, TextDocumentKind.Document)
+        internal Document(Project project, DocumentState state)
+            : base(project, state, TextDocumentKind.Document)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Serialization
 {
     internal sealed class SolutionStateChecksums : ChecksumWithChildren
     {
-        public SolutionStateChecksums(Checksum infoChecksum, ProjectChecksumCollection projectChecksums) :
-            this((object)infoChecksum, projectChecksums)
+        public SolutionStateChecksums(Checksum infoChecksum, ProjectChecksumCollection projectChecksums)
+            : this((object)infoChecksum, projectChecksums)
         {
         }
 
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.Serialization
             MetadataReferenceChecksumCollection metadataReferenceChecksums,
             AnalyzerReferenceChecksumCollection analyzerReferenceChecksums,
             TextDocumentChecksumCollection additionalDocumentChecksums,
-            AnalyzerConfigDocumentChecksumCollection analyzerConfigDocumentChecksumCollection) :
-            this(
+            AnalyzerConfigDocumentChecksumCollection analyzerConfigDocumentChecksumCollection)
+            : this(
                 (object)infoChecksum,
                 compilationOptionsChecksum,
                 parseOptionsChecksum,
@@ -232,8 +232,8 @@ namespace Microsoft.CodeAnalysis.Serialization
 
     internal class DocumentStateChecksums : ChecksumWithChildren
     {
-        public DocumentStateChecksums(Checksum infoChecksum, Checksum textChecksum) :
-            this((object)infoChecksum, textChecksum)
+        public DocumentStateChecksums(Checksum infoChecksum, Checksum textChecksum)
+            : this((object)infoChecksum, textChecksum)
         {
         }
 

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -726,8 +726,8 @@ MefHostServices.DefaultAssemblies.Add(typeof(Host.TemporaryStorageServiceFactory
 
         private class MissingMetadataReference : PortableExecutableReference
         {
-            public MissingMetadataReference() :
-                base(MetadataReferenceProperties.Assembly, "missing_reference", XmlDocumentationProvider.Default)
+            public MissingMetadataReference()
+                : base(MetadataReferenceProperties.Assembly, "missing_reference", XmlDocumentationProvider.Default)
             {
             }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
@@ -8,8 +8,8 @@ namespace Microsoft.CodeAnalysis.Remote
     // root level service for all Roslyn services
     internal partial class CodeAnalysisService : ServiceHubServiceBase
     {
-        public CodeAnalysisService(Stream stream, IServiceProvider serviceProvider) :
-            base(serviceProvider, stream)
+        public CodeAnalysisService(Stream stream, IServiceProvider serviceProvider)
+            : base(serviceProvider, stream)
         {
             StartService();
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -55,8 +55,8 @@ namespace Microsoft.CodeAnalysis.Remote
             SetNativeDllSearchDirectories();
         }
 
-        public RemoteHostService(Stream stream, IServiceProvider serviceProvider) :
-            base(serviceProvider, stream)
+        public RemoteHostService(Stream stream, IServiceProvider serviceProvider)
+            : base(serviceProvider, stream)
         {
             _shutdownCancellationSource = new CancellationTokenSource();
 

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         private readonly AssetSource _source;
 
-        public SnapshotService(Stream stream, IServiceProvider serviceProvider) :
-            base(serviceProvider, stream)
+        public SnapshotService(Stream stream, IServiceProvider serviceProvider)
+            : base(serviceProvider, stream)
         {
             _source = new JsonRpcAssetSource(this);
 

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -48,8 +48,8 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private bool _disposed;
 
-        protected ServiceHubServiceBase(IServiceProvider serviceProvider, Stream stream) :
-            this(serviceProvider, stream, SpecializedCollections.EmptyEnumerable<JsonConverter>())
+        protected ServiceHubServiceBase(IServiceProvider serviceProvider, Stream stream)
+            : this(serviceProvider, stream, SpecializedCollections.EmptyEnumerable<JsonConverter>())
         {
         }
 


### PR DESCRIPTION
It's always been an annoyance of mine how these calls are inconsistent across the IDE.  I did a check to see what the numbers were like, and it was about 350 (across the entire codebase, around 150 in the IDE) of the form:

```c#
public Foo(...) :
    this(...)
{
}
```

And about *16,000* of the form:

```c#
public Foo(...)
    : this(...)
{
}
```

That's less than 3% of the code uses the first form.  So this PR just makes the IDE codebase consistent here on this one style.

Note: in the future, i'd love a formatting rule that checked fort his (and would be happy to contribute it).  that way you'd get a nice squigle if you didn't write it either on the same line, or in this form.