### PR TITLE
Ensure we have stack spilling support for the recently-added expression node `BoundReadOnlySpanFromArray`

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -1184,6 +1184,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return UpdateExpression(builder, node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.Type));
         }
 
+        public override BoundNode VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
+        {
+            BoundSpillSequenceBuilder builder = null;
+            BoundExpression operand = VisitExpression(ref builder, node.Operand);
+            return UpdateExpression(builder, node.Update(operand, node.ConversionMethod, node.Type));
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #36856

@dotnet/roslyn-compiler May I please have a couple of reviews of this tiny bug fix?
