### PR TITLE
Update liveshare diagnostic list table to use new constructor.

### DIFF
--- a/src/Tools/ExternalAccess/LiveShare/RemoteDiagnosticListTable.cs
+++ b/src/Tools/ExternalAccess/LiveShare/RemoteDiagnosticListTable.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
         }
 
         private RemoteDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
-            : base(workspace, diagnosticService, provider)
+            : base(workspace, provider)
         {
             _source = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);
             AddInitialTableSource(workspace.CurrentSolution, _source);


### PR DESCRIPTION
3 arg constructor removed, bad merge was let through, see https://github.com/dotnet/roslyn/pull/36969#issuecomment-508644518 