### PR TITLE
Fix attribute params with regards to nullability

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -909,20 +909,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            TypeSymbol argumentType = (TypeSymbol)argument.Type;
-            // Easy out (i.e. don't bother classifying conversion).
-            if (TypeSymbol.Equals(argumentType, parameter.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
-            {
-                result = argument;
-                return true;
-            }
-
             HashSet<DiagnosticInfo> useSiteDiagnostics = null; // ignoring, since already bound argument and parameter
-            Conversion conversion = conversions.ClassifyBuiltInConversion(argumentType, parameter.Type, ref useSiteDiagnostics);
+            Conversion conversion = conversions.ClassifyBuiltInConversion((TypeSymbol)argument.Type, parameter.Type, ref useSiteDiagnostics);
 
             // NOTE: Won't always succeed, even though we've performed overload resolution.
             // For example, passing int[] to params object[] actually treats the int[] as an element of the object[].
-            if (conversion.IsValid && conversion.Kind == ConversionKind.ImplicitReference)
+            if (conversion.IsValid && (conversion.Kind == ConversionKind.ImplicitReference || conversion.Kind == ConversionKind.Identity))
             {
                 result = argument;
                 return true;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -911,7 +911,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol argumentType = (TypeSymbol)argument.Type;
             // Easy out (i.e. don't bother classifying conversion).
-            if (TypeSymbol.Equals(argumentType, parameter.Type, TypeCompareKind.ConsiderEverything2))
+            if (TypeSymbol.Equals(argumentType, parameter.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
             {
                 result = argument;
                 return true;

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -153,28 +153,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             set
             {
-                // We merge values into Nullable, prioritizing Nullable value over NullableContextOptions value
                 if (!string.IsNullOrEmpty(value))
                 {
                     _store[nameof(Nullable)] = value;
                 }
             }
             get { return (string)_store[nameof(Nullable)]; }
-        }
-
-        [Obsolete("This property will be removed. Please use 'Nullable' instead")]
-        public string NullableContextOptions
-        {
-            // This property should be removed. https://github.com/dotnet/roslyn/issues/35788
-            set
-            {
-                // We merge values into Nullable, prioritizing Nullable value over NullableContextOptions value
-                if (string.IsNullOrEmpty(Nullable))
-                {
-                    Nullable = value;
-                }
-            }
-            get { return Nullable; }
         }
 
         #endregion

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -162,8 +162,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (string)_store[nameof(Nullable)]; }
         }
 
+        [Obsolete("This property will be removed. Please use 'Nullable' instead")]
         public string NullableContextOptions
         {
+            // This property should be removed. https://github.com/dotnet/roslyn/issues/35788
             set
             {
                 // We merge values into Nullable, prioritizing Nullable value over NullableContextOptions value

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -351,41 +351,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
-#pragma warning disable CS0618
-        // NullableContextOptions is Obsolete
-        [Theory]
-        [InlineData(null, "disable")]
-        [InlineData("", "disable")]
-        [InlineData("enable", "disable")]
-        [InlineData("other", "disable")]
-        [InlineData("disable", null)]
-        [InlineData("disable", "")]
-        public void NullableReferenceTypes_NullableWins_Disable(string nullableContextOptions, string nullable)
-        {
-            var csc = new Csc();
-            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = nullableContextOptions;
-            csc.Nullable = nullable;
-            Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
-        }
-
-        [Theory]
-        [InlineData(null, "enable")]
-        [InlineData("", "enable")]
-        [InlineData("disable", "enable")]
-        [InlineData("other", "enable")]
-        [InlineData("enable", null)]
-        [InlineData("enable", "")]
-        public void NullableReferenceTypes_NullableWins_Enable(string nullableContextOptions, string nullable)
-        {
-            var csc = new Csc();
-            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
-            csc.NullableContextOptions = nullableContextOptions;
-            csc.Nullable = nullable;
-            Assert.Equal("/nullable:enable /out:test.exe test.cs", csc.GenerateResponseFileContents());
-        }
-#pragma warning restore CS0618
-
         [Fact]
         public void NullableReferenceTypes_Safeonly()
         {

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -351,6 +351,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             Assert.Equal("/nullable:disable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
 
+#pragma warning disable CS0618
+        // NullableContextOptions is Obsolete
         [Theory]
         [InlineData(null, "disable")]
         [InlineData("", "disable")]
@@ -382,6 +384,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
             csc.Nullable = nullable;
             Assert.Equal("/nullable:enable /out:test.exe test.cs", csc.GenerateResponseFileContents());
         }
+#pragma warning restore CS0618
 
         [Fact]
         public void NullableReferenceTypes_Safeonly()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36974

I'm also adding `[Obsolete]` on `NullableContextOptions` API which we intend to remove, but don't want to rush.