### PR TITLE
Fix Solution.WithDocumentFilePath not updating the file path of the tree

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -401,12 +401,14 @@ namespace Microsoft.CodeAnalysis
 
         public DocumentState UpdateFilePath(string filePath)
         {
+            var newAttributes = this.Attributes.With(filePath: filePath);
+
             // TODO: it's overkill to fully reparse the tree if we had the tree already; all we have to do is update the
             // file path and diagnostic options for that tree.
             var newTreeSource = CreateLazyFullyParsedTree(
                 this.TextAndVersionSource,
                 this.Id.ProjectId,
-                GetSyntaxTreeFilePath(this.Attributes),
+                GetSyntaxTreeFilePath(newAttributes),
                 _options,
                 _analyzerConfigSetSource,
                 _languageServices,
@@ -416,7 +418,7 @@ namespace Microsoft.CodeAnalysis
                 _languageServices,
                 this.solutionServices,
                 this.Services,
-                this.Attributes.With(filePath: filePath),
+                newAttributes,
                 _options,
                 _analyzerConfigSetSource,
                 this.sourceTextOpt,

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.VisualStudio.Threading;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -641,6 +642,35 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             Assert.Equal(true, annotatedRoot.IsEquivalentTo(root2));
             Assert.Equal(true, root2.HasAnnotation(annotation));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestUpdatingFilePathUpdatesSyntaxTree()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            const string OldFilePath = @"Z:\OldFilePath.cs";
+            const string NewFilePath = @"Z:\NewFilePath.cs";
+
+            var solution = CreateSolution()
+                .AddProject(projectId, "goo", "goo.dll", LanguageNames.CSharp)
+                .AddDocument(documentId, "OldFilePath.cs", "public class Goo { }", filePath: OldFilePath);
+
+            // scope so later asserts don't accidentally use oldDocument
+            {
+                var oldDocument = solution.GetDocument(documentId);
+                Assert.Equal(OldFilePath, oldDocument.FilePath);
+                Assert.Equal(OldFilePath, oldDocument.GetSyntaxTreeAsync().Result.FilePath);
+            }
+
+            solution = solution.WithDocumentFilePath(documentId, NewFilePath);
+
+            {
+                var newDocument = solution.GetDocument(documentId);
+                Assert.Equal(NewFilePath, newDocument.FilePath);
+                Assert.Equal(NewFilePath, newDocument.GetSyntaxTreeAsync().Result.FilePath);
+            }
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/13433"), Trait(Traits.Feature, Traits.Features.Workspace)]


### PR DESCRIPTION
DocumentState.UpdateFilePath was still passing in the old attributes when producing a new tree source -- oops!