### PR TITLE
Let #nullable directive enable/disable all nullable-related warnings

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1919,7 +1919,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (string.Equals(id, "nullable", StringComparison.OrdinalIgnoreCase))
                 {
-                    foreach (var errorCode in ErrorFacts.NullableFlowAnalysisWarnings)
+                    foreach (var errorCode in ErrorFacts.NullableWarnings)
                     {
                         yield return errorCode;
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var tree = location?.SourceTree as CSharpSyntaxTree;
             var position = location.SourceSpan.Start;
 
-            bool isNullableFlowAnalysisWarning = ErrorFacts.NullableFlowAnalysisWarnings.Contains(id);
+            bool isNullableFlowAnalysisWarning = ErrorFacts.NullableWarnings.Contains(id);
             if (isNullableFlowAnalysisWarning)
             {
                 var nullableWarningsGloballyEnabled = nullableOption == NullableContextOptions.Enable || nullableOption == NullableContextOptions.Warnings;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -21,54 +21,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ImmutableHashSet<string>.Builder builder = ImmutableHashSet.CreateBuilder<string>();
 
-            builder.Add(getId(ErrorCode.WRN_ConvertingNullableToNonNullable));
-            builder.Add(getId(ErrorCode.WRN_NullReferenceAssignment));
-            builder.Add(getId(ErrorCode.WRN_NullReferenceReceiver));
-            builder.Add(getId(ErrorCode.WRN_NullReferenceReturn));
-            builder.Add(getId(ErrorCode.WRN_NullReferenceArgument));
-            builder.Add(getId(ErrorCode.WRN_UnboxPossibleNull));
-            builder.Add(getId(ErrorCode.WRN_NullReferenceIterationVariable));
-            builder.Add(getId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnImplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnImplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_UninitializedNonNullableField));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInAssignment));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgument));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput));
-            builder.Add(getId(ErrorCode.WRN_NullAsNonNullable));
-            builder.Add(getId(ErrorCode.WRN_AsOperatorMayReturnNull));
-            builder.Add(getId(ErrorCode.WRN_NullableValueTypeMayBeNull));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInConstraintsOnImplicitImplementation));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint));
-            builder.Add(getId(ErrorCode.WRN_ConditionalAccessMayReturnNull));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInExplicitlyImplementedInterface));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInInterfaceImplementedByBase));
-            builder.Add(getId(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList));
-            builder.Add(getId(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT));
-            builder.Add(getId(ErrorCode.WRN_NullLiteralMayIntroduceNullT));
-            builder.Add(getId(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull));
-
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInConstraintsOnPartialImplementation));
-
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint));
-
             builder.Add(getId(ErrorCode.WRN_NullReferenceAssignment));
             builder.Add(getId(ErrorCode.WRN_NullReferenceReceiver));
             builder.Add(getId(ErrorCode.WRN_NullReferenceReturn));
             builder.Add(getId(ErrorCode.WRN_NullReferenceArgument));
             builder.Add(getId(ErrorCode.WRN_NullReferenceIterationVariable));
-            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
             builder.Add(getId(ErrorCode.WRN_UninitializedNonNullableField));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInAssignment));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgument));
@@ -90,6 +47,22 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             builder.Add(getId(ErrorCode.WRN_ConvertingNullableToNonNullable));
             builder.Add(getId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
+
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInConstraintsOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInExplicitlyImplementedInterface));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInInterfaceImplementedByBase));
+            builder.Add(getId(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInConstraintsOnPartialImplementation));
 
             NullableWarnings = builder.ToImmutable();
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -15,16 +15,60 @@ namespace Microsoft.CodeAnalysis.CSharp
         private const string s_descriptionSuffix = "_Description";
         private static readonly Lazy<ImmutableDictionary<ErrorCode, string>> s_helpLinksMap = new Lazy<ImmutableDictionary<ErrorCode, string>>(CreateHelpLinks);
         private static readonly Lazy<ImmutableDictionary<ErrorCode, string>> s_categoriesMap = new Lazy<ImmutableDictionary<ErrorCode, string>>(CreateCategoriesMap);
-        public static readonly ImmutableHashSet<string> NullableFlowAnalysisWarnings;
+        public static readonly ImmutableHashSet<string> NullableWarnings;
 
         static ErrorFacts()
         {
             ImmutableHashSet<string>.Builder builder = ImmutableHashSet.CreateBuilder<string>();
+
+            builder.Add(getId(ErrorCode.WRN_ConvertingNullableToNonNullable));
+            builder.Add(getId(ErrorCode.WRN_NullReferenceAssignment));
+            builder.Add(getId(ErrorCode.WRN_NullReferenceReceiver));
+            builder.Add(getId(ErrorCode.WRN_NullReferenceReturn));
+            builder.Add(getId(ErrorCode.WRN_NullReferenceArgument));
+            builder.Add(getId(ErrorCode.WRN_UnboxPossibleNull));
+            builder.Add(getId(ErrorCode.WRN_NullReferenceIterationVariable));
+            builder.Add(getId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnOverride));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnPartial));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnExplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnExplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOnExplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_UninitializedNonNullableField));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInAssignment));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgument));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOfTargetDelegate));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInParameterTypeOfTargetDelegate));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgumentForOutput));
+            builder.Add(getId(ErrorCode.WRN_NullAsNonNullable));
+            builder.Add(getId(ErrorCode.WRN_AsOperatorMayReturnNull));
+            builder.Add(getId(ErrorCode.WRN_NullableValueTypeMayBeNull));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeParameterConstraint));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInConstraintsOnImplicitImplementation));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeParameterReferenceTypeConstraint));
+            builder.Add(getId(ErrorCode.WRN_ConditionalAccessMayReturnNull));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInExplicitlyImplementedInterface));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInInterfaceImplementedByBase));
+            builder.Add(getId(ErrorCode.WRN_DuplicateInterfaceWithNullabilityMismatchInBaseList));
+            builder.Add(getId(ErrorCode.WRN_DefaultExpressionMayIntroduceNullT));
+            builder.Add(getId(ErrorCode.WRN_NullLiteralMayIntroduceNullT));
+            builder.Add(getId(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull));
+
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInConstraintsOnPartialImplementation));
+
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint));
+
             builder.Add(getId(ErrorCode.WRN_NullReferenceAssignment));
             builder.Add(getId(ErrorCode.WRN_NullReferenceReceiver));
             builder.Add(getId(ErrorCode.WRN_NullReferenceReturn));
             builder.Add(getId(ErrorCode.WRN_NullReferenceArgument));
             builder.Add(getId(ErrorCode.WRN_NullReferenceIterationVariable));
+            builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
             builder.Add(getId(ErrorCode.WRN_UninitializedNonNullableField));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInAssignment));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInArgument));
@@ -47,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             builder.Add(getId(ErrorCode.WRN_ConvertingNullableToNonNullable));
             builder.Add(getId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
 
-            NullableFlowAnalysisWarnings = builder.ToImmutable();
+            NullableWarnings = builder.ToImmutable();
 
             string getId(ErrorCode errorCode)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportDiagnostic(ErrorCode errorCode, Location location, params object[] arguments)
         {
-            Debug.Assert(ErrorFacts.NullableFlowAnalysisWarnings.Contains(MessageProvider.Instance.GetIdForErrorCode((int)errorCode)));
+            Debug.Assert(ErrorFacts.NullableWarnings.Contains(MessageProvider.Instance.GetIdForErrorCode((int)errorCode)));
             if (IsReachable() && !_disableDiagnostics)
             {
                 Diagnostics.Add(errorCode, location, arguments);

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -3128,9 +3128,9 @@ class C
             Assert.Empty(errors);
 
             Assert.Equal(expected: ReportDiagnostic.Default, actual: arguments.CompilationOptions.GeneralDiagnosticOption);
-            Assert.Equal(expected: ErrorFacts.NullableFlowAnalysisWarnings.Count, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
+            Assert.Equal(expected: ErrorFacts.NullableWarnings.Count, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
 
-            foreach (string warning in ErrorFacts.NullableFlowAnalysisWarnings)
+            foreach (string warning in ErrorFacts.NullableWarnings)
             {
                 Assert.Equal(expected: ReportDiagnostic.Suppress, actual: arguments.CompilationOptions.SpecificDiagnosticOptions[warning]);
             }
@@ -3156,9 +3156,9 @@ class C
             Assert.Empty(errors);
 
             Assert.Equal(expected: ReportDiagnostic.Default, actual: arguments.CompilationOptions.GeneralDiagnosticOption);
-            Assert.Equal(expected: ErrorFacts.NullableFlowAnalysisWarnings.Count, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
+            Assert.Equal(expected: ErrorFacts.NullableWarnings.Count, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
 
-            foreach (string warning in ErrorFacts.NullableFlowAnalysisWarnings)
+            foreach (string warning in ErrorFacts.NullableWarnings)
             {
                 Assert.Equal(expected: ReportDiagnostic.Suppress, actual: arguments.CompilationOptions.SpecificDiagnosticOptions[warning]);
             }
@@ -3184,9 +3184,9 @@ class C
             Assert.Empty(errors);
 
             Assert.Equal(expected: ReportDiagnostic.Default, actual: arguments.CompilationOptions.GeneralDiagnosticOption);
-            Assert.Equal(expected: ErrorFacts.NullableFlowAnalysisWarnings.Count + 1, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
+            Assert.Equal(expected: ErrorFacts.NullableWarnings.Count + 1, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
 
-            foreach (string warning in ErrorFacts.NullableFlowAnalysisWarnings)
+            foreach (string warning in ErrorFacts.NullableWarnings)
             {
                 Assert.Equal(expected: ReportDiagnostic.Suppress, actual: arguments.CompilationOptions.SpecificDiagnosticOptions[warning]);
             }
@@ -3216,7 +3216,7 @@ class C
             Assert.Equal(expected: ReportDiagnostic.Default, actual: arguments.CompilationOptions.GeneralDiagnosticOption);
             Assert.Equal(expected: 25, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
 
-            foreach (string warning in ErrorFacts.NullableFlowAnalysisWarnings)
+            foreach (string warning in ErrorFacts.NullableWarnings)
             {
                 Assert.Equal(expected: ReportDiagnostic.Error, actual: arguments.CompilationOptions.SpecificDiagnosticOptions[warning]);
             }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -3214,7 +3214,7 @@ class C
             Assert.Empty(errors);
 
             Assert.Equal(expected: ReportDiagnostic.Default, actual: arguments.CompilationOptions.GeneralDiagnosticOption);
-            Assert.Equal(expected: 25, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
+            Assert.Equal(expected: ErrorFacts.NullableWarnings.Count, actual: arguments.CompilationOptions.SpecificDiagnosticOptions.Count);
 
             foreach (string warning in ErrorFacts.NullableWarnings)
             {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -30565,7 +30565,7 @@ public interface I3 : I1<string?>
 ";
 
             var source2 =
-@"
+@"#nullable enable warnings
 class Test1 : I2, I3
 {
 }
@@ -30631,7 +30631,6 @@ class Test1 : I2, I3
             var source1 =
 @"
 #nullable enable
-
 public interface I1<T>
 {
     void M1(); 
@@ -30653,7 +30652,7 @@ public interface I3 : I1<string?>
 ";
 
             var source2 =
-@"
+@"#nullable enable warnings
 class Test1 : I2, I3, I1<string>
 {
 }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -324,6 +324,38 @@ class X
         }
 
         [Fact]
+        public void NullableWarnings()
+        {
+            foreach (ErrorCode error in Enum.GetValues(typeof(ErrorCode)))
+            {
+                if ((int)error < 8600 || (int)error >= 9000)
+                {
+                    continue;
+                }
+
+                if (!error.ToString().StartsWith("WRN"))
+                {
+                    // Only interested in warnings
+                    continue;
+                }
+
+                if (ErrorFacts.NullableWarnings.Contains(MessageProvider.Instance.GetIdForErrorCode((int)error)))
+                {
+                    continue;
+                }
+
+                // Nullable-unrelated warnings in the C# 8 range should be added to this array.
+                var nullableUnrelatedWarnings = new[]
+                {
+                    ErrorCode.WRN_MissingNonNullTypesContextForAnnotation,
+                    ErrorCode.WRN_ImplicitCopyInReadOnlyMember,
+                };
+
+                Assert.Contains(error, nullableUnrelatedWarnings);
+            }
+        }
+
+        [Fact]
         public void Warning_1()
         {
             var text = @"


### PR DESCRIPTION
Resolves #32742

Would like to know what people think about:
1. the decision to control all nullable-related warnings via `#nullable enable warnings` (except using the annotation outside of nullable annotations context warning)
2. this solution to ensure via tests/automated checks that any new nullable-related warnings are either manually added to the set or marked as non-nullable-related