### PR TITLE
IDE EnC support for all C# 8.0 features

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBLambdaTests.vb
@@ -157,6 +157,68 @@ End Module
         End Sub
 
         <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
+        Public Sub NestedLambdaFunction()
+            Dim source = "
+Class C
+    Sub F()
+        Dim f = Function(a) Function(b) b + 1
+    End Sub
+End Class"
+
+            Dim compilation = CreateCompilation(source, options:=TestOptions.DebugDll)
+
+            ' Notice the that breakpoint spans of the inner function overlap with the breakpoint span of the outer function body
+            ' and that the two sequence points have the same start position.
+            ' Dim f = Function(a) [|[|Function(b)|] b + 1|]
+
+            compilation.VerifyPdb("C+_Closure$__._Lambda$__1-0",
+ <symbols>
+     <files>
+         <file id="1" name="" language="VB"/>
+     </files>
+     <methods>
+         <method containingType="C+_Closure$__" name="_Lambda$__1-0" parameterNames="a">
+             <customDebugInfo>
+                 <encLocalSlotMap>
+                     <slot kind="21" offset="8"/>
+                 </encLocalSlotMap>
+             </customDebugInfo>
+             <sequencePoints>
+                 <entry offset="0x0" startLine="4" startColumn="17" endLine="4" endColumn="28" document="1"/>
+                 <entry offset="0x1" startLine="4" startColumn="29" endLine="4" endColumn="46" document="1"/>
+             </sequencePoints>
+             <scope startOffset="0x0" endOffset="0x2a">
+                 <importsforward declaringType="C" methodName="F"/>
+             </scope>
+         </method>
+     </methods>
+ </symbols>)
+
+            compilation.VerifyPdb("C+_Closure$__._Lambda$__1-1",
+<symbols>
+    <files>
+        <file id="1" name="" language="VB"/>
+    </files>
+    <methods>
+        <method containingType="C+_Closure$__" name="_Lambda$__1-1" parameterNames="b">
+            <customDebugInfo>
+                <encLocalSlotMap>
+                    <slot kind="21" offset="20"/>
+                </encLocalSlotMap>
+            </customDebugInfo>
+            <sequencePoints>
+                <entry offset="0x0" startLine="4" startColumn="29" endLine="4" endColumn="40" document="1"/>
+                <entry offset="0x1" startLine="4" startColumn="41" endLine="4" endColumn="46" document="1"/>
+            </sequencePoints>
+            <scope startOffset="0x0" endOffset="0x12">
+                <importsforward declaringType="C" methodName="F"/>
+            </scope>
+        </method>
+    </methods>
+</symbols>)
+        End Sub
+
+        <ConditionalFact(GetType(WindowsOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
         <WorkItem(544000, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544000")>
         Public Sub TestLambdaNameStability()
             Dim source =

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.Methods.cs
@@ -597,7 +597,7 @@ class C
 
             // Can be improved with https://github.com/dotnet/roslyn/issues/22696
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.DeleteActiveStatement, "=>       M()"));
+                Diagnostic(RudeEditKind.DeleteActiveStatement, "int P"));
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -5459,6 +5459,526 @@ class C
 
         #endregion
 
+        #region Switch When Clauses, Patterns
+
+        [Fact]
+        public void SwitchWhenClause_PatternUpdate1()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case int a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+                
+            case byte a when G5(a):
+                return 10;
+                
+            case double b when G2(b):
+                return 20;
+                
+            case C { X: 2 } when G4(9):
+                return 30;
+                
+            case C { X: 2, Y: C { X: 1 } } c1 when G3(c1):
+                return 40;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case int a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+                
+            case byte a when G5(a):
+                return 10;
+                
+            case double b when G2(b):
+                return 20;
+                
+            case C { X: 2 } when G4(9):
+                return 30;
+                
+            case C { X: 2, Y: C { X: 2 } } c1 when G3(c1):
+                return 40;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "switch (F())", CSharpFeaturesResources.switch_statement_case_clause));
+        }
+
+        [Fact]
+        public void SwitchWhenClause_PatternInsert()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case int a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "switch (F())", CSharpFeaturesResources.switch_statement_case_clause));
+        }
+
+        [Fact]
+        public void SwitchWhenClause_PatternDelete()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case int a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "switch (F())", CSharpFeaturesResources.switch_statement_case_clause));
+        }
+
+        [Fact]
+        public void SwitchWhenClause_WhenDelete()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case byte a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case byte a1:
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "switch (F())", CSharpFeaturesResources.switch_statement_case_clause));
+        }
+
+        [Fact]
+        public void SwitchWhenClause_WhenAdd()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case byte a1:
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case byte a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "switch (F())", CSharpFeaturesResources.switch_statement_case_clause));
+        }
+
+        [Fact]
+        public void SwitchWhenClause_WhenUpdate()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case byte a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F())
+		{
+			case byte a1 when G1(a1 * 2):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void SwitchWhenClause_UpdateGoverningExpression()
+        {
+            var src1 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F(1))
+		{
+			case int a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+	public static int Main()
+	{
+		switch (F(2))
+		{
+			case int a1 when G1(a1):
+            case int a2 <AS:0>when G1(a2)</AS:0>:
+                return 10;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "switch (F(2))", CSharpFeaturesResources.switch_statement));
+        }
+
+        [Fact]
+        public void Switch_PropertyPattern_Update_NonLeaf()
+        {
+            var src1 = @"
+class C
+{
+    public int X { get => <AS:0>1</AS:0>; }
+
+	public static int F(object obj)
+	{
+		<AS:1>switch (obj)</AS:1>
+		{
+			case C { X: 1 }:
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+    public int X { get => <AS:0>1</AS:0>; }
+
+	public static int F(object obj)
+	{
+		<AS:1>switch (obj)</AS:1>
+		{
+			case C { X: 2 }:
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "switch (obj)"));
+        }
+
+        [Fact]
+        public void Switch_PositionalPattern_Update_NonLeaf()
+        {
+            var src1 = @"
+class C
+{
+    public void Deconstruct(out int x) => <AS:0>x = X</AS:0>;
+
+	public static int F(object obj)
+	{
+		<AS:1>switch (obj)</AS:1>
+		{
+			case C ( x: 1 ):
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+    public void Deconstruct(out int x) => <AS:0>x = X</AS:0>;
+
+	public static int F(object obj)
+	{
+		<AS:1>switch (obj)</AS:1>
+		{
+			case C ( x: 2 ):
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "switch (obj)"));
+        }
+
+        [Fact]
+        public void Switch_VarPattern_Update_NonLeaf()
+        {
+            var src1 = @"
+class C
+{
+    public static object G() => <AS:0>null</AS:0>;
+	
+    public static int F(object obj)
+	{
+		<AS:1>switch (G())</AS:1>
+		{
+			case var (x, y):
+                return 1;
+
+			case 2:
+                return 2;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+    public static object G() => <AS:0>null</AS:0>;
+
+    public static int F(object obj)
+	{
+		<AS:1>switch (G())</AS:1>
+		{
+			case var (x, y):
+                return 1;
+
+			case 3:
+                return 2;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "switch (G())"));
+        }
+
+        [Fact]
+        public void Switch_DiscardPattern_Update_NonLeaf()
+        {
+            var src1 = @"
+class C
+{
+    public static object G() => <AS:0>null</AS:0>;
+	
+    public static int F(object obj)
+	{
+		<AS:1>switch (G())</AS:1>
+		{
+			case bool _:
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+    public static object G() => <AS:0>null</AS:0>;
+
+	public static int F(object obj)
+	{
+		<AS:1>switch (G())</AS:1>
+		{
+			case int _:
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "switch (G())"));
+        }
+
+        [Fact]
+        public void Switch_NoPatterns_Update_NonLeaf()
+        {
+            var src1 = @"
+class C
+{
+    public static object G() => <AS:0>null</AS:0>;
+	
+    public static int F(object obj)
+	{
+		<AS:1>switch (G())</AS:1>
+		{
+			case 1:
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var src2 = @"
+class C
+{
+    public static object G() => <AS:0>null</AS:0>;
+
+	public static int F(object obj)
+	{
+		<AS:1>switch (G())</AS:1>
+		{
+			case 2:
+                return 1;
+        }
+
+        return 0;
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        #endregion
+
         #region Try
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -8023,7 +8023,7 @@ class C
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "yield return 1;", CSharpFeaturesResources.yield_statement));
+                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "yield return 1;", CSharpFeaturesResources.yield_return_statement));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -9274,7 +9274,7 @@ class C
             var src2 = @"
 class C
 {
-    static async void F()
+    static void F()
     {
         var f = new Action(async () => { <AS:0>Console.WriteLine(1);</AS:0> });
     }
@@ -9285,6 +9285,34 @@ class C
 
             edits.VerifyRudeDiagnostics(active,
                 Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "()"));
+        }
+
+        [Fact]
+        public void LambdaToAsyncLambda_WithActiveStatement_NoAwait_Nested()
+        {
+            var src1 = @"
+class C
+{
+    static void F()
+    {
+        var f = new Func<int, Func<int, int>>(a => <AS:0>b => 1</AS:0>);
+    }
+}
+";
+            var src2 = @"
+class C
+{
+    static void F()
+    {
+        var f = new Func<int, Func<int, int>>(async a => <AS:0>b => 1</AS:0>);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "a"));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -4716,7 +4716,219 @@ class Test
         }
 
         [Fact]
-        public void Using_Expression_InLambdaBody1()
+        public void UsingStatement_Update_NonLeaf1()
+        {
+            var src1 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        using (var a = new Disposable(1)) { System.Console.Write(); <AS:1>}</AS:1>
+    }
+}";
+            var src2 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        using (var a = new Disposable(2)) { System.Console.Write(); <AS:1>}</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "}"));
+        }
+
+        [Fact]
+        public void UsingStatement_Update_NonLeaf2()
+        {
+            var src1 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        using (Disposable a = new Disposable(1), b = Disposable(2)) { System.Console.Write(); <AS:1>}</AS:1>
+    }
+}";
+            var src2 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        using (Disposable a = new Disposable(1)) { System.Console.Write(); <AS:1>}</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "}"));
+        }
+
+        [Fact]
+        public void UsingStatement_Update_NonLeaf_Lambda()
+        {
+            var src1 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        using (var a = new Disposable(() => 1)) { System.Console.Write(); <AS:1>}</AS:1>
+    }
+}";
+            var src2 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        using (var a = new Disposable(() => 2)) { System.Console.Write(); <AS:1>}</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void UsingLocalDeclaration_Update_NonLeaf1()
+        {
+            var src1 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        if (F())
+        {        
+            using Disposable a = new Disposable(1);
+
+            using Disposable b = new Disposable(2), c = new Disposable(3);
+
+  <AS:1>}</AS:1>
+    }
+}";
+            var src2 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        if (F())
+        {        
+            using Disposable a = new Disposable(1);
+
+            using Disposable b = new Disposable(20), c = new Disposable(3);
+
+  <AS:1>}</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ActiveStatementUpdate, "}"));
+        }
+
+        [Fact]
+        public void UsingLocalDeclaration_Update_NonLeaf_Lambda()
+        {
+            var src1 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        if (F())
+        {        
+            using Disposable a = new Disposable(() => 1);
+
+            {
+                using var x = new Disposable(1);
+            }
+
+            using Disposable b = new Disposable(() => 2), c = new Disposable(() => 3);
+
+  <AS:1>}</AS:1>
+    }
+}";
+            var src2 = @"
+class Disposable : IDisposable
+{
+    public void Dispose() <AS:0>{</AS:0>}
+}
+
+class Test
+{
+    static void Main(string[] args)
+    {
+        if (F())
+        {        
+            using Disposable a = new Disposable(() => 10);
+
+            {
+                using var x = new Disposable(2);
+            }
+
+            Console.WriteLine(1);
+
+            using Disposable b = new Disposable(() => 20), c = new Disposable(() => 30);
+
+  <AS:1>}</AS:1>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void UsingStatement_Expression_InLambdaBody1()
         {
             var src1 = @"
 class Test
@@ -4777,7 +4989,7 @@ class Test
         }
 
         [Fact]
-        public void Using_Expression_Update_Lambda1()
+        public void UsingStatement_Expression_Update_Lambda1()
         {
             var src1 = @"
 class C
@@ -4810,7 +5022,7 @@ class C
         }
 
         [Fact]
-        public void Using_Expression_Update_Lambda2()
+        public void UsingStatement_Expression_Update_Lambda2()
         {
             var src1 = @"
 class C

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                     node = node.Parent;
                 }
 
-                var actual = CSharpEditAndContinueAnalyzer.GetDiagnosticSpanImpl(node.Kind(), node, EditKind.Update);
+                var actual = CSharpEditAndContinueAnalyzer.GetDiagnosticSpan(node, EditKind.Update);
                 var actualText = source.Substring(actual.Start, actual.Length);
 
-                Assert.True(expected == actual, "\r\n" +
-                    "Expected span: '" + expectedText + "' " + expected + "\r\n" +
-                    "Actual span: '" + actualText + "' " + actual);
+                Assert.True(expected == actual,
+                    $"{Environment.NewLine}Expected span: '{expectedText}' {expected}" +
+                    $"{Environment.NewLine}Actual span: '{actualText}' {actual}");
             }
         }
 
@@ -73,17 +73,20 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             var unhandledKinds = new List<SyntaxKind>();
             foreach (var kind in Enum.GetValues(typeof(SyntaxKind)).Cast<SyntaxKind>().Where(hasLabel))
             {
+                TextSpan? span;
                 try
                 {
-                    CSharpEditAndContinueAnalyzer.GetDiagnosticSpanImpl(kind, null, EditKind.Update);
+                    span = CSharpEditAndContinueAnalyzer.TryGetDiagnosticSpanImpl(kind, null, EditKind.Update);
                 }
                 catch (NullReferenceException)
                 {
                     // expected, we passed null node
+                    continue;
                 }
-                catch (Exception)
+
+                // unexpected:
+                if (span == null)
                 {
-                    // unexpected:
                     unhandledKinds.Add(kind);
                 }
             }
@@ -224,7 +227,7 @@ class C
         }
 
         /// <summary>
-        /// Verifies that <see cref="CSharpEditAndContinueAnalyzer.GetDiagnosticSpanImpl"/> handles all <see cref="SyntaxKind"/>s.
+        /// Verifies that <see cref="CSharpEditAndContinueAnalyzer.TryGetDiagnosticSpanImpl"/> handles all <see cref="SyntaxKind"/>s.
         /// </summary>
         [Fact]
         public void ErrorSpansAllKinds()

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -1204,7 +1204,6 @@ foreach (var (a, b) in e1) { }
                 "Move [foreach ((var x, var y) in e2) { }]@39 -> @4");
         }
 
-
         #endregion
 
         #region For Statement

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -8209,8 +8209,8 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Changing, "yield break;", CSharpFeaturesResources.yield_return_statement, CSharpFeaturesResources.yield_break_statement),
-                Diagnostic(RudeEditKind.Changing, "yield return 4;", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.yield_return_statement));
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "yield break;", CSharpFeaturesResources.yield_return_statement, CSharpFeaturesResources.yield_break_statement),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "yield return 4;", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.yield_return_statement));
         }
 
         [Fact]
@@ -9098,12 +9098,12 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Changing, "await foreach (var x in G()) { }", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.foreach_statement),
-                Diagnostic(RudeEditKind.Changing, "x = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.using_declaration),
-                Diagnostic(RudeEditKind.Changing, "y = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.using_declaration),
-                Diagnostic(RudeEditKind.Changing, "await Task.FromResult(1)", CSharpFeaturesResources.yield_return_statement, CSharpFeaturesResources.await_expression),
-                Diagnostic(RudeEditKind.Changing, "await Task.FromResult(1)", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.await_expression),
-                Diagnostic(RudeEditKind.Changing, "yield return 1;", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.yield_return_statement));
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "await foreach (var x in G()) { }", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.foreach_statement),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "x = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.using_declaration),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "y = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.using_declaration),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "await Task.FromResult(1)", CSharpFeaturesResources.yield_return_statement, CSharpFeaturesResources.await_expression),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "await Task.FromResult(1)", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.await_expression),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "yield return 1;", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.yield_return_statement));
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementEditingTests.cs
@@ -8709,7 +8709,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
-                Diagnostic(RudeEditKind.Delete, "{", CSharpFeaturesResources.foreach_statement));
+                Diagnostic(RudeEditKind.Delete, "{", CSharpFeaturesResources.asynchronous_foreach_statement));
         }
 
         [Fact]
@@ -8736,7 +8736,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
-                Diagnostic(RudeEditKind.Delete, "await using", CSharpFeaturesResources.using_declaration));
+                Diagnostic(RudeEditKind.Delete, "await using", CSharpFeaturesResources.asynchronous_using_declaration));
         }
 
         [Fact]
@@ -8763,7 +8763,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
-                Diagnostic(RudeEditKind.Delete, "await using", CSharpFeaturesResources.using_declaration));
+                Diagnostic(RudeEditKind.Delete, "await using", CSharpFeaturesResources.asynchronous_using_declaration));
         }
 
         [Fact]
@@ -8789,8 +8789,8 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(ActiveStatementsDescription.Empty,
-                Diagnostic(RudeEditKind.Delete, "{", CSharpFeaturesResources.using_declaration),
-                Diagnostic(RudeEditKind.Delete, "{", CSharpFeaturesResources.using_declaration));
+                Diagnostic(RudeEditKind.Delete, "{", CSharpFeaturesResources.asynchronous_using_declaration),
+                Diagnostic(RudeEditKind.Delete, "{", CSharpFeaturesResources.asynchronous_using_declaration));
         }
 
         [Fact]
@@ -9031,7 +9031,7 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Insert, "y = new D()", CSharpFeaturesResources.using_declaration));
+                Diagnostic(RudeEditKind.Insert, "y = new D()", CSharpFeaturesResources.asynchronous_using_declaration));
         }
 
         [Fact]
@@ -9098,9 +9098,9 @@ class C
             var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ChangingStateMachineShape, "await foreach (var x in G()) { }", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.foreach_statement),
-                Diagnostic(RudeEditKind.ChangingStateMachineShape, "x = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.using_declaration),
-                Diagnostic(RudeEditKind.ChangingStateMachineShape, "y = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.using_declaration),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "await foreach (var x in G()) { }", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.asynchronous_foreach_statement),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "x = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.asynchronous_using_declaration),
+                Diagnostic(RudeEditKind.ChangingStateMachineShape, "y = new D()", CSharpFeaturesResources.await_expression, CSharpFeaturesResources.asynchronous_using_declaration),
                 Diagnostic(RudeEditKind.ChangingStateMachineShape, "await Task.FromResult(1)", CSharpFeaturesResources.yield_return_statement, CSharpFeaturesResources.await_expression),
                 Diagnostic(RudeEditKind.ChangingStateMachineShape, "await Task.FromResult(1)", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.await_expression),
                 Diagnostic(RudeEditKind.ChangingStateMachineShape, "yield return 1;", CSharpFeaturesResources.yield_break_statement, CSharpFeaturesResources.yield_return_statement));

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -825,6 +825,86 @@ F(a =>
             expected.AssertEqual(actual);
         }
 
+        [Fact]
+        public void LambdasInArrayType()
+        {
+            var src1 = "var x = new int[F(a => 1)];";
+            var src2 = "var x = new int[F(a => 2)];";
+
+            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var x = new int[F(a => 1)];", "var x = new int[F(a => 2)];" },
+                { "var x = new int[F(a => 1)]", "var x = new int[F(a => 2)]" },
+                { "x = new int[F(a => 1)]", "x = new int[F(a => 2)]" },
+                { "a => 1", "a => 2" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void LambdasInArrayInitializer()
+        {
+            var src1 = "var x = new int[] { F(a => 1) };";
+            var src2 = "var x = new int[] { F(a => 2) };";
+
+            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var x = new int[] { F(a => 1) };", "var x = new int[] { F(a => 2) };" },
+                { "var x = new int[] { F(a => 1) }", "var x = new int[] { F(a => 2) }" },
+                { "x = new int[] { F(a => 1) }", "x = new int[] { F(a => 2) }" },
+                { "a => 1", "a => 2" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void LambdasInStackalloc()
+        {
+            var src1 = "var x = stackalloc int[F(a => 1)];";
+            var src2 = "var x = stackalloc int[F(a => 2)];";
+
+            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var x = stackalloc int[F(a => 1)];", "var x = stackalloc int[F(a => 2)];" },
+                { "var x = stackalloc int[F(a => 1)]", "var x = stackalloc int[F(a => 2)]" },
+                { "x = stackalloc int[F(a => 1)]", "x = stackalloc int[F(a => 2)]" },
+                { "a => 1", "a => 2" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void LambdasInStackalloc_Initializer()
+        {
+            var src1 = "var x = stackalloc[] { F(a => 1) };";
+            var src2 = "var x = stackalloc[] { F(a => 2) };";
+
+            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var x = stackalloc[] { F(a => 1) };", "var x = stackalloc[] { F(a => 2) };" },
+                { "var x = stackalloc[] { F(a => 1) }", "var x = stackalloc[] { F(a => 2) }" },
+                { "x = stackalloc[] { F(a => 1) }", "x = stackalloc[] { F(a => 2) }" },
+                { "a => 1", "a => 2" },
+            };
+
+            expected.AssertEqual(actual);
+        }
+
         #endregion
 
         #region Local Functions

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -1305,7 +1305,7 @@ var q = from a in await seq1
         select a + 1;
 ";
 
-            var match = GetMethodMatches(src1, src2);
+            var match = GetMethodMatches(src1, src2, MethodKind.Async);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs
@@ -1338,7 +1338,7 @@ var q = from a in await seq1
             var src1 = "F(from a in await b from x in y select c);";
             var src2 = "F(from a in await c from x in y select c);";
 
-            var match = GetMethodMatches(src1, src2);
+            var match = GetMethodMatches(src1, src2, MethodKind.Async);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs
@@ -1546,13 +1546,13 @@ foreach ((var b3, int b2) in e) { A2(); }
         public void ForeachVariable_Update2()
         {
             var src1 = @"
-foreach (_ in e2) { yield return 4; }
+foreach (_ in e2) { }
 foreach (_ in e3) { A(); }
 ";
 
             var src2 = @"
 foreach (_ in e4) { A(); }
-foreach (var b in e2) { yield return 4; }
+foreach (var b in e2) { }
 ";
 
             var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
@@ -1560,9 +1560,8 @@ foreach (var b in e2) { yield return 4; }
 
             var expected = new MatchingPairs
             {
-                { "foreach (_ in e2) { yield return 4; }", "foreach (var b in e2) { yield return 4; }" },
-                { "{ yield return 4; }", "{ yield return 4; }" },
-                { "yield return 4;", "yield return 4;" },
+                { "foreach (_ in e2) { }", "foreach (var b in e2) { }" },
+                { "{ }", "{ }" },
                 { "foreach (_ in e3) { A(); }", "foreach (_ in e4) { A(); }" },
                 { "{ A(); }", "{ A(); }" },
                 { "A();", "A();" }
@@ -1844,7 +1843,7 @@ if (o is string { Length: 7 } s7) return 5;
 };
 ";
 
-            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Async);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs {

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/StatementMatchingTests.cs
@@ -831,7 +831,7 @@ F(a =>
             var src1 = "var x = new int[F(a => 1)];";
             var src2 = "var x = new int[F(a => 2)];";
 
-            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var match = GetMethodMatch(src1, src2);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs
@@ -851,7 +851,7 @@ F(a =>
             var src1 = "var x = new int[] { F(a => 1) };";
             var src2 = "var x = new int[] { F(a => 2) };";
 
-            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var match = GetMethodMatch(src1, src2);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs
@@ -871,7 +871,7 @@ F(a =>
             var src1 = "var x = stackalloc int[F(a => 1)];";
             var src2 = "var x = stackalloc int[F(a => 2)];";
 
-            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var match = GetMethodMatch(src1, src2);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs
@@ -891,7 +891,7 @@ F(a =>
             var src1 = "var x = stackalloc[] { F(a => 1) };";
             var src2 = "var x = stackalloc[] { F(a => 2) };";
 
-            var match = GetMethodMatch(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var match = GetMethodMatch(src1, src2);
             var actual = ToMatchingPairs(match);
 
             var expected = new MatchingPairs

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
@@ -3,6 +3,7 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Test.Utilities;
 using Xunit;
 using SyntaxUtilities = Microsoft.CodeAnalysis.CSharp.EditAndContinue.SyntaxUtilities;
 
@@ -150,6 +151,96 @@ class C
             SyntaxUtilities.FindLeafNodeAndPartner(leftRoot, leftPosition, rightRoot, out var leftNode, out var rightNodeOpt);
             Assert.Equal("3", leftNode.ToString());
             Assert.Null(rightNodeOpt);
+        }
+
+        [Fact]
+        public void IsIteratorDeclaration()
+        {
+            var tree = SyntaxFactory.ParseSyntaxTree(@"
+class C
+{
+    IEnumerable<int> X = new[] { 1, 2, 3 };
+
+    IEnumerable<int> M1() { yield return 1; }
+    
+    void M2() 
+    {
+        IEnumerable<int> f() { yield return 1; }
+    }
+}
+");
+
+            var x = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "X");
+            var m1 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M1");
+            var m2 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M2");
+            var f = m2.DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single(m => m.Identifier.ValueText == "f");
+
+            Assert.False(SyntaxUtilities.IsIteratorDeclaration(x));
+            Assert.True(SyntaxUtilities.IsIteratorDeclaration(m1));
+            Assert.False(SyntaxUtilities.IsIteratorDeclaration(m2));
+            Assert.True(SyntaxUtilities.IsIteratorDeclaration(f));
+
+            Assert.Equal(0, SyntaxUtilities.GetYieldStatements(x.Initializer).Length);
+            Assert.Equal(1, SyntaxUtilities.GetYieldStatements(m1.Body).Length);
+            Assert.Equal(0, SyntaxUtilities.GetYieldStatements(m2.Body).Length);
+            Assert.Equal(1, SyntaxUtilities.GetYieldStatements(f.Body).Length);
+        }
+
+        [Fact]
+        public void IsAsyncDeclaration()
+        {
+            var tree = SyntaxFactory.ParseSyntaxTree(@"
+class C
+{
+    async Task<int> M1() => await Task.FromResult(1);
+    async Task<int> M2() { return await Task.FromResult(1); }
+
+    void M3()
+    {
+        async Task<int> f1() => await Task.FromResult(1);
+        async Task<int> f2() { return await Task.FromResult(1); }
+
+        var l1 = new Func<Task<int>>(async () => await Task.FromResult(1));
+        var l2 = new Func<Task<int>>(async () => { return await Task.FromResult(1); });
+
+        var l3 = new Func<Task<int>>(async delegate () { return await Task.FromResult(1); });
+    }
+}
+");
+
+            var m1 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M1");
+            var m2 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M2");
+            var m3 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M3");
+
+            var f1 = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single(m => m.Identifier.ValueText == "f1");
+            var f2 = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single(m => m.Identifier.ValueText == "f2");
+
+            var l1 = m3.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "l1").Initializer.
+                DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
+
+            var l2 = m3.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "l2").Initializer.
+                DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
+
+            var l3 = m3.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "l3").Initializer.
+                DescendantNodes().OfType<AnonymousFunctionExpressionSyntax>().Single();
+
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(m1.ExpressionBody));
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(m2));
+            Assert.False(SyntaxUtilities.IsAsyncDeclaration(m3));
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(f1.ExpressionBody));
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(f2));
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(l1));
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(l2));
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(l3));
+
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(m1.ExpressionBody).Length);
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(m2.Body).Length);
+            Assert.Equal(0, SyntaxUtilities.GetAwaitExpressions(m3.Body).Length);
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(f1.ExpressionBody).Length);
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(f2.Body).Length);
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(l1.Body).Length);
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(l2.Body).Length);
+            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(l3.Body).Length);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/SyntaxUtilitiesTests.cs
@@ -154,44 +154,12 @@ class C
         }
 
         [Fact]
-        public void IsIteratorDeclaration()
-        {
-            var tree = SyntaxFactory.ParseSyntaxTree(@"
-class C
-{
-    IEnumerable<int> X = new[] { 1, 2, 3 };
-
-    IEnumerable<int> M1() { yield return 1; }
-    
-    void M2() 
-    {
-        IEnumerable<int> f() { yield return 1; }
-    }
-}
-");
-
-            var x = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "X");
-            var m1 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M1");
-            var m2 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M2");
-            var f = m2.DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single(m => m.Identifier.ValueText == "f");
-
-            Assert.False(SyntaxUtilities.IsIteratorDeclaration(x));
-            Assert.True(SyntaxUtilities.IsIteratorDeclaration(m1));
-            Assert.False(SyntaxUtilities.IsIteratorDeclaration(m2));
-            Assert.True(SyntaxUtilities.IsIteratorDeclaration(f));
-
-            Assert.Equal(0, SyntaxUtilities.GetYieldStatements(x.Initializer).Length);
-            Assert.Equal(1, SyntaxUtilities.GetYieldStatements(m1.Body).Length);
-            Assert.Equal(0, SyntaxUtilities.GetYieldStatements(m2.Body).Length);
-            Assert.Equal(1, SyntaxUtilities.GetYieldStatements(f.Body).Length);
-        }
-
-        [Fact]
         public void IsAsyncDeclaration()
         {
             var tree = SyntaxFactory.ParseSyntaxTree(@"
 class C
 {
+    async Task<int> M0() => 1;
     async Task<int> M1() => await Task.FromResult(1);
     async Task<int> M2() { return await Task.FromResult(1); }
 
@@ -208,6 +176,7 @@ class C
 }
 ");
 
+            var m0 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M0");
             var m1 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M1");
             var m2 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M2");
             var m3 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M3");
@@ -224,6 +193,7 @@ class C
             var l3 = m3.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "l3").Initializer.
                 DescendantNodes().OfType<AnonymousFunctionExpressionSyntax>().Single();
 
+            Assert.True(SyntaxUtilities.IsAsyncDeclaration(m0.ExpressionBody));
             Assert.True(SyntaxUtilities.IsAsyncDeclaration(m1.ExpressionBody));
             Assert.True(SyntaxUtilities.IsAsyncDeclaration(m2));
             Assert.False(SyntaxUtilities.IsAsyncDeclaration(m3));
@@ -233,14 +203,67 @@ class C
             Assert.True(SyntaxUtilities.IsAsyncDeclaration(l2));
             Assert.True(SyntaxUtilities.IsAsyncDeclaration(l3));
 
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(m1.ExpressionBody).Length);
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(m2.Body).Length);
-            Assert.Equal(0, SyntaxUtilities.GetAwaitExpressions(m3.Body).Length);
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(f1.ExpressionBody).Length);
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(f2.Body).Length);
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(l1.Body).Length);
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(l2.Body).Length);
-            Assert.Equal(1, SyntaxUtilities.GetAwaitExpressions(l3.Body).Length);
+            Assert.Equal(0, SyntaxUtilities.GetSuspensionPoints(m0.ExpressionBody).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(m1.ExpressionBody).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(m2.Body).Count());
+            Assert.Equal(0, SyntaxUtilities.GetSuspensionPoints(m3.Body).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(f1.ExpressionBody).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(f2.Body).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(l1.Body).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(l2.Body).Count());
+            Assert.Equal(1, SyntaxUtilities.GetSuspensionPoints(l3.Body).Count());
+        }
+
+        [Fact]
+        public void GetSuspensionPoints()
+        {
+            var tree = SyntaxFactory.ParseSyntaxTree(@"
+class C
+{
+    IEnumerable<int> X = new[] { 1, 2, 3 };
+
+    IEnumerable<int> M1() { yield return 1; }
+    
+    void M2() 
+    {
+        IAsyncEnumerable<int> f() 
+        {
+            yield return 1;
+
+            yield break;
+
+            await Task.FromResult(1);
+
+            await foreach (var x in F()) { }
+
+            await foreach (var (x, y) in F()) { }
+
+            await using T x1 = F1(), x2 = F2(), x3 = F3();
+        }
+    }
+}
+");
+
+            var x = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(m => m.Identifier.ValueText == "X");
+            var m1 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M1");
+            var m2 = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single(m => m.Identifier.ValueText == "M2");
+            var f = m2.DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single(m => m.Identifier.ValueText == "f");
+
+            AssertEx.Empty(SyntaxUtilities.GetSuspensionPoints(x.Initializer));
+            AssertEx.Equal(new[] { "yield return 1;" }, SyntaxUtilities.GetSuspensionPoints(m1.Body).Select(n => n.ToString()));
+            AssertEx.Empty(SyntaxUtilities.GetSuspensionPoints(m2.Body));
+
+            AssertEx.Equal(new[]
+            {
+                "yield return 1;",
+                "yield break;",
+                "await Task.FromResult(1)",
+                "await foreach (var x in F()) { }",
+                "await foreach (var (x, y) in F()) { }",
+                "x1 = F1()",
+                "x2 = F2()",
+                "x3 = F3()",
+            }, SyntaxUtilities.GetSuspensionPoints(f.Body).Select(n => n.ToString()));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -2989,7 +2989,6 @@ class Test
 {
     public async Task<int> WaitAsync()
     {
-        await Task.Delay(1000);
         return 1;
     }
 }";
@@ -2998,14 +2997,12 @@ class Test
 {
     public Task<int> WaitAsync()
     {
-        await Task.Delay(1000);
-        return 1;
+        return Task.FromResult(1);
     }
 }";
             var edits = GetTopEdits(src1, src2);
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.Delete, "await", CSharpFeaturesResources.await_expression),
-                Diagnostic(RudeEditKind.ModifiersUpdate, "public Task<int> WaitAsync()", FeaturesResources.method));
+                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "public Task<int> WaitAsync()", FeaturesResources.method));
         }
 
         [Fact]
@@ -3579,7 +3576,7 @@ class C
 {
     static int F(int a) => a switch { 0 => 0, _ => 2 };
 }";
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
@@ -3635,7 +3632,7 @@ class C
             var src1 = "class C { void M() { F(1, a => a switch { 0 => 0, _ => 2 }); } }";
             var src2 = "class C { void M() { F(2, a => a switch { 0 => 0, _ => 2 }); } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics();
         }
@@ -3646,7 +3643,7 @@ class C
             var src1 = "class C { void M() { F(1, a => a switch { 0 => 0, _ => 2 }); } }";
             var src2 = "class C { void M() { F(2, a => a switch { 0 => 0, _ => 2 }); } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics();
         }
@@ -3657,7 +3654,7 @@ class C
             var src1 = "class C { void M() { F(1, delegate(int a) { return a switch { 0 => 0, _ => 2 }; }); } }";
             var src2 = "class C { void M() { F(2, delegate(int a) { return a switch { 0 => 0, _ => 2 }; }); } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics();
         }
@@ -3668,7 +3665,7 @@ class C
             var src1 = "class C { void M() { int f(int a) => a switch { 0 => 0, _ => 2 }; f(1); } }";
             var src2 = "class C { void M() { int f(int a) => a switch { 0 => 0, _ => 2 }; f(2); } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics();
         }
@@ -3679,7 +3676,7 @@ class C
             var src1 = "class C { void M() { var x = from z in new[] { 1, 2, 3 } where z switch { 0 => true, _ => false } select z + 1; } }";
             var src2 = "class C { void M() { var x = from z in new[] { 1, 2, 3 } where z switch { 0 => true, _ => false } select z + 2; } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifyRudeDiagnostics();
         }
@@ -5944,7 +5941,7 @@ public class C
             var src1 = "class C { int a = 1; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
             var src2 = "class C { int a = 2; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));
@@ -5994,7 +5991,7 @@ public class C
             var src1 = "class C { int a { get; } = 1; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
             var src2 = "class C { int a { get; } = 2; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));
@@ -6007,7 +6004,7 @@ public class C
             var src1 = "class C { int a { get; } = 1; public C() : this(1) { var b = a switch { 0 => 0, _ => 1 }; } public C(int a) { } }";
             var src2 = "class C { int a { get; } = 2; public C() : this(1) { var b = a switch { 0 => 0, _ => 1 }; } public C(int a) { } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics();
         }
@@ -6019,7 +6016,7 @@ public class C
             var src1 = "class C { int a { get; } = 1; public C() { } public C(int b) { var b = a switch { 0 => 0, _ => 1 }; } }";
             var src2 = "class C { int a { get; } = 2; public C() { } public C(int b) { var b = a switch { 0 => 0, _ => 1 }; } }";
 
-            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+            var edits = GetTopEdits(src1, src2);
 
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -3549,11 +3549,47 @@ class C
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.method));
         }
 
+        [Theory]
+        [InlineData("stackalloc int[3]")]
+        [InlineData("stackalloc int[3] { 1, 2, 3 }")]
+        [InlineData("stackalloc int[] { 1, 2, 3 }")]
+        [InlineData("stackalloc[] { 1, 2, 3 }")]
+        public void MethodUpdate_UpdateStackAlloc2(string stackallocDecl)
+        {
+            var src1 = @"unsafe class C { static int F() { var x = " + stackallocDecl + "; return 1; } }";
+            var src2 = @"unsafe class C { static int F() { var x = " + stackallocDecl + "; return 2; } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.method));
+        }
+
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [Fact]
+        public void MethodUpdate_UpdateSwitchExpression()
+        {
+            var src1 = @"
+class C
+{
+    static int F(int a) => a switch { 0 => 0, _ => 1 };
+}";
+            var src2 = @"
+class C
+{
+    static int F(int a) => a switch { 0 => 0, _ => 2 };
+}";
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.method));
+        }
+
         [Fact]
         public void MethodUpdate_UpdateStackAllocInLambda1()
         {
-            var src1 = "class C { void M() { F(1, () => { int* a = stackalloc int[10]; }); } }";
-            var src2 = "class C { void M() { F(2, () => { int* a = stackalloc int[10]; }); } }";
+            var src1 = "unsafe class C { void M() { F(1, () => { int* a = stackalloc int[10]; }); } }";
+            var src2 = "unsafe class C { void M() { F(2, () => { int* a = stackalloc int[10]; }); } }";
 
             var edits = GetTopEdits(src1, src2);
 
@@ -3563,10 +3599,87 @@ class C
         [Fact]
         public void MethodUpdate_UpdateStackAllocInLambda2()
         {
-            var src1 = "class C { void M() { F(1, x => { int* a = stackalloc int[10]; }); } }";
-            var src2 = "class C { void M() { F(2, x => { int* a = stackalloc int[10]; }); } }";
+            var src1 = "unsafe class C { void M() { F(1, x => { int* a = stackalloc int[10]; }); } }";
+            var src2 = "unsafe class C { void M() { F(2, x => { int* a = stackalloc int[10]; }); } }";
 
             var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_UpdateStackAllocInAnonymousMethod()
+        {
+            var src1 = "unsafe class C { void M() { F(1, delegate(int x) { int* a = stackalloc int[10]; }); } }";
+            var src2 = "unsafe class C { void M() { F(2, delegate(int x) { int* a = stackalloc int[10]; }); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_UpdateStackAllocInLocalFunction()
+        {
+            var src1 = "class C { void M() { unsafe void f(int x) { int* a = stackalloc int[10]; } f(1); } }";
+            var src2 = "class C { void M() { unsafe void f(int x) { int* a = stackalloc int[10]; } f(2); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_SwitchExpressionInLambda1()
+        {
+            var src1 = "class C { void M() { F(1, a => a switch { 0 => 0, _ => 2 }); } }";
+            var src2 = "class C { void M() { F(2, a => a switch { 0 => 0, _ => 2 }); } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_SwitchExpressionInLambda2()
+        {
+            var src1 = "class C { void M() { F(1, a => a switch { 0 => 0, _ => 2 }); } }";
+            var src2 = "class C { void M() { F(2, a => a switch { 0 => 0, _ => 2 }); } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_SwitchExpressionInAnonymousMethod()
+        {
+            var src1 = "class C { void M() { F(1, delegate(int a) { return a switch { 0 => 0, _ => 2 }; }); } }";
+            var src2 = "class C { void M() { F(2, delegate(int a) { return a switch { 0 => 0, _ => 2 }; }); } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_SwitchExpressionInLocalFunction()
+        {
+            var src1 = "class C { void M() { int f(int a) => a switch { 0 => 0, _ => 2 }; f(1); } }";
+            var src2 = "class C { void M() { int f(int a) => a switch { 0 => 0, _ => 2 }; f(2); } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void MethodUpdate_SwitchExpressionInQuery()
+        {
+            var src1 = "class C { void M() { var x = from z in new[] { 1, 2, 3 } where z switch { 0 => true, _ => false } select z + 1; } }";
+            var src2 = "class C { void M() { var x = from z in new[] { 1, 2, 3 } where z switch { 0 => true, _ => false } select z + 2; } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
 
             edits.VerifyRudeDiagnostics();
         }
@@ -5824,6 +5937,19 @@ public class C
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
         }
 
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [Fact]
+        public void FieldInitializerUpdate_SwitchExpressionInConstructor()
+        {
+            var src1 = "class C { int a = 1; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
+            var src2 = "class C { int a = 2; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));
+        }
+
         [Fact]
         public void PropertyInitializerUpdate_StackAllocInConstructor1()
         {
@@ -5859,6 +5985,44 @@ public class C
             // TODO (tomat): diagnostic should point to the property initializer
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", FeaturesResources.constructor));
+        }
+
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [Fact]
+        public void PropertyInitializerUpdate_SwitchExpressionInConstructor1()
+        {
+            var src1 = "class C { int a { get; } = 1; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
+            var src2 = "class C { int a { get; } = 2; public C() { var b = a switch { 0 => 0, _ => 1 }; } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));
+        }
+
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [Fact]
+        public void PropertyInitializerUpdate_SwitchExpressionInConstructor2()
+        {
+            var src1 = "class C { int a { get; } = 1; public C() : this(1) { var b = a switch { 0 => 0, _ => 1 }; } public C(int a) { } }";
+            var src2 = "class C { int a { get; } = 2; public C() : this(1) { var b = a switch { 0 => 0, _ => 1 }; } public C(int a) { } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifySemanticDiagnostics();
+        }
+
+        [WorkItem(37172, "https://github.com/dotnet/roslyn/issues/37172")]
+        [Fact]
+        public void PropertyInitializerUpdate_SwitchExpressionInConstructor3()
+        {
+            var src1 = "class C { int a { get; } = 1; public C() { } public C(int b) { var b = a switch { 0 => 0, _ => 1 }; } }";
+            var src2 = "class C { int a { get; } = 2; public C() { } public C(int b) { var b = a switch { 0 => 0, _ => 1 }; } }";
+
+            var edits = GetTopEdits(src1, src2, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.SwitchExpressionUpdate, "switch", FeaturesResources.constructor));
         }
 
         [Fact]

--- a/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RudeEditDiagnosticTests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 RudeEditKind.AccessingCapturedVariableInLambda,
                 RudeEditKind.NotAccessingCapturedVariableInLambda,
                 RudeEditKind.RenamingCapturedVariable,
+                RudeEditKind.ChangingStateMachineShape,
                 RudeEditKind.InternalError,
             };
 

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             var diagnostics = new List<RudeEditDiagnostic>();
             var editMap = Analyzer.BuildEditMap(editScript);
 
-            var triviaEdits = new List<KeyValuePair<SyntaxNode, SyntaxNode>>();
+            var triviaEdits = new List<(SyntaxNode OldNode, SyntaxNode NewNode)>();
             var actualLineEdits = new List<LineChange>();
 
             Analyzer.GetTestAccessor().AnalyzeTrivia(
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             AssertEx.Equal(expectedLineEdits, actualLineEdits, itemSeparator: ",\r\n");
 
-            var actualNodeUpdates = triviaEdits.Select(e => e.Value.ToString().ToLines().First());
+            var actualNodeUpdates = triviaEdits.Select(e => e.NewNode.ToString().ToLines().First());
             AssertEx.Equal(expectedNodeUpdates, actualNodeUpdates, itemSeparator: ",\r\n");
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             var oldActiveStatements = activeStatements.OldStatements.AsImmutable();
             var updatedActiveMethodMatches = new List<AbstractEditAndContinueAnalyzer.UpdatedMemberInfo>();
-            var triviaEdits = new List<KeyValuePair<SyntaxNode, SyntaxNode>>();
+            var triviaEdits = new List<(SyntaxNode OldNode, SyntaxNode NewNode)>();
             var actualLineEdits = new List<LineChange>();
             var actualSemanticEdits = new List<SemanticEdit>();
             var diagnostics = new List<RudeEditDiagnostic>();

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -437,7 +437,7 @@ End Class
 
         <Fact>
         Public Sub Delete_Inner_ElseIf1()
-            Dim src1 = <![CDATA[
+            Dim src1 = "
 Class C 
     Shared Sub Main()
         If c1 Then
@@ -453,9 +453,9 @@ Class C
         <AS:0>Console.WriteLine(a)</AS:0>
     End Sub
 End Class
-]]>.Value
+"
 
-            Dim src2 = <![CDATA[
+            Dim src2 = "
 Class C 
     Shared Sub Main()
         If c1 Then
@@ -469,7 +469,7 @@ Class C
         <AS:0>Console.WriteLine(a)</AS:0>
     End Sub
 End Class
-]]>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
             Dim active = GetActiveStatements(src1, src2)
             edits.VerifyRudeDiagnostics(active,
@@ -4915,6 +4915,33 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub MethodToIteratorMethod_WithActiveStatement_NoYield()
+            Dim src1 = "
+Imports System
+Imports System.Collections.Generic
+Class C
+    Function F() As IEnumerable(Of Integer)
+        <AS:0>Console.WriteLine(1)</AS:0>
+    End Function
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Collections.Generic
+Class C
+    Iterator Function F() As IEnumerable(Of Integer)
+        <AS:0>Console.WriteLine(1)</AS:0>
+    End Function
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "Iterator Function F()"))
+        End Sub
+
+        <Fact>
         Public Sub MethodToIteratorMethod_WithActiveStatementInLambda()
             Dim src1 = "
 Imports System
@@ -5230,6 +5257,193 @@ End Class
             Dim active = GetActiveStatements(src1, src2)
 
             edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub LambdaToAsyncLambda_WithActiveStatement_NoAwait()
+            Dim src1 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Sub F()
+        Dim f = Sub() <AS:0>Console.WriteLine(1)</AS:0>
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Sub F()
+        Dim f = Async Sub() <AS:0>Console.WriteLine(1)</AS:0>
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "Async Sub()"))
+        End Sub
+
+        <Fact>
+        Public Sub LambdaToAsyncLambda_WithActiveStatement_NoAwait_Nested1()
+            Dim src1 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Sub F()
+        Dim f = Function(a) <AS:0>Function(b) a + b</AS:0>
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Sub F()
+        Dim f = Async Function(a) <AS:0>Function(b) a + b</AS:0>
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            ' Rude edit since the AS is within the outer function.
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "Async Function(a)"))
+        End Sub
+
+        <Fact>
+        Public Sub LambdaToAsyncLambda_WithActiveStatement_NoAwait_Nested2()
+            Dim src1 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Sub F()
+        Dim f = Function(a) <AS:0>Function(b)</AS:0> a + b
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Sub F()
+        Dim f = Async Function(a) <AS:0>Function(b)</AS:0> a + b
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            ' No rude edit since the AS is within the nested function.
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub LambdaToIteratorLambda_WithActiveStatement_NoYield()
+            Dim src1 = "
+Class C
+    Function G() As IEnumerable(Of Integer)
+        Return Nothing
+    End Function
+ 
+    Sub F()
+        Dim f = Function() <AS:0>G()</AS:0>
+    End Sub
+End Class
+"
+            Dim src2 = "
+Class C
+    Function G() As IEnumerable(Of Integer)
+        Return Nothing
+    End Function
+ 
+    Sub F()
+        Dim f = <AS:0>Iterator Function()</AS:0>
+                  G()
+                End Function
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.UpdatingStateMachineMethodAroundActiveStatement, "Iterator Function()"))
+        End Sub
+
+        <Fact>
+        Public Sub AsyncLambdaToLambda_WithoutActiveStatement_NoAwait()
+            Dim src1 = "
+Class C
+    Function G() As Task(Of Integer)
+        Return Nothing
+    End Function
+ 
+    Sub F()
+        Dim f = Async Function() As Task(Of Integer)
+                End Function
+    End Sub
+End Class
+"
+            Dim src2 = "
+Class C
+    Function G() As Task(Of Integer)
+        Return Nothing
+    End Function
+ 
+    Sub F()
+        Dim f = Function() As Task(Of Integer)
+                  Return G()
+                End Function
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "Function() As Task(Of Integer)", VBFeaturesResources.Lambda))
+        End Sub
+
+        <Fact>
+        Public Sub IteratorLambdaToLambda_WithoutActiveStatement_NoYield()
+            Dim src1 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Function G() As IEnumerable(Of Integer)
+        Return Nothing
+    End Function
+ 
+    Sub F()
+        Dim f = Iterator Function() As IEnumerable(Of Integer)
+                End Function
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Function G() As IEnumerable(Of Integer)
+        Return Nothing
+    End Function
+ 
+    Sub F()
+        Dim f = Function() As IEnumerable(Of Integer)
+                  Return G()
+                End Function
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active,
+                Diagnostic(RudeEditKind.ModifiersUpdate, "Function() As IEnumerable(Of Integer)", VBFeaturesResources.Lambda))
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/BreakpointSpansTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/BreakpointSpansTests.vb
@@ -85,7 +85,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             Dim lastSpanEnd = 0
             While position < endPosition
                 Dim span As TextSpan = Nothing
-                If BreakpointSpans.TryGetEnclosingBreakpointSpan(root, position, span) AndAlso span.End > lastSpanEnd Then
+                If BreakpointSpans.TryGetEnclosingBreakpointSpan(root, position, minLength:=0, span) AndAlso span.End > lastSpanEnd Then
                     position = span.End
                     lastSpanEnd = span.End
                     Yield span
@@ -2109,6 +2109,16 @@ End Class</text>)
 Class C
   Sub Goo()
     Console.WriteLine([|$$Async Function()|] x + x)
+  End Sub
+End Class</text>)
+        End Sub
+
+        <Fact>
+        Public Sub Lambda_SingleLine_Header_Nested()
+            TestSpan(<text>
+Class C
+  Sub Goo()
+    Dim x = Function(a) [|$$Function(b)|] a + b
   End Sub
 End Class</text>)
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -1922,7 +1922,36 @@ End Class
                 "Update [Async Function F() As Task(Of String)]@11 -> [Function F() As Task(Of String)]@11")
 
             edits.VerifyRudeDiagnostics(
-                Diagnostic(RudeEditKind.ModifiersUpdate, "Function F()", FeaturesResources.method))
+                Diagnostic(RudeEditKind.ChangingFromAsynchronousToSynchronous, "Function F()", FeaturesResources.method))
+        End Sub
+
+        <Fact>
+        Public Sub MethodUpdate_IteratorModifier1()
+            Dim src1 = "Class C : " & vbLf & "Function F() As Task(Of String) : End Function : End Class"
+            Dim src2 = "Class C : " & vbLf & "Iterator Function F() As Task(Of String) : End Function : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Function F() As Task(Of String) : End Function]@11 -> [Iterator Function F() As Task(Of String) : End Function]@11",
+                "Update [Function F() As Task(Of String)]@11 -> [Iterator Function F() As Task(Of String)]@11")
+
+            edits.VerifyRudeDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub MethodUpdate_IteratorModifier2()
+            Dim src1 = "Class C : " & vbLf & "Iterator Function F() As Task(Of String) : End Function : End Class"
+            Dim src2 = "Class C : " & vbLf & "Function F() As Task(Of String) : End Function : End Class"
+
+            Dim edits = GetTopEdits(src1, src2)
+
+            edits.VerifyEdits(
+                "Update [Iterator Function F() As Task(Of String) : End Function]@11 -> [Function F() As Task(Of String) : End Function]@11",
+                "Update [Iterator Function F() As Task(Of String)]@11 -> [Function F() As Task(Of String)]@11")
+
+            edits.VerifyRudeDiagnostics(
+                 Diagnostic(RudeEditKind.ModifiersUpdate, "Function F()", FeaturesResources.method))
         End Sub
 
         <Fact>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -1268,6 +1268,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to switch statement.
+        /// </summary>
+        internal static string switch_statement {
+            get {
+                return ResourceManager.GetString("switch_statement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to switch statement case clause.
+        /// </summary>
+        internal static string switch_statement_case_clause {
+            get {
+                return ResourceManager.GetString("switch_statement_case_clause", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name &apos;{0}&apos; does not exist in the current context..
         /// </summary>
         internal static string The_name_0_does_not_exist_in_the_current_context {
@@ -1509,15 +1527,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string using_statement {
             get {
                 return ResourceManager.GetString("using_statement", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to C# 7 enhanced switch statement.
-        /// </summary>
-        internal static string v7_switch {
-            get {
-                return ResourceManager.GetString("v7_switch", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -800,6 +800,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to local variable declaration.
+        /// </summary>
+        internal static string local_variable_declaration {
+            get {
+                return ResourceManager.GetString("local_variable_declaration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to lock statement.
         /// </summary>
         internal static string lock_statement {
@@ -1423,6 +1432,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to using declaration.
+        /// </summary>
+        internal static string using_declaration {
+            get {
+                return ResourceManager.GetString("using_declaration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to using directive.
         /// </summary>
         internal static string using_directive {
@@ -1513,11 +1531,20 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to yield statement.
+        ///   Looks up a localized string similar to yield break statement.
         /// </summary>
-        internal static string yield_statement {
+        internal static string yield_break_statement {
             get {
-                return ResourceManager.GetString("yield_statement", resourceCulture);
+                return ResourceManager.GetString("yield_break_statement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to yield return statement.
+        /// </summary>
+        internal static string yield_return_statement {
+            get {
+                return ResourceManager.GetString("yield_return_statement", resourceCulture);
             }
         }
     }

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -232,6 +232,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to asynchronous foreach statement.
+        /// </summary>
+        internal static string asynchronous_foreach_statement {
+            get {
+                return ResourceManager.GetString("asynchronous_foreach_statement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to asynchronous using declaration.
+        /// </summary>
+        internal static string asynchronous_using_declaration {
+            get {
+                return ResourceManager.GetString("asynchronous_using_declaration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to attribute target.
         /// </summary>
         internal static string attribute_target {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -316,6 +316,18 @@
     <value>foreach statement</value>
     <comment>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</comment>
   </data>
+  <data name="asynchronous_foreach_statement" xml:space="preserve">
+    <value>asynchronous foreach statement</value>
+    <comment>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</comment>
+  </data>
+  <data name="using_declaration" xml:space="preserve">
+    <value>using declaration</value>
+    <comment>{Locked="using"} "using" is a C# keyword and should not be localized.</comment>
+  </data>
+  <data name="asynchronous_using_declaration" xml:space="preserve">
+    <value>asynchronous using declaration</value>
+    <comment>{Locked="using"} "using" is a C# keyword and should not be localized.</comment>
+  </data>
   <data name="checked_statement" xml:space="preserve">
     <value>checked statement</value>
     <comment>{Locked="checked"} "checked" is a C# keyword and should not be localized.</comment>
@@ -640,8 +652,5 @@
   </data>
   <data name="local_variable_declaration" xml:space="preserve">
     <value>local variable declaration</value>
-  </data>
-  <data name="using_declaration" xml:space="preserve">
-    <value>using declaration</value>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -324,9 +324,13 @@
     <value>unchecked statement</value>
     <comment>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</comment>
   </data>
-  <data name="yield_statement" xml:space="preserve">
-    <value>yield statement</value>
-    <comment>{Locked="yield"} "yield" is a C# keyword and should not be localized.</comment>
+  <data name="yield_return_statement" xml:space="preserve">
+    <value>yield return statement</value>
+    <comment>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</comment>
+  </data>
+  <data name="yield_break_statement" xml:space="preserve">
+    <value>yield break statement</value>
+    <comment>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</comment>
   </data>
   <data name="await_expression" xml:space="preserve">
     <value>await expression</value>
@@ -633,5 +637,11 @@
   </data>
   <data name="_0_may_be_null_here" xml:space="preserve">
     <value>'{0}' may be null here.</value>
+  </data>
+  <data name="local_variable_declaration" xml:space="preserve">
+    <value>local variable declaration</value>
+  </data>
+  <data name="using_declaration" xml:space="preserve">
+    <value>using declaration</value>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -409,8 +409,9 @@
     <value>ref local or expression</value>
     <comment>{Locked="ref"} "ref" is a C# keyword and should not be localized.</comment>
   </data>
-  <data name="v7_switch" xml:space="preserve">
-    <value>C# 7 enhanced switch statement</value>
+  <data name="switch_statement" xml:space="preserve">
+    <value>switch statement</value>
+    <comment>{Locked="switch"} "switch" is a C# keyword and should not be localized.</comment>
   </data>
   <data name="global_statement" xml:space="preserve">
     <value>global statement</value>
@@ -652,5 +653,9 @@
   </data>
   <data name="local_variable_declaration" xml:space="preserve">
     <value>local variable declaration</value>
+  </data>
+  <data name="switch_statement_case_clause" xml:space="preserve">
+    <value>switch statement case clause</value>
+    <comment>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</comment>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -247,8 +247,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return bodyOrMatchRoot;
         }
 
-        protected override SyntaxNode FindStatementAndPartner(SyntaxNode declarationBody, int position, SyntaxNode partnerDeclarationBodyOpt, out SyntaxNode partnerOpt, out int statementPart)
+        protected override SyntaxNode FindStatementAndPartner(SyntaxNode declarationBody, TextSpan span, SyntaxNode partnerDeclarationBodyOpt, out SyntaxNode partnerOpt, out int statementPart)
         {
+            int position = span.Start;
+
             SyntaxUtilities.AssertIsBody(declarationBody, allowLambda: false);
 
             if (position < declarationBody.SpanStart)
@@ -629,7 +631,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return BreakpointSpans.TryGetClosestBreakpointSpan(root, position, out span);
         }
 
-        protected override bool TryGetActiveSpan(SyntaxNode node, int statementPart, out TextSpan span)
+        protected override bool TryGetActiveSpan(SyntaxNode node, int statementPart, int minLength, out TextSpan span)
         {
             switch (node.Kind())
             {

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1729,6 +1729,23 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
+        protected override string GetSuspensionPointDisplayName(SyntaxNode node, EditKind editKind)
+        {
+            switch (node.Kind())
+            {
+                case SyntaxKind.ForEachStatement:
+                    Debug.Assert(((CommonForEachStatementSyntax)node).AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword));
+                    return CSharpFeaturesResources.asynchronous_foreach_statement;
+
+                case SyntaxKind.VariableDeclarator:
+                    Debug.Assert(((LocalDeclarationStatementSyntax)node.Parent.Parent).AwaitKeyword.IsKind(SyntaxKind.AwaitKeyword));
+                    return CSharpFeaturesResources.asynchronous_using_declaration;
+
+                default:
+                    return base.GetSuspensionPointDisplayName(node, editKind);
+            }
+        }
+
         #endregion
 
         #region Top-Level Syntactic Rude Edits
@@ -3121,7 +3138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     newLocalDeclaration.AwaitKeyword.Span,
                     newLocalDeclaration,
                     new[] { newLocalDeclaration.AwaitKeyword.ToString() }));
-
+                
                 return;
             }
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1303,6 +1303,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.StackAllocArrayCreationExpression:
                     return ((StackAllocArrayCreationExpressionSyntax)node).StackAllocKeyword.Span;
 
+                case SyntaxKind.ImplicitStackAllocArrayCreationExpression:
+                    return ((ImplicitStackAllocArrayCreationExpressionSyntax)node).StackAllocKeyword.Span;
+
                 case SyntaxKind.TryStatement:
                     return ((TryStatementSyntax)node).TryKeyword.Span;
 
@@ -1439,6 +1442,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.SingleVariableDesignation:
                 case SyntaxKind.CasePatternSwitchLabel:
                     return node.Span;
+
+                case SyntaxKind.SwitchExpression:
+                    return ((SwitchExpressionSyntax)node).SwitchKeyword.Span;
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(kind);
@@ -2836,21 +2842,20 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             public void ClassifyDeclarationBodyRudeUpdates(SyntaxNode newDeclarationOrBody)
             {
-                foreach (var node in newDeclarationOrBody.DescendantNodesAndSelf(ChildrenCompiledInBody))
+                foreach (var node in newDeclarationOrBody.DescendantNodesAndSelf(LambdaUtilities.IsNotLambda))
                 {
                     switch (node.Kind())
                     {
                         case SyntaxKind.StackAllocArrayCreationExpression:
+                        case SyntaxKind.ImplicitStackAllocArrayCreationExpression:
                             ReportError(RudeEditKind.StackAllocUpdate, node, _newNode);
                             return;
+
+                        case SyntaxKind.SwitchExpression:
+                            ReportError(RudeEditKind.SwitchExpressionUpdate, node, _newNode);
+                            break;
                     }
                 }
-            }
-
-            private static bool ChildrenCompiledInBody(SyntaxNode node)
-            {
-                return node.Kind() != SyntaxKind.ParenthesizedLambdaExpression
-                    && node.Kind() != SyntaxKind.SimpleLambdaExpression;
             }
 
             #endregion

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -1021,7 +1021,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return true;
         }
 
-        // doesn't include variables declared in declaration expressions
+        // Doesn't include variables declared in declaration expressions
+        // Consider including them (https://github.com/dotnet/roslyn/issues/37460).
         private static void GetLocalNames(BlockSyntax block, ref List<SyntaxToken> result)
         {
             foreach (var child in block.ChildNodes())
@@ -1033,7 +1034,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
-        // doesn't include variables declared in declaration expressions
+        // Doesn't include variables declared in declaration expressions
+        // Consider including them (https://github.com/dotnet/roslyn/issues/37460).
         private static void GetLocalNames(VariableDeclarationSyntax localDeclaration, ref List<SyntaxToken> result)
         {
             foreach (var local in localDeclaration.Variables)

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
 
@@ -456,15 +457,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.TypeArgumentList:
                 case SyntaxKind.AliasQualifiedName:
                 case SyntaxKind.PredefinedType:
-                case SyntaxKind.ArrayType:
-                case SyntaxKind.ArrayRankSpecifier:
                 case SyntaxKind.PointerType:
                 case SyntaxKind.NullableType:
                 case SyntaxKind.TupleType:
                 case SyntaxKind.RefType:
                 case SyntaxKind.OmittedTypeArgument:
                 case SyntaxKind.NameColon:
-                case SyntaxKind.StackAllocArrayCreationExpression:
                 case SyntaxKind.OmittedArraySizeExpression:
                 case SyntaxKind.ThisExpression:
                 case SyntaxKind.BaseExpression:

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxUtilities.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 {
@@ -227,30 +229,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return null;
         }
 
-        public static bool IsMethod(SyntaxNode declaration)
-        {
-            switch (declaration.Kind())
-            {
-                case SyntaxKind.MethodDeclaration:
-                case SyntaxKind.ConversionOperatorDeclaration:
-                case SyntaxKind.OperatorDeclaration:
-                case SyntaxKind.SetAccessorDeclaration:
-                case SyntaxKind.AddAccessorDeclaration:
-                case SyntaxKind.RemoveAccessorDeclaration:
-                case SyntaxKind.GetAccessorDeclaration:
-                case SyntaxKind.ConstructorDeclaration:
-                case SyntaxKind.DestructorDeclaration:
-                    return true;
-
-                case SyntaxKind.IndexerDeclaration:
-                    // expression bodied indexer
-                    return ((IndexerDeclarationSyntax)declaration).ExpressionBody != null;
-
-                default:
-                    return false;
-            }
-        }
-
         public static bool IsParameterlessConstructor(SyntaxNode declaration)
         {
             if (!declaration.IsKind(SyntaxKind.ConstructorDeclaration))
@@ -274,26 +252,29 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 && property.AccessorList.Accessors.Any(e => e.Body == null);
         }
 
-        public static bool IsAsyncMethodOrLambda(SyntaxNode declaration)
+        /// <summary>
+        /// True if the specified declaration node is an async method, anonymous function, lambda, local function.
+        /// </summary>
+        public static bool IsAsyncDeclaration(SyntaxNode declaration)
         {
+            // lambdas and anonymous functions
             if (declaration is AnonymousFunctionExpressionSyntax anonymousFunction)
             {
                 return anonymousFunction.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword);
             }
 
-            // expression bodied methods:
+            // expression bodied methods/local functions:
             if (declaration.IsKind(SyntaxKind.ArrowExpressionClause))
             {
                 declaration = declaration.Parent;
             }
 
-            if (!declaration.IsKind(SyntaxKind.MethodDeclaration))
+            return declaration switch
             {
-                return false;
-            }
-
-            var method = (MethodDeclarationSyntax)declaration;
-            return method.Modifiers.Any(SyntaxKind.AsyncKeyword);
+                MethodDeclarationSyntax method => method.Modifiers.Any(SyntaxKind.AsyncKeyword),
+                LocalFunctionStatementSyntax localFunction => localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword),
+                _ => false
+            };
         }
 
         public static ImmutableArray<SyntaxNode> GetAwaitExpressions(SyntaxNode body)
@@ -305,27 +286,38 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         public static ImmutableArray<SyntaxNode> GetYieldStatements(SyntaxNode body)
         {
             // lambdas and expression-bodied methods can't be iterators:
-            if (!body.Parent.IsKind(SyntaxKind.MethodDeclaration))
+            if (!body.Parent.IsKind(SyntaxKind.MethodDeclaration) &&
+                !body.Parent.IsKind(SyntaxKind.LocalFunctionStatement))
             {
                 return ImmutableArray<SyntaxNode>.Empty;
             }
 
             // enumerate statements:
-            return ImmutableArray.CreateRange(body.DescendantNodes(n => !(n is ExpressionSyntax))
-                   .Where(n => n.IsKind(SyntaxKind.YieldBreakStatement) || n.IsKind(SyntaxKind.YieldReturnStatement)));
+            return EnumerateYieldStatements(body).ToImmutableArray();
         }
 
-        public static bool IsIteratorMethod(SyntaxNode declaration)
+        public static bool IsIteratorDeclaration(SyntaxNode declaration)
         {
-            // lambdas and expression-bodied methods can't be iterators:
-            if (!declaration.IsKind(SyntaxKind.MethodDeclaration))
+            // lambdas and expression-bodied methods/functions can't be iterators:
+            var blockBody = declaration switch
             {
-                return false;
-            }
+                MethodDeclarationSyntax method => method.Body,
+                LocalFunctionStatementSyntax localFunction => localFunction.Body,
+                _ => null
+            };
 
-            // enumerate statements:
-            return declaration.DescendantNodes(n => !(n is ExpressionSyntax))
-                   .Any(n => n.IsKind(SyntaxKind.YieldBreakStatement) || n.IsKind(SyntaxKind.YieldReturnStatement));
+            return blockBody != null && EnumerateYieldStatements(blockBody).Any();
+        }
+
+        private static IEnumerable<SyntaxNode> EnumerateYieldStatements(SyntaxNode body)
+        {
+            foreach (var descendant in body.DescendantNodes(n => !(n is ExpressionSyntax) && !n.IsKind(SyntaxKind.LocalFunctionStatement)))
+            {
+                if (descendant.IsKind(SyntaxKind.YieldBreakStatement) || descendant.IsKind(SyntaxKind.YieldReturnStatement))
+                {
+                    yield return descendant;
+                }
+            }
         }
     }
 }

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">Příkaz if lze zjednodušit.</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Automatický výběr je zakázaný kvůli možné deklaraci lambda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;název členu&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">příkaz fixed</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">příkaz using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">příkaz unchecked</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">příkaz yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.cs.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Direktiva Using není potřebná.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">blok try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">lokální proměnná podle odkazu nebo odkaz</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">příkaz switch s rozšířením C# 7</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">Die If-Anweisung kann vereinfacht werden.</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Automatische Auswahl aufgrund einer potenziellen Lambdadeklaration deaktiviert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;Membername&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">fixed-Anweisung</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">Using-Anweisung</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">unchecked-Anweisung</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">yield-Anweisung</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.de.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Using-Direktive ist unnötig.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try-Block</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">Lokaler Verweis oder Ausdruck</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">Erweiterte C# 7 switch-Anweisung</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -407,6 +407,16 @@
         <target state="translated">El uso de la directiva no es necesario.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">bloque try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref local o expresión</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">Instrucción switch de C# 7 mejorada</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">La instrucción "if" se puede simplificar</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.es.xlf
@@ -172,6 +172,11 @@
         <target state="translated">La selección automática se ha deshabilitado debido posiblemente a una declaración lambda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;nombre&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">instrucción fija</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">instrucción using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">instrucción sin activar</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">instrucción yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">L'instruction 'if' peut être simplifiée</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Sélection automatique désactivée en raison d'une déclaration lambda éventuelle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;nom de membre&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">instruction fixed</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">instruction using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">instruction unchecked</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">instruction yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.fr.xlf
@@ -407,6 +407,16 @@
         <target state="translated">La directive using n'est pas nécessaire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">bloc try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">variable locale ou expression ref</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">instruction switch améliorée C# 7</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">L'istruzione 'If' può essere semplificata</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -407,6 +407,16 @@
         <target state="translated">La direttiva using non è necessaria.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">blocco try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">variabile locale ref o espressione</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">istruzione switch migliorata di C# 7</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.it.xlf
@@ -172,6 +172,11 @@
         <target state="translated">La selezione automatica è disabilitata a causa di una potenziale dichiarazione lambda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;nome membro&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">istruzione fixed</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">istruzione using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">istruzione unchecked</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">istruzione yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Using ディレクティブは必要ありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try ブロック</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">ref ローカルまたは式</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">C# 7 拡張 switch ステートメント</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">'if' ステートメントは簡素化できます</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ja.xlf
@@ -172,6 +172,11 @@
         <target state="translated">ラムダが宣言された可能性があるため、自動選択は無効になっています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;メンバー名&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">fixed ステートメント</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">using ステートメント</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">未確認のステートメント</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">yield ステートメント</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -172,6 +172,11 @@
         <target state="translated">람다 선언이 있을 수 있어 자동 선택을 사용하지 않도록 설정했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;멤버 이름&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">fixed 문</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">using 문</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">unchecked 문</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">yield 문</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">'if' 문을 간단하게 줄일 수 있습니다.</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ko.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Using 지시문은 필요하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try 블록</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">참조 로컬 또는 식</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">C# 7 향상된 switch 문</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Dyrektywa using jest niepotrzebna.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">blok try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">odwołanie lokalne lub wyrażenie</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">Ulepszona instrukcja switch C# 7</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">Instrukcja „if” może zostać uproszczona</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pl.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Automatyczne zaznaczanie zostało wyłączone z powodu możliwej deklaracji lambda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;nazwa składowej&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">instrukcja fixed</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">instrukcja using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">instrukcja unchecked</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">instrukcja yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Seleção automática desabilitada devido à possível declaração lambda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;nome do membro&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">instrução fixa</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">instrução using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">instrução não verificada</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">instrução yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -407,6 +407,16 @@
         <target state="translated">O uso da diretiva é desnecessário.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">bloco try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">local ou expressão de ref.</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">C# 7 avançado com instrução de comutador</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.pt-BR.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">A instrução 'if' pode ser simplificada</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Автовыбор отключен из-за возможного объявления лямбды.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;имя члена&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">оператор fixed</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">оператор using</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">оператор unchecked</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">оператор yield</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Директива using не нужна.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">блок try</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">локальная ссылка или выражение</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">Улучшенный оператор switch C# 7</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.ru.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">Оператор if можно упростить</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Otomatik seçim, olası lambda bildirimi nedeniyle devre dışı bırakıldı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt; üye adı &gt; = </target>
@@ -417,6 +422,11 @@
         <target state="translated">fixed deyimi</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">using deyimi</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">unchecked deyimi</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">yield deyimi</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Using yönergesi gerekli değildir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try bloğu</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">yerel başvuru veya ifade</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">C# 7 geliştirilmiş switch ifadesi</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.tr.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">'If' deyimi basitleştirilebilir</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">可简化“If”语句</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -407,6 +407,16 @@
         <target state="translated">Using 指令是不需要的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try 块</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">引用本地函数或表达式</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">C# 7 增强的 switch 语句</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hans.xlf
@@ -172,6 +172,11 @@
         <target state="translated">由于可能出现 lambda 声明，已禁用自动选择。</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;成员名称&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">fixed 语句</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">using 语句</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">unchecked 语句</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">yield 语句</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -157,6 +157,16 @@
         <target state="new">'{0}' may be null here.</target>
         <note />
       </trans-unit>
+      <trans-unit id="asynchronous_foreach_statement">
+        <source>asynchronous foreach statement</source>
+        <target state="new">asynchronous foreach statement</target>
+        <note>{Locked="foreach"} "foreach" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="asynchronous_using_declaration">
+        <source>asynchronous using declaration</source>
+        <target state="new">asynchronous using declaration</target>
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="if_statement_can_be_simplified">
         <source>'if' statement can be simplified</source>
         <target state="translated">'if' 陳述式可簡化</target>
@@ -425,7 +435,7 @@
       <trans-unit id="using_declaration">
         <source>using declaration</source>
         <target state="new">using declaration</target>
-        <note />
+        <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -172,6 +172,11 @@
         <target state="translated">由於可能的 Lambda 宣告，所以停用自動選取。</target>
         <note />
       </trans-unit>
+      <trans-unit id="local_variable_declaration">
+        <source>local variable declaration</source>
+        <target state="new">local variable declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="member_name">
         <source>&lt;member name&gt; = </source>
         <target state="translated">&lt;成員名稱&gt; =</target>
@@ -417,6 +422,11 @@
         <target state="translated">fixed 陳述式</target>
         <note>{Locked="fixed"} "fixed" is a C# keyword and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="using_declaration">
+        <source>using declaration</source>
+        <target state="new">using declaration</target>
+        <note />
+      </trans-unit>
       <trans-unit id="using_statement">
         <source>using statement</source>
         <target state="translated">using 陳述式</target>
@@ -441,11 +451,6 @@
         <source>unchecked statement</source>
         <target state="translated">unchecked 陳述式</target>
         <note>{Locked="unchecked"} "unchecked" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="yield_statement">
-        <source>yield statement</source>
-        <target state="translated">yield 陳述式</target>
-        <note>{Locked="yield"} "yield" is a C# keyword and should not be localized.</note>
       </trans-unit>
       <trans-unit id="await_expression">
         <source>await expression</source>
@@ -806,6 +811,16 @@
         <source>Warning: Moving using directives may change code meaning.</source>
         <target state="new">Warning: Moving using directives may change code meaning.</target>
         <note>{Locked="using"} "using" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_break_statement">
+        <source>yield break statement</source>
+        <target state="new">yield break statement</target>
+        <note>{Locked="yield break"} "yield break" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="yield_return_statement">
+        <source>yield return statement</source>
+        <target state="new">yield return statement</target>
+        <note>{Locked="yield return"} "yield return" is a C# keyword and should not be localized.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
+++ b/src/Features/CSharp/Portable/xlf/CSharpFeaturesResources.zh-Hant.xlf
@@ -407,6 +407,16 @@
         <target state="translated">無須使用指示詞。</target>
         <note />
       </trans-unit>
+      <trans-unit id="switch_statement">
+        <source>switch statement</source>
+        <target state="new">switch statement</target>
+        <note>{Locked="switch"} "switch" is a C# keyword and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="switch_statement_case_clause">
+        <source>switch statement case clause</source>
+        <target state="new">switch statement case clause</target>
+        <note>{Locked="switch"}{Locked="case"} "switch" and "case" are a C# keyword and should not be localized.</note>
+      </trans-unit>
       <trans-unit id="try_block">
         <source>try block</source>
         <target state="translated">try 區塊</target>
@@ -551,11 +561,6 @@
         <source>ref local or expression</source>
         <target state="translated">參考本機或運算式</target>
         <note>{Locked="ref"} "ref" is a C# keyword and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="v7_switch">
-        <source>C# 7 enhanced switch statement</source>
-        <target state="translated">C# 7 增強的 switch 陳述式</target>
-        <note />
       </trans-unit>
       <trans-unit id="global_statement">
         <source>global statement</source>

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1793,7 +1793,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected void ReportUnmatchedStatements<TSyntaxNode>(
             List<RudeEditDiagnostic> diagnostics,
             Match<SyntaxNode> match,
-            int[] syntaxKinds,
+            Func<SyntaxNode, bool> nodeSelector,
             SyntaxNode oldActiveStatement,
             SyntaxNode newActiveStatement,
             Func<TSyntaxNode, TSyntaxNode, bool> areEquivalent,
@@ -1801,8 +1801,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             where TSyntaxNode : SyntaxNode
         {
             List<SyntaxNode> oldNodes = null, newNodes = null;
-            GetAncestors(GetEncompassingAncestor(match.OldRoot), oldActiveStatement, syntaxKinds, ref oldNodes);
-            GetAncestors(GetEncompassingAncestor(match.NewRoot), newActiveStatement, syntaxKinds, ref newNodes);
+            GetAncestors(GetEncompassingAncestor(match.OldRoot), oldActiveStatement, nodeSelector, ref oldNodes);
+            GetAncestors(GetEncompassingAncestor(match.NewRoot), newActiveStatement, nodeSelector, ref newNodes);
 
             if (newNodes != null)
             {
@@ -1933,11 +1933,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return -1;
         }
 
-        private static void GetAncestors(SyntaxNode root, SyntaxNode node, int[] syntaxKinds, ref List<SyntaxNode> list)
+        private static void GetAncestors(SyntaxNode root, SyntaxNode node, Func<SyntaxNode, bool> nodeSelector, ref List<SyntaxNode> list)
         {
             while (node != root)
             {
-                if (syntaxKinds.Contains(node.RawKind))
+                if (nodeSelector(node))
                 {
                     if (list == null)
                     {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1417,7 +1417,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     else
                     {
                         diagnostics.Add(new RudeEditDiagnostic(
-                            RudeEditKind.Changing,
+                            RudeEditKind.ChangingStateMachineShape,
                             newNode.Span,
                             newNode,
                             new[] { GetDisplayName(oldNode, EditKind.Update), GetDisplayName(newNode, EditKind.Update) }));

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -283,6 +283,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         protected abstract string TryGetDisplayName(SyntaxNode node, EditKind editKind);
 
+        protected virtual string GetSuspensionPointDisplayName(SyntaxNode node, EditKind editKind)
+            => GetDisplayName(node, editKind);
+
         protected abstract SymbolDisplayFormat ErrorDisplayFormat { get; }
         protected abstract List<SyntaxNode> GetExceptionHandlingAncestors(SyntaxNode node, bool isNonLeaf);
         protected abstract void GetStateMachineInfo(SyntaxNode body, out ImmutableArray<SyntaxNode> suspensionPoints, out StateMachineKinds kinds);
@@ -1420,7 +1423,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             RudeEditKind.ChangingStateMachineShape,
                             newNode.Span,
                             newNode,
-                            new[] { GetDisplayName(oldNode, EditKind.Update), GetDisplayName(newNode, EditKind.Update) }));
+                            new[] { GetSuspensionPointDisplayName(oldNode, EditKind.Update), GetSuspensionPointDisplayName(newNode, EditKind.Update) }));
                     }
 
                     ReportStateMachineSuspensionPointRudeEdits(diagnostics, oldNode, newNode);
@@ -1458,7 +1461,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 RudeEditKind.Delete,
                 GetDeletedNodeDiagnosticSpan(match.Matches, deletedSuspensionPoint),
                 deletedSuspensionPoint,
-                new[] { GetDisplayName(deletedSuspensionPoint, EditKind.Delete) }));
+                new[] { GetSuspensionPointDisplayName(deletedSuspensionPoint, EditKind.Delete) }));
         }
 
         internal virtual void ReportStateMachineSuspensionPointInsertedRudeEdit(List<RudeEditDiagnostic> diagnostics, Match<SyntaxNode> match, SyntaxNode insertedSuspensionPoint, bool aroundActiveStatement)
@@ -1467,7 +1470,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 aroundActiveStatement ? RudeEditKind.InsertAroundActiveStatement : RudeEditKind.Insert,
                 GetDiagnosticSpan(insertedSuspensionPoint, EditKind.Insert),
                 insertedSuspensionPoint,
-                new[] { GetDisplayName(insertedSuspensionPoint, EditKind.Insert) }));
+                new[] { GetSuspensionPointDisplayName(insertedSuspensionPoint, EditKind.Insert) }));
         }
 
         private static void AddMatchingActiveNodes(ref List<KeyValuePair<SyntaxNode, SyntaxNode>> lazyKnownMatches, IEnumerable<ActiveNode> activeNodes)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1747,7 +1747,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         #region Rude Edits around Active Statement 
 
-        protected void AddRudeDiagnostic(List<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode, TextSpan newActiveStatementSpan)
+        protected void AddAroundActiveStatementRudeDiagnostic(List<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode, TextSpan newActiveStatementSpan)
         {
             if (oldNode == null)
             {

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -86,6 +86,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.InternalError,                             FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error) },
             { GetDescriptorPair(RudeEditKind.SwitchExpressionUpdate,                    FeaturesResources.Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.ChangingFromAsynchronousToSynchronous,     FeaturesResources.Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing) },
+            { GetDescriptorPair(RudeEditKind.Changing,                                  FeaturesResources.Changing_0_to_1_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing) },
 
             // VB specific,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.InsertIntoInterface,                       FeaturesResources.Adding_0_into_an_interface_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.InsertLocalFunctionIntoInterfaceMethod,    FeaturesResources.Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.InternalError,                             FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error) },
+            { GetDescriptorPair(RudeEditKind.SwitchExpressionUpdate,                    FeaturesResources.Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing) },
 
             // VB specific,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.InternalError,                             FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error) },
             { GetDescriptorPair(RudeEditKind.SwitchExpressionUpdate,                    FeaturesResources.Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.ChangingFromAsynchronousToSynchronous,     FeaturesResources.Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing) },
-            { GetDescriptorPair(RudeEditKind.Changing,                                  FeaturesResources.Changing_0_to_1_will_prevent_the_debug_session_from_continuing) },
+            { GetDescriptorPair(RudeEditKind.ChangingStateMachineShape,                 FeaturesResources.Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine) },
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing) },
 
             // VB specific,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -85,6 +85,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.InsertLocalFunctionIntoInterfaceMethod,    FeaturesResources.Adding_0_into_an_interface_method_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.InternalError,                             FeaturesResources.Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error) },
             { GetDescriptorPair(RudeEditKind.SwitchExpressionUpdate,                    FeaturesResources.Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing) },
+            { GetDescriptorPair(RudeEditKind.ChangingFromAsynchronousToSynchronous,     FeaturesResources.Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.RUDE_EDIT_COMPLEX_QUERY_EXPRESSION,        FeaturesResources.Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing) },
 
             // VB specific,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditDiagnosticDescriptors.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             { GetDescriptorPair(RudeEditKind.InsertAroundActiveStatement,               FeaturesResources.Adding_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.DeleteAroundActiveStatement,               FeaturesResources.Deleting_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.DeleteActiveStatement,                     FeaturesResources.An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session) },
-            { GetDescriptorPair(RudeEditKind.UpdateAroundActiveStatement,               FeaturesResources.Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing) },
+            { GetDescriptorPair(RudeEditKind.UpdateAroundActiveStatement,               FeaturesResources.Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.UpdateExceptionHandlerOfActiveTry,         FeaturesResources.Modifying_a_catch_finally_handler_with_an_active_statement_in_the_try_block_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.UpdateTryOrCatchWithActiveFinally,         FeaturesResources.Modifying_a_try_catch_finally_statement_when_the_finally_block_is_active_will_prevent_the_debug_session_from_continuing) },
             { GetDescriptorPair(RudeEditKind.UpdateCatchHandlerAroundActiveStatement,   FeaturesResources.Modifying_a_catch_handler_around_an_active_statement_will_prevent_the_debug_session_from_continuing) },

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -102,9 +102,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertMethodWithExplicitInterfaceSpecifier = 81,
         InsertIntoInterface = 82,
         InsertLocalFunctionIntoInterfaceMethod = 83,
-
-
         SwitchExpressionUpdate = 84,
+        ChangingFromAsynchronousToSynchronous = 85,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -103,6 +103,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertIntoInterface = 82,
         InsertLocalFunctionIntoInterfaceMethod = 83,
 
+
+        SwitchExpressionUpdate = 84,
+
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,
     }

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -104,6 +104,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertLocalFunctionIntoInterfaceMethod = 83,
         SwitchExpressionUpdate = 84,
         ChangingFromAsynchronousToSynchronous = 85,
+        Changing = 86,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,

--- a/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
+++ b/src/Features/Core/Portable/EditAndContinue/RudeEditKind.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         InsertLocalFunctionIntoInterfaceMethod = 83,
         SwitchExpressionUpdate = 84,
         ChangingFromAsynchronousToSynchronous = 85,
-        Changing = 86,
+        ChangingStateMachineShape = 86,
 
         // TODO: remove values below
         RUDE_EDIT_COMPLEX_QUERY_EXPRESSION = 0x103,

--- a/src/Features/Core/Portable/EditAndContinue/StateMachineKinds.cs
+++ b/src/Features/Core/Portable/EditAndContinue/StateMachineKinds.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 
+using System;
+
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal enum StateMachineKind
+    [Flags]
+    internal enum StateMachineKinds
     {
-        None,
-        Async,
-        Iterator
+        None = 0,
+        Async = 1,
+        Iterator = 1 << 1,
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -835,11 +835,12 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Changing &apos;{0}&apos; to &apos;{1}&apos; will prevent the debug session from continuing..
+        ///   Looks up a localized string similar to Changing &apos;{0}&apos; to &apos;{1}&apos; will prevent the debug session from continuing because it changes the shape of the state machine..
         /// </summary>
-        internal static string Changing_0_to_1_will_prevent_the_debug_session_from_continuing {
+        internal static string Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine {
             get {
-                return ResourceManager.GetString("Changing_0_to_1_will_prevent_the_debug_session_from_continuing", resourceCulture);
+                return ResourceManager.GetString("Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes" +
+                        "_the_shape_of_the_state_machine", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -825,6 +825,16 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Changing &apos;{0}&apos; from asynchronous to synchronous will prevent the debug session from continuing..
+        /// </summary>
+        internal static string Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing {
+            get {
+                return ResourceManager.GetString("Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_c" +
+                        "ontinuing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changing the constraint from &apos;{0}&apos; to &apos;{1}&apos; will prevent the debug session from continuing..
         /// </summary>
         internal static string Changing_the_constraint_from_0_to_1_will_prevent_the_debug_session_from_continuing {

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -2534,6 +2534,16 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Modifying &apos;{0}&apos; which contains a switch expression will prevent the debug session from continuing..
+        /// </summary>
+        internal static string Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing {
+            get {
+                return ResourceManager.GetString("Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_fro" +
+                        "m_continuing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Modifying &apos;{0}&apos; which contains an Aggregate, Group By, or Join query clauses will prevent the debug session from continuing..
         /// </summary>
         internal static string Modifying_0_which_contains_an_Aggregate_Group_By_or_Join_query_clauses_will_prevent_the_debug_session_from_continuing {

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -4021,12 +4021,12 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updating a &apos;{0}&apos; statement around an active statement will prevent the debug session from continuing..
+        ///   Looks up a localized string similar to Updating a &apos;{0}&apos; around an active statement will prevent the debug session from continuing..
         /// </summary>
-        internal static string Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing {
+        internal static string Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing {
             get {
-                return ResourceManager.GetString("Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_" +
-                        "from_continuing", resourceCulture);
+                return ResourceManager.GetString("Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_conti" +
+                        "nuing", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -835,6 +835,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Changing &apos;{0}&apos; to &apos;{1}&apos; will prevent the debug session from continuing..
+        /// </summary>
+        internal static string Changing_0_to_1_will_prevent_the_debug_session_from_continuing {
+            get {
+                return ResourceManager.GetString("Changing_0_to_1_will_prevent_the_debug_session_from_continuing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changing the constraint from &apos;{0}&apos; to &apos;{1}&apos; will prevent the debug session from continuing..
         /// </summary>
         internal static string Changing_the_constraint_from_0_to_1_will_prevent_the_debug_session_from_continuing {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -351,6 +351,9 @@
   <data name="Updating_0_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Updating '{0}' will prevent the debug session from continuing.</value>
   </data>
+  <data name="Changing_0_to_1_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Changing '{0}' to '{1}' will prevent the debug session from continuing.</value>
+  </data>
   <data name="Updating_a_complex_statement_containing_an_await_expression_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Updating a complex statement containing an await expression will prevent the debug session from continuing.</value>
   </data>

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -351,8 +351,8 @@
   <data name="Updating_0_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Updating '{0}' will prevent the debug session from continuing.</value>
   </data>
-  <data name="Changing_0_to_1_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Changing '{0}' to '{1}' will prevent the debug session from continuing.</value>
+  <data name="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine" xml:space="preserve">
+    <value>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</value>
   </data>
   <data name="Updating_a_complex_statement_containing_an_await_expression_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Updating a complex statement containing an await expression will prevent the debug session from continuing.</value>

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -544,6 +544,9 @@
   <data name="Modifying_0_which_contains_the_stackalloc_operator_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Modifying '{0}' which contains the 'stackalloc' operator will prevent the debug session from continuing.</value>
   </data>
+  <data name="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</value>
+  </data>
   <data name="Modifying_an_active_0_which_contains_On_Error_or_Resume_statements_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Modifying an active '{0}' which contains 'On Error' or 'Resume' statements will prevent the debug session from continuing.</value>
   </data>

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -508,6 +508,9 @@
     <value>Updating async or iterator modifier around an active statement will prevent the debug session from continuing.</value>
     <comment>{Locked="async"}{Locked="iterator"} "async" and "iterator" are C#/VB keywords and should not be localized.</comment>
   </data>
+  <data name="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</value>
+  </data>
   <data name="Modifying_a_generic_method_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Modifying a generic method will prevent the debug session from continuing.</value>
   </data>

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -504,8 +504,8 @@
   <data name="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session" xml:space="preserve">
     <value>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</value>
   </data>
-  <data name="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
-    <value>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</value>
+  <data name="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
+    <value>Updating a '{0}' around an active statement will prevent the debug session from continuing.</value>
   </data>
   <data name="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing" xml:space="preserve">
     <value>Updating async or iterator modifier around an active statement will prevent the debug session from continuing.</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Kvalita kódu</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Zrušit zalomení seznamu parametrů</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Aktivní příkaz je odstraněný z jeho původní metody. Pro pokračování musíte vzít zpátky změny nebo restartovat ladicí relaci.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Aktualizace příkazu {0} v okolí aktivního příkazu zabrání v pokračování relace ladění.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Změnit na globální obor názvů</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Kvalita kódu</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Codequalität</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">In globalen Namespace ändern</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Codequalität</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Parameterliste entpacken</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Eine aktive Anweisung wurde aus der ursprünglichen Methode entfernt. Sie müssen Ihre Änderungen rückgängig machen, um die Debuggingsitzung fortzusetzen oder neu zu starten.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Durch Aktualisieren einer "{0}"-Anweisung um eine aktive Anweisung herum wird verhindert, dass die Debuggingsitzung fortgesetzt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Cambiar al espacio de nombres global</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Calidad del código</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Desajustar la lista de parámetros</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Se quitó una instrucción activa de su método original. Debe revertir los cambios para continuar o reiniciar la sesión de depuración.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Actualizar una instrucción '{0}' en una instrucción activa impedirá que continúe la sesión de depuración.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Calidad del código</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Remplacer par l'espace de noms général</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Qualité du code</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Exclure du wrapper la liste de paramètres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Une instruction active a été supprimée de sa méthode d'origine. Annulez vos modifications si vous voulez continuer ou redémarrez la session de débogage.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">La mise à jour d'une instruction '{0}' autour d'une instruction active empêche la session de débogage de se poursuivre.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Qualité du code</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Passa allo spazio dei nomi globale</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Qualità del codice</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Qualità del codice</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Annulla ritorno a capo per elenco di parametri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Un'istruzione attiva è stata rimossa dal metodo originale. Annullare le modifiche per continuare oppure riavviare la sessione di debug.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Se si aggiorna un'istruzione '{0}' in prossimità di un'istruzione attiva, la sessione di debug non potrà continuare.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">グローバル名前空間に変更します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">コードの品質</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">コードの品質</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -487,6 +487,11 @@
         <target state="translated">パラメーター リストのラップを解除します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">アクティブ ステートメントは元のメソッドから削除されました。変更を元に戻して続行するか、またはデバッグ セッションを再開してください。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">アクティブ ステートメントの前後の '{0}' ステートメントを更新すると、デバッグ セッションは続行されません。</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -487,6 +487,11 @@
         <target state="translated">매개 변수 목록 줄 바꿈 조정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">원래 메서드에서 활성 문이 제거되었습니다. 변경 내용을 취소하고 계속하거나 디버깅 세션을 다시 시작해야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">활성 문 주위의 '{0}' 문을 업데이트하면 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">전역 네임스페이스로 변경</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">코드 품질</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">코드 품질</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Odpakuj listę parametrów</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Aktywna instrukcja została usunięta ze swojej oryginalnej metody. Musisz cofnąć zmiany, aby kontynuować, lub uruchomić ponownie sesję debugowania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Aktualizacja instrukcji „{0}” w pobliżu aktywnej instrukcji uniemożliwi kontynuowanie sesji debugowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Jakość kodu</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Zmień na globalną przestrzeń nazw</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Jakość kodu</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Desencapsular a lista de parâmetros</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Uma instrução ativa foi removida de seu método original. Você deve reverter as alterações para continuar ou reiniciar a sessão de depuração.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Atualizar uma instrução "{0}" em uma instrução ativa impedirá que a sessão de depuração continue.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Qualidade do Código</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Alterar para o namespace global</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Qualidade do Código</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Качество кода</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Изменить на глобальное пространство имен</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Качество кода</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Развернуть список параметров</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Активный оператор был удален из исходного метода. Чтобы продолжить выполнение сеанса отладки, необходимо отменить изменения или перезапустить сеанс.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Обновление оператора "{0}" рядом с активным оператором сделает продолжение сеанса отладки невозможным.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Kod kalite</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -487,6 +487,11 @@
         <target state="translated">Parametre listesinin sarmalamasını kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">Etkin bir deyim özgün yönteminden kaldırılmış. Devam etmek için değişikliklerinizi geri almalısınız veya hata ayıklama oturumunu yeniden başlatmalısınız.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">Etkin bir deyim etrafındaki '{0}' deyimini güncelleştirme, hata ayıklama oturumunun devam etmesini engelleyecek.</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Genel ad alanı olarak değiştir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">Kod kalite</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">更改为全局命名空间</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">代码质量</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">代码质量</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -487,6 +487,11 @@
         <target state="translated">展开参数列表</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">活动语句已从其初始方法中删除。必须还原更改才能继续或重新启动调试会话。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">更新活动语句周围的“{0}”语句将阻止调试会话继续。</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">變更為全域命名空間</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_from_asynchronous_to_synchronous_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">程式碼品質</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -487,6 +487,11 @@
         <target state="translated">將參數清單取消換行</target>
         <note />
       </trans-unit>
+      <trans-unit id="Updating_a_0_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
+        <source>Updating a '{0}' around an active statement will prevent the debug session from continuing.</source>
+        <target state="new">Updating a '{0}' around an active statement will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseRecommendedDisposePatternDescription">
         <source>Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</source>
         <target state="new">Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a 'using' statement or a 'using' declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the 'finally' region, say 'x?.Dispose()'. If the object is explicitly disposed within the try region or the dispose ownership is transfered to another object or method, assign 'null' to the local variable just after such an operation to prevent double dispose in 'finally'</target>
@@ -1245,11 +1250,6 @@
       <trans-unit id="An_active_statement_has_been_removed_from_its_original_method_You_must_revert_your_changes_to_continue_or_restart_the_debugging_session">
         <source>An active statement has been removed from its original method. You must revert your changes to continue or restart the debugging session.</source>
         <target state="translated">現用陳述式已從其原始方法中移除。您必須還原您的變更才能繼續，或是重新啟動偵錯工作階段。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Updating_a_0_statement_around_an_active_statement_will_prevent_the_debug_session_from_continuing">
-        <source>Updating a '{0}' statement around an active statement will prevent the debug session from continuing.</source>
-        <target state="translated">更新現用陳述式前後的 '{0}' 陳述式，會造成偵錯工作階段無法繼續。</target>
         <note />
       </trans-unit>
       <trans-unit id="Updating_async_or_iterator_modifier_around_an_active_statement_will_prevent_the_debug_session_from_continuing">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -92,9 +92,9 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
-        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
-        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing_because_it_changes_the_shape_of_the_state_machine">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing because it changes the shape of the state machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="Code_Quality">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <target state="new">Changing '{0}' from asynchronous to synchronous will prevent the debug session from continuing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changing_0_to_1_will_prevent_the_debug_session_from_continuing">
+        <source>Changing '{0}' to '{1}' will prevent the debug session from continuing.</source>
+        <target state="new">Changing '{0}' to '{1}' will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Code_Quality">
         <source>Code Quality</source>
         <target state="translated">程式碼品質</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -282,6 +282,11 @@
         <target state="new">{0} must return a stream that supports read and seek operations.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Modifying_0_which_contains_a_switch_expression_will_prevent_the_debug_session_from_continuing">
+        <source>Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</source>
+        <target state="new">Modifying '{0}' which contains a switch expression will prevent the debug session from continuing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Move_contents_to_namespace">
         <source>Move contents to namespace...</source>
         <target state="new">Move contents to namespace...</target>

--- a/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxUtilities.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/SyntaxUtilities.vb
@@ -119,24 +119,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             Return rightNode
         End Function
 
-        Public Shared Function IsMethod(declaration As SyntaxNode) As Boolean
-            Select Case declaration.Kind
-                Case SyntaxKind.SubBlock,
-                     SyntaxKind.FunctionBlock,
-                     SyntaxKind.ConstructorBlock,
-                     SyntaxKind.OperatorBlock,
-                     SyntaxKind.GetAccessorBlock,
-                     SyntaxKind.SetAccessorBlock,
-                     SyntaxKind.AddHandlerAccessorBlock,
-                     SyntaxKind.RemoveHandlerAccessorBlock,
-                     SyntaxKind.RaiseEventAccessorBlock
-                    Return True
-
-                Case Else
-                    Return False
-            End Select
-        End Function
-
         Public Shared Function IsParameterlessConstructor(declaration As SyntaxNode) As Boolean
             If Not declaration.IsKind(SyntaxKind.ConstructorBlock) Then
                 Return False

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -3159,22 +3159,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             ' 
             ' Unlike exception regions matching where we use LCS, we allow reordering of the statements.
 
-            ReportUnmatchedStatements(Of SyncLockBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.SyncLockBlock}, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of SyncLockBlockSyntax)(diagnostics, match, Function(node) node.IsKind(SyntaxKind.SyncLockBlock), oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.SyncLockStatement.Expression, n2.SyncLockStatement.Expression),
                 areSimilar:=Nothing)
 
-            ReportUnmatchedStatements(Of WithBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.WithBlock}, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of WithBlockSyntax)(diagnostics, match, Function(node) node.IsKind(SyntaxKind.WithBlock), oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.WithStatement.Expression, n2.WithStatement.Expression),
                 areSimilar:=Nothing)
 
-            ReportUnmatchedStatements(Of UsingBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.UsingBlock}, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of UsingBlockSyntax)(diagnostics, match, Function(node) node.IsKind(SyntaxKind.UsingBlock), oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.UsingStatement.Expression, n2.UsingStatement.Expression),
                 areSimilar:=Nothing)
 
-            ReportUnmatchedStatements(Of ForOrForEachBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.ForEachBlock}, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of ForOrForEachBlockSyntax)(diagnostics, match, Function(node) node.IsKind(SyntaxKind.ForEachBlock), oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.ForOrForEachStatement, n2.ForOrForEachStatement),
                 areSimilar:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(DirectCast(n1.ForOrForEachStatement, ForEachStatementSyntax).ControlVariable,
-                                                                         DirectCast(n2.ForOrForEachStatement, ForEachStatementSyntax).ControlVariable))
+                                                                               DirectCast(n2.ForOrForEachStatement, ForEachStatementSyntax).ControlVariable))
         End Sub
 
 #End Region

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2927,7 +2927,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                 Debug.Assert(edit.Kind <> EditKind.Update OrElse edit.OldNode.RawKind = edit.NewNode.RawKind)
 
                 If edit.Kind <> EditKind.Update OrElse Not AreExceptionHandlingPartsEquivalent(edit.OldNode, edit.NewNode) Then
-                    AddRudeDiagnostic(diagnostics, edit.OldNode, edit.NewNode, newStatementSpan)
+                    AddAroundActiveStatementRudeDiagnostic(diagnostics, edit.OldNode, edit.NewNode, newStatementSpan)
                 End If
             Next
         End Sub
@@ -3122,7 +3122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
             Dim onErrorOrResumeStatement = FindOnErrorOrResumeStatement(match.NewRoot)
             If onErrorOrResumeStatement IsNot Nothing Then
-                AddRudeDiagnostic(diagnostics, oldActiveStatement, onErrorOrResumeStatement, newActiveStatement.Span)
+                AddAroundActiveStatementRudeDiagnostic(diagnostics, oldActiveStatement, onErrorOrResumeStatement, newActiveStatement.Span)
             End If
 
             ReportRudeEditsForAncestorsDeclaringInterStatementTemps(diagnostics, match, oldActiveStatement, newActiveStatement)

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2616,8 +2616,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             End Sub
 
             Private Function ClassifyMethodModifierUpdate(oldModifiers As SyntaxTokenList, newModifiers As SyntaxTokenList) As Boolean
-                ' Ignore async keyword when matching modifiers.
-                ' async checks are done in ComputeBodyMatch.
+                ' Ignore Async and Iterator keywords when matching modifiers.
+                ' State machine checks are done in ComputeBodyMatch.
 
                 Dim oldAsyncIndex = oldModifiers.IndexOf(SyntaxKind.AsyncKeyword)
                 Dim newAsyncIndex = newModifiers.IndexOf(SyntaxKind.AsyncKeyword)
@@ -2639,11 +2639,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
 
                 If newIteratorIndex >= 0 Then
                     newModifiers = newModifiers.RemoveAt(newIteratorIndex)
-                End If
-
-                ' 'iterator' keyword is allowed to add, but not to remove
-                If oldIteratorIndex >= 0 AndAlso newIteratorIndex < 0 Then
-                    Return False
                 End If
 
                 Return SyntaxFactory.AreEquivalent(oldModifiers, newModifiers)

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -2989,17 +2989,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                    SyntaxUtilities.IsIteratorMethodOrLambda(declaration)
         End Function
 
-        Protected Overrides Sub GetStateMachineInfo(body As SyntaxNode, ByRef suspensionPoints As ImmutableArray(Of SyntaxNode), ByRef kind As StateMachineKind)
+        Protected Overrides Sub GetStateMachineInfo(body As SyntaxNode, ByRef suspensionPoints As ImmutableArray(Of SyntaxNode), ByRef kind As StateMachineKinds)
             ' In VB declaration and body are represented by the same node for both lambdas and methods (unlike C#)
             If SyntaxUtilities.IsAsyncMethodOrLambda(body) Then
                 suspensionPoints = SyntaxUtilities.GetAwaitExpressions(body)
-                kind = StateMachineKind.Async
+                kind = StateMachineKinds.Async
             ElseIf SyntaxUtilities.IsIteratorMethodOrLambda(body) Then
                 suspensionPoints = SyntaxUtilities.GetYieldStatements(body)
-                kind = StateMachineKind.Iterator
+                kind = StateMachineKinds.Iterator
             Else
                 suspensionPoints = ImmutableArray(Of SyntaxNode).Empty
-                kind = StateMachineKind.None
+                kind = StateMachineKinds.None
             End If
         End Sub
 


### PR DESCRIPTION
Methods containing switch expressions can't be edited due to https://github.com/dotnet/roslyn/issues/37172.

Handle all kinds of `stackalloc` nodes.

Validate updated modifiers of local functions (fixes https://github.com/dotnet/roslyn/issues/37054).

Treat `await foreach` and `await using` as state machine suspension points, report appropriate rude edits when changing these statements.

Relax restrictions on editing using statements around active statement - allow updates when the statements does not generate a temp variable.

Test edits around `using` declarations.

Report rude edits when editing cases of a switch statement containing patterns while the switch governing expression is a non-leaf active statement. Non-leaf active statement can't be edited and the patterns contribute to the decision tree covered by this active statement.

Report rude edits when editing switch cases while a `when` clause is active. This is necessary since `when` clause might be followed by a branch back to the decision tree. The decision tree emits synthesized variables that need to be mapped to the corresponding synthesized variables in the new decision tree (after edit). The compiler is only able to map the variables if the decision tree is unchanged.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/891931.

Fixes handling of active statements in nested VB single-line lambdas (e.g. `Function(a) Function(b) a + b`), where previously the logic might have confused the lambda the active statement belongs to leading to misreported rude edits and potentially allowing changes that shouldn't be allowed.