### PR TITLE
Turn on nullable semantic analysis by default

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -179,20 +179,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// True if we should enable nullable semantic analysis in this compilation.
         /// </summary>
-        // Note that this is intentionally not conditioned off RunNullableWalker currently. Once we fully enable
-        // the nullable analysis semantic model feature and feel confident in it, we only run the analysis if
-        // the feature flag is set.
         internal bool NullableSemanticAnalysisEnabled
         {
             get
             {
-                const string NullableAnalysisFlag = "run-nullable-analysis";
-                if (Feature(NullableAnalysisFlag) is "false")
+                var nullableAnalysisFlag = Feature("run-nullable-analysis");
+                if (nullableAnalysisFlag == "false")
                 {
                     return false;
                 }
 
-                return ShouldRunNullableWalker || Feature(NullableAnalysisFlag) is "true";
+                return ShouldRunNullableWalker || nullableAnalysisFlag == "true";
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -182,7 +182,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Note that this is intentionally not conditioned off RunNullableWalker currently. Once we fully enable
         // the nullable analysis semantic model feature and feel confident in it, we only run the analysis if
         // the feature flag is set.
-        internal bool NullableSemanticAnalysisEnabled => Feature("run-nullable-analysis") is "true";
+        internal bool NullableSemanticAnalysisEnabled
+        {
+            get
+            {
+                const string NullableAnalysisFlag = "run-nullable-analysis";
+                if (Feature(NullableAnalysisFlag) is "false")
+                {
+                    return false;
+                }
+
+                return ShouldRunNullableWalker || Feature(NullableAnalysisFlag) is "true";
+            }
+        }
 
         /// <summary>
         /// True when the "peverify-compat" feature flag is set or the language version is below C# 7.2.
@@ -567,37 +579,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         _syntaxAndDeclarations.MessageProvider,
                         _syntaxAndDeclarations.IsSubmission,
                         state: null));
-        }
-
-        /// <summary>
-        /// Returns a new compilation with the listed additional features. This method does not reparse syntax trees
-        /// with the new features enabled.
-        /// </summary>
-        internal CSharpCompilation WithAdditionalFeatures(params (string feature, string value)[] additionalFeatures)
-        {
-            var newFeatures = new Dictionary<string, string>();
-            foreach (var (key, value) in _features)
-            {
-                newFeatures[key] = value;
-            }
-
-            foreach (var (key, value) in additionalFeatures)
-            {
-                newFeatures[key] = value;
-            }
-
-            return new CSharpCompilation(
-                this.AssemblyName,
-                this.Options,
-                this.ExternalReferences,
-                this.PreviousSubmission,
-                this.SubmissionReturnType,
-                this.HostObjectType,
-                this.IsSubmission,
-                _referenceManager,
-                reuseReferenceManager: true,
-                _syntaxAndDeclarations,
-                newFeatures);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.SpeculativeMemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.SpeculativeMemberSemanticModel.cs
@@ -19,9 +19,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// Creates a speculative SemanticModel for a TypeSyntax node at a position within an existing MemberSemanticModel.
             /// </summary>
-            public SpeculativeMemberSemanticModel(SyntaxTreeSemanticModel parentSemanticModel, Symbol owner, TypeSyntax root, Binder rootBinder, int position)
-                : base(root, owner, rootBinder, containingSemanticModelOpt: null, parentSemanticModelOpt: parentSemanticModel, snapshotManagerOpt: null, speculatedPosition: position)
+            public SpeculativeMemberSemanticModel(SyntaxTreeSemanticModel parentSemanticModel, Symbol owner, TypeSyntax root, Binder rootBinder, NullableWalker.SnapshotManager snapshotManagerOpt, int position)
+                : base(root, owner, rootBinder, containingSemanticModelOpt: null, parentSemanticModelOpt: parentSemanticModel, snapshotManagerOpt, speculatedPosition: position)
             {
+            }
+
+            protected override NullableWalker.SnapshotManager GetSnapshotManager()
+            {
+                // In this override, current nullability state cannot influence anything of speculatively bound expressions.
+                return _parentSnapshotManagerOpt;
             }
 
             protected override BoundNode RewriteNullableBoundNodesWithSnapshots(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots, out NullableWalker.SnapshotManager snapshotManager)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1651,15 +1651,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     bodyBinder.ValidateIteratorMethods(diagnostics);
 
                     BoundNode methodBody = bodyBinder.BindMethodBody(syntaxNode, diagnostics);
+                    BoundNode methodBodyForSemanticModel = methodBody;
                     if (bodyBinder.Compilation.NullableSemanticAnalysisEnabled)
                     {
                         // Currently, we're passing an empty DiagnosticBag here because the flow analysis pass later will
                         // also run the nullable walker, and issue duplicate warnings. We should try to only run the pass
                         // once.
                         // https://github.com/dotnet/roslyn/issues/35041
-                        methodBody = NullableWalker.AnalyzeAndRewrite(bodyBinder.Compilation, method, methodBody, bodyBinder, new DiagnosticBag(), createSnapshots: true, out snapshotManager);
+                        methodBodyForSemanticModel = NullableWalker.AnalyzeAndRewrite(bodyBinder.Compilation, method, methodBody, bodyBinder, new DiagnosticBag(), createSnapshots: true, out snapshotManager);
                     }
-                    forSemanticModel = (syntaxNode, methodBody, bodyBinder, snapshotManager);
+                    forSemanticModel = (syntaxNode, methodBodyForSemanticModel, bodyBinder, snapshotManager);
 
                     switch (methodBody.Kind)
                     {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -57,10 +57,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override BoundNode Visit(BoundNode node)
             {
                 // Ensure that we always have a snapshot for every BoundExpression in the map
-                if (_snapshotManager != null && node != null)
-                {
-                    _snapshotManager.VerifyNode(node);
-                }
+                // Re-enable of this assert is tracked by https://github.com/dotnet/roslyn/issues/36844
+                //if (_snapshotManager != null && node != null)
+                //{
+                //    _snapshotManager.VerifyNode(node);
+                //}
 
                 if (node is BoundExpression expr)
                 {
@@ -170,6 +171,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Visit(node.SourceTuple);
                 return base.VisitConvertedTupleLiteral(node);
+            }
+
+            public override BoundNode VisitTypeExpression(BoundTypeExpression node)
+            {
+                // Ignore any dimensions
+                VerifyExpression(node);
+                Visit(node.BoundContainingTypeOpt);
+                return null;
             }
         }
 #endif

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1859,10 +1859,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var currentDeclaration = node.Declarations[currentDeclarationIndex];
 
-                // https://github.com/dotnet/roslyn/issues/35044: This works for simple success cases, but does not work for failures. Likely will have to do something more complicated here involving rebinding the
-                // declarators based on the newly constructed anonymous type symbol above and matching them to the existing symbol
-                if (currentDeclaration.Property.Name == currentProperty.Name &&
-                    currentDeclaration.Property.Type.Equals(currentProperty.Type, TypeCompareKind.ConsiderEverything | TypeCompareKind.AllNullableIgnoreOptions))
+                if (currentDeclaration.Property.MemberIndexOpt == currentProperty.MemberIndexOpt)
                 {
                     currentDeclarationIndex++;
                     return currentDeclaration;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1956,6 +1956,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                             checkConversion: true, fromExplicitCast: false, useLegacyWarnings: false, AssignmentKind.Assignment, reportRemainingWarnings: false);
                     }
                 }
+                else
+                {
+                    // We need to ensure that we're tracking the inferred type with nullability of any conversions that
+                    // were stripped off.
+                    for (int i = 0; i < n; i++)
+                    {
+                        TrackAnalyzedNullabilityThroughConversionGroup(inferredType.ToTypeWithState(), expressions[i] as BoundConversion, expressionsNoConversions[i]);
+                    }
+                }
 
                 expressionsNoConversions.Free();
                 conversions.Free();
@@ -3151,24 +3160,33 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // Visit outbound assignments and post-conditions
                 // Note: the state may get split in this step
-                if (!node.HasErrors && !parameters.IsDefault)
+                for (int i = 0; i < argumentsNoConversions.Length; i++)
                 {
-                    for (int i = 0; i < argumentsNoConversions.Length; i++)
+                    (ParameterSymbol parameter, TypeWithAnnotations parameterType, FlowAnalysisAnnotations parameterAnnotations) = GetCorrespondingParameter(i, parameters, argsToParamsOpt, expanded);
+                    if (parameter is null)
                     {
-                        (ParameterSymbol parameter, TypeWithAnnotations parameterType, FlowAnalysisAnnotations parameterAnnotations) = GetCorrespondingParameter(i, parameters, argsToParamsOpt, expanded);
-                        if (parameter is null)
-                        {
-                            continue;
-                        }
-
-                        VisitArgumentOutboundAssignmentsAndPostConditions(
-                            arguments[i],
-                            GetRefKind(refKindsOpt, i),
-                            parameter,
-                            parameterType,
-                            parameterAnnotations,
-                            results[i]);
+                        continue;
                     }
+
+                    VisitArgumentOutboundAssignmentsAndPostConditions(
+                        arguments[i],
+                        GetRefKind(refKindsOpt, i),
+                        parameter,
+                        parameterType,
+                        parameterAnnotations,
+                        results[i]);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < arguments.Length; i++)
+                {
+                    // We can hit this case when dynamic methods are involved, or when there are errors. In either case we have no information,
+                    // so just assume that the conversions have the same nullability as the underlying result
+                    var argument = arguments[i];
+                    var result = results[i];
+                    var argumentNoConversion = argumentsNoConversions[i];
+                    TrackAnalyzedNullabilityThroughConversionGroup(TypeWithState.Create(argument.Type, result.RValueType.State), argument as BoundConversion, argumentNoConversion);
                 }
             }
 
@@ -6190,6 +6208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                Visit(node.IterationVariableType);
                 foreach (var iterationVariable in node.IterationVariables)
                 {
                     var state = NullableFlowState.NotNull;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -444,11 +444,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
                 var currentDeclaration = declarations[currentDeclarationIndex];
 
-                // https://github.com/dotnet/roslyn/issues/35044: This works for simple success cases, but does not work for failures. Likely will have to do something more complicated here involving rebinding the
-                // declarators based on the newly constructed anonymous type symbol above and matching them to the existing symbol
-                if ((object)currentProperty == currentDeclaration.Property ||
-                    (currentDeclaration.Property.Name == currentProperty.Name &&
-                     currentDeclaration.Property.Type.Equals(currentProperty.Type, TypeCompareKind.ConsiderEverything | TypeCompareKind.AllNullableIgnoreOptions)))
+                if (currentProperty.MemberIndexOpt == currentDeclaration.Property.MemberIndexOpt)
                 {
                     currentDeclarationIndex++;
                     return currentDeclaration;

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -395,9 +395,9 @@ namespace Microsoft.CodeAnalysis.Operations
                         isImplicit: true);
 
                 // Find matching declaration for the current argument.
-                IPropertySymbol property = AnonymousTypeManager.GetAnonymousTypeProperty((NamedTypeSymbol)type, i);
-                if (currentDeclarationIndex >= declarations.Length ||
-                    (object)property != declarations[currentDeclarationIndex].Property)
+                PropertySymbol property = AnonymousTypeManager.GetAnonymousTypeProperty((NamedTypeSymbol)type, i);
+                BoundAnonymousPropertyDeclaration anonymousProperty = getDeclaration(declarations, property, ref currentDeclarationIndex);
+                if (anonymousProperty is null)
                 {
                     // No matching declaration, synthesize a property reference to be assigned.
                     target = new PropertyReferenceOperation(
@@ -413,7 +413,6 @@ namespace Microsoft.CodeAnalysis.Operations
                 }
                 else
                 {
-                    BoundAnonymousPropertyDeclaration anonymousProperty = declarations[currentDeclarationIndex++];
                     target = new PropertyReferenceOperation(anonymousProperty.Property,
                                                             instance,
                                                             ImmutableArray<IArgumentOperation>.Empty,
@@ -435,6 +434,28 @@ namespace Microsoft.CodeAnalysis.Operations
 
             Debug.Assert(currentDeclarationIndex == declarations.Length);
             return builder.ToImmutableAndFree();
+
+            static BoundAnonymousPropertyDeclaration getDeclaration(ImmutableArray<BoundAnonymousPropertyDeclaration> declarations, PropertySymbol currentProperty, ref int currentDeclarationIndex)
+            {
+                if (currentDeclarationIndex >= declarations.Length)
+                {
+                    return null;
+                }
+
+                var currentDeclaration = declarations[currentDeclarationIndex];
+
+                // https://github.com/dotnet/roslyn/issues/35044: This works for simple success cases, but does not work for failures. Likely will have to do something more complicated here involving rebinding the
+                // declarators based on the newly constructed anonymous type symbol above and matching them to the existing symbol
+                if ((object)currentProperty == currentDeclaration.Property ||
+                    (currentDeclaration.Property.Name == currentProperty.Name &&
+                     currentDeclaration.Property.Type.Equals(currentProperty.Type, TypeCompareKind.ConsiderEverything | TypeCompareKind.AllNullableIgnoreOptions)))
+                {
+                    currentDeclarationIndex++;
+                    return currentDeclaration;
+                }
+
+                return null;
+            }
         }
 
         internal class Helper

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IAnonymousObjectCreationOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IAnonymousObjectCreationOperation.cs
@@ -1639,5 +1639,46 @@ Block[B9] - Exit
 
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedFlowGraph, expectedDiagnostics);
         }
+
+        [Fact]
+        public void AnonymousObjectCreation_NullableEnabled_PropertyMatches()
+        {
+            var source = @"
+#nullable enable
+class C
+{
+    void M(int i1, object o1)
+    {
+        var obj = /*<bind>*/new { a = i1, o1, b = ""Hello world!"" }/*</bind>*/;
+    }
+}";
+
+            var expectedOperationTree = @"
+IAnonymousObjectCreationOperation (OperationKind.AnonymousObjectCreation, Type: <anonymous type: System.Int32 a, System.Object o1, System.String b>) (Syntax: 'new { a = i ... o world!"" }')
+  Initializers(3):
+      ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32) (Syntax: 'a = i1')
+        Left: 
+          IPropertyReferenceOperation: System.Int32 <anonymous type: System.Int32 a, System.Object o1, System.String b>.a { get; } (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'a')
+            Instance Receiver: 
+              IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: System.Int32 a, System.Object o1, System.String b>, IsImplicit) (Syntax: 'new { a = i ... o world!"" }')
+        Right: 
+          IParameterReferenceOperation: i1 (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'i1')
+      ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Object, IsImplicit) (Syntax: 'o1')
+        Left: 
+          IPropertyReferenceOperation: System.Object <anonymous type: System.Int32 a, System.Object o1, System.String b>.o1 { get; } (OperationKind.PropertyReference, Type: System.Object, IsImplicit) (Syntax: 'o1')
+            Instance Receiver: 
+              IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: System.Int32 a, System.Object o1, System.String b>, IsImplicit) (Syntax: 'new { a = i ... o world!"" }')
+        Right: 
+          IParameterReferenceOperation: o1 (OperationKind.ParameterReference, Type: System.Object) (Syntax: 'o1')
+      ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.String, Constant: ""Hello world!"") (Syntax: 'b = ""Hello world!""')
+        Left: 
+          IPropertyReferenceOperation: System.String <anonymous type: System.Int32 a, System.Object o1, System.String b>.b { get; } (OperationKind.PropertyReference, Type: System.String) (Syntax: 'b')
+            Instance Receiver: 
+              IInstanceReferenceOperation (ReferenceKind: ImplicitReceiver) (OperationKind.InstanceReference, Type: <anonymous type: System.Int32 a, System.Object o1, System.String b>, IsImplicit) (Syntax: 'new { a = i ... o world!"" }')
+        Right: 
+          ILiteralOperation (OperationKind.Literal, Type: System.String, Constant: ""Hello world!"") (Syntax: '""Hello world!""')";
+
+            VerifyOperationTreeAndDiagnosticsForTest<AnonymousObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: DiagnosticDescription.None);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -32,7 +32,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (6,20): warning CS8619: Nullability of reference types in value of type 'C?[]' doesn't match target type 'C[]'.
                 //         C[] arr2 = (C[])arr1;
@@ -70,7 +70,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
 
             var syntaxTree = comp.SyntaxTrees[0];
@@ -385,14 +385,14 @@ public static class CExt
 }
 ";
 
-            var comp1 = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp1 = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp1.VerifyDiagnostics(
                 // (20,33): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //     public static void M8(this C? c) {}
                 Diagnostic(ErrorCode.WRN_MissingNonNullTypesContextForAnnotation, "?").WithLocation(20, 33));
             verifyCompilation(comp1);
 
-            var comp2 = CreateCompilation(source, options: WithNonNullTypesFalse(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp2 = CreateCompilation(source, options: WithNonNullTypesFalse());
             comp2.VerifyDiagnostics(
                 // (20,33): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' context.
                 //     public static void M8(this C? c) {}
@@ -422,12 +422,12 @@ public static class CExt
             verifyCompilation(comp3);
 
             var comp1Emit = comp1.EmitToImageReference();
-            var comp4 = CreateCompilation("", references: new[] { comp1Emit }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp4 = CreateCompilation("", references: new[] { comp1Emit }, options: WithNonNullTypesTrue());
             comp4.VerifyDiagnostics();
             verifyCompilation(comp4);
 
             var comp2Emit = comp2.EmitToImageReference();
-            var comp5 = CreateCompilation("", references: new[] { comp2Emit }, options: WithNonNullTypesFalse(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp5 = CreateCompilation("", references: new[] { comp2Emit }, options: WithNonNullTypesFalse());
             comp5.VerifyDiagnostics();
             verifyCompilation(comp5);
 
@@ -596,11 +596,11 @@ public class C
                                                  params PublicNullableAnnotation[] expectedNullabilities)
         {
 
-            var comp1 = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp1 = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp1.VerifyDiagnostics(nullableEnabledErrors);
             verifyCompilation(comp1);
 
-            var comp2 = CreateCompilation(source, options: WithNonNullTypesFalse(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp2 = CreateCompilation(source, options: WithNonNullTypesFalse());
             comp2.VerifyDiagnostics(nullableEnabledErrors);
             verifyCompilation(comp2);
 
@@ -611,12 +611,12 @@ public class C
             if (!testMetadata) return;
 
             var comp1Emit = comp1.EmitToImageReference();
-            var comp4 = CreateCompilation("", references: new[] { comp1Emit }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp4 = CreateCompilation("", references: new[] { comp1Emit }, options: WithNonNullTypesTrue());
             comp4.VerifyDiagnostics();
             verifyCompilation(comp4);
 
             var comp2Emit = comp2.EmitToImageReference();
-            var comp5 = CreateCompilation("", references: new[] { comp2Emit }, options: WithNonNullTypesFalse(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp5 = CreateCompilation("", references: new[] { comp2Emit }, options: WithNonNullTypesFalse());
             comp5.VerifyDiagnostics();
             verifyCompilation(comp5);
 
@@ -650,7 +650,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
 
             var syntaxTree = comp.SyntaxTrees[0];
@@ -678,7 +678,7 @@ enum E2
     A2 = E1.A1
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
 
             var syntaxTree = comp.SyntaxTrees[0];
             var root = syntaxTree.GetRoot();
@@ -702,7 +702,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
 
             comp.VerifyDiagnostics();
             comp.VerifyAnalyzerDiagnostics(new[] { new NullabilityPrinter() }, null, null, true,
@@ -749,7 +749,7 @@ class E
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (10,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
                 //         var d = (D)(C?)new B();
@@ -801,7 +801,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics(
                 // (6,21): error CS0246: The type or namespace name 'Undefined' could not be found (are you missing a using directive or an assembly reference?)
                 //         var x = new Undefined() ? new object() : null;
@@ -902,7 +902,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
 
             var syntaxTree = comp.SyntaxTrees[0];
@@ -982,7 +982,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
 
             var syntaxTree = comp.SyntaxTrees[0];
@@ -1085,6 +1085,36 @@ class C
                 specTypeInfo = model.GetSpeculativeTypeInfo(position, newCoalesce, SpeculativeBindingOption.BindAsExpression);
                 Assert.Equal(PublicNullableFlowState.NotNull, specTypeInfo.Nullability.FlowState);
             }
+
+        }
+
+        [Fact]
+        public void FeatureFlagTurnsOffNullableAnalysis()
+        {
+            var source =
+@"
+#nullable enable
+class C
+{
+    void M()
+    {
+        object o = null;
+    }
+}
+";
+
+            var featureFlagOff = TestOptions.Regular8.WithFeature("run-nullable-analysis", "false");
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: featureFlagOff);
+            comp.VerifyDiagnostics(
+                    // (7,16): warning CS0219: The variable 'o' is assigned but its value is never used
+                    //         object o = null;
+                    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(7, 16),
+                    // (7,20): warning CS8600: Converting null literal or possible null value to non-nullable type.
+                    //         object o = null;
+                    Diagnostic(ErrorCode.WRN_ConvertingNullableToNonNullable, "null").WithLocation(7, 20));
+
+            Assert.False(comp.NullableSemanticAnalysisEnabled);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -1055,7 +1055,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
             comp.VerifyDiagnostics();
 
             var syntaxTree = comp.SyntaxTrees[0];

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -1085,7 +1085,6 @@ class C
                 specTypeInfo = model.GetSpeculativeTypeInfo(position, newCoalesce, SpeculativeBindingOption.BindAsExpression);
                 Assert.Equal(PublicNullableFlowState.NotNull, specTypeInfo.Nullability.FlowState);
             }
-
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -286,12 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         /// </summary>
         internal static void VerifyTypes(this CSharpCompilation compilation, SyntaxTree tree = null)
         {
-            // When nullable analysis does not require a feature flag, this can be removed so that we
-            // don't need to create an extra compilation
-            if (compilation.Feature("run-nullable-analysis") != "true")
-            {
-                compilation = compilation.WithAdditionalFeatures(("run-nullable-analysis", "true"));
-            }
+            Assert.True(compilation.NullableSemanticAnalysisEnabled);
 
             if (tree == null)
             {

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions RegularDefault = Regular.WithLanguageVersion(LanguageVersion.Default);
         public static readonly CSharpParseOptions RegularPreview = Regular.WithLanguageVersion(LanguageVersion.Preview);
         public static readonly CSharpParseOptions Regular8 = Regular.WithLanguageVersion(LanguageVersion.CSharp8);
-        public static readonly CSharpParseOptions Regular8WithNullableAnalysis = Regular8.WithFeature("run-nullable-analysis");
         public static readonly CSharpParseOptions RegularWithDocumentationComments = Regular.WithDocumentationMode(DocumentationMode.Diagnose);
         public static readonly CSharpParseOptions RegularWithLegacyStrongName = Regular.WithFeature("UseLegacyStrongNameProvider");
         public static readonly CSharpParseOptions WithoutImprovedOverloadCandidates = Regular.WithLanguageVersion(MessageID.IDS_FeatureImprovedOverloadCandidates.RequiredVersion() - 1);

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -122,7 +122,7 @@ class goo
     }
 }
 ";
-            await TestAllOptionsOffAsync(text, expected, index: 1, parseOptions: TestOptions.Regular8WithNullableAnalysis);
+            await TestAllOptionsOffAsync(text, expected, index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -3133,7 +3133,7 @@ class C
     void M2(string? s)
     {
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
         public Task TestIntroduceLocal_NullableType_FlowStateNull()
@@ -3166,7 +3166,7 @@ class C
     void M2(string? s)
     {
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
 
         [WorkItem(1065661, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1065661")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -322,7 +322,7 @@ class Class
     {
         throw new NotImplementedException();
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
@@ -356,7 +356,7 @@ class Class
     {
         throw new NotImplementedException();
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
 
@@ -1138,7 +1138,7 @@ class Class
     {
         throw new NotImplementedException();
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
@@ -1174,7 +1174,7 @@ class Class
     {
         throw new NotImplementedException();
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36044"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
@@ -1212,7 +1212,7 @@ class Class
     {
         throw new NotImplementedException();
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -1438,7 +1438,6 @@ internal class T
         this.s = s;
     }
 }",
-parseOptions: TestOptions.Regular8WithNullableAnalysis,
 index: 1);
         }
 
@@ -1474,7 +1473,6 @@ internal class T
         this.s = s;
     }
 }",
-parseOptions: TestOptions.Regular8WithNullableAnalysis,
 index: 1);
         }
 

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -3745,7 +3745,7 @@ class C
         string? s = null;
         new C(s);
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
@@ -3782,7 +3782,7 @@ class C
         IEnumerable<string?> s;
         new C(s);
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -230,7 +230,7 @@ class Class
     {
         Method(goo);
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -260,7 +260,7 @@ class Class
     {
         Method(goo);
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -3959,7 +3959,7 @@ class Program
     {
     }
 }",
-index: LocalIndex, parseOptions: TestOptions.Regular8WithNullableAnalysis);
+index: LocalIndex);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -3993,7 +3993,7 @@ class Program
     {
     }
 }",
-index: LocalIndex, parseOptions: TestOptions.Regular8WithNullableAnalysis);
+index: LocalIndex);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.QuickInfo;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -6351,7 +6352,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableParameterThatIsMaybeNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 class X
@@ -6368,7 +6369,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableParameterThatIsNotNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 class X
@@ -6386,7 +6387,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableFieldThatIsMaybeNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 class X
@@ -6405,7 +6406,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableFieldThatIsNotNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 class X
@@ -6425,7 +6426,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullablePropertyThatIsMaybeNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 class X
@@ -6444,7 +6445,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullablePropertyThatIsNotNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 class X
@@ -6464,7 +6465,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableRangeVariableThatIsMaybeNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 using System.Collections.Generic;
@@ -6488,7 +6489,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableRangeVariableThatIsNotNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 using System.Collections.Generic;
@@ -6512,7 +6513,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableLocalThatIsMaybeNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 using System.Collections.Generic;
@@ -6532,7 +6533,7 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableLocalThatIsNotNull()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8WithNullableAnalysis,
+            await TestWithOptionsAsync(TestOptions.Regular8,
 @"#nullable enable
 
 using System.Collections.Generic;
@@ -6572,7 +6573,8 @@ class X
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task NullableNotShownWithoutFeatureFlag()
         {
-            await TestWithOptionsAsync(TestOptions.Regular8,
+            var options = TestOptions.Regular8.WithFeature(CompilerFeatureFlags.RunNullableAnalysis, "false");
+            await TestWithOptionsAsync(options,
 @"#nullable enable
 
 using System.Collections.Generic;

--- a/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseLocalFunction/UseLocalFunctionTests.cs
@@ -3687,7 +3687,7 @@ class Program
     {
         static string? f(string? s) => s;
     }
-}", parseOptions: TestOptions.Regular8WithNullableAnalysis);
+}", parseOptions: TestOptions.Regular8);
         }
     }
 }

--- a/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
@@ -56,11 +56,6 @@ namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
                 return default;
             }
 
-            if (!parseOptions.Features.ContainsKey(CompilerFeatureFlags.RunNullableAnalysis))
-            {
-                return default;
-            }
-
             var syntaxFacts = workspace.Services.GetLanguageServices(semanticModel.Language).GetRequiredService<ISyntaxFactsService>();
             var bindableParent = syntaxFacts.GetBindableParent(token);
             var symbolInfo = semanticModel.GetSymbolInfo(bindableParent, cancellationToken);


### PR DESCRIPTION
Commit 1 ties the nullable semantic analysis to whether or not we will run the nullable walker during compilation.
Commit 2 fixes some DebugVerifier asserts caught after the verifier is run over more code.
Commit 3 updates the method compiler to not use the rewritten method body for emit.
Commit 4 adjusts IOperation to correctly retrieve anonymous properties, and adds a test. Caught by the debug bootstrap compiler.
Commit 5 adjust the BoundAnonymousObjectCreation handling and fixes https://github.com/dotnet/roslyn/issues/35044, thanks @cston for pointing out the correct way to do the comparisons.

Fixes https://github.com/dotnet/roslyn/issues/35374.