### PR TITLE
Consistently name C#/VB editors

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackageRegistration.pkgdef
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackageRegistration.pkgdef
@@ -8,7 +8,7 @@
 "ExcludeDefTextEditor"=dword:00000001
 "LinkedEditorGuid"="{A6C744A8-0E4A-4FC6-886A-064283054674}"
 "Package"="{13C3BBB4-F18F-4111-9F54-A0FB010D9194}"
-@="Microsoft CSharp Editor Factory with Encoding"
+@="C# Editor with Encoding"
 
 [$RootKey$\Editors\{08467b34-b90f-4d91-bdca-eb8c8cf3033a}\Extensions]
 "cs"=dword:00000027
@@ -29,7 +29,7 @@
 "EditorTrustLevel"=dword:00000002
 "ExcludeDefTextEditor"=dword:00000001
 "Package"="{13C3BBB4-F18F-4111-9F54-A0FB010D9194}"
-@="Microsoft CSharp Editor Factory"
+@="C# Editor"
 
 [$RootKey$\Editors\{A6C744A8-0E4A-4FC6-886A-064283054674}\Extensions]
 "cs"=dword:00000028

--- a/src/VisualStudio/CSharp/Impl/VSPackage.resx
+++ b/src/VisualStudio/CSharp/Impl/VSPackage.resx
@@ -307,10 +307,10 @@ Show name suggestions;</value>
     <value>Spacing</value>
   </data>
   <data name="2358" xml:space="preserve">
-    <value>CSharp Editor</value>
+    <value>C# Editor</value>
   </data>
   <data name="2359" xml:space="preserve">
-    <value>CSharp Editor with Encoding</value>
+    <value>C# Editor with Encoding</value>
   </data>
   <data name="113" xml:space="preserve">
     <value>Microsoft Visual C#</value>

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.cs.xlf
@@ -327,13 +327,13 @@ Zobrazovat návrhy názvů;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Editor CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Editor CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Editor CSharp s kódováním</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Editor CSharp s kódováním</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.de.xlf
@@ -327,13 +327,13 @@ Namensvorschläge anzeigen;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">CSharp-Editor</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">CSharp-Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">CSharp-Editor mit Codierung</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">CSharp-Editor mit Codierung</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.es.xlf
@@ -327,13 +327,13 @@ Mostrar sugerencias de nombre;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Editor de CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Editor de CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Editor de CSharp con Encoding</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Editor de CSharp con Encoding</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.fr.xlf
@@ -327,13 +327,13 @@ Afficher les suggestions de nom;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Éditeur CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Éditeur CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Éditeur CSharp avec encodage</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Éditeur CSharp avec encodage</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.it.xlf
@@ -327,13 +327,13 @@ Mostra suggerimenti per nomi;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Editor CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Editor CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Editor CSharp con codifica</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Editor CSharp con codifica</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ja.xlf
@@ -284,13 +284,13 @@ Enter キーで常に新しい行を追加する;
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">CSharp エディター</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">CSharp エディター</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Encoding 付き CSharp エディター</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Encoding 付き CSharp エディター</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ko.xlf
@@ -326,13 +326,13 @@ Show name suggestions;</source>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">CSharp 편집기</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">CSharp 편집기</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">CSharp 편집기(인코딩 사용)</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">CSharp 편집기(인코딩 사용)</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pl.xlf
@@ -327,13 +327,13 @@ Pokaż sugestie dotyczące nazw;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Edytor CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Edytor CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Edytor CSharp z kodowaniem</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Edytor CSharp z kodowaniem</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.pt-BR.xlf
@@ -327,13 +327,13 @@ Mostrar sugestões de nome;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Editor CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Editor CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Editor CSharp com Codificação</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Editor CSharp com Codificação</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.ru.xlf
@@ -285,13 +285,13 @@ Show name suggestions;</source>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">Редактор CSharp</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">Редактор CSharp</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Редактор CSharp с кодировкой</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Редактор CSharp с кодировкой</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.tr.xlf
@@ -327,13 +327,13 @@ Adı önerilerini göster;</target>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">CSharp Düzenleyici</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">CSharp Düzenleyici</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">Encoding ile CSharp Düzenleyici</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">Encoding ile CSharp Düzenleyici</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hans.xlf
@@ -327,13 +327,13 @@ Show name suggestions;</source>
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">CSharp 编辑器</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">CSharp 编辑器</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">带编码功能的 CSharp 编辑器</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">带编码功能的 CSharp 编辑器</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/VSPackage.zh-Hant.xlf
@@ -327,13 +327,13 @@ Enter 鍵行為;
         <note />
       </trans-unit>
       <trans-unit id="2358">
-        <source>CSharp Editor</source>
-        <target state="translated">CSharp 編輯器</target>
+        <source>C# Editor</source>
+        <target state="needs-review-translation">CSharp 編輯器</target>
         <note />
       </trans-unit>
       <trans-unit id="2359">
-        <source>CSharp Editor with Encoding</source>
-        <target state="translated">具備編碼功能的 CSharp 編輯器</target>
+        <source>C# Editor with Encoding</source>
+        <target state="needs-review-translation">具備編碼功能的 CSharp 編輯器</target>
         <note />
       </trans-unit>
       <trans-unit id="113">

--- a/src/VisualStudio/VisualBasic/Impl/VSPackage.resx
+++ b/src/VisualStudio/VisualBasic/Impl/VSPackage.resx
@@ -122,10 +122,10 @@
     <comment>Used anywhere the string is needed (that is, everywhere.)</comment>
   </data>
   <data name="1012" xml:space="preserve">
-    <value>Microsoft Visual Basic Code Page Editor</value>
+    <value>Visual Basic Editor with Encoding</value>
   </data>
   <data name="1013" xml:space="preserve">
-    <value>Microsoft Visual Basic Editor</value>
+    <value>Visual Basic Editor</value>
   </data>
   <data name="10160" xml:space="preserve">
     <value>Automatic insertion of end constructs;Change pretty listing settings;Change outlining mode;Automatic insertion of Interface and MustOverride members;Show or hide procedure line separators;Turn error correction suggestions on or off;Turn highlighting of references and keywords on or off;Regex;Colorize regular expressions;Highlight related components under cursor;Report invalid regular expressions;regex;regular expression;</value>

--- a/src/VisualStudio/VisualBasic/Impl/VisualBasicPackageRegistration.pkgdef
+++ b/src/VisualStudio/VisualBasic/Impl/VisualBasicPackageRegistration.pkgdef
@@ -8,7 +8,7 @@
 "ExcludeDefTextEditor"=dword:00000001
 "EditorTrustLevel"=dword:00000002
 "LinkedEditorGuid"="{2C015C70-C72C-11D0-88C3-00A0C9110049}"
-@="Microsoft Visual Basic Editor with Encoding"
+@="Visual Basic Editor with Encoding"
 
 [$RootKey$\Editors\{6C33E1AA-1401-4536-AB67-0E21E6E569DA}\LogicalViews]
 "{7651a700-06e5-11d1-8ebd-00a0c90f26ea}"=""
@@ -36,7 +36,7 @@
 "CommonPhysicalViewAttributes"=dword:00000002
 "ExcludeDefTextEditor"=dword:00000001
 "EditorTrustLevel"=dword:00000002
-@="Microsoft Visual Basic Editor"
+@="Visual Basic Editor"
 
 [$RootKey$\Editors\{2C015C70-C72C-11D0-88C3-00A0C9110049}\LogicalViews]
 "{7651a700-06e5-11d1-8ebd-00a0c90f26ea}"=""

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.cs.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.cs.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Editor stránky kódu Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Editor stránky kódu Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic Editor</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.de.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.de.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Microsoft Visual Basic-Codepage-Editor</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Microsoft Visual Basic-Codepage-Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic-Editor</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic-Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.es.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.es.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Editor de páginas de código de Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Editor de páginas de código de Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Editor de Microsoft Visual Basic</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Editor de Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.fr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.fr.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Éditeur de page de codes Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Éditeur de page de codes Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic Editor</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.it.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.it.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Editor tabella codici di Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Editor tabella codici di Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic Editor</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ja.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ja.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Microsoft Visual Basic コード ページ エディター</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Microsoft Visual Basic コード ページ エディター</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic エディター</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic エディター</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ko.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ko.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Microsoft Visual Basic 코드 페이지 편집기</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Microsoft Visual Basic 코드 페이지 편집기</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic Editor</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic Editor</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pl.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pl.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Edytor strony kodowej Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Edytor strony kodowej Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Edytor Microsoft Visual Basic</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Edytor Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pt-BR.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.pt-BR.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Editor de Página de Código do Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Editor de Página de Código do Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Editor do Microsoft Visual Basic</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Editor do Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ru.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.ru.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Редактор кодовых страниц Microsoft Visual Basic</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Редактор кодовых страниц Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Редактор Microsoft Visual Basic</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Редактор Microsoft Visual Basic</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.tr.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.tr.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Microsoft Visual Basic Kod Sayfası Düzenleyicisi</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Microsoft Visual Basic Kod Sayfası Düzenleyicisi</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic Düzenleyicisi</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic Düzenleyicisi</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hans.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hans.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Microsoft Visual Basic 代码页编辑器</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Microsoft Visual Basic 代码页编辑器</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic 编辑器</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic 编辑器</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">

--- a/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hant.xlf
+++ b/src/VisualStudio/VisualBasic/Impl/xlf/VSPackage.zh-Hant.xlf
@@ -8,13 +8,13 @@
         <note>Used anywhere the string is needed (that is, everywhere.)</note>
       </trans-unit>
       <trans-unit id="1012">
-        <source>Microsoft Visual Basic Code Page Editor</source>
-        <target state="translated">Microsoft Visual Basic 字碼頁編輯器</target>
+        <source>Visual Basic Editor with Encoding</source>
+        <target state="needs-review-translation">Microsoft Visual Basic 字碼頁編輯器</target>
         <note />
       </trans-unit>
       <trans-unit id="1013">
-        <source>Microsoft Visual Basic Editor</source>
-        <target state="translated">Microsoft Visual Basic 編輯器</target>
+        <source>Visual Basic Editor</source>
+        <target state="needs-review-translation">Microsoft Visual Basic 編輯器</target>
         <note />
       </trans-unit>
       <trans-unit id="10160">


### PR DESCRIPTION
This changes the names of the C# and VB editors so that they have a name that matches the other editors and usage elsewhere.

Old Name|New Name
---|---
CSharp Editor|C# Editor
CSharp Editor with Encoding|C# Editor with Encoding
Microsoft Visual Basic Editor|Visual Basic Editor
Microsoft Visual Basic Code Page Editor|Visual Basic Editor with Encoding

This PR renames this usage:

![image](https://user-images.githubusercontent.com/1103906/60408567-cde95780-9c02-11e9-8d7f-f03be54dff12.png)
![image](https://user-images.githubusercontent.com/1103906/60408598-eeb1ad00-9c02-11e9-901a-667e88febce0.png)