### PR TITLE
Determine the maximum supported language version

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -54,9 +54,11 @@
            actually used during compilation. .NETCore 3.0 supports up to C# 8.0, while all others support up to 7.3 by default.
            Note that other frameworks (e.g., Xamarin, Unity, etc.) are expected to override this by setting
            MaxSupportedLangVersion themselves. -->
+      <!-- Strip the 'v' off the beginning of TargetFrameworkVersion so we can actually compare it as a version. -->
+      <_TargetFrameworkVersionAsVersion>$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkVersionAsVersion>
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == '' AND
                                           '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
-                                          '$(TargetFrameworkVersion.Substring(0,3)) == 'v3.'">8.0</MaxSupportedLangVersion>
+                                          '$(_TargetFrameworkVersionAsVersion) >= '3.0'">8.0</MaxSupportedLangVersion>
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>
 
       <LangVersion Condition="'$(LangVersion)' == ''">$(MaxSupportedLangVersion)</LangVersion>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -54,9 +54,9 @@
            actually used during compilation. .NETCore 3.0 supports up to C# 8.0, while all others support up to 7.3 by default.
            Note that other frameworks (e.g., Xamarin, Unity, etc.) are expected to override this by setting
            MaxSupportedLangVersion themselves. -->
-      <MaxSupportedLangVersion Condition="('$(MaxSupportedLangVersion)' == '') AND
-                                          ('$(TargetFrameworkIdentifier)' == '.NETCore') AND
-                                          ('$(TargetFrameworkVersion.Substring(0,3)) == 'v3.')">8.0</MaxSupportedLangVersion>
+      <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == '' AND
+                                          '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
+                                          '$(TargetFrameworkVersion.Substring(0,3)) == 'v3.'">8.0</MaxSupportedLangVersion>
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>
 
       <LangVersion Condition="'$(LangVersion)' == ''">$(MaxSupportedLangVersion)</LangVersion>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -58,7 +58,7 @@
       <_TargetFrameworkVersionAsVersion>$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkVersionAsVersion>
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == '' AND
                                           '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
-                                          '$(_TargetFrameworkVersionAsVersion) >= '3.0'">8.0</MaxSupportedLangVersion>
+                                          '$(_TargetFrameworkVersionAsVersion)' >= '3.0'">8.0</MaxSupportedLangVersion>
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>
 
       <LangVersion Condition="'$(LangVersion)' == ''">$(MaxSupportedLangVersion)</LangVersion>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -50,9 +50,16 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <LangVersion Condition="'$(LangVersion)' == '' AND
-        (('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' == 'v3.0') OR
-         ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' == 'v2.1'))">preview</LangVersion>
+      <!-- To aid certain IDE features we make a distinction between the maximum supported language version, and the version 
+           actually used during compilation. .NETCore 3.0 supports up to C# 8.0, while all others support up to 7.3 by default.
+           Note that other frameworks (e.g., Xamarin, Unity, etc.) are expected to override this by setting
+           MaxSupportedLangVersion themselves. -->
+      <MaxSupportedLangVersion Condition="('$(MaxSupportedLangVersion)' == '') AND
+                                          ('$(TargetFrameworkIdentifier)' == '.NETCore') AND
+                                          ('$(TargetFrameworkVersion.Substring(0,3)) == 'v3.')">8.0</MaxSupportedLangVersion>
+      <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>
+
+      <LangVersion Condition="'$(LangVersion)' == ''">$(MaxSupportedLangVersion)</LangVersion>
     </PropertyGroup>
 
     <!-- Condition is to filter out the _CoreCompileResourceInputs so that it doesn't pass in culture resources to the compiler -->

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -55,7 +55,7 @@
            Note that other frameworks (e.g., Xamarin, Unity, etc.) are expected to override this by setting
            MaxSupportedLangVersion themselves. -->
       <!-- Strip the 'v' off the beginning of TargetFrameworkVersion so we can actually compare it as a version. -->
-      <_TargetFrameworkVersionAsVersion>$(TargetFrameworkVersion.Substring(1))</_TargetFrameworkVersionAsVersion>
+      <_TargetFrameworkVersionAsVersion>$(TargetFrameworkVersion.TrimStart(vV))</_TargetFrameworkVersionAsVersion>
       <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == '' AND
                                           '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
                                           '$(_TargetFrameworkVersionAsVersion)' >= '3.0'">8.0</MaxSupportedLangVersion>


### PR DESCRIPTION
.NETCore (version 3.0) supports C# 8.0.

.NETFramework (all versions), .NETStandard (all versions up through 2.1,
the latest at this time), and .NETCore (all versions before 3.0) support
version 7.3 of the C# language. Use of a later version with any of those
frameworks is not supported, though it will not be blocked.

Certain IDE features need to know this maximum supported
lang version in addition to the existing 'LangVersion' property. Here we
capture that as the 'MaxSupportedLangVersion' property. The project
systems will query for this property and pass it along to the language
service.

Note that other frameworks (e.g. Xamarin, Unity, etc.) are expected to
set this property themselves if they wish to use something other than
7.3.