### PR TITLE
Fix for #37051 and add test.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -477,6 +477,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
+            if (unsubstitutedReturnType1.Type is null || unsubstitutedReturnType2.Type is null)
+            {
+                return false;
+            }
+
             var isVoid1 = unsubstitutedReturnType1.IsVoidType();
             var isVoid2 = unsubstitutedReturnType2.IsVoidType();
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -8210,6 +8210,29 @@ class C
 
         #region PointerTypes tests
 
+        [WorkItem(37051, "https://github.com/dotnet/roslyn/issues/37051")]
+        [Fact]
+        public void OverrideMethodReturningGenericPointer()
+        {
+            var text = @"using System;
+
+public unsafe abstract class Base
+{
+    public abstract T* Alloc<T>()
+        where T : unmanaged;
+}
+
+public unsafe class Derived : Base
+{
+    public override T* Alloc<T>()
+    {
+        throw new NotImplementedException();
+    }
+}";
+            CreateCompilation(text, options: TestOptions.UnsafeDebugDll).VerifyDiagnostics();
+        }
+
+
         [WorkItem(5712, "https://github.com/dotnet/roslyn/issues/5712")]
         [Fact]
         public void PathologicalRefStructPtrMultiDimensionalArray()


### PR DESCRIPTION
This PR provides a possible fix for #37051 where the C# compiler crashes when it meets an `override` method with a generic pointer (`T*`) return type.

The crash is caused by an `NullReferenceException` when trying to locate the override's parent method. The crash happens because a `TypeWithAnnotations.Type` property is `null` but assumed not to be. I believe the reason it's `null` is because this code path is triggered when a higher level method tries to resolve the return type or the generic constraints in the first place (and the overridden properties for overrides take control and they make the assumption that everything is already resolved).

