### PR TITLE
Unskip tests around tuple nullable annotations

### DIFF
--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -3007,7 +3007,7 @@ class C
 @"(int i, _) =  [||]", "(global::System.Int32 i, global::System.Object _)", testNode: false);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36047"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
         public async Task TestDeconstructionWithNullableElement()
         {
             await TestInMethodAsync(

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 foreach (var element in symbol.TupleElements)
                 {
                     var name = element.IsImplicitlyDeclared ? default : SyntaxFactory.Identifier(element.Name);
-                    list = list.Add(SyntaxFactory.TupleElement(element.Type.GenerateTypeSyntax(), name));
+                    list = list.Add(SyntaxFactory.TupleElement(element.GetTypeWithAnnotatedNullability().GenerateTypeSyntax(), name));
                 }
 
                 return AddInformationTo(SyntaxFactory.TupleType(list), symbol);

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2123,8 +2123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return null;
                 }
 
-                // TODO: pass nullability once https://github.com/dotnet/roslyn/issues/36047 is fixed
-                return Compilation.CreateTupleTypeSymbol(elementTypes.SelectAsArray(t => t.WithoutNullability()), elementNames);
+                return Compilation.CreateTupleTypeSymbol(elementTypes.SelectAsArray(t => t.WithoutNullability()), elementNames, elementNullableAnnotations: elementTypes.SelectAsArray(t => t.GetNullability()));
             }
 
             private bool TryGetTupleTypesAndNames(


### PR DESCRIPTION
Now that https://github.com/dotnet/roslyn/issues/36047 is fixed, unskip type inferrer tests.