### PR TITLE
Update to System.Memory 4.5.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -181,7 +181,7 @@
     <SystemIOFileSystemVersion>4.3.0</SystemIOFileSystemVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
     <SystemIOPipesAccessControlVersion>4.3.0</SystemIOPipesAccessControlVersion>
-    <SystemMemoryVersion>4.5.2</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.3</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.5.2</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemTextEncodingCodePagesVersion>4.5.1</SystemTextEncodingCodePagesVersion>


### PR DESCRIPTION
This will update Roslyn and Visual Studio to System.Memory 4.5.3, which is needed by MSBuild's reference to System.Resources.Extensions, which depends on System.Memory 4.5.3.