### PR TITLE
Fix significant wrong translation in CodeStyle.Resources.zh-Hans.xlf

### DIFF
--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.zh-Hans.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.zh-Hans.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="Fix_formatting">
         <source>Fix formatting</source>
-        <target state="translated">固定格式</target>
+        <target state="translated">修正格式</target>
         <note />
       </trans-unit>
       <trans-unit id="Indentation_and_spacing">
@@ -34,7 +34,7 @@
       </trans-unit>
       <trans-unit id="None">
         <source>None</source>
-        <target state="translated">没有</target>
+        <target state="translated">无</target>
         <note />
       </trans-unit>
       <trans-unit id="Refactoring_Only">


### PR DESCRIPTION
This could be agreed by anyone who understands Chinese. I just used the correct translation from Traditional Chinese version.