### PR TITLE
Require System.Index/Range to be present to offer to use the new language features.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
@@ -63,6 +63,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -71,6 +72,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -85,6 +87,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -93,6 +96,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -109,6 +113,7 @@ class C
 @"
 using System.Linq;
 
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] ss)
@@ -119,6 +124,7 @@ class C
 @"
 using System.Linq;
 
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] ss)
@@ -329,10 +335,25 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIndexOperator)]
+        public async Task TestMissingWithNoSystemIndex()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    void Goo(string[] s)
+    {
+        var v = s[[||]s.Length - 1];
+    }
+}", new TestParameters(parseOptions: s_parseOptions));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIndexOperator)]
         public async Task TestArray()
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] s)
@@ -341,6 +362,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] s)
@@ -355,6 +377,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -364,6 +387,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -379,6 +403,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -388,6 +413,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string s)
@@ -403,6 +429,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] s)
@@ -411,6 +438,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] s)
@@ -425,6 +453,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] s)
@@ -433,6 +462,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Index { } }
 class C
 {
     void Goo(string[] s)

--- a/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseIndexOperatorTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseIndexOrRangeOperator
@@ -334,6 +335,7 @@ class C
 }", parameters: s_testParameters);
         }
 
+        [WorkItem(36909, "https://github.com/dotnet/roslyn/issues/36909")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseIndexOperator)]
         public async Task TestMissingWithNoSystemIndex()
         {

--- a/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseRangeOperatorTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseIndexOrRangeOperator/UseRangeOperatorTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseIndexOrRangeOperator
@@ -58,11 +59,27 @@ class C
 </Workspace>");
         }
 
+        [WorkItem(36909, "https://github.com/dotnet/roslyn/issues/36909")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseRangeOperator)]
+        public async Task TestNotWithoutSystemRange()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+class C
+{
+    void Goo(string s)
+    {
+        var v = s.Substring([||]1, s.Length - 1);
+    }
+}", new TestParameters(parseOptions: s_parseOptions));
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseRangeOperator)]
         public async Task TestSimple()
         {
             await TestAsync(
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s)
@@ -71,6 +88,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s)
@@ -85,6 +103,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s, int bar, int baz)
@@ -93,6 +112,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s, int bar, int baz)
@@ -107,6 +127,7 @@ class C
         {
             await TestAsync(
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s)
@@ -115,6 +136,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s)
@@ -183,6 +205,7 @@ class C
             // simplify even further.
             await TestAsync(
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s, string t)
@@ -191,6 +214,7 @@ class C
     }
 }",
 @"
+namespace System { public struct Range { } }
 class C
 {
     void Goo(string s, string t)

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.InfoCache.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.InfoCache.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             /// The System.Index type.  Needed so that we only fixup code if we see the type
             /// we're using has an indexer that takes an Index.
             /// </summary>
-            private readonly INamedTypeSymbol _indexType;
+            public readonly INamedTypeSymbol IndexType;
 
             /// <summary>
             /// Mapping from a method like 'MyType.Get(int)' to the Length/Count property for
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
 
             public InfoCache(Compilation compilation)
             {
-                _indexType = compilation.GetTypeByMetadataName("System.Index");
+                IndexType = compilation.GetTypeByMetadataName("System.Index");
 
                 _methodToMemberInfo = new ConcurrentDictionary<IMethodSymbol, MemberInfo>();
 
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                     // this is the getter for an indexer.  i.e. the user is calling something
                     // like s[...].  We need to see if there's an indexer that takes a System.Index
                     // value.
-                    var indexer = GetIndexer(containingType, _indexType, method.ReturnType);
+                    var indexer = GetIndexer(containingType, IndexType, method.ReturnType);
                     if (indexer != null)
                     {
                         // Type had a matching indexer.  We can convert calls to the int-indexer to
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                     Debug.Assert(method.MethodKind == MethodKind.Ordinary);
                     // it's a method like:   `SomeType MyType.Get(int index)`.  Look 
                     // for an overload like: `SomeType MyType.Get(Range)`
-                    var overloadedIndexMethod = GetOverload(method, _indexType);
+                    var overloadedIndexMethod = GetOverload(method, IndexType);
                     if (overloadedIndexMethod != null)
                     {
                         return new MemberInfo(lengthLikeProperty, overloadedIndexMethod);

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.cs
@@ -58,6 +58,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                 var compilation = startContext.Compilation;
                 var infoCache = new InfoCache(compilation);
 
+                // The System.Index type is always required to offer this fix.
+                if (infoCache.IndexType == null)
+                {
+                    return;
+                }
+
                 // Register to hear property references, so we can hear about calls to indexers
                 // like: s[s.Length - n]
                 context.RegisterOperationAction(

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorCodeFixProvider.cs
@@ -64,8 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             InvocationExpressionSyntax currentInvocation,
             CancellationToken cancellationToken)
         {
-            var invocation = semanticModel.GetOperation(currentInvocation, cancellationToken) as IInvocationOperation;
-            if (invocation != null)
+            if (semanticModel.GetOperation(currentInvocation, cancellationToken) is IInvocationOperation invocation)
             {
                 var infoCache = new InfoCache(semanticModel.Compilation);
                 var resultOpt = AnalyzeInvocation(
@@ -74,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                 if (resultOpt != null)
                 {
                     var result = resultOpt.Value;
-                    var updatedNode = FixOne(semanticModel, result, cancellationToken);
+                    var updatedNode = FixOne(result, cancellationToken);
                     if (updatedNode != null)
                     {
                         return currentRoot.ReplaceNode(result.Invocation, updatedNode);
@@ -88,15 +87,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
         private static InvocationExpressionSyntax GetInvocationExpression(Diagnostic d, CancellationToken cancellationToken)
             => (InvocationExpressionSyntax)d.AdditionalLocations[0].FindNode(getInnermostNodeForTie: true, cancellationToken);
 
-        private ExpressionSyntax FixOne(
-            SemanticModel semanticModel, Result result, CancellationToken cancellationToken)
+        private ExpressionSyntax FixOne(Result result, CancellationToken cancellationToken)
         {
             var invocation = result.Invocation;
             var expression = invocation.Expression is MemberAccessExpressionSyntax memberAccess
                 ? memberAccess.Expression
                 : invocation.Expression;
 
-            var rangeExpression = CreateRangeExpression(semanticModel, result, cancellationToken);
+            var rangeExpression = CreateRangeExpression(result);
             var argument = Argument(rangeExpression).WithAdditionalAnnotations(Formatter.Annotation);
             var arguments = SingletonSeparatedList(argument);
 
@@ -118,22 +116,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             }
         }
 
-        private RangeExpressionSyntax CreateRangeExpression(
-            SemanticModel semanticModel, Result result, CancellationToken cancellationToken)
-        {
-            switch (result.Kind)
+        private RangeExpressionSyntax CreateRangeExpression(Result result)
+            => result.Kind switch
             {
-                case ResultKind.Computed:
-                    return CreateComputedRange(semanticModel, result, cancellationToken);
-                case ResultKind.Constant:
-                    return CreateConstantRange(semanticModel, result, cancellationToken);
-                default:
-                    throw ExceptionUtilities.Unreachable;
-            }
-        }
+                ResultKind.Computed => CreateComputedRange(result),
+                ResultKind.Constant => CreateConstantRange(result),
+                _ => throw ExceptionUtilities.Unreachable,
+            };
 
-        private RangeExpressionSyntax CreateComputedRange(
-            SemanticModel semanticModel, Result result, CancellationToken cancellationToken)
+        private RangeExpressionSyntax CreateComputedRange(Result result)
         {
             // We have enough information now to generate `start..end`.  However, this will often
             // not be what the user wants.  For example, generating `start..expr.Length` is not as
@@ -143,24 +134,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             var startOperation = result.Op1;
             var endOperation = result.Op2;
 
-            var startExpr = (ExpressionSyntax)startOperation.Syntax;
-            var endExpr = (ExpressionSyntax)endOperation.Syntax;
-
-            var startFromEnd = false;
-            var endFromEnd = false;
-
             var lengthLikeProperty = result.MemberInfo.LengthLikeProperty;
             var instance = result.InvocationOperation.Instance;
 
             // If our start-op is actually equivalent to `expr.Length - val`, then just change our
             // start-op to be `val` and record that we should emit it as `^val`.
-            startFromEnd = IsFromEnd(lengthLikeProperty, instance, ref startOperation);
-            startExpr = (ExpressionSyntax)startOperation.Syntax;
+            var startFromEnd = IsFromEnd(lengthLikeProperty, instance, ref startOperation);
+            var startExpr = (ExpressionSyntax)startOperation.Syntax;
 
             // Similarly, if our end-op is actually equivalent to `expr.Length - val`, then just
             // change our end-op to be `val` and record that we should emit it as `^val`.
-            endFromEnd = IsFromEnd(lengthLikeProperty, instance, ref endOperation);
-            endExpr = (ExpressionSyntax)endOperation.Syntax;
+            var endFromEnd = IsFromEnd(lengthLikeProperty, instance, ref endOperation);
+            var endExpr = (ExpressionSyntax)endOperation.Syntax;
 
             // If the range operation goes to 'expr.Length' then we can just leave off the end part
             // of the range.  i.e. `start..`
@@ -182,16 +167,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                 endExpr != null && endFromEnd ? IndexExpression(endExpr) : endExpr);
         }
 
-        private static ExpressionSyntax GetExpression(ImmutableDictionary<string, string> props, ExpressionSyntax expr, string omitKey, string fromEndKey)
-            => props.ContainsKey(omitKey)
-                ? null
-                : props.ContainsKey(fromEndKey) ? IndexExpression(expr) : expr;
-
-        private static RangeExpressionSyntax CreateConstantRange(
-            SemanticModel semanticModel, Result result, CancellationToken cancellationToken)
+        private static RangeExpressionSyntax CreateConstantRange(Result result)
         {
             var constant1Syntax = (ExpressionSyntax)result.Op1.Syntax;
-            var constant2Syntax = (ExpressionSyntax)result.Op2.Syntax;
 
             // the form is s.Slice(constant1, s.Length - constant2).  Want to generate
             // s[constant1..(constant2-constant1)]

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.InfoCache.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.InfoCache.cs
@@ -20,12 +20,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             /// The System.Range type.  Needed so that we only fixup code if we see the type
             /// we're using has an indexer that takes a Range.
             /// </summary>
-            private readonly INamedTypeSymbol _rangeType;
+            public readonly INamedTypeSymbol RangeType;
             private readonly ConcurrentDictionary<IMethodSymbol, MemberInfo> _methodToMemberInfo;
 
             public InfoCache(Compilation compilation)
             {
-                _rangeType = compilation.GetTypeByMetadataName("System.Range");
+                RangeType = compilation.GetTypeByMetadataName("System.Range");
 
                 _methodToMemberInfo = new ConcurrentDictionary<IMethodSymbol, MemberInfo>();
 
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                     // it's a method like:  MyType MyType.Slice(int start, int length).  Look for an
                     // indexer like  `MyType MyType.this[Range range]`. If we can't find one return
                     // 'default' so we'll consider this named-type non-viable.
-                    var indexer = GetIndexer(containingType, _rangeType, containingType);
+                    var indexer = GetIndexer(containingType, RangeType, containingType);
                     if (indexer != null)
                     {
                         return new MemberInfo(lengthLikeProperty, overloadedMethodOpt: null);
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
 
                 // it's a method like:   `SomeType MyType.Slice(int start, int length)`.  Look 
                 // for an overload like: `SomeType MyType.Slice(Range)`
-                var overloadedRangeMethod = GetOverload(sliceLikeMethod, _rangeType);
+                var overloadedRangeMethod = GetOverload(sliceLikeMethod, RangeType);
                 if (overloadedRangeMethod != null)
                 {
                     return new MemberInfo(lengthLikeProperty, overloadedRangeMethod);

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
@@ -52,9 +52,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
                 // We're going to be checking every invocation in the compilation. Cache information
                 // we compute in this object so we don't have to continually recompute it.
                 var infoCache = new InfoCache(compilationContext.Compilation);
-                compilationContext.RegisterOperationAction(
-                    c => AnalyzeInvocation(c, infoCache),
-                    OperationKind.Invocation);
+
+                // The System.Range type is always required to offer this fix.
+                if (infoCache.RangeType != null)
+                {
+                    compilationContext.RegisterOperationAction(
+                        c => AnalyzeInvocation(c, infoCache),
+                        OperationKind.Invocation);
+                }
             });
         }
 

--- a/src/Features/CSharp/Portable/UseIndexOrRangeOperator/Helpers.cs
+++ b/src/Features/CSharp/Portable/UseIndexOrRangeOperator/Helpers.cs
@@ -67,9 +67,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             return false;
         }
 
-        private static bool IsConstantInt32(IOperation operation)
-            => operation.ConstantValue.HasValue && operation.ConstantValue.Value is int;
-
         /// <summary>
         /// Look for methods like "SomeType MyType.Get(int)".  Also matches against the 'getter'
         /// of an indexer like 'SomeType MyType.this[int]`


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36909

A while back the compiler had a permissive view of indexing into a string or array with an `^` indexer, or a Range.  Specifically, it would allow doing this *even if* there was no System.Index or System.Range present.  This was fine as the compiler wasn't using those types anyways, it was just translating things to the underlying calls to the int based indexers/substrings/array-copies.

When i added the "use index or range operator" feature i took this into account, and we would offer the feature on strings/arrays when possible.

However, at some point teh compiler changed their strategy, and these types are still required to be present (even if they are unused).

This changes the IDE feature to respect that and to not offer the feature unless those types are present.

