### PR TITLE
Fix typo in EmitStreamSignKind

### DIFF
--- a/src/Compilers/Core/Portable/Compilation.EmitStream.cs
+++ b/src/Compilers/Core/Portable/Compilation.EmitStream.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             /// This form of signing occurs in memory using the <see cref="PEBuilder"/> APIs. This is the default 
             /// form of signing and will be used when a strong name key is provided in a file on disk.
             /// </summary>
-            SignedWithBulider,
+            SignedWithBuilder,
 
             /// <summary>
             /// This form of signing occurs using the <see cref="IClrStrongName"/> COM APIs. This form of signing

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2653,7 +2653,7 @@ namespace Microsoft.CodeAnalysis
             try
             {
                 var signKind = IsRealSigned
-                    ? (SignUsingBuilder ? EmitStreamSignKind.SignedWithBulider : EmitStreamSignKind.SignedWithFile)
+                    ? (SignUsingBuilder ? EmitStreamSignKind.SignedWithBuilder : EmitStreamSignKind.SignedWithFile)
                     : EmitStreamSignKind.None;
                 emitPeStream = new EmitStream(peStreamProvider, signKind, Options.StrongNameProvider);
                 emitMetadataStream = metadataPEStreamProvider == null


### PR DESCRIPTION
Just a small typo fix in an internal enum I happened to stumble across :)