### PR TITLE
Introduce CodeFixContext.IsBlocking

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -349,10 +349,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     var includeSuppressionFixes = requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Any);
 
                     var fixes = Task.Run(
-#pragma warning disable CS0618 // Type or member is obsolete
                         () => _owner._codeFixService.GetFixesAsync(
                                 document, range.Span.ToTextSpan(), includeSuppressionFixes, isBlocking: true, cancellationToken),
-#pragma warning restore CS0618 // Type or member is obsolete
                         cancellationToken).WaitAndGetResult(cancellationToken);
 
                     var filteredFixes = FilterOnUIThread(fixes, workspace);
@@ -753,10 +751,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     // the background so that no one takes an accidentally dependency on running on 
                     // the UI thread.
                     var refactorings = Task.Run(
-#pragma warning disable CS0618 // Type or member is obsolete
                         () => _owner._codeRefactoringService.GetRefactoringsAsync(
                             document, selection, isBlocking: true, cancellationToken),
-#pragma warning restore CS0618 // Type or member is obsolete
                         cancellationToken).WaitAndGetResult(cancellationToken);
 
                     var filteredRefactorings = FilterOnUIThread(refactorings, workspace);

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -753,8 +753,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     // the background so that no one takes an accidentally dependency on running on 
                     // the UI thread.
                     var refactorings = Task.Run(
+#pragma warning disable CS0618 // Type or member is obsolete
                         () => _owner._codeRefactoringService.GetRefactoringsAsync(
-                            document, selection, cancellationToken),
+                            document, selection, isBlocking: true, cancellationToken),
+#pragma warning restore CS0618 // Type or member is obsolete
                         cancellationToken).WaitAndGetResult(cancellationToken);
 
                     var filteredRefactorings = FilterOnUIThread(refactorings, workspace);

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -349,8 +349,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     var includeSuppressionFixes = requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Any);
 
                     var fixes = Task.Run(
+#pragma warning disable CS0618 // Type or member is obsolete
                         () => _owner._codeFixService.GetFixesAsync(
-                                document, range.Span.ToTextSpan(), includeSuppressionFixes, cancellationToken),
+                                document, range.Span.ToTextSpan(), includeSuppressionFixes, isBlocking: true, cancellationToken),
+#pragma warning restore CS0618 // Type or member is obsolete
                         cancellationToken).WaitAndGetResult(cancellationToken);
 
                     var filteredFixes = FilterOnUIThread(fixes, workspace);

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -141,9 +141,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         public Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan range, bool includeConfigurationFixes, CancellationToken cancellationToken)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             return ((ICodeFixService)this).GetFixesAsync(document, range, includeConfigurationFixes, isBlocking: false, cancellationToken);
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         async Task<ImmutableArray<CodeFixCollection>> ICodeFixService.GetFixesAsync(Document document, TextSpan range, bool includeConfigurationFixes, bool isBlocking, CancellationToken cancellationToken)
@@ -336,7 +334,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
             var fixes = ArrayBuilder<CodeFix>.GetInstance();
-#pragma warning disable CS0618 // Type or member is obsolete
             var context = new CodeFixContext(document, span, diagnostics,
                 // TODO: Can we share code between similar lambdas that we pass to this API in BatchFixAllProvider.cs, CodeFixService.cs and CodeRefactoringService.cs?
                 (action, applicableDiagnostics) =>
@@ -350,7 +347,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 verifyArguments: false,
                 isBlocking,
                 cancellationToken: cancellationToken);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             var task = fixer.RegisterCodeFixesAsync(context) ?? Task.CompletedTask;
             await task.ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -139,7 +139,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             return null;
         }
 
-        public async Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan range, bool includeConfigurationFixes, CancellationToken cancellationToken)
+        public Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan range, bool includeConfigurationFixes, CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return ((ICodeFixService)this).GetFixesAsync(document, range, includeConfigurationFixes, isBlocking: false, cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        async Task<ImmutableArray<CodeFixCollection>> ICodeFixService.GetFixesAsync(Document document, TextSpan range, bool includeConfigurationFixes, bool isBlocking, CancellationToken cancellationToken)
         {
             // REVIEW: this is the first and simplest design. basically, when ctrl+. is pressed, it asks diagnostic service to give back
             // current diagnostics for the given span, and it will use that to get fixes. internally diagnostic service will either return cached information
@@ -170,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             foreach (var spanAndDiagnostic in aggregatedDiagnostics)
             {
                 await AppendFixesAsync(
-                    document, spanAndDiagnostic.Key, spanAndDiagnostic.Value, fixAllForInSpan: false,
+                    document, spanAndDiagnostic.Key, spanAndDiagnostic.Value, fixAllForInSpan: false, isBlocking,
                     result, cancellationToken).ConfigureAwait(false);
             }
 
@@ -221,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             }
 
             var result = ArrayBuilder<CodeFixCollection>.GetInstance();
-            await AppendFixesAsync(document, range, diagnostics, fixAllForInSpan: true, result, cancellationToken).ConfigureAwait(false);
+            await AppendFixesAsync(document, range, diagnostics, fixAllForInSpan: true, isBlocking: false, result, cancellationToken).ConfigureAwait(false);
 
             // TODO: Just get the first fix for now until we have a way to config user's preferred fix
             // https://github.com/dotnet/roslyn/issues/27066
@@ -253,6 +260,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             TextSpan span,
             IEnumerable<DiagnosticData> diagnostics,
             bool fixAllForInSpan,
+            bool isBlocking,
             ArrayBuilder<CodeFixCollection> result,
             CancellationToken cancellationToken)
         {
@@ -308,12 +316,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                         if (fixAllForInSpan)
                         {
                             var primaryDiagnostic = dxs.First();
-                            return GetCodeFixesAsync(document, primaryDiagnostic.Location.SourceSpan, fixer, ImmutableArray.Create(primaryDiagnostic), cancellationToken);
+                            return GetCodeFixesAsync(document, primaryDiagnostic.Location.SourceSpan, fixer, isBlocking, ImmutableArray.Create(primaryDiagnostic), cancellationToken);
 
                         }
                         else
                         {
-                            return GetCodeFixesAsync(document, span, fixer, dxs, cancellationToken);
+                            return GetCodeFixesAsync(document, span, fixer, isBlocking, dxs, cancellationToken);
                         }
                     },
                     cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -324,10 +332,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         private async Task<ImmutableArray<CodeFix>> GetCodeFixesAsync(
-            Document document, TextSpan span, CodeFixProvider fixer,
+            Document document, TextSpan span, CodeFixProvider fixer, bool isBlocking,
             ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
             var fixes = ArrayBuilder<CodeFix>.GetInstance();
+#pragma warning disable CS0618 // Type or member is obsolete
             var context = new CodeFixContext(document, span, diagnostics,
                 // TODO: Can we share code between similar lambdas that we pass to this API in BatchFixAllProvider.cs, CodeFixService.cs and CodeRefactoringService.cs?
                 (action, applicableDiagnostics) =>
@@ -339,7 +348,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     }
                 },
                 verifyArguments: false,
+                isBlocking,
                 cancellationToken: cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var task = fixer.RegisterCodeFixesAsync(context) ?? Task.CompletedTask;
             await task.ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -12,7 +11,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
-        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
         Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, bool isBlocking, CancellationToken cancellationToken);
         Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, CancellationToken cancellationToken);
         Task<CodeFixCollection> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
+++ b/src/Features/Core/Portable/CodeFixes/ICodeFixService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -11,6 +12,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 {
     internal interface ICodeFixService
     {
+        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
+        Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, bool isBlocking, CancellationToken cancellationToken);
         Task<ImmutableArray<CodeFixCollection>> GetFixesAsync(Document document, TextSpan textSpan, bool includeSuppressionFixes, CancellationToken cancellationToken);
         Task<CodeFixCollection> GetDocumentFixAllForIdInSpanAsync(Document document, TextSpan textSpan, string diagnosticId, CancellationToken cancellationToken);
         Task<Document> ApplyCodeFixesForSpecificDiagnosticIdAsync(Document document, string diagnosticId, IProgressTracker progressTracker, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var refactoring = await GetRefactoringFromProviderAsync(
-                    document, state, provider, extensionManager, cancellationToken).ConfigureAwait(false);
+                    document, state, provider, extensionManager, isBlocking: false, cancellationToken).ConfigureAwait(false);
 
                 if (refactoring != null)
                 {
@@ -89,9 +89,20 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             return false;
         }
 
-        public async Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(
+        public Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(
             Document document,
             TextSpan state,
+            CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return ((ICodeRefactoringService)this).GetRefactoringsAsync(document, state, isBlocking: false, cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        async Task<ImmutableArray<CodeRefactoring>> ICodeRefactoringService.GetRefactoringsAsync(
+            Document document,
+            TextSpan state,
+            bool isBlocking,
             CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Refactoring_CodeRefactoringService_GetRefactoringsAsync, cancellationToken))
@@ -102,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                 foreach (var provider in GetProviders(document))
                 {
                     tasks.Add(Task.Run(
-                        () => GetRefactoringFromProviderAsync(document, state, provider, extensionManager, cancellationToken), cancellationToken));
+                        () => GetRefactoringFromProviderAsync(document, state, provider, extensionManager, isBlocking, cancellationToken), cancellationToken));
                 }
 
                 var results = await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -115,6 +126,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan state,
             CodeRefactoringProvider provider,
             IExtensionManager extensionManager,
+            bool isBlocking,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -126,6 +138,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             try
             {
                 var actions = ArrayBuilder<CodeAction>.GetInstance();
+#pragma warning disable CS0618 // Type or member is obsolete
                 var context = new CodeRefactoringContext(document, state,
 
                     // TODO: Can we share code between similar lambdas that we pass to this API in BatchFixAllProvider.cs, CodeFixService.cs and CodeRefactoringService.cs?
@@ -137,7 +150,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                             actions.Add(a);
                         }
                     },
+                    isBlocking,
                     cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 var task = provider.ComputeRefactoringsAsync(context) ?? Task.CompletedTask;
                 await task.ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -94,9 +94,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan state,
             CancellationToken cancellationToken)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             return ((ICodeRefactoringService)this).GetRefactoringsAsync(document, state, isBlocking: false, cancellationToken);
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         async Task<ImmutableArray<CodeRefactoring>> ICodeRefactoringService.GetRefactoringsAsync(
@@ -138,7 +136,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             try
             {
                 var actions = ArrayBuilder<CodeAction>.GetInstance();
-#pragma warning disable CS0618 // Type or member is obsolete
                 var context = new CodeRefactoringContext(document, state,
 
                     // TODO: Can we share code between similar lambdas that we pass to this API in BatchFixAllProvider.cs, CodeFixService.cs and CodeRefactoringService.cs?
@@ -152,7 +149,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                     },
                     isBlocking,
                     cancellationToken);
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 var task = provider.ComputeRefactoringsAsync(context) ?? Task.CompletedTask;
                 await task.ConfigureAwait(false);

--- a/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +13,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 
         Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
 
-        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
         Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, bool isBlocking, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ICodeRefactoringService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,5 +13,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         Task<bool> HasRefactoringsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
 
         Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+
+        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
+        Task<ImmutableArray<CodeRefactoring>> GetRefactoringsAsync(Document document, TextSpan textSpan, bool isBlocking, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -48,6 +48,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
+        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
+        internal bool IsBlocking { get; }
+
         /// <summary>
         /// Creates a code fix context to be passed into <see cref="CodeFixProvider.RegisterCodeFixesAsync(CodeFixContext)"/> method.
         /// </summary>
@@ -102,7 +105,20 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             bool verifyArguments,
             CancellationToken cancellationToken)
-            : this(document, document.Project, span, diagnostics, registerCodeFix, verifyArguments, cancellationToken)
+            : this(document, document.Project, span, diagnostics, registerCodeFix, verifyArguments, isBlocking: false, cancellationToken)
+        {
+        }
+
+        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
+        internal CodeFixContext(
+            Document document,
+            TextSpan span,
+            ImmutableArray<Diagnostic> diagnostics,
+            Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
+            bool verifyArguments,
+            bool isBlocking,
+            CancellationToken cancellationToken)
+            : this(document, document.Project, span, diagnostics, registerCodeFix, verifyArguments, isBlocking, cancellationToken)
         {
         }
 
@@ -111,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             CancellationToken cancellationToken)
-            : this(document: null, project: project, span: default, diagnostics: diagnostics, registerCodeFix: registerCodeFix, verifyArguments: false, cancellationToken: cancellationToken)
+            : this(document: null, project: project, span: default, diagnostics: diagnostics, registerCodeFix: registerCodeFix, verifyArguments: false, isBlocking: false, cancellationToken: cancellationToken)
         {
         }
 
@@ -122,6 +138,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             ImmutableArray<Diagnostic> diagnostics,
             Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix,
             bool verifyArguments,
+            bool isBlocking,
             CancellationToken cancellationToken)
         {
             if (verifyArguments)
@@ -145,6 +162,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             _diagnostics = diagnostics;
             _registerCodeFix = registerCodeFix;
             _cancellationToken = cancellationToken;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            IsBlocking = isBlocking;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         internal CodeFixContext(

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
     /// <summary>
     /// Context for code fixes provided by a <see cref="CodeFixProvider"/>.
     /// </summary>
-    public struct CodeFixContext
+    public struct CodeFixContext : ITypeScriptCodeFixContext
     {
         private readonly Document _document;
         private readonly Project _project;
@@ -48,8 +48,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
-        internal bool IsBlocking { get; }
+        private readonly bool _isBlocking;
+        bool ITypeScriptCodeFixContext.IsBlocking => _isBlocking;
 
         /// <summary>
         /// Creates a code fix context to be passed into <see cref="CodeFixProvider.RegisterCodeFixesAsync(CodeFixContext)"/> method.
@@ -109,7 +109,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
         }
 
-        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
         internal CodeFixContext(
             Document document,
             TextSpan span,
@@ -163,9 +162,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             _registerCodeFix = registerCodeFix;
             _cancellationToken = cancellationToken;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            IsBlocking = isBlocking;
-#pragma warning restore CS0618 // Type or member is obsolete
+            _isBlocking = isBlocking;
         }
 
         internal CodeFixContext(
@@ -257,5 +254,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 throw new ArgumentException(string.Format(WorkspacesResources.Diagnostic_must_have_span_0, span.ToString()), nameof(diagnostics));
             }
         }
+    }
+
+    internal interface ITypeScriptCodeFixContext
+    {
+        bool IsBlocking { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -27,6 +27,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
+        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
+        internal bool IsBlocking { get; }
+
         private readonly Action<CodeAction> _registerRefactoring;
 
         /// <summary>
@@ -37,10 +40,24 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan span,
             Action<CodeAction> registerRefactoring,
             CancellationToken cancellationToken)
+#pragma warning disable CS0618 // Type or member is obsolete
+            : this(document, span, registerRefactoring, isBlocking: false, cancellationToken)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+        }
+
+        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
+        internal CodeRefactoringContext(
+            Document document,
+            TextSpan span,
+            Action<CodeAction> registerRefactoring,
+            bool isBlocking,
+            CancellationToken cancellationToken)
         {
             Document = document ?? throw new ArgumentNullException(nameof(document));
             Span = span;
             _registerRefactoring = registerRefactoring ?? throw new ArgumentNullException(nameof(registerRefactoring));
+            IsBlocking = isBlocking;
             CancellationToken = cancellationToken;
         }
 

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     /// <summary>
     /// Context for code refactorings provided by a <see cref="CodeRefactoringProvider"/>.
     /// </summary>
-    public struct CodeRefactoringContext
+    public struct CodeRefactoringContext : ITypeScriptCodeRefactoringContext
     {
         /// <summary>
         /// Document corresponding to the <see cref="CodeRefactoringContext.Span"/> to refactor.
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
-        internal bool IsBlocking { get; }
+        private readonly bool _isBlocking;
+        bool ITypeScriptCodeRefactoringContext.IsBlocking => _isBlocking;
 
         private readonly Action<CodeAction> _registerRefactoring;
 
@@ -40,13 +40,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             TextSpan span,
             Action<CodeAction> registerRefactoring,
             CancellationToken cancellationToken)
-#pragma warning disable CS0618 // Type or member is obsolete
             : this(document, span, registerRefactoring, isBlocking: false, cancellationToken)
-#pragma warning restore CS0618 // Type or member is obsolete
         {
         }
 
-        [Obsolete("This is a hack to support TypeScript; please do not use it.")]
         internal CodeRefactoringContext(
             Document document,
             TextSpan span,
@@ -57,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             Document = document ?? throw new ArgumentNullException(nameof(document));
             Span = span;
             _registerRefactoring = registerRefactoring ?? throw new ArgumentNullException(nameof(registerRefactoring));
-            IsBlocking = isBlocking;
+            _isBlocking = isBlocking;
             CancellationToken = cancellationToken;
         }
 
@@ -74,5 +71,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 
             _registerRefactoring(action);
         }
+    }
+
+    internal interface ITypeScriptCodeRefactoringContext
+    {
+        bool IsBlocking { get; }
     }
 }


### PR DESCRIPTION
...to tell TypeScript whether code fixes are being requested for a
blocking operation or a speculative background operation.  Since
TypeScript only has one thread, it wants to preempt running operations
if the code fix request is blocking, but not otherwise.