### PR TITLE
Hang on applying code action on a single unopened file

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -165,11 +165,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     FunctionId.CodeFixes_ApplyChanges, KeyValueLogMessage.Create(LogType.UserAction, m => CreateLogProperties(m)), cancellationToken))
                 {
                     // Note: we want to block the UI thread here so the user cannot modify anything while the codefix applies
-                    var applicationTask = EditHandler.ApplyAsync(Workspace, getFromDocument(),
+                    _isApplied = EditHandler.Apply(Workspace, getFromDocument(),
                         operations.ToImmutableArray(), CodeAction.Title,
                         progressTracker, cancellationToken);
-                    applicationTask.Wait(cancellationToken);
-                    _isApplied = applicationTask.Result;
                 }
             }
         }

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -146,8 +146,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             var singleChangedDocument = TryGetSingleChangedText(oldSolution, operations);
             if (singleChangedDocument != null)
             {
-                // ConfigureAwait(true) so we come back to the same thread as 
-                // we do all application on the UI thread.
                 var text = singleChangedDocument.GetTextSynchronously(cancellationToken);
 
                 using (workspace.Services.GetService<ISourceTextUndoService>().RegisterUndoTransaction(text, title))

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -120,8 +120,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             {
                 foreach (var document in project.Documents)
                 {
-                    // ConfigureAwait(true) so we come back to the same thread as 
-                    // we do all application on the UI thread.                    
                     if (!document.HasAnyErrorsAsync(cancellationToken).Result)
                     {
                         documentErrorLookup.Add(document.Id);

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             {
                 foreach (var document in project.Documents)
                 {
-                    if (!document.HasAnyErrorsAsync(cancellationToken).Result)
+                    if (!document.HasAnyErrorsAsync(cancellationToken).WaitAndGetResult(cancellationToken))
                     {
                         documentErrorLookup.Add(document.Id);
                     }

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -6,7 +6,6 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Undo;
@@ -94,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             return currentResult;
         }
 
-        public async Task<bool> ApplyAsync(
+        public bool Apply(
             Workspace workspace, Document fromDocument,
             ImmutableArray<CodeActionOperation> operations,
             string title, IProgressTracker progressTracker,
@@ -123,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                 {
                     // ConfigureAwait(true) so we come back to the same thread as 
                     // we do all application on the UI thread.                    
-                    if (!await document.HasAnyErrorsAsync(cancellationToken).ConfigureAwait(true))
+                    if (!document.HasAnyErrorsAsync(cancellationToken).Result)
                     {
                         documentErrorLookup.Add(document.Id);
                     }
@@ -149,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             {
                 // ConfigureAwait(true) so we come back to the same thread as 
                 // we do all application on the UI thread.
-                var text = await singleChangedDocument.GetTextAsync(cancellationToken).ConfigureAwait(true);
+                var text = singleChangedDocument.GetTextSynchronously(cancellationToken);
 
                 using (workspace.Services.GetService<ISourceTextUndoService>().RegisterUndoTransaction(text, title))
                 {

--- a/src/EditorFeatures/Core/Implementation/CodeRefactorings/ICodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeRefactorings/ICodeActionEditHandlerService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor
         SolutionPreviewResult GetPreviews(
             Workspace workspace, ImmutableArray<CodeActionOperation> operations, CancellationToken cancellationToken);
 
-        Task<bool> ApplyAsync(
+        bool Apply(
             Workspace workspace, Document fromDocument,
             ImmutableArray<CodeActionOperation> operations,
             string title, IProgressTracker progressTracker,

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1191,7 +1191,7 @@ class C
                 Dim notificationService = DirectCast(workspace.Services.GetService(Of INotificationService)(), INotificationServiceCallback)
                 notificationService.NotificationCallback = Sub(message, title, severity) actualSeverity = severity
 
-                Await editHandler.ApplyAsync(
+                editHandler.Apply(
                     workspace,
                     workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id),
                     Await actions.First().NestedCodeActions.First().GetOperationsAsync(CancellationToken.None),

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -374,13 +374,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             {
                 var operations = ImmutableArray.Create<CodeActionOperation>(new ApplyChangesOperation(newSolution));
                 var cancellationToken = context.CancellationToken;
-                _editHandlerService.ApplyAsync(
+                _editHandlerService.Apply(
                     _workspace,
                     fromDocument: null,
                     operations: operations,
                     title: title,
                     progressTracker: context.ProgressTracker,
-                    cancellationToken: cancellationToken).Wait(cancellationToken);
+                    cancellationToken: cancellationToken);
             }
 
             result = InvokeWithWaitDialog(applyFix, title, waitDialogMessage);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36938

`Microsoft.CodeAnalysis.EditorFeatures.Wpf.dll!Microsoft.CodeAnalysis.Editor.Implementation.Suggestions.SuggestedAction.InvokeWorker(System.Func<Microsoft.CodeAnalysis.Document> getFromDocument, Microsoft.CodeAnalysis.Shared.Utilities.IProgressTracker progressTracker, System.Threading.CancellationToken cancellationToken) `
calls
`EditHandler.Apply(Async)`

ApplyAsync has the only asynchronous call to 
```
// ConfigureAwait(true) so we come back to the same thread as 	                
// we do all application on the UI thread.
var text = await singleChangedDocument.GetTextAsync(cancellationToken).ConfigureAwait(true);
```
which could lead to a deadlock with the caller.
  