### PR TITLE
Ensure that IVsContainedLanguage.SetHost(null) won't fail a second time

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.IVsContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.IVsContainedLanguage.cs
@@ -77,14 +77,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public int SetHost(IVsContainedLanguageHost host)
         {
+            if (ContainedDocument.ContainedLanguageHost == host)
+            {
+                return VSConstants.S_OK;
+            }
+
+            ContainedDocument.ContainedLanguageHost = host;
+
             // Are we going away due to the contained language being disconnected?
-            if (this.ContainedDocument.ContainedLanguageHost != null && host == null)
+            if (host == null)
             {
                 OnDisconnect();
-            }
-            else
-            {
-                ContainedDocument.ContainedLanguageHost = host;
             }
 
             return VSConstants.S_OK;


### PR DESCRIPTION
If you called SetHost(null) we didn't null out our internal field, so a second call would call ontainedLanguage.OnDisconnect() a second time.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/857221