### PR TITLE
Copy sources from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,30 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="system-commandline" value="https://dotnet.myget.org/F/system-commandline/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="myget-dotnet-coreclr" value="https://dotnet.myget.org/F/dotnet-coreclr/api/v3/index.json" />
+    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-corefxtestdata" value="https://dotnet.myget.org/F/dotnet-corefxtestdata/api/v3/index.json" />
+    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="experimental-vs-packages" value="https://dotnet.myget.org/F/experimental-vs-packages/api/v3/index.json" />
+    <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
+    <add key="symreader-portable" value="https://dotnet.myget.org/F/symreader-portable/api/v3/index.json" />
+    <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="symreader-native" value="https://dotnet.myget.org/F/symreader-native/api/v3/index.json" />
+    <add key="metadata-tools" value="https://dotnet.myget.org/F/metadata-tools/api/v3/index.json" />
+    <add key="interactive-window" value="https://dotnet.myget.org/F/interactive-window/api/v3/index.json" />
+    <add key="roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
+    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="sourcelink" value="https://dotnet.myget.org/F/sourcelink/api/v3/index.json" />
+    <add key="vs-devcore" value="https://myget.org/F/vs-devcore/api/v3/index.json" />
+    <add key="vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
+    <add key="roslyn_concord" value="https://myget.org/F/roslyn_concord/api/v3/index.json" />
+    <add key="vssdk" value="https://vside.myget.org/F/vssdk/api/v3/index.json" />
+    <add key="vs-impl" value="https://vside.myget.org/F/vs-impl/api/v3/index.json" />
+    <add key="system-commandline" value="https://dotnet.myget.org/F/system-commandline/api/v3/index.json" />
+    <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
**TL;DR**

We need that all restore sources are located in `NuGet.config` since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)