### PR TITLE
Add feature to introduce a local variable immediately after writing its initializer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/IntroduceVariable/IntroduceLocalForExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/IntroduceVariable/IntroduceLocalForExpressionTests.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.IntroduceVariable;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+using Microsoft.CodeAnalysis.CodeStyle;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntroduceVariable
+{
+    public partial class IntroduceLocalForExpressionTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpIntroduceLocalForExpressionCodeRefactoringProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_NoSemicolon()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        new DateTime()[||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_Semicolon()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        new DateTime();[||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_Space()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        new DateTime(); [||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime(); 
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_LeadingTrivia()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        // Comment
+        new DateTime();[||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        // Comment
+        DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_PreferVar()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        new DateTime();[||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        var {|Rename:dateTime|} = new DateTime();
+    }
+}", options: OptionsSet(
+    (CSharpCodeStyleOptions.VarElsewhere, CodeStyleOptions.TrueWithSuggestionEnforcement),
+    (CSharpCodeStyleOptions.VarWhenTypeIsApparent, CodeStyleOptions.TrueWithSuggestionEnforcement)));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task MissingOnVoidCall()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        Console.WriteLine();[||]
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/IntroduceVariable/IntroduceLocalForExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/IntroduceVariable/IntroduceLocalForExpressionTests.cs
@@ -43,6 +43,34 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_NoSemicolon_BlankLineAfter()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        new DateTime()[||]
+
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
         public async Task IntroduceLocal_NoSemicolon_SelectExpression()
         {
             await TestInRegularAndScriptAsync(
@@ -90,6 +118,34 @@ class C
     void M()
     {
         DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_Semicolon_BlankLineAfter()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        new DateTime();[||]
+
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/IntroduceVariable/IntroduceLocalForExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/IntroduceVariable/IntroduceLocalForExpressionTests.cs
@@ -2,12 +2,12 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.IntroduceVariable;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
-using Microsoft.CodeAnalysis.CodeStyle;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntroduceVariable
 {
@@ -43,6 +43,32 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_NoSemicolon_SelectExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        [|new DateTime()|]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
         public async Task IntroduceLocal_Semicolon()
         {
             await TestInRegularAndScriptAsync(
@@ -54,6 +80,58 @@ class C
     void M()
     {
         new DateTime();[||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_Semicolon_SelectExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        [|new DateTime()|];
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        DateTime {|Rename:dateTime|} = new DateTime();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_Semicolon_SelectStatement()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        [|new DateTime();|]
     }
 }",
 @"
@@ -162,6 +240,48 @@ class C
     void M()
     {
         Console.WriteLine();[||]
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task MissingOnDeclaration()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        var v = new DateTime()[||]
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)]
+        public async Task IntroduceLocal_ArithmeticExpression()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        1 + 1[||]
+    }
+}",
+@"
+using System;
+
+class C
+{
+    void M()
+    {
+        int {|Rename:v|} = 1 + 1;
     }
 }");
         }

--- a/src/EditorFeatures/VisualBasicTest/IntroduceVariable/IntroduceLocalForExpressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/IntroduceVariable/IntroduceLocalForExpressionTests.vb
@@ -40,6 +40,35 @@ end class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function IntroduceLocal_TrailingBlankLine() As Task
+            Await TestInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        N()[||]
+
+    end sub
+
+    function N() as string
+    end function
+end class",
+"
+imports System
+
+class C
+    sub M()
+        Dim {|Rename:v|} = N()
+
+    end sub
+
+    function N() as string
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
         Public Async Function IntroduceLocal_Selection() As Task
             Await TestInRegularAndScriptAsync(
 "

--- a/src/EditorFeatures/VisualBasicTest/IntroduceVariable/IntroduceLocalForExpressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/IntroduceVariable/IntroduceLocalForExpressionTests.vb
@@ -1,0 +1,154 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
+Imports Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.IntroduceVariable
+    Partial Public Class IntroduceLocalForExpressionTests
+        Inherits AbstractVisualBasicCodeActionTest
+
+        Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
+            Return New VisualBasicIntroduceLocalForExpressionCodeRefactoringProvider()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function IntroduceLocal() As Task
+            Await TestInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        N()[||]
+    end sub
+
+    function N() as string
+    end function
+end class",
+"
+imports System
+
+class C
+    sub M()
+        Dim {|Rename:v|} = N()
+    end sub
+
+    function N() as string
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function IntroduceLocal_Selection() As Task
+            Await TestInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        [|N()|]
+    end sub
+
+    function N() as string
+    end function
+end class",
+"
+imports System
+
+class C
+    sub M()
+        Dim {|Rename:v|} = N()
+    end sub
+
+    function N() as string
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function IntroduceLocal_Space() As Task
+            Await TestInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        N() [||]
+    end sub
+
+    function N() as string
+    end function
+end class",
+"
+imports System
+
+class C
+    sub M()
+        Dim {|Rename:v|} = N() 
+    end sub
+
+    function N() as string
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function IntroduceLocal_LeadingTrivia() As Task
+            Await TestInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        ' Comment
+        N()[||]
+    end sub
+
+    function N() as string
+    end function
+end class",
+"
+imports System
+
+class C
+    sub M()
+        ' Comment
+        Dim {|Rename:v|} = N()
+    end sub
+
+    function N() as string
+    end function
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function MissingOnVoidCall() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        Console.WriteLine()[||]
+    end sub
+end class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceLocalForExpression)>
+        Public Async Function MissingOnDeclaration() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"
+imports System
+
+class C
+    sub M()
+        dim x = N()[||]
+    end sub
+
+    function N() as string
+    end function
+end class")
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceLocalForExpressionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceLocalForExpressionCodeRefactoringProvider.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp), Shared]
+    internal class CSharpIntroduceLocalForExpressionCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var span = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            var expressionStatement = await GetExpressionStatementAsync(document, span, cancellationToken).ConfigureAwait(false);
+            if (expressionStatement == null)
+            {
+                return;
+            }
+
+            var expression = expressionStatement.Expression;
+
+            // Expression is likely too simple to want to offer to generate a local for.
+            // This leads to too many false cases where this is offered.
+            if (span.IsEmpty &&
+                expressionStatement.SemicolonToken.IsMissing &&
+                expression.IsKind(SyntaxKind.IdentifierName))
+            {
+                return;
+            }
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var type = semanticModel.GetTypeInfo(expression).Type;
+            if (type == null ||
+                type.SpecialType == SpecialType.System_Void)
+            {
+                return;
+            }
+
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var singleLineExpression = syntaxFacts.ConvertToSingleLine(expression);
+            var nodeString = singleLineExpression.ToString();
+
+            context.RegisterRefactoring(new MyCodeAction(
+                string.Format(FeaturesResources.Introduce_local_for_0, nodeString),
+                c => IntroduceLocalAsync(document, span, c)));
+        }
+
+        private static async Task<ExpressionStatementSyntax> GetExpressionStatementAsync(Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var helpers = document.GetLanguageService<IRefactoringHelpersService>();
+            var expressionStatement = await helpers.TryGetSelectedNodeAsync<ExpressionStatementSyntax>(document, span, cancellationToken).ConfigureAwait(false);
+            return expressionStatement;
+        }
+
+        private async Task<Document> IntroduceLocalAsync(Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var expressionStatement = await GetExpressionStatementAsync(document, span, cancellationToken).ConfigureAwait(false);
+            var expression = expressionStatement.Expression;
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            var semanticFacts = document.GetLanguageService<ISemanticFactsService>();
+            var baseName = semanticFacts.GenerateNameForExpression(semanticModel, expression, capitalize: false, cancellationToken);
+            var uniqueName = semanticFacts.GenerateUniqueLocalName(semanticModel, expression, containerOpt: null, baseName, cancellationToken)
+                                          .WithAdditionalAnnotations(RenameAnnotation.Create());
+
+            var type = semanticModel.GetTypeInfo(expression).Type;
+            var variableDeclaration =
+                SyntaxFactory.VariableDeclaration(
+                    type.GenerateTypeSyntax(),
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.VariableDeclarator(uniqueName)
+                                     .WithInitializer(SyntaxFactory.EqualsValueClause(
+                                         expression.WithoutLeadingTrivia()))));
+            var localDeclaration =
+                SyntaxFactory.LocalDeclarationStatement(variableDeclaration)
+                             .WithSemicolonToken(expressionStatement.SemicolonToken)
+                             .WithLeadingTrivia(expression.GetLeadingTrivia());
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = root.ReplaceNode(expressionStatement, localDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.IntroduceVariable;

--- a/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                     }
 
                     leftNode = leftNode.Parent;
-                    if (leftNode == null || leftNode.Span.End != location)
+                    if (leftNode == null || leftNode.GetLastToken().Span.End != location)
                     {
                         break;
                     }

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringContextExtensions.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringContextExtensions.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CodeRefactorings
 {
@@ -21,6 +23,15 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                     context.RegisterRefactoring(action);
                 }
             }
+        }
+
+        internal static Task<TSyntaxNode> TryGetSelectedNodeAsync<TSyntaxNode>(this CodeRefactoringContext context)
+            where TSyntaxNode : SyntaxNode
+        {
+            var document = context.Document;
+            var helpers = document.GetLanguageService<IRefactoringHelpersService>();
+
+            return helpers.TryGetSelectedNodeAsync<TSyntaxNode>(document, context.Span, context.CancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/IntroduceVariable/IntroduceLocalForExpressionCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/IntroduceLocalForExpressionCodeRefactoringProvider.cs
@@ -2,17 +2,86 @@
 
 using System;
 using System.Collections.Generic;
+using System.Composition;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.IntroduceVariable
 {
-    internal class IntroduceLocalForExpressionCodeRefactoringProvider : CodeRefactoringProvider
+    internal abstract class AbstractIntroduceLocalForExpressionCodeRefactoringProvider<
+        TStatementSyntax,
+        TExpressionStatementSyntax,
+        TLocalDeclarationStatementSyntax> : CodeRefactoringProvider
+        where TStatementSyntax : SyntaxNode
+        where TExpressionStatementSyntax : TStatementSyntax
+        where TLocalDeclarationStatementSyntax : TStatementSyntax
     {
-        public override Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        protected abstract bool IsValid(TExpressionStatementSyntax expressionStatement, TextSpan span);
+        protected abstract Task<TLocalDeclarationStatementSyntax> CreateLocalDeclarationAsync(Document document, TExpressionStatementSyntax expressionStatement, CancellationToken cancellationToken);
+
+        public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
-            throw new NotImplementedException();
+            var document = context.Document;
+            var span = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            var expressionStatement = await GetExpressionStatementAsync(document, span, cancellationToken).ConfigureAwait(false);
+            if (expressionStatement == null)
+            {
+                return;
+            }
+
+            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var expression = syntaxFacts.GetExpressionOfExpressionStatement(expressionStatement);
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var type = semanticModel.GetTypeInfo(expression).Type;
+            if (type == null ||
+                type.SpecialType == SpecialType.System_Void)
+            {
+                return;
+            }
+
+            var singleLineExpression = syntaxFacts.ConvertToSingleLine(expression);
+            var nodeString = singleLineExpression.ToString();
+
+            context.RegisterRefactoring(new MyCodeAction(
+                string.Format(FeaturesResources.Introduce_local_for_0, nodeString),
+                c => IntroduceLocalAsync(document, span, c)));
+        }
+
+        protected async Task<TExpressionStatementSyntax> GetExpressionStatementAsync(Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var helpers = document.GetLanguageService<IRefactoringHelpersService>();
+            var expressionStatement = await helpers.TryGetSelectedNodeAsync<TExpressionStatementSyntax>(document, span, cancellationToken).ConfigureAwait(false);
+            return expressionStatement != null && IsValid(expressionStatement, span)
+                ? expressionStatement
+                : null;
+        }
+
+        private async Task<Document> IntroduceLocalAsync(Document document, TextSpan span, CancellationToken cancellationToken)
+        {
+            var expressionStatement = await GetExpressionStatementAsync(document, span, cancellationToken).ConfigureAwait(false);
+            var localDeclaration = await CreateLocalDeclarationAsync(document, expressionStatement, cancellationToken).ConfigureAwait(false);
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = root.ReplaceNode(expressionStatement, localDeclaration);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(title, createChangedDocument)
+            {
+            }
         }
     }
 }

--- a/src/Features/Core/Portable/IntroduceVariable/IntroduceLocalForExpressionCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/IntroduceLocalForExpressionCodeRefactoringProvider.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Composition;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -35,7 +32,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 return;
             }
 
-            var (document, span, cancellationToken) = context;
+            var (document, _, cancellationToken) = context;
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             var expression = syntaxFacts.GetExpressionOfExpressionStatement(expressionStatement);
 

--- a/src/Features/Core/Portable/IntroduceVariable/IntroduceLocalForExpressionCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/IntroduceLocalForExpressionCodeRefactoringProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+
+namespace Microsoft.CodeAnalysis.IntroduceVariable
+{
+    internal class IntroduceLocalForExpressionCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceLocalForExpressionCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceLocalForExpressionCodeRefactoringProvider.vb
@@ -1,0 +1,46 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.IntroduceVariable
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
+    <ExportCodeRefactoringProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicIntroduceLocalForExpressionCodeRefactoringProvider
+        Inherits AbstractIntroduceLocalForExpressionCodeRefactoringProvider(Of
+            ExpressionSyntax,
+            StatementSyntax,
+            ExpressionStatementSyntax,
+            LocalDeclarationStatementSyntax)
+
+        Protected Overrides Function IsValid(expressionStatement As ExpressionStatementSyntax, span As TextSpan) As Boolean
+            ' Expression is likely too simple to want to offer to generate a local for.
+            ' This leads to too many false cases where this is offered.
+            If span.IsEmpty AndAlso expressionStatement.Expression.IsKind(SyntaxKind.IdentifierName) Then
+                Return False
+            End If
+
+            Return True
+        End Function
+
+        Protected Overrides Async Function CreateLocalDeclarationAsync(
+            document As Document, expressionStatement As ExpressionStatementSyntax, cancellationToken As CancellationToken) As Task(Of LocalDeclarationStatementSyntax)
+
+            Dim expression = expressionStatement.Expression
+
+            Dim uniqueName = Await GenerateUniqueNameAsync(document, expression, cancellationToken).configureawait(False)
+            Dim declarator =
+                SyntaxFactory.VariableDeclarator(SyntaxFactory.ModifiedIdentifier(uniqueName)).
+                              WithInitializer(SyntaxFactory.EqualsValue(expression.WithoutLeadingTrivia()))
+
+            Dim localDeclaration = SyntaxFactory.LocalDeclarationStatement(
+                SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.DimKeyword)),
+                SyntaxFactory.SingletonSeparatedList(declarator)).WithLeadingTrivia(expression.GetLeadingTrivia())
+
+            Return localDeclaration
+        End Function
+    End Class
+End Namespace

--- a/src/Test/Utilities/Portable/Traits/Traits.cs
+++ b/src/Test/Utilities/Portable/Traits/Traits.cs
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsInsertMissingTokens = "CodeActions.InsertMissingTokens";
             public const string CodeActionsIntroduceUsingStatement = "CodeActions.IntroduceUsingStatement";
             public const string CodeActionsIntroduceVariable = "CodeActions.IntroduceVariable";
+            public const string CodeActionsIntroduceLocalForExpression = "CodeActions.IntroduceLocalForExpression";
             public const string CodeActionsInvertConditional = "CodeActions.InvertConditional";
             public const string CodeActionsInvertIf = "CodeActions.InvertIf";
             public const string CodeActionsInvertLogical = "CodeActions.InvertLogical";

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -57,5 +57,12 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 
             _registerRefactoring(action);
         }
+
+        internal void Deconstruct(out Document document, out TextSpan span, out CancellationToken cancellationToken)
+        {
+            document = Document;
+            span = Span;
+            cancellationToken = CancellationToken;
+        }
     }
 }


### PR DESCRIPTION
requested by customer (@johanlarson)

Looks like this:

You start by just writing any particular expression, like so:

![image](https://user-images.githubusercontent.com/4564579/61262535-6111a980-a73a-11e9-8694-1d6839f49afc.png)

Bringing up the lightbulb you get:

![image](https://user-images.githubusercontent.com/4564579/61262551-71298900-a73a-11e9-871a-8ab7e2f7e646.png)

Invoking it gives you:

![image](https://user-images.githubusercontent.com/4564579/61262562-7ab2f100-a73a-11e9-90fe-49b94dc5fcc8.png)

--

TODO: 

- [x] VB
- [x] VB tests.