### PR TITLE
Add nullability information to GetSymbolInfo for invocations.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1422,7 +1422,7 @@
     <Field Name="Properties" Type="ImmutableArray&lt;PropertySymbol&gt;" />
   </Node>
 
-  <Node Name="BoundCall" Base="BoundExpression">
+  <Node Name="BoundCall" Base="BoundExpression" SkipInNullabilityRewriter="true">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+#nullable enable
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -10,17 +11,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class NullabilityRewriter : BoundTreeRewriter
     {
-        protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+        protected override BoundExpression? VisitExpressionWithoutStackGuard(BoundExpression node)
         {
             return (BoundExpression)Visit(node);
         }
 
-        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
         {
             return VisitBinaryOperatorBase(node);
         }
 
-        public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
+        public override BoundNode? VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
         {
             return VisitBinaryOperatorBase(node);
         }
@@ -30,14 +31,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Use an explicit stack to avoid blowing the managed stack when visiting deeply-recursive
             // binary nodes
             var stack = ArrayBuilder<BoundBinaryOperatorBase>.GetInstance();
-            BoundBinaryOperatorBase currentBinary = binaryOperator;
+            BoundBinaryOperatorBase? currentBinary = binaryOperator;
 
             do
             {
                 stack.Push(currentBinary);
                 currentBinary = currentBinary.Left as BoundBinaryOperatorBase;
             }
-            while (currentBinary != null);
+            while (currentBinary is object);
 
             Debug.Assert(stack.Count > 0);
             var leftChild = (BoundExpression)Visit(stack.Peek().Left);
@@ -71,6 +72,25 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(currentBinary != null);
             return currentBinary;
+        }
+
+        public override BoundNode? VisitCall(BoundCall node)
+        {
+            BoundExpression? receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
+            BoundCall updatedNode;
+
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType) &&
+                _updatedMethodSymbols.TryGetValue(node, out MethodSymbol updatedMethodSymbol))
+            {
+                updatedNode = node.Update(receiverOpt, updatedMethodSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, node.Type);
+            }
+            return updatedNode;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -124,6 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                        delegateInvokeMethod: delegateType?.DelegateInvokeMethod,
                                        initialState: nullableState,
                                        analyzedNullabilityMapOpt: null,
+                                       updatedMethodSymbolMapOpt: null,
                                        snapshotBuilderOpt: null,
                                        returnTypes);
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -16,14 +17,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         private sealed class DebugVerifier : BoundTreeWalker
         {
             private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> _analyzedNullabilityMap;
+            private readonly ImmutableDictionary<BoundCall, MethodSymbol> _updatedMethodSymbols;
             private readonly SnapshotManager _snapshotManager;
             private readonly HashSet<BoundExpression> _visitedExpressions = new HashSet<BoundExpression>();
             private int _recursionDepth;
 
-            private DebugVerifier(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, SnapshotManager snapshotManager)
+            private DebugVerifier(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, ImmutableDictionary<BoundCall, MethodSymbol> updatedMethodSymbols, SnapshotManager snapshotManager)
             {
                 _analyzedNullabilityMap = analyzedNullabilityMap;
                 _snapshotManager = snapshotManager;
+                _updatedMethodSymbols = updatedMethodSymbols;
             }
 
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
@@ -31,9 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false; // Same behavior as NullableWalker
             }
 
-            public static void Verify(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, SnapshotManager snapshotManagerOpt, BoundNode node)
+            public static void Verify(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, ImmutableDictionary<BoundCall, MethodSymbol> updatedMethodSymbols, SnapshotManager snapshotManagerOpt, BoundNode node)
             {
-                var verifier = new DebugVerifier(analyzedNullabilityMap, snapshotManagerOpt);
+                var verifier = new DebugVerifier(analyzedNullabilityMap, updatedMethodSymbols, snapshotManagerOpt);
                 verifier.Visit(node);
                 // Can't just remove nodes from _analyzedNullabilityMap and verify no nodes remaining because nodes can be reused.
                 Debug.Assert(verifier._analyzedNullabilityMap.Count == verifier._visitedExpressions.Count, $"Visited {verifier._visitedExpressions.Count} nodes, expected to visit {verifier._analyzedNullabilityMap.Count}");
@@ -48,13 +51,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+            protected override BoundExpression? VisitExpressionWithoutStackGuard(BoundExpression node)
             {
                 VerifyExpression(node);
                 return (BoundExpression)base.Visit(node);
             }
 
-            public override BoundNode Visit(BoundNode node)
+            public override BoundNode? Visit(BoundNode node)
             {
                 // Ensure that we always have a snapshot for every BoundExpression in the map
                 // Re-enable of this assert is tracked by https://github.com/dotnet/roslyn/issues/36844
@@ -70,13 +73,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return base.Visit(node);
             }
 
-            public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+            public override BoundNode? VisitCall(BoundCall node)
+            {
+                Debug.Assert(_updatedMethodSymbols.ContainsKey(node), $"Did not find updated method symbol for {node} `{node.Syntax}`.");
+                return base.VisitCall(node);
+            }
+
+            public override BoundNode? VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
             {
                 // https://github.com/dotnet/roslyn/issues/35010: handle
                 return null;
             }
 
-            public override BoundNode VisitBadExpression(BoundBadExpression node)
+            public override BoundNode? VisitBadExpression(BoundBadExpression node)
             {
                 // Regardless of what the BadExpression is, we need to add all of its direct children to the visited map. They
                 // could be things like object initializers (see New_01.F1).
@@ -95,19 +104,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode VisitQueryClause(BoundQueryClause node)
+            public override BoundNode? VisitQueryClause(BoundQueryClause node)
             {
                 Visit(node.UnoptimizedForm ?? node.Value);
                 return null;
             }
 
-            public override BoundNode VisitUnboundLambda(UnboundLambda node)
+            public override BoundNode? VisitUnboundLambda(UnboundLambda node)
             {
                 Visit(node.BindForErrorRecovery().Body);
                 return null;
             }
 
-            public override BoundNode VisitForEachStatement(BoundForEachStatement node)
+            public override BoundNode? VisitForEachStatement(BoundForEachStatement node)
             {
                 Visit(node.IterationVariableType);
                 Visit(node.Expression);
@@ -117,32 +126,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode VisitGotoStatement(BoundGotoStatement node)
+            public override BoundNode? VisitGotoStatement(BoundGotoStatement node)
             {
                 // There's no need to verify the label children. They do not have types or nullabilities
                 return null;
             }
 
-            public override BoundNode VisitTypeOrValueExpression(BoundTypeOrValueExpression node)
+            public override BoundNode? VisitTypeOrValueExpression(BoundTypeOrValueExpression node)
             {
                 Visit(node.Data.ValueExpression);
                 return base.VisitTypeOrValueExpression(node);
             }
 
-            public override BoundNode VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
+            public override BoundNode? VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
             {
                 // https://github.com/dotnet/roslyn/issues/33441 dynamic collection initializers aren't being handled correctly
                 VerifyExpression(node, overrideSkippedExpression: true);
                 return null;
             }
 
-            public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+            public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
             {
                 VisitBinaryOperatorChildren(node);
                 return null;
             }
 
-            public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
+            public override BoundNode? VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
             {
                 VisitBinaryOperatorChildren(node);
                 return null;
@@ -167,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            public override BoundNode VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
+            public override BoundNode? VisitConvertedTupleLiteral(BoundConvertedTupleLiteral node)
             {
                 Visit(node.SourceTuple);
                 return base.VisitConvertedTupleLiteral(node);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (BoundExpression)base.Visit(node);
             }
 
-            public override BoundNode? Visit(BoundNode node)
+            public override BoundNode? Visit(BoundNode? node)
             {
                 // Ensure that we always have a snapshot for every BoundExpression in the map
                 // Re-enable of this assert is tracked by https://github.com/dotnet/roslyn/issues/36844
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return base.VisitConvertedTupleLiteral(node);
             }
 
-            public override BoundNode VisitTypeExpression(BoundTypeExpression node)
+            public override BoundNode? VisitTypeExpression(BoundTypeExpression node)
             {
                 // Ignore any dimensions
                 VerifyExpression(node);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundNode nodeToAnalyze,
                 Binder binder,
                 ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMap,
+                ImmutableDictionary<BoundCall, MethodSymbol>.Builder updatedMethodSymbolMap,
                 SnapshotManager.Builder newManagerOpt)
             {
                 var snapshotPosition = _incrementalSnapshots.BinarySearch(position, BinarySearchComparer);
@@ -76,6 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                            variableState,
                                            returnTypesOpt: null,
                                            analyzedNullabilityMap,
+                                           updatedMethodSymbolMap,
                                            snapshotBuilderOpt: newManagerOpt,
                                            isSpeculative: true),
                         variableState,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5277,6 +5277,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_disableNullabilityAnalysis)
                 {
                     analyzedNullabilityMap = null;
+                    updatedMethodSymbolMap = null;
                     snapshotBuilder = null;
                 }
 

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -10656,10 +10656,12 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed partial class NullabilityRewriter : BoundTreeRewriter
     {
         private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> _updatedNullabilities;
+        private readonly ImmutableDictionary<BoundCall, MethodSymbol> _updatedMethodSymbols;
 
-        public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities)
+        public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities, ImmutableDictionary<BoundCall, MethodSymbol> updatedMethodSymbols)
         {
             _updatedNullabilities = updatedNullabilities;
+            _updatedMethodSymbols = updatedMethodSymbols;
         }
 
         public override BoundNode? VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
@@ -11743,24 +11745,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 updatedNode = node.Update(node.Properties, receiverOpt, node.ResultKind);
-            }
-            return updatedNode;
-        }
-
-        public override BoundNode? VisitCall(BoundCall node)
-        {
-            BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
-            BoundCall updatedNode;
-
-            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, infoAndType.Type);
-                updatedNode.TopLevelNullability = infoAndType.Info;
-            }
-            else
-            {
-                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1438,12 +1438,15 @@ namespace BoundTreeGenerator
                         Brace();
 
                         var updatedNullabilities = "_updatedNullabilities";
+                        var updatedMethodSymbols = "_updatedMethodSymbols";
                         WriteLine($"private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> {updatedNullabilities};");
+                        WriteLine($"private readonly ImmutableDictionary<BoundCall, MethodSymbol> {updatedMethodSymbols};");
 
                         Blank();
-                        WriteLine("public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities)");
+                        WriteLine("public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities, ImmutableDictionary<BoundCall, MethodSymbol> updatedMethodSymbols)");
                         Brace();
                         WriteLine($"{updatedNullabilities} = updatedNullabilities;");
+                        WriteLine($"{updatedMethodSymbols} = updatedMethodSymbols;");
                         Unbrace();
 
                         foreach (var node in _tree.Types.OfType<Node>().Where(n => IsDerivedType("BoundExpression", n.Name)))


### PR DESCRIPTION
This will conflict with https://github.com/dotnet/roslyn/pull/36869, so I'll wait on that to be merged.

This PR adds a very simple cache for just BoundCalls, so calls to GetSymbolInfo involving them will return information including analyzed nullability. @dotnet/roslyn-compiler @chsienki for review.
This addresses a single case of https://github.com/dotnet/roslyn/issues/35031, but there will be more required.

FYI @jasonmalinowski @ryzngard.