### PR TITLE
Add cache to target-typed completion

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 }
             }
 
-            var type = (symbol.GetMemberType() ?? symbol.GetSymbolType()).WithoutNullability();
+            var type = symbol.GetMemberType() ?? symbol.GetSymbolType();
             if (type == null)
             {
                 return false;
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                                select g;
 
             var itemListBuilder = ImmutableArray.CreateBuilder<CompletionItem>();
-            var typeConvertibilityCache = new Dictionary<ITypeSymbol, bool>();
+            var typeConvertibilityCache = new Dictionary<ITypeSymbol, bool>(AllNullabilityIgnoringSymbolComparer.Instance);
 
             foreach (var symbolGroup in symbolGroups)
             {


### PR DESCRIPTION
This helps address a performance issue discovered in a very specific scenario with a huge multitargeted VB file. In the case of the compiler not yet being warmed up, I've seen this drop perf from ~200ms to ~100ms. Once the compiler is warmed up, things are much faster. Perhaps there is more to be done here (parallelization, timeboxing, etc.) but this is definitely an improvement that I think we can use to justify re-enabling for internal teams.