### PR TITLE
fixing crash at GetMemberBodySpanForSpeculativeBinding

### DIFF
--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1069,7 +1069,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public TextSpan GetMemberBodySpanForSpeculativeBinding(SyntaxNode node)
         {
-            if (node.Span.IsEmpty)
+            if (node == null || node.Span.IsEmpty)
             {
                 return default;
             }


### PR DESCRIPTION
There is a crash in 16.2 Preview 3 with high number of hits. I have found from dumps that it crashes at the line fixed and `node == null`. Please let me know if the fix is correct, who knows how what tests to be added and so on. My PR is just to point to the issue.

It is valid for 16.2 GA if we can provide a reasonable fix.

FYI: @jinujoseph 