### PR TITLE
Make Field Readonly - Keep leading trivia

### DIFF
--- a/src/EditorFeatures/CSharpTest/MakeFieldReadonly/MakeFieldReadonlyTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeFieldReadonly/MakeFieldReadonlyTests.cs
@@ -174,6 +174,26 @@ $@"class MyClass
 }");
         }
 
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)]
+        [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\r\n\r\n")]
+        public async Task MultipleFieldsAssignedInline_LeadingCommentAndWhitespace(string leadingTrvia)
+        {
+            await TestInRegularAndScriptAsync(
+$@"class MyClass
+{{
+    //Comment{leadingTrvia}
+    private int _goo = 0, [|_bar|] = 0;
+}}",
+$@"class MyClass
+{{
+    //Comment{leadingTrvia}
+    private int _goo = 0;
+    private readonly int _bar = 0;
+}}");
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)]
         public async Task FieldAssignedInCtor()
         {

--- a/src/EditorFeatures/VisualBasicTest/MakeFieldReadonly/MakeFieldReadonlyTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MakeFieldReadonly/MakeFieldReadonlyTests.vb
@@ -465,6 +465,23 @@ End Class",
 End Class")
         End Function
 
+        <Theory, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)>
+        <InlineData("")>
+        <InlineData("\r\n")>
+        <InlineData("\r\n\r\n")>
+        Public Async Function MultipleFieldsAssignedInline_LeadingCommentAndWhitespace(leadingTrivia As String) As Task
+            Await TestInRegularAndScriptAsync(
+$"Class C
+    'Comment{leadingTrivia}
+    Private _goo As Integer = 0, [|_bar|] As Integer = 0
+End Class",
+$"Class C
+    'Comment{leadingTrivia}
+    Private _goo As Integer = 0
+    Private ReadOnly _bar As Integer = 0
+End Class")
+        End Function
+
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)>
         Public Async Function FieldAssignedInCtor() As Task
             Await TestInRegularAndScriptAsync(

--- a/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeFieldReadonly/AbstractMakeFieldReadonlyCodeFixProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.MakeFieldReadonly
                         editor.InsertAfter(fieldDeclarators.Key, newDeclaration);
                     }
 
-                    editor.RemoveNode(fieldDeclarators.Key);
+                    editor.RemoveNode(fieldDeclarators.Key, SyntaxRemoveOptions.KeepLeadingTrivia);
                 }
             }
         }


### PR DESCRIPTION
This addresses #36759 by keeping leading trivia when removing the original node.