### PR TITLE
Completion should select IntelliCode item when possible

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 roslynItem, completionListSpan, commitChar, triggerSnapshot, serviceRules,
                 filterText, cancellationToken);
 
-            _recentItemsManager.MakeMostRecentItem(roslynItem.DisplayText);
+            _recentItemsManager.MakeMostRecentItem(roslynItem.FilterText);
             return new AsyncCompletionData.CommitResult(isHandled: true, commitBehavior);
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -4,6 +4,8 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.VisualStudio.Text;
 using AsyncCompletionData = Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using RoslynTrigger = Microsoft.CodeAnalysis.Completion.CompletionTrigger;
+using RoslynCompletionItem = Microsoft.CodeAnalysis.Completion.CompletionItem;
+using VSCompletionItem = Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data.CompletionItem;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 {
@@ -63,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
         }
 
-        internal static bool IsFilterCharacter(CompletionItem item, char ch, string textTypedSoFar)
+        internal static bool IsFilterCharacter(RoslynCompletionItem item, char ch, string textTypedSoFar)
         {
             // First see if the item has any specific filter rules it wants followed.
             foreach (var rule in item.Rules.FilterCharacterRules)
@@ -97,5 +99,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             return false;
         }
+
+        // This is a temporarily method to support preferrrence of IntelliCode items comparing to non-IntelliCode items.
+        // We expect that Editor will intorduce this support and we will get rid of relying on the "★" then.
+        internal static bool IsPreferredItem(this RoslynCompletionItem completionItem)
+            => completionItem.DisplayText.StartsWith("★");
+
+        // This is a temporarily method to support preferrrence of IntelliCode items comparing to non-IntelliCode items.
+        // We expect that Editor will intorduce this support and we will get rid of relying on the "★" then.
+        internal static bool IsPreferredItem(this VSCompletionItem completionItem)
+            => completionItem.DisplayText.StartsWith("★");
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -100,12 +100,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             return false;
         }
 
-        // This is a temporarily method to support preferrrence of IntelliCode items comparing to non-IntelliCode items.
+        // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will intorduce this support and we will get rid of relying on the "★" then.
         internal static bool IsPreferredItem(this RoslynCompletionItem completionItem)
             => completionItem.DisplayText.StartsWith("★");
 
-        // This is a temporarily method to support preferrrence of IntelliCode items comparing to non-IntelliCode items.
+        // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will intorduce this support and we will get rid of relying on the "★" then.
         internal static bool IsPreferredItem(this VSCompletionItem completionItem)
             => completionItem.DisplayText.StartsWith("★");

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (bestItem != null)
             {
                 selectedItemIndex = itemsInList.IndexOf(i => Equals(i.FilterResult.CompletionItem, bestItem));
-                var deduplicatedList = matchingItems.Where(r => !r.DisplayText.StartsWith("★"));
+                var deduplicatedList = matchingItems.Where(r => !r.IsPreferredItem());
                 if (selectedItemIndex > -1 &&
                     deduplicatedList.Count() == 1 &&
                     filterText.Length > 0)
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 hardSelect = false;
             }
 
-            var deduplicatedListCount = matchingItems.Where(r => !r.VSCompletionItem.DisplayText.StartsWith("★")).Count();
+            var deduplicatedListCount = matchingItems.Where(r => !r.VSCompletionItem.IsPreferredItem()).Count();
 
             return new FilteredCompletionModel(
                 highlightedList, index, filters,

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -293,12 +293,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (bestItem != null)
             {
                 selectedItemIndex = itemsInList.IndexOf(i => Equals(i.FilterResult.CompletionItem, bestItem));
-                var deduplicatedList = matchingItems.Where(r => !r.IsPreferredItem());
+                var deduplicatedListCount = matchingItems.Where(r => !r.IsPreferredItem()).Count();
                 if (selectedItemIndex > -1 &&
-                    deduplicatedList.Count() == 1 &&
+                    deduplicatedListCount == 1 &&
                     filterText.Length > 0)
                 {
-                    var uniqueItemIndex = itemsInList.IndexOf(i => Equals(i.FilterResult.CompletionItem, deduplicatedList.First()));
+                    var uniqueItemIndex = itemsInList.IndexOf(i => Equals(i.FilterResult.CompletionItem, bestItem));
                     uniqueItem = highlightedList[uniqueItemIndex].CompletionItem;
                 }
             }
@@ -514,7 +514,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 var bestItemPriority = bestItem.Rules.MatchPriority;
                 var currentItemPriority = chosenItem.Rules.MatchPriority;
 
-                if ((currentItemPriority > bestItemPriority) || 
+                if ((currentItemPriority > bestItemPriority) ||
                     ((currentItemPriority == bestItemPriority) && !bestItem.IsPreferredItem() && chosenItem.IsPreferredItem()))
                 {
                     bestItem = chosenItem;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         internal static int GetRecentItemIndex(ImmutableArray<string> recentItems, RoslynCompletionItem item)
         {
-            var index = recentItems.IndexOf(item.DisplayText);
+            var index = recentItems.IndexOf(item.FilterText);
             return -index;
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -493,7 +493,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 var mruIndex1 = GetRecentItemIndex(recentItems, bestItem);
                 var mruIndex2 = GetRecentItemIndex(recentItems, chosenItem);
 
-                if (mruIndex2 < mruIndex1)
+                if ((mruIndex2 < mruIndex1) ||
+                    (mruIndex2 == mruIndex1 && !bestItem.IsPreferredItem() && chosenItem.IsPreferredItem()))
                 {
                     bestItem = chosenItem;
                 }
@@ -513,7 +514,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 var bestItemPriority = bestItem.Rules.MatchPriority;
                 var currentItemPriority = chosenItem.Rules.MatchPriority;
 
-                if (currentItemPriority > bestItemPriority)
+                if ((currentItemPriority > bestItemPriority) || 
+                    ((currentItemPriority == bestItemPriority) && !bestItem.IsPreferredItem() && chosenItem.IsPreferredItem()))
                 {
                     bestItem = chosenItem;
                 }
@@ -565,7 +567,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 {
                     return true;
                 }
+
+                if (result1.CompletionItem.IsPreferredItem() && !result2.CompletionItem.IsPreferredItem())
+                {
+                    return true;
+                }
             }
+
             return false;
         }
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5011,7 +5011,7 @@ class C
                 state.AssertCompletionItemsContainAll({"Normalize", "★ Normalize"})
                 state.SendCommitUniqueCompletionListItem()
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("s.Normalize", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("s.Normalize()", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -5451,15 +5451,25 @@ class C
 
             Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
                 context.AddItem(CompletionItem.Create(displayText:="★ Length", filterText:="Length"))
-                context.AddItem(CompletionItem.Create(displayText:="★ Normalize", filterText:="Normalize"))
+                context.AddItem(CompletionItem.Create(displayText:="★ Normalize", filterText:="Normalize", displayTextSuffix:="()"))
                 context.AddItem(CompletionItem.Create(displayText:="Length", filterText:="Length"))
-                context.AddItem(CompletionItem.Create(displayText:="ToString()", filterText:="ToString"))
-                context.AddItem(CompletionItem.Create(displayText:="First()", filterText:="First"))
+                context.AddItem(CompletionItem.Create(displayText:="ToString", filterText:="ToString", displayTextSuffix:="()"))
+                context.AddItem(CompletionItem.Create(displayText:="First", filterText:="First", displayTextSuffix:="()"))
                 Return Task.CompletedTask
             End Function
 
             Public Overrides Function ShouldTriggerCompletion(text As SourceText, caretPosition As Integer, trigger As CompletionTrigger, options As OptionSet) As Boolean
                 Return True
+            End Function
+
+            Public Overrides Function GetChangeAsync(document As Document, item As CompletionItem, commitKey As Char?, cancellationToken As CancellationToken) As Task(Of CompletionChange)
+                Dim commitText = item.DisplayText + item.DisplayTextSuffix
+                If commitText.StartsWith("★") Then
+                    ' remove the star and the following space
+                    commitText = commitText.Substring(2)
+                End If
+
+                Return Task.FromResult(CompletionChange.Create(New TextChange(item.Span, commitText)))
             End Function
         End Class
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5477,17 +5477,13 @@ class C
         ' We want to ignore these items in CommitIfUnique.
         ' This situation should not happen. Tests with this provider were added to cover protective scenarios.
         Private Class IntelliCodeMockWeirdProvider
-            Inherits CompletionProvider
+            Inherits IntelliCodeMockProvider
 
             Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
                 context.AddItem(CompletionItem.Create(displayText:="★ Length2", filterText:="Length2"))
                 context.AddItem(CompletionItem.Create(displayText:="Length", filterText:="Length"))
                 context.AddItem(CompletionItem.Create(displayText:="★ Length3", filterText:="Length3"))
                 Return Task.CompletedTask
-            End Function
-
-            Public Overrides Function ShouldTriggerCompletion(text As SourceText, caretPosition As Integer, trigger As CompletionTrigger, options As OptionSet) As Boolean
-                Return True
             End Function
         End Class
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5057,7 +5057,7 @@ class C
 
                 state.SendTypeChars(".len")
                 Await state.AssertCompletionSession()
-                state.AssertCompletionItemsContainAll({"Length", "★ Length3", "★ Length2"})
+                state.AssertCompletionItemsContainAll({"Length", "★ Length", "★ Length2"})
                 state.SendCommitUniqueCompletionListItem()
                 Await state.AssertNoCompletionSession()
                 Assert.Contains("s.Length", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
@@ -5479,11 +5479,9 @@ class C
         Private Class IntelliCodeMockWeirdProvider
             Inherits IntelliCodeMockProvider
 
-            Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
-                context.AddItem(CompletionItem.Create(displayText:="★ Length2", filterText:="Length2"))
-                context.AddItem(CompletionItem.Create(displayText:="Length", filterText:="Length"))
-                context.AddItem(CompletionItem.Create(displayText:="★ Length3", filterText:="Length3"))
-                Return Task.CompletedTask
+            Public Overrides Async Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                Await MyBase.ProvideCompletionsAsync(context).ConfigureAwait(False)
+                context.AddItem(CompletionItem.Create(displayText:="★ Length2", filterText:="Length"))
             End Function
         End Class
     End Class

--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -291,15 +291,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End If
         End Sub
 
-        Private Function GetRoslynCompletionItemOpt(editorCompletionItem As Data.CompletionItem) As CompletionItem
-            Dim roslynCompletionItem As CompletionItem = Nothing
-            If editorCompletionItem?.Properties.TryGetProperty(RoslynItem, roslynCompletionItem) Then
-                Return roslynCompletionItem
-            End If
-
-            Return Nothing
-        End Function
-
         Public Overrides Function GetCompletionItems() As IList(Of CompletionItem)
             WaitForAsynchronousOperationsAsync()
             Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(TextView)

--- a/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/ModernCompletionTestState.vb
@@ -153,7 +153,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim completionItems = session.GetComputedItems(CancellationToken.None)
             ' During the computation we can explicitly dismiss the session or we can return no items.
             ' Each of these conditions mean that there is no active completion.
-            Assert.True(session.IsDismissed OrElse completionItems.Items.Count() = 0)
+            Assert.True(session.IsDismissed OrElse completionItems.Items.Count() = 0, "AssertNoCompletionSession")
         End Function
 
         Public Overrides Sub AssertNoCompletionSessionWithNoBlock()
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             Await WaitForAsynchronousOperationsAsync()
             Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(view)
-            Assert.NotNull(session)
+            Assert.True(session IsNot Nothing, "AssertCompletionSession")
         End Function
 
         Public Overrides Async Function AssertCompletionSessionAfterTypingHash() As Task

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateBase.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateBase.vb
@@ -259,6 +259,31 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         Public MustOverride Function WaitForUIRenderedAsync() As Task
 
+        Public Sub NavigateToDisplayText(targetText As String)
+            Dim currentText = GetSelectedItem().DisplayText
+
+            ' GetComputedItems provided by the Editor for tests does not guarantee that 
+            ' the order of items match the order of items actually displayed in the completion popup.
+            ' For example, they put starred items (intellicode) below non-starred ones.
+            ' And the order they display those items in the UI is opposite.
+            ' Therefore, we do the full traverse: down to the bottom and if not found up to the top.
+            Do While currentText <> targetText
+                SendDownKey()
+                Dim newText = GetSelectedItem().DisplayText
+                If currentText = newText Then
+                    ' Nothing found on going down. Try going up
+                    Do While currentText <> targetText
+                        SendUpKey()
+                        newText = GetSelectedItem().DisplayText
+                        Assert.True(newText <> currentText, "Reached the bottom, then the top and didn't find the match")
+                        currentText = newText
+                    Loop
+                End If
+
+                currentText = newText
+            Loop
+        End Sub
+
 #End Region
 
 #Region "Signature Help Operations"


### PR DESCRIPTION
Here is a summary of the design meeting with the IntelliCode team:

1. Intellicode items should always be preferred comparing to non-Intellicode items.
2. All current Roslyn heuristics such as MRU or matching should be kept without changes.
3. If there is a starred copy for an item to be selected, the starred copy should be selected.
4. If user committed the unstarred instance of an item in a previous session, the starred instance should be considered in the MRU selection.
5. If the current selected item is a starred one and changing selection switches the item to a non-starred one, selection should make a jump in the completion popup maybe many frames below.
6. If the current selected item is a non-starred one and changing selection switches the item to an item with a starred copy, selection should make a jump in the completion popup to the starred one maybe many frames above.