### PR TITLE
Define IProjectSiteEx.SetProperty

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Interop/IProjectSiteEx.cs
@@ -14,5 +14,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.I
         void EndBatch();
 
         void AddFileEx([MarshalAs(UnmanagedType.LPWStr)] string filePath, [MarshalAs(UnmanagedType.LPWStr)] string linkMetadata);
+
+        /// <summary>
+        /// Allows the project system to pass along property values not covered by the
+        /// compiler's command line arguments.
+        /// See <see cref="LanguageServices.ProjectSystem.IWorkspaceProjectContext.SetProperty(string, string)"/>
+        /// for the corresponding method for CPS-based projects.
+        /// </summary>
+        void SetProperty([MarshalAs(UnmanagedType.LPWStr)] string property, [MarshalAs(UnmanagedType.LPWStr)] string value);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
@@ -32,5 +32,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             //    : SourceCodeKind.Regular;
             AddFile(filePath, linkMetadata, SourceCodeKind.Regular);
         }
+
+        public void SetProperty([MarshalAs(UnmanagedType.LPWStr)] string property, [MarshalAs(UnmanagedType.LPWStr)] string value)
+        {
+            // TODO: Handle the properties we care about.
+        }
     }
 }


### PR DESCRIPTION
We currently have no way to pass arbitrary property values (that is,
those beyond what is covered by the compiler command line arguments)
from the CSProj project system to the Language Service. Instead the LS
must go back to the `IVsHierarchy` for the project, query for the
`IVsBuildPropertyStorage` interface, and then query for the desired
property. This must all happen on the UI thread and thus risks UI
delays.

This commit expands the `IProjectSiteEx` interface to include a
`SetProperty` method that takes the property name and value. This allows
the project system to "push" values to the LS rather than requiring the
LS to "pull them".