### PR TITLE
Remark about F# not supported

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/LanguageNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/LanguageNames.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis
         /// The common name used for the F# language.
         /// </summary>
         /// <remarks>
-        /// This value is not currently supported by Roslyn.
+        /// F# is not a supported compile target for the Roslyn compiler.
         /// </remarks>
         public const string FSharp = "F#";
     }

--- a/src/Compilers/Core/Portable/Symbols/LanguageNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/LanguageNames.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The common name used for the F# language.
         /// </summary>
+        /// <remarks>
+        /// This value is not currently supported by Roslyn.
+        /// </remarks>
         public const string FSharp = "F#";
     }
 }


### PR DESCRIPTION
Issue was raised in the dotnet docs about this API. I've filed a fix for the API docs dotnet/roslyn-api-docs#64 and I wanted to sync here.