### PR TITLE
Revert "Fix couple of false positives in unused parameter analyzer"

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1305,18 +1305,5 @@ public sealed class C : IDisposable
     public void Dispose() => foo.Result.Fooed -= fooed;
 }", options);
         }
-
-        [WorkItem(36817, "https://github.com/dotnet/roslyn/issues/36817")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
-        public async Task ParameterWithoutName_NoDiagnostic()
-        {
-            await TestDiagnosticMissingAsync(
-@"public class C
-{
-    public void M[|(int )|]
-    {
-    }
-}");
-        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
@@ -97,21 +97,5 @@ $"Class C
     End Sub
 End Class")
         End Function
-
-        <WorkItem(36816, "https://github.com/dotnet/roslyn/issues/36816")>
-        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)>
-        Public Async Function PartialMethodParameter_NoDiagnostic() As Task
-            Await TestDiagnosticMissingAsync(
-$"Class C
-    [|Partial Private Sub M(str As String)|]
-    End Sub
-End Class
-
-Partial Class C
-    Private Sub M(str As String)
-        Dim x = str.ToString()
-    End Sub
-End Class")
-        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -57,12 +57,6 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 var deserializationConstructorCheck = new DeserializationConstructorCheck(context.Compilation);
                 context.RegisterSymbolStartAction(symbolStartContext =>
                 {
-                    if (HasSyntaxErrors((INamedTypeSymbol)symbolStartContext.Symbol, symbolStartContext.CancellationToken))
-                    {
-                        // Bail out on syntax errors.
-                        return;
-                    }
-
                     // Create a new SymbolStartAnalyzer instance for every named type symbol
                     // to ensure there is no shared state (such as identified unused parameters within the type),
                     // as that would lead to duplicate diagnostics being reported from symbol end action callbacks
@@ -70,23 +64,6 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     var symbolAnalyzer = new SymbolStartAnalyzer(analyzer, eventsArgType, attributeSetForMethodsToIgnore, deserializationConstructorCheck);
                     symbolAnalyzer.OnSymbolStart(symbolStartContext);
                 }, SymbolKind.NamedType);
-
-                return;
-
-                // Local functions
-                static bool HasSyntaxErrors(INamedTypeSymbol namedTypeSymbol, CancellationToken cancellationToken)
-                {
-                    foreach (var syntaxRef in namedTypeSymbol.DeclaringSyntaxReferences)
-                    {
-                        var syntax = syntaxRef.GetSyntax(cancellationToken);
-                        if (syntax.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                }
             }
 
             private void OnSymbolStart(SymbolStartAnalysisContext context)
@@ -213,7 +190,6 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     method.IsAbstract ||
                     method.IsVirtual ||
                     method.IsOverride ||
-                    method.PartialImplementationPart != null ||
                     !method.ExplicitOrImplicitInterfaceImplementations().IsEmpty ||
                     method.IsAccessor() ||
                     method.IsAnonymousFunction() ||


### PR DESCRIPTION
Reverts dotnet/roslyn#36818 in order to make the release branch state match what we've shipped