### PR TITLE
Add nullable annotations to parts of the Workspace API

### DIFF
--- a/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
+++ b/src/CodeStyle/Core/Analyzers/Microsoft.CodeAnalysis.CodeStyle.csproj
@@ -173,6 +173,7 @@
     <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\IBidirectionalMap.cs" Link="InternalUtilities\IBidirectionalMap.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\LazyInitialization.cs" Link="Formatting\LazyInitialization.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\NonReentrantLock.cs" Link="Formatting\NonReentrantLock.cs" />
+    <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\NullableHelpers\NullableAttributes.cs" Link="Formatting\NullableAttributes.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\ObjectPools\Extensions.cs" Link="Formatting\Extensions.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\ObjectPools\PooledObject.cs" Link="Formatting\PooledObject.cs" />
     <Compile Include="..\..\..\Workspaces\Core\Portable\Utilities\ObjectPools\SharedPools.cs" Link="Formatting\SharedPools.cs" />

--- a/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
+++ b/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\Contract.cs" Link="Utilities\Contract.cs" />
+    <Compile Include="..\..\Workspaces\Core\Portable\Utilities\NullableHelpers\NullableAttributes.cs" Link="Utilities\NullableAttributes.cs" />
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\TaskExtensions.cs" Link="Utilities\TaskExtensions.cs" />
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\AsyncLazy`1.cs" Link="Utilities\AsyncLazy`1.cs" />
     <Compile Include="..\..\Workspaces\Core\Portable\Utilities\NonReentrantLock.cs" Link="Utilities\NonReentrantLock.cs" />

--- a/src/Workspaces/Core/Portable/Utilities/Contract.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Contract.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
@@ -11,7 +14,7 @@ namespace Roslyn.Utilities
         /// Throws a non-accessible exception if the provided value is null.  This method executes in
         /// all builds
         /// </summary>
-        public static void ThrowIfNull<T>(T value, string message = null) where T : class
+        public static void ThrowIfNull<T>([NotNull] T value, string? message = null) where T : class?
         {
             if (value == null)
             {
@@ -24,7 +27,7 @@ namespace Roslyn.Utilities
         /// Throws a non-accessible exception if the provided value is false.  This method executes
         /// in all builds
         /// </summary>
-        public static void ThrowIfFalse(bool condition, string message = null)
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string? message = null)
         {
             if (!condition)
             {
@@ -37,7 +40,7 @@ namespace Roslyn.Utilities
         /// Throws a non-accessible exception if the provided value is true. This method executes in
         /// all builds.
         /// </summary>
-        public static void ThrowIfTrue(bool condition, string message = null)
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, string? message = null)
         {
             if (condition)
             {
@@ -47,12 +50,14 @@ namespace Roslyn.Utilities
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         public static void Fail(string message = "Unexpected")
         {
             throw new InvalidOperationException(message);
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         public static T FailWithReturn<T>(string message = "Unexpected")
         {
             throw new InvalidOperationException(message);

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableAttributes.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableAttributes.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This was copied from https://github.com/dotnet/coreclr/blob/60f1e6265bd1039f023a82e0643b524d6aaf7845/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+// and updated to have the scope of the attributes be internal.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostLanguageServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostLanguageServices.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.CodeAnalysis.Host
 {
@@ -23,12 +26,14 @@ namespace Microsoft.CodeAnalysis.Host
         /// Gets a language specific service provided by the host identified by the service type. 
         /// If the host does not provide the service, this method returns null.
         /// </summary>
+        [return: MaybeNull]
         public abstract TLanguageService GetService<TLanguageService>() where TLanguageService : ILanguageService;
 
         /// <summary>
         /// Gets a language specific service provided by the host identified by the service type. 
         /// If the host does not provide the service, this method returns throws <see cref="InvalidOperationException"/>.
         /// </summary>
+        [return: NotNull]
         public TLanguageService GetRequiredService<TLanguageService>() where TLanguageService : ILanguageService
         {
             var service = GetService<TLanguageService>();
@@ -45,13 +50,13 @@ namespace Microsoft.CodeAnalysis.Host
         /// <summary>
         /// A factory for creating compilations instances.
         /// </summary>
-        internal virtual ICompilationFactoryService CompilationFactory
+        internal virtual ICompilationFactoryService? CompilationFactory
         {
             get { return this.GetService<ICompilationFactoryService>(); }
         }
 
         // needs some work on the interface before it can be public
-        internal virtual ISyntaxTreeFactoryService SyntaxTreeFactory
+        internal virtual ISyntaxTreeFactoryService? SyntaxTreeFactory
         {
             get { return this.GetService<ISyntaxTreeFactoryService>(); }
         }

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -27,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Host
         /// Gets a workspace specific service provided by the host identified by the service type. 
         /// If the host does not provide the service, this method returns null.
         /// </summary>
+        [return: MaybeNull]
         public abstract TWorkspaceService GetService<TWorkspaceService>() where TWorkspaceService : IWorkspaceService;
 
         /// <summary>
@@ -34,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Host
         /// If the host does not provide the service, this method throws <see cref="InvalidOperationException"/>.
         /// </summary>
         /// <exception cref="InvalidOperationException">The host does not provide the service.</exception>
+        [return: NotNull]
         public TWorkspaceService GetRequiredService<TWorkspaceService>() where TWorkspaceService : IWorkspaceService
         {
             var service = GetService<TWorkspaceService>();
@@ -88,6 +93,7 @@ namespace Microsoft.CodeAnalysis.Host
         /// <summary>
         /// Gets the <see cref="HostLanguageServices"/> for the language name.
         /// </summary>
+        /// <exception cref="NotSupportedException">Thrown if the language isn't supported.</exception>
         public virtual HostLanguageServices GetLanguageServices(string languageName)
         {
             throw new NotSupportedException(string.Format(WorkspacesResources.The_language_0_is_not_supported, languageName));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Serialization;
@@ -28,14 +30,14 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The path to the solution file, or null if there is no solution file.
         /// </summary>
-        public string FilePath => Attributes.FilePath;
+        public string? FilePath => Attributes.FilePath;
 
         /// <summary>
         /// A list of projects initially associated with the solution.
         /// </summary>
         public IReadOnlyList<ProjectInfo> Projects { get; }
 
-        private SolutionInfo(SolutionAttributes attributes, IEnumerable<ProjectInfo> projects)
+        private SolutionInfo(SolutionAttributes attributes, IEnumerable<ProjectInfo>? projects)
         {
             Attributes = attributes;
             Projects = projects.ToImmutableReadOnlyListOrEmpty();
@@ -47,15 +49,15 @@ namespace Microsoft.CodeAnalysis
         public static SolutionInfo Create(
             SolutionId id,
             VersionStamp version,
-            string filePath = null,
-            IEnumerable<ProjectInfo> projects = null)
+            string? filePath = null,
+            IEnumerable<ProjectInfo>? projects = null)
         {
             return new SolutionInfo(new SolutionAttributes(id, version, filePath), projects);
         }
 
         private SolutionInfo With(
-            SolutionAttributes attributes = null,
-            IEnumerable<ProjectInfo> projects = null)
+            SolutionAttributes? attributes = null,
+            IEnumerable<ProjectInfo>? projects = null)
         {
             var newAttributes = attributes ?? Attributes;
             var newProjects = projects ?? Projects;
@@ -74,7 +76,7 @@ namespace Microsoft.CodeAnalysis
             return With(attributes: new SolutionAttributes(Attributes.Id, version, Attributes.FilePath));
         }
 
-        internal SolutionInfo WithFilePath(string filePath)
+        internal SolutionInfo WithFilePath(string? filePath)
         {
             return With(attributes: new SolutionAttributes(Attributes.Id, Attributes.Version, filePath));
         }
@@ -103,9 +105,9 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// The path to the solution file, or null if there is no solution file.
             /// </summary>
-            public string FilePath { get; }
+            public string? FilePath { get; }
 
-            public SolutionAttributes(SolutionId id, VersionStamp version, string filePath)
+            public SolutionAttributes(SolutionId id, VersionStamp version, string? filePath)
             {
                 Id = id ?? throw new ArgumentNullException(nameof(id));
                 Version = version;
@@ -139,7 +141,7 @@ namespace Microsoft.CodeAnalysis
                 return new SolutionAttributes(solutionId, VersionStamp.Create(), filePath);
             }
 
-            private Checksum _lazyChecksum;
+            private Checksum? _lazyChecksum;
             Checksum IChecksummedObject.Checksum
             {
                 get

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -84,14 +87,15 @@ namespace Microsoft.CodeAnalysis
                 workspaceVersion: 0,
                 solutionServices: new SolutionServices(workspace),
                 solutionAttributes: solutionAttributes,
-                projectIds: null,
+                projectIds: ImmutableArray<ProjectId>.Empty,
                 idToProjectStateMap: ImmutableDictionary<ProjectId, ProjectState>.Empty,
                 projectIdToTrackerMap: ImmutableDictionary<ProjectId, CompilationTracker>.Empty,
                 filePathToDocumentIdsMap: ImmutableDictionary.Create<string, ImmutableArray<DocumentId>>(StringComparer.OrdinalIgnoreCase),
                 dependencyGraph: ProjectDependencyGraph.Empty,
+#nullable disable warnings // we are passing null here but we're immediately overwriting it -- better to keep the parameter non-null
                 lazyLatestProjectVersion: null)
+#nullable enable warnings
         {
-            // this is for the very first solution state ever created
             _lazyLatestProjectVersion = new Lazy<VersionStamp>(() => ComputeLatestProjectVersion());
         }
 
@@ -113,7 +117,7 @@ namespace Microsoft.CodeAnalysis
             foreach (var projectId in this.ProjectIds)
             {
                 var project = this.GetProjectState(projectId);
-                latestVersion = project.Version.GetNewerVersion(latestVersion);
+                latestVersion = project!.Version.GetNewerVersion(latestVersion);
             }
 
             return latestVersion;
@@ -153,7 +157,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The path to the solution file or null if there is no solution file.
         /// </summary>
-        public string FilePath => _solutionAttributes.FilePath;
+        public string? FilePath => _solutionAttributes.FilePath;
 
         /// <summary>
         /// The solution version. This equates to the solution file's version.
@@ -175,13 +179,13 @@ namespace Microsoft.CodeAnalysis
         }
 
         private SolutionState Branch(
-            SolutionInfo.SolutionAttributes solutionAttributes = null,
-            IEnumerable<ProjectId> projectIds = null,
-            ImmutableDictionary<ProjectId, ProjectState> idToProjectStateMap = null,
-            ImmutableDictionary<ProjectId, CompilationTracker> projectIdToTrackerMap = null,
-            ImmutableDictionary<string, ImmutableArray<DocumentId>> filePathToDocumentIdsMap = null,
-            ProjectDependencyGraph dependencyGraph = null,
-            Lazy<VersionStamp> lazyLatestProjectVersion = null)
+            SolutionInfo.SolutionAttributes? solutionAttributes = null,
+            IEnumerable<ProjectId>? projectIds = null,
+            ImmutableDictionary<ProjectId, ProjectState>? idToProjectStateMap = null,
+            ImmutableDictionary<ProjectId, CompilationTracker>? projectIdToTrackerMap = null,
+            ImmutableDictionary<string, ImmutableArray<DocumentId>>? filePathToDocumentIdsMap = null,
+            ProjectDependencyGraph? dependencyGraph = null,
+            Lazy<VersionStamp>? lazyLatestProjectVersion = null)
         {
             var branchId = GetBranchId();
 
@@ -264,7 +268,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// True if the solution contains a project with the specified project ID.
         /// </summary>
-        public bool ContainsProject(ProjectId projectId)
+        public bool ContainsProject([NotNullWhen(returnValue: true)] ProjectId? projectId)
         {
             return projectId != null && _projectIdToProjectStateMap.ContainsKey(projectId);
         }
@@ -272,37 +276,37 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// True if the solution contains the document in one of its projects
         /// </summary>
-        public bool ContainsDocument(DocumentId documentId)
+        public bool ContainsDocument([NotNullWhen(returnValue: true)] DocumentId? documentId)
         {
             return
                 documentId != null &&
                 this.ContainsProject(documentId.ProjectId) &&
-                this.GetProjectState(documentId.ProjectId).ContainsDocument(documentId);
+                this.GetProjectState(documentId.ProjectId)!.ContainsDocument(documentId);
         }
 
         /// <summary>
         /// True if the solution contains the additional document in one of its projects
         /// </summary>
-        public bool ContainsAdditionalDocument(DocumentId documentId)
+        public bool ContainsAdditionalDocument([NotNullWhen(returnValue: true)] DocumentId? documentId)
         {
             return
                 documentId != null &&
                 this.ContainsProject(documentId.ProjectId) &&
-                this.GetProjectState(documentId.ProjectId).ContainsAdditionalDocument(documentId);
+                this.GetProjectState(documentId.ProjectId)!.ContainsAdditionalDocument(documentId);
         }
 
         /// <summary>
         /// True if the solution contains the analyzer config document in one of its projects
         /// </summary>
-        public bool ContainsAnalyzerConfigDocument(DocumentId documentId)
+        public bool ContainsAnalyzerConfigDocument([NotNullWhen(returnValue: true)] DocumentId? documentId)
         {
             return
                 documentId != null &&
                 this.ContainsProject(documentId.ProjectId) &&
-                this.GetProjectState(documentId.ProjectId).ContainsAnalyzerConfigDocument(documentId);
+                this.GetProjectState(documentId.ProjectId)!.ContainsAnalyzerConfigDocument(documentId);
         }
 
-        private DocumentState GetDocumentState(DocumentId documentId)
+        private DocumentState? GetDocumentState(DocumentId? documentId)
         {
             if (documentId != null)
             {
@@ -316,7 +320,7 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        private DocumentState GetDocumentState(SyntaxTree syntaxTree, ProjectId projectId)
+        private DocumentState? GetDocumentState(SyntaxTree? syntaxTree, ProjectId? projectId)
         {
             if (syntaxTree != null)
             {
@@ -340,7 +344,7 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        private TextDocumentState GetAdditionalDocumentState(DocumentId documentId)
+        private TextDocumentState? GetAdditionalDocumentState(DocumentId? documentId)
         {
             if (documentId != null)
             {
@@ -354,7 +358,7 @@ namespace Microsoft.CodeAnalysis
             return null;
         }
 
-        private AnalyzerConfigDocumentState GetAnalyzerConfigDocumentState(DocumentId documentId)
+        private AnalyzerConfigDocumentState? GetAnalyzerConfigDocumentState(DocumentId? documentId)
         {
             if (documentId != null)
             {
@@ -378,7 +382,7 @@ namespace Microsoft.CodeAnalysis
             return this.GetCompilationTracker(projectId).GetDependentSemanticVersionAsync(this, cancellationToken);
         }
 
-        public ProjectState GetProjectState(ProjectId projectId)
+        public ProjectState? GetProjectState(ProjectId projectId)
         {
             _projectIdToProjectStateMap.TryGetValue(projectId, out var state);
             return state;
@@ -387,7 +391,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets the <see cref="Project"/> associated with an assembly symbol.
         /// </summary>
-        public ProjectState GetProjectState(IAssemblySymbol assemblySymbol, CancellationToken cancellationToken)
+        public ProjectState? GetProjectState(IAssemblySymbol? assemblySymbol, CancellationToken cancellationToken)
         {
             if (assemblySymbol == null)
             {
@@ -411,7 +415,7 @@ namespace Microsoft.CodeAnalysis
             return id == null ? null : this.GetProjectState(id);
         }
 
-        private bool TryGetCompilationTracker(ProjectId projectId, out CompilationTracker tracker)
+        private bool TryGetCompilationTracker(ProjectId projectId, [NotNullWhen(returnValue: true)] out CompilationTracker? tracker)
         {
             return _projectIdToTrackerMap.TryGetValue(projectId, out tracker);
         }
@@ -619,7 +623,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.UpdateAssemblyName(assemblyName);
 
             if (oldProject == newProject)
@@ -633,7 +637,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new solution instance with the project specified updated to have the output file path.
         /// </summary>
-        public SolutionState WithProjectOutputFilePath(ProjectId projectId, string outputFilePath)
+        public SolutionState WithProjectOutputFilePath(ProjectId projectId, string? outputFilePath)
         {
             if (projectId == null)
             {
@@ -642,7 +646,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProjectState = this.GetProjectState(projectId);
+            var oldProjectState = this.GetProjectState(projectId)!;
             var newProjectState = oldProjectState.UpdateOutputFilePath(outputFilePath);
 
             if (oldProjectState == newProjectState)
@@ -656,7 +660,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new solution instance with the project specified updated to have the output file path.
         /// </summary>
-        public SolutionState WithProjectOutputRefFilePath(ProjectId projectId, string outputRefFilePath)
+        public SolutionState WithProjectOutputRefFilePath(ProjectId projectId, string? outputRefFilePath)
         {
             if (projectId == null)
             {
@@ -665,7 +669,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProjectState = this.GetProjectState(projectId);
+            var oldProjectState = this.GetProjectState(projectId)!;
             var newProjectState = oldProjectState.UpdateOutputRefFilePath(outputRefFilePath);
 
             if (oldProjectState == newProjectState)
@@ -679,7 +683,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new solution instance with the project specified updated to have the default namespace.
         /// </summary>
-        public SolutionState WithProjectDefaultNamespace(ProjectId projectId, string defaultNamespace)
+        public SolutionState WithProjectDefaultNamespace(ProjectId projectId, string? defaultNamespace)
         {
             if (projectId == null)
             {
@@ -688,7 +692,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProjectState = this.GetProjectState(projectId);
+            var oldProjectState = this.GetProjectState(projectId)!;
             var newProjectState = oldProjectState.UpdateDefaultNamespace(defaultNamespace);
 
             if (oldProjectState == newProjectState)
@@ -711,7 +715,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProjectState = this.GetProjectState(projectId);
+            var oldProjectState = this.GetProjectState(projectId)!;
             var newProjectState = oldProjectState.UpdateName(name);
 
             if (oldProjectState == newProjectState)
@@ -725,7 +729,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new solution instance with the project specified updated to have the project file path.
         /// </summary>
-        public SolutionState WithProjectFilePath(ProjectId projectId, string filePath)
+        public SolutionState WithProjectFilePath(ProjectId projectId, string? filePath)
         {
             if (projectId == null)
             {
@@ -734,7 +738,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProjectState = this.GetProjectState(projectId);
+            var oldProjectState = this.GetProjectState(projectId)!;
             var newProjectState = oldProjectState.UpdateFilePath(filePath);
 
             if (oldProjectState == newProjectState)
@@ -763,7 +767,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.UpdateCompilationOptions(options);
 
             if (oldProject == newProject)
@@ -787,7 +791,7 @@ namespace Microsoft.CodeAnalysis
 
             Debug.Assert(this.ContainsProject(projectId));
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.UpdateParseOptions(options);
 
             if (oldProject == newProject)
@@ -822,7 +826,7 @@ namespace Microsoft.CodeAnalysis
 
             Debug.Assert(this.ContainsProject(projectId));
 
-            return ForkProject(GetProjectState(projectId));
+            return ForkProject(GetProjectState(projectId)!);
         }
 
         /// <summary>
@@ -838,7 +842,7 @@ namespace Microsoft.CodeAnalysis
 
             Debug.Assert(this.ContainsProject(projectId));
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.UpdateHasAllInformation(hasAllInformation);
 
             if (oldProject == newProject)
@@ -881,7 +885,7 @@ namespace Microsoft.CodeAnalysis
                 CheckNotSecondSubmissionReference(projectId, referencedProject.ProjectId);
             }
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.AddProjectReferences(projectReferences);
             var newDependencyGraph = _dependencyGraph.WithAdditionalProjectReferences(projectId, projectReferences.Select(r => r.ProjectId).ToList());
 
@@ -907,7 +911,7 @@ namespace Microsoft.CodeAnalysis
             CheckContainsProject(projectId);
             CheckContainsProject(projectReference.ProjectId);
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.RemoveProjectReference(projectReference);
 
             return this.ForkProject(newProject, newDependencyGraph: _dependencyGraph.WithProjectReferences(projectId, newProject.ProjectReferences.Select(p => p.ProjectId)));
@@ -931,7 +935,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.WithProjectReferences(projectReferences);
 
             return this.ForkProject(newProject, newDependencyGraph: _dependencyGraph.WithProjectReferences(projectId, projectReferences.Select(p => p.ProjectId)));
@@ -955,7 +959,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsProject(projectId);
 
-            var oldProject = this.GetProjectState(projectId);
+            var oldProject = this.GetProjectState(projectId)!;
             var newProject = oldProject.UpdateDocumentsOrder(documentIds);
 
             if (oldProject == newProject)
@@ -985,7 +989,7 @@ namespace Microsoft.CodeAnalysis
             CheckContainsProject(projectId);
 
             return this.ForkProject(
-                this.GetProjectState(projectId).AddMetadataReference(metadataReference));
+                this.GetProjectState(projectId)!.AddMetadataReference(metadataReference));
         }
 
         /// <summary>
@@ -1005,7 +1009,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             CheckContainsProject(projectId);
-            return this.ForkProject(this.GetProjectState(projectId).AddMetadataReferences(metadataReferences));
+            return this.ForkProject(this.GetProjectState(projectId)!.AddMetadataReferences(metadataReferences));
         }
 
         /// <summary>
@@ -1027,7 +1031,7 @@ namespace Microsoft.CodeAnalysis
             CheckContainsProject(projectId);
 
             return this.ForkProject(
-                this.GetProjectState(projectId).RemoveMetadataReference(metadataReference));
+                this.GetProjectState(projectId)!.RemoveMetadataReference(metadataReference));
         }
 
         /// <summary>
@@ -1047,7 +1051,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             CheckContainsProject(projectId);
-            return this.ForkProject(this.GetProjectState(projectId).WithMetadataReferences(metadataReferences));
+            return this.ForkProject(this.GetProjectState(projectId)!.WithMetadataReferences(metadataReferences));
         }
 
         /// <summary>
@@ -1067,7 +1071,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             CheckContainsProject(projectId);
-            return this.ForkProject(this.GetProjectState(projectId).AddAnalyzerReference(analyzerReference));
+            return this.ForkProject(this.GetProjectState(projectId)!.AddAnalyzerReference(analyzerReference));
         }
 
         /// <summary>
@@ -1092,7 +1096,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             CheckContainsProject(projectId);
-            return this.ForkProject(this.GetProjectState(projectId).AddAnalyzerReferences(analyzerReferences));
+            return this.ForkProject(this.GetProjectState(projectId)!.AddAnalyzerReferences(analyzerReferences));
         }
 
         /// <summary>
@@ -1112,7 +1116,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             CheckContainsProject(projectId);
-            return this.ForkProject(this.GetProjectState(projectId).RemoveAnalyzerReference(analyzerReference));
+            return this.ForkProject(this.GetProjectState(projectId)!.RemoveAnalyzerReference(analyzerReference));
         }
 
         /// <summary>
@@ -1132,7 +1136,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             CheckContainsProject(projectId);
-            return this.ForkProject(this.GetProjectState(projectId).WithAnalyzerReferences(analyzerReferences));
+            return this.ForkProject(this.GetProjectState(projectId)!.WithAnalyzerReferences(analyzerReferences));
         }
 
         /// <summary>
@@ -1155,7 +1159,7 @@ namespace Microsoft.CodeAnalysis
         private SolutionState AddDocumentsToMultipleProjects<T>(
             ImmutableArray<DocumentInfo> documentInfos,
             Func<DocumentInfo, ProjectState, T> createDocumentState,
-            Func<ProjectState, ImmutableArray<T>, (ProjectState newState, CompilationTranslationAction translationAction)> addDocumentsToProjectState)
+            Func<ProjectState, ImmutableArray<T>, (ProjectState newState, CompilationTranslationAction? translationAction)> addDocumentsToProjectState)
             where T : TextDocumentState
         {
             if (documentInfos.IsDefault)
@@ -1178,6 +1182,11 @@ namespace Microsoft.CodeAnalysis
             {
                 CheckContainsProject(documentInfosInProject.Key);
                 var oldProject = this.GetProjectState(documentInfosInProject.Key);
+
+                if (oldProject == null)
+                {
+                    throw new InvalidOperationException(string.Format(WorkspacesResources._0_is_not_part_of_the_workspace, documentInfosInProject.Key));
+                }
 
                 var newDocumentStatesForProjectBuilder = ArrayBuilder<T>.GetInstance();
 
@@ -1222,7 +1231,7 @@ namespace Microsoft.CodeAnalysis
         {
             CheckContainsAnalyzerConfigDocument(documentId);
 
-            var oldProject = this.GetProjectState(documentId.ProjectId);
+            var oldProject = this.GetProjectState(documentId.ProjectId)!;
             var newProject = oldProject.RemoveAnalyzerConfigDocument(documentId);
             var documentStates = SpecializedCollections.SingletonEnumerable(oldProject.GetAnalyzerConfigDocumentState(documentId));
 
@@ -1239,7 +1248,7 @@ namespace Microsoft.CodeAnalysis
         {
             CheckContainsDocument(documentId);
 
-            var oldProject = this.GetProjectState(documentId.ProjectId);
+            var oldProject = this.GetProjectState(documentId.ProjectId)!;
             var oldDocument = oldProject.GetDocumentState(documentId);
             var newProject = oldProject.RemoveDocument(documentId);
             var documentStates = SpecializedCollections.SingletonEnumerable(oldProject.GetDocumentState(documentId));
@@ -1257,9 +1266,9 @@ namespace Microsoft.CodeAnalysis
         {
             CheckContainsAdditionalDocument(documentId);
 
-            var oldProject = this.GetProjectState(documentId.ProjectId);
+            var oldProject = this.GetProjectState(documentId.ProjectId)!;
             var newProject = oldProject.RemoveAdditionalDocument(documentId);
-            var documentStates = SpecializedCollections.SingletonEnumerable(GetAdditionalDocumentState(documentId));
+            var documentStates = SpecializedCollections.SingletonEnumerable(GetAdditionalDocumentState(documentId)!);
 
             return this.ForkProject(newProject,
                 newFilePathToDocumentIdsMap: CreateFilePathToDocumentIdsMapWithRemovedDocuments(documentStates));
@@ -1280,7 +1289,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
             var newDocument = oldDocument.UpdateName(name);
 
             return this.WithDocumentState(newDocument);
@@ -1304,7 +1313,7 @@ namespace Microsoft.CodeAnalysis
 
             var folderCollection = folders.WhereNotNull().ToReadOnlyCollection();
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
             var newDocument = oldDocument.UpdateFolders(folderCollection);
 
             return this.WithDocumentState(newDocument);
@@ -1320,12 +1329,13 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(documentId));
             }
 
+            // TODO: why? we support nullable file paths
             if (filePath == null)
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
             var newDocument = oldDocument.UpdateFilePath(filePath);
 
             return this.WithDocumentState(newDocument);
@@ -1349,7 +1359,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsDocument(documentId);
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
             if (oldDocument.TryGetText(out var oldText) && text == oldText)
             {
                 return this;
@@ -1376,7 +1386,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsAdditionalDocument(documentId);
 
-            var oldDocument = this.GetAdditionalDocumentState(documentId);
+            var oldDocument = this.GetAdditionalDocumentState(documentId)!;
             if (oldDocument.TryGetText(out var oldText) && text == oldText)
             {
                 return this;
@@ -1404,7 +1414,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsAnalyzerConfigDocument(documentId);
 
-            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId);
+            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId)!;
             if (oldDocument.TryGetText(out var oldText) && text == oldText)
             {
                 return this;
@@ -1431,7 +1441,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsDocument(documentId);
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
 
             return WithDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
         }
@@ -1454,7 +1464,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsAdditionalDocument(documentId);
 
-            var oldDocument = this.GetAdditionalDocumentState(documentId);
+            var oldDocument = this.GetAdditionalDocumentState(documentId)!;
 
             return WithAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
         }
@@ -1477,7 +1487,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsAnalyzerConfigDocument(documentId);
 
-            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId);
+            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId)!;
 
             return WithAnalyzerConfigDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
         }
@@ -1500,7 +1510,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsDocument(documentId);
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
             if (oldDocument.TryGetSyntaxTree(out var oldTree) &&
                 oldTree.TryGetRoot(out var oldRoot) &&
                 oldRoot == root)
@@ -1535,7 +1545,7 @@ namespace Microsoft.CodeAnalysis
 
             CheckContainsDocument(documentId);
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
 
             if (oldDocument.SourceCodeKind == sourceCodeKind)
             {
@@ -1545,15 +1555,15 @@ namespace Microsoft.CodeAnalysis
             return WithDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), textChanged: true);
         }
 
-        public SolutionState WithDocumentTextLoader(DocumentId documentId, TextLoader loader, SourceText textOpt, PreservationMode mode)
+        public SolutionState WithDocumentTextLoader(DocumentId documentId, TextLoader loader, SourceText? text, PreservationMode mode)
         {
             CheckContainsDocument(documentId);
 
-            var oldDocument = this.GetDocumentState(documentId);
+            var oldDocument = this.GetDocumentState(documentId)!;
 
             // assumes that text has changed. user could have closed a doc without saving and we are loading text from closed file with
             // old content. also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return this.WithDocumentState(oldDocument.UpdateText(loader, textOpt, mode), textChanged: true, recalculateDependentVersions: true);
+            return this.WithDocumentState(oldDocument.UpdateText(loader, text, mode), textChanged: true, recalculateDependentVersions: true);
         }
 
         /// <summary>
@@ -1564,7 +1574,7 @@ namespace Microsoft.CodeAnalysis
         {
             CheckContainsAdditionalDocument(documentId);
 
-            var oldDocument = this.GetAdditionalDocumentState(documentId);
+            var oldDocument = this.GetAdditionalDocumentState(documentId)!;
 
             // assumes that text has changed. user could have closed a doc without saving and we are loading text from closed file with
             // old content. also this should make sure we don't re-use latest doc version with data associated with opened document.
@@ -1579,7 +1589,7 @@ namespace Microsoft.CodeAnalysis
         {
             CheckContainsAnalyzerConfigDocument(documentId);
 
-            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId);
+            var oldDocument = this.GetAnalyzerConfigDocumentState(documentId)!;
 
             // assumes that text has changed. user could have closed a doc without saving and we are loading text from closed file with
             // old content. also this should make sure we don't re-use latest doc version with data associated with opened document.
@@ -1608,7 +1618,7 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(this.ContainsDocument(documentId));
 
-            var oldProject = this.GetProjectState(documentId.ProjectId);
+            var oldProject = this.GetProjectState(documentId.ProjectId)!;
             var newProject = touchProject(oldProject);
 
             if (oldProject == newProject)
@@ -1638,7 +1648,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            var oldProject = this.GetProjectState(newDocument.Id.ProjectId);
+            var oldProject = this.GetProjectState(newDocument.Id.ProjectId)!;
             var newProject = oldProject.UpdateAdditionalDocument(newDocument, textChanged, recalculateDependentVersions);
 
             if (oldProject == newProject)
@@ -1665,7 +1675,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            var oldProject = this.GetProjectState(newDocument.Id.ProjectId);
+            var oldProject = this.GetProjectState(newDocument.Id.ProjectId)!;
             var newProject = oldProject.UpdateAnalyzerConfigDocument(newDocument, textChanged, recalculateDependentVersions);
 
             if (oldProject == newProject)
@@ -1685,9 +1695,9 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         private SolutionState ForkProject(
             ProjectState newProjectState,
-            CompilationTranslationAction translate = null,
-            ProjectDependencyGraph newDependencyGraph = null,
-            ImmutableDictionary<string, ImmutableArray<DocumentId>> newFilePathToDocumentIdsMap = null,
+            CompilationTranslationAction? translate = null,
+            ProjectDependencyGraph? newDependencyGraph = null,
+            ImmutableDictionary<string, ImmutableArray<DocumentId>>? newFilePathToDocumentIdsMap = null,
             bool forkTracker = true)
         {
             var projectId = newProjectState.Id;
@@ -1722,7 +1732,7 @@ namespace Microsoft.CodeAnalysis
         /// Gets the set of <see cref="DocumentId"/>s in this <see cref="Solution"/> with a
         /// <see cref="TextDocument.FilePath"/> that matches the given file path.
         /// </summary>
-        public ImmutableArray<DocumentId> GetDocumentIdsWithFilePath(string filePath)
+        public ImmutableArray<DocumentId> GetDocumentIdsWithFilePath(string? filePath)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -1785,18 +1795,19 @@ namespace Microsoft.CodeAnalysis
         }
 
         // this lock guards all the mutable fields (do not share lock with derived classes)
-        private NonReentrantLock _stateLockBackingField;
+        private NonReentrantLock? _stateLockBackingField;
         private NonReentrantLock StateLock
         {
             get
             {
-                return LazyInitializer.EnsureInitialized(ref _stateLockBackingField, NonReentrantLock.Factory);
+                // TODO: why did I need to do a nullable suppression here?
+                return LazyInitializer.EnsureInitialized(ref _stateLockBackingField, NonReentrantLock.Factory)!;
             }
         }
 
-        private WeakReference<SolutionState> _latestSolutionWithPartialCompilation;
+        private WeakReference<SolutionState>? _latestSolutionWithPartialCompilation;
         private DateTime _timeOfLatestSolutionWithPartialCompilation;
-        private DocumentId _documentIdOfLatestSolutionWithPartialCompilation;
+        private DocumentId? _documentIdOfLatestSolutionWithPartialCompilation;
 
         /// <summary>
         /// Creates a branch of the solution that has its compilations frozen in whatever state they are in at the time, assuming a background compiler is
@@ -1810,7 +1821,7 @@ namespace Microsoft.CodeAnalysis
         {
             try
             {
-                var doc = this.GetDocumentState(documentId);
+                var doc = this.GetDocumentState(documentId)!;
                 var tree = doc.GetSyntaxTree(cancellationToken);
 
                 using (this.StateLock.DisposableWait(cancellationToken))
@@ -1821,7 +1832,7 @@ namespace Microsoft.CodeAnalysis
                         return this;
                     }
 
-                    SolutionState currentPartialSolution = null;
+                    SolutionState? currentPartialSolution = null;
                     if (_latestSolutionWithPartialCompilation != null)
                     {
                         _latestSolutionWithPartialCompilation.TryGetTarget(out currentPartialSolution);
@@ -1835,7 +1846,7 @@ namespace Microsoft.CodeAnalysis
                     if (reuseExistingPartialSolution)
                     {
                         SolutionLogger.UseExistingPartialSolution();
-                        return currentPartialSolution;
+                        return currentPartialSolution!;
                     }
 
                     // if we don't have one or it is stale, create a new partial solution
@@ -1896,7 +1907,7 @@ namespace Microsoft.CodeAnalysis
             return solution;
         }
 
-        public bool TryGetCompilation(ProjectId projectId, out Compilation compilation)
+        public bool TryGetCompilation(ProjectId projectId, [NotNullWhen(returnValue: true)] out Compilation? compilation)
         {
             CheckContainsProject(projectId);
             compilation = null;
@@ -1909,20 +1920,21 @@ namespace Microsoft.CodeAnalysis
         /// Returns the compilation for the specified <see cref="ProjectId"/>.  Can return <see langword="null"/> when the project
         /// does not support compilations.
         /// </summary>
-        private Task<Compilation> GetCompilationAsync(ProjectId projectId, CancellationToken cancellationToken)
+        private Task<Compilation?> GetCompilationAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
-            return GetCompilationAsync(GetProjectState(projectId), cancellationToken);
+            // TODO: figure out where this is called and why the nullable suppression is required
+            return GetCompilationAsync(GetProjectState(projectId)!, cancellationToken);
         }
 
         /// <summary>
         /// Returns the compilation for the specified <see cref="ProjectState"/>.  Can return <see langword="null"/> when the project
         /// does not support compilations.
         /// </summary>
-        public Task<Compilation> GetCompilationAsync(ProjectState project, CancellationToken cancellationToken)
+        public Task<Compilation?> GetCompilationAsync(ProjectState project, CancellationToken cancellationToken)
         {
             return project.SupportsCompilation
                 ? this.GetCompilationTracker(project.Id).GetCompilationAsync(this, cancellationToken)
-                : SpecializedTasks.Default<Compilation>();
+                : SpecializedTasks.Default<Compilation?>();
         }
 
         /// <summary>
@@ -1943,8 +1955,9 @@ namespace Microsoft.CodeAnalysis
         private static readonly ConditionalWeakTable<ISymbol, ProjectId> s_assemblyOrModuleSymbolToProjectMap =
             new ConditionalWeakTable<ISymbol, ProjectId>();
 
-        private static void RecordSourceOfAssemblySymbol(ISymbol assemblyOrModuleSymbol, ProjectId projectId)
+        private static void RecordSourceOfAssemblySymbol(ISymbol? assemblyOrModuleSymbol, ProjectId projectId)
         {
+            // TODO: how would we ever get a null here?
             if (assemblyOrModuleSymbol == null)
             {
                 return;
@@ -1988,7 +2001,7 @@ namespace Microsoft.CodeAnalysis
         /// Attempt to get the best readily available compilation for the project. It may be a
         /// partially built compilation.
         /// </summary>
-        private MetadataReference GetPartialMetadataReference(
+        private MetadataReference? GetPartialMetadataReference(
             ProjectReference projectReference,
             ProjectState fromProject,
             CancellationToken cancellationToken)
@@ -2107,7 +2120,7 @@ namespace Microsoft.CodeAnalysis
 
         private void CheckNotContainsProjectReference(ProjectId projectId, ProjectReference referencedProject)
         {
-            if (this.GetProjectState(projectId).ProjectReferences.Contains(referencedProject))
+            if (this.GetProjectState(projectId)!.ProjectReferences.Contains(referencedProject))
             {
                 throw new InvalidOperationException(WorkspacesResources.The_project_already_references_the_target_project);
             }
@@ -2126,9 +2139,9 @@ namespace Microsoft.CodeAnalysis
         {
             var projectState = GetProjectState(projectId);
 
-            if (projectState.IsSubmission && GetProjectState(toProjectId).IsSubmission)
+            if (projectState!.IsSubmission && GetProjectState(toProjectId)!.IsSubmission)
             {
-                if (projectState.ProjectReferences.Any(p => GetProjectState(p.ProjectId).IsSubmission))
+                if (projectState.ProjectReferences.Any(p => GetProjectState(p.ProjectId)!.IsSubmission))
                 {
                     throw new InvalidOperationException(WorkspacesResources.This_submission_already_references_another_submission_project);
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Call this method when the workspace is disposed.
         ///
-        /// Override this method to do addition work when the workspace is disposed.
+        /// Override this method to do additional work when the workspace is disposed.
         /// Call this method at the end of your method.
         /// </summary>
         protected virtual void Dispose(bool finalize)

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -694,7 +694,7 @@ namespace Microsoft.CodeAnalysis
                 var newSolution = oldSolution.WithDocumentTextLoader(documentId, loader, PreservationMode.PreserveValue);
                 newSolution = this.SetCurrentSolution(newSolution);
 
-                var newDocument = newSolution.GetDocument(documentId);
+                var newDocument = newSolution.GetDocument(documentId)!;
                 this.OnDocumentTextChanged(newDocument);
 
                 this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.DocumentChanged, oldSolution, newSolution, documentId: documentId);
@@ -750,7 +750,7 @@ namespace Microsoft.CodeAnalysis
                 var oldSolution = this.CurrentSolution;
 
                 var newSolution = oldSolution;
-                var oldAttributes = oldSolution.GetDocument(documentId).State.Attributes;
+                var oldAttributes = oldSolution.GetDocument(documentId)!.State.Attributes;
 
                 if (oldAttributes.Name != newInfo.Name)
                 {
@@ -880,6 +880,7 @@ namespace Microsoft.CodeAnalysis
                         foreach (var updatedDocumentId in updatedDocumentIds)
                         {
                             var newDocument = newSolution.GetDocument(updatedDocumentId);
+                            Contract.ThrowIfNull(newDocument);
                             OnDocumentTextChanged(newDocument);
                         }
                     }
@@ -908,7 +909,7 @@ namespace Microsoft.CodeAnalysis
                 var oldSolution = this.CurrentSolution;
                 var newSolution = this.SetCurrentSolution(oldSolution.WithDocumentSourceCodeKind(documentId, sourceCodeKind));
 
-                var newDocument = newSolution.GetDocument(documentId);
+                var newDocument = newSolution.GetDocument(documentId)!;
                 this.OnDocumentTextChanged(newDocument);
 
                 this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.DocumentChanged, oldSolution, newSolution, documentId: documentId);
@@ -1035,7 +1036,7 @@ namespace Microsoft.CodeAnalysis
             // now fix each project if necessary
             foreach (var pid in solution.ProjectIds)
             {
-                var project = solution.GetProject(pid);
+                var project = solution.GetProject(pid)!;
 
                 // convert metadata references to project references if the metadata reference matches some project's output assembly.
                 foreach (var meta in project.MetadataReferences)
@@ -1788,7 +1789,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectHasProjectReference(ProjectId fromProjectId, ProjectReference projectReference)
         {
-            if (!this.CurrentSolution.GetProject(fromProjectId).ProjectReferences.Contains(projectReference))
+            if (!this.CurrentSolution.GetProject(fromProjectId)!.ProjectReferences.Contains(projectReference))
             {
                 throw new ArgumentException(string.Format(
                     WorkspacesResources._0_is_not_referenced,
@@ -1801,7 +1802,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectDoesNotHaveProjectReference(ProjectId fromProjectId, ProjectReference projectReference)
         {
-            if (this.CurrentSolution.GetProject(fromProjectId).ProjectReferences.Contains(projectReference))
+            if (this.CurrentSolution.GetProject(fromProjectId)!.ProjectReferences.Contains(projectReference))
             {
                 throw new ArgumentException(string.Format(
                     WorkspacesResources._0_is_already_referenced,
@@ -1828,7 +1829,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectHasMetadataReference(ProjectId projectId, MetadataReference metadataReference)
         {
-            if (!this.CurrentSolution.GetProject(projectId).MetadataReferences.Contains(metadataReference))
+            if (!this.CurrentSolution.GetProject(projectId)!.MetadataReferences.Contains(metadataReference))
             {
                 throw new ArgumentException(WorkspacesResources.Metadata_is_not_referenced);
             }
@@ -1839,7 +1840,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectDoesNotHaveMetadataReference(ProjectId projectId, MetadataReference metadataReference)
         {
-            if (this.CurrentSolution.GetProject(projectId).MetadataReferences.Contains(metadataReference))
+            if (this.CurrentSolution.GetProject(projectId)!.MetadataReferences.Contains(metadataReference))
             {
                 throw new ArgumentException(WorkspacesResources.Metadata_is_already_referenced);
             }
@@ -1850,7 +1851,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectHasAnalyzerReference(ProjectId projectId, AnalyzerReference analyzerReference)
         {
-            if (!this.CurrentSolution.GetProject(projectId).AnalyzerReferences.Contains(analyzerReference))
+            if (!this.CurrentSolution.GetProject(projectId)!.AnalyzerReferences.Contains(analyzerReference))
             {
                 throw new ArgumentException(string.Format(WorkspacesResources._0_is_not_present, analyzerReference));
             }
@@ -1861,7 +1862,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected void CheckProjectDoesNotHaveAnalyzerReference(ProjectId projectId, AnalyzerReference analyzerReference)
         {
-            if (this.CurrentSolution.GetProject(projectId).AnalyzerReferences.Contains(analyzerReference))
+            if (this.CurrentSolution.GetProject(projectId)!.AnalyzerReferences.Contains(analyzerReference))
             {
                 throw new ArgumentException(string.Format(WorkspacesResources._0_is_already_present, analyzerReference));
             }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -187,12 +187,12 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                return _services.GetService<IOptionService>().GetOptions();
+                return _services.GetRequiredService<IOptionService>().GetOptions();
             }
 
             set
             {
-                _services.GetService<IOptionService>().SetOptions(value);
+                _services.GetRequiredService<IOptionService>().SetOptions(value);
             }
         }
 


### PR DESCRIPTION
This is an initial pass through a few files in the workspace API adding annotations and fixing warnings. The primary goal of this exercise was dogfooding and kicking the tires of some features, but it also did find a few bugs in our APIs as well which is fantastic.