### PR TITLE
Respect root editorconfig files when getting options for a file

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1103,6 +1103,31 @@ dotnet_diagnostic.cs000.severity = none", "Z:\\.editorconfig"));
             }
         }
 
+        private static void VerifyTreeOptions(
+            (string diagId, ReportDiagnostic severity)[][] expected,
+            AnalyzerConfigOptionsResult[] options)
+        {
+            Assert.Equal(expected.Length, options.Length);
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                if (expected[i] is null)
+                {
+                    Assert.Null(options[i]);
+                }
+                else
+                {
+                    var treeOptions = options[i].TreeOptions;
+                    Assert.Equal(expected[i].Length, treeOptions.Count);
+                    foreach (var item in expected[i])
+                    {
+                        Assert.True(treeOptions.TryGetValue(item.diagId, out var severity));
+                        Assert.Equal(item.severity, severity);
+                    }
+                }
+            }
+        }
+
         [Fact]
         public void SimpleAnalyzerOptions()
         {
@@ -1202,6 +1227,44 @@ dotnet_diagnostic.cs000.some_key = c_val", "/src/.editorconfig"));
                     new[] { ("dotnet_diagnostic.cs000.some_key", "a_val") }
                },
                 options);
+        }
+
+        [Fact]
+        public void NestedBothOptionsWithSectionOverrides()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.severity = warning
+somekey = a_val", "/.editorconfig"));
+            configs.Add(Parse(@"
+[test.*]
+dotnet_diagnostic.cs000.severity = error
+somekey = b_val
+
+[*.cs]
+dotnet_diagnostic.cs000.severity = none
+somekey = c_val", "/src/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/src/test.cs", "/src/test.vb", "/root.cs" },
+                configs);
+            configs.Free();
+
+            VerifyAnalyzerOptions(
+                new[] {
+                    new[] { ("somekey", "c_val") },
+                    new[] { ("somekey", "b_val") },
+                    new[] { ("somekey", "a_val") }
+               }, options);
+
+            VerifyTreeOptions(
+                new[]
+                {
+                    new[] { ("cs000", ReportDiagnostic.Suppress) },
+                    new[] { ("cs000", ReportDiagnostic.Error) },
+                    new[] { ("cs000", ReportDiagnostic.Warn) }
+                }, options);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1152,6 +1152,59 @@ dotnet_diagnostic.cs000.some_key = some_val", "/src/.editorconfig"));
         }
 
         [Fact]
+        public void NestedAnalyzerOptionsWithOverrides()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.some_key = a_val", "/.editorconfig"));
+            configs.Add(Parse(@"
+[test.*]
+dotnet_diagnostic.cs000.some_key = b_val", "/src/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/src/test.cs", "/src/test.vb", "/root.cs" },
+                configs);
+            configs.Free();
+
+            VerifyAnalyzerOptions(
+                new[] {
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "b_val") },
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "b_val") },
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "a_val") }
+               },
+                options);
+        }
+
+        [Fact]
+        public void NestedAnalyzerOptionsWithSectionOverrides()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.some_key = a_val", "/.editorconfig"));
+            configs.Add(Parse(@"
+[test.*]
+dotnet_diagnostic.cs000.some_key = b_val
+
+[*.cs]
+dotnet_diagnostic.cs000.some_key = c_val", "/src/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/src/test.cs", "/src/test.vb", "/root.cs" },
+                configs);
+            configs.Free();
+
+            VerifyAnalyzerOptions(
+                new[] {
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "c_val") },
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "b_val") },
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "a_val") }
+               },
+                options);
+        }
+
+        [Fact]
         public void FromMultipleSectionsAnalyzerOptions()
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1125,6 +1125,33 @@ dotnet_diagnostic.cs000.some_key = some_val", "/.editorconfig"));
         }
 
         [Fact]
+        public void NestedAnalyzerOptionsWithRoot()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.bad_key = bad_val", "/.editorconfig"));
+            configs.Add(Parse(@"
+root = true
+
+[*.cs]
+dotnet_diagnostic.cs000.some_key = some_val", "/src/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/src/test.cs", "/src/test.vb", "/root.cs" },
+                configs);
+            configs.Free();
+
+            VerifyAnalyzerOptions(
+                new[] {
+                    new[] { ("dotnet_diagnostic.cs000.some_key", "some_val") },
+                    new (string, string) [] { },
+                    new[] { ("dotnet_diagnostic.cs000.bad_key", "bad_val") }
+               },
+                options);
+        }
+
+        [Fact]
         public void FromMultipleSectionsAnalyzerOptions()
         {
             var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -103,6 +103,15 @@ namespace Microsoft.CodeAnalysis
 
                 if (normalizedPath.StartsWith(config.NormalizedDirectory, StringComparison.Ordinal))
                 {
+                    // If this config is a root config, then clear earlier options since they don't apply
+                    // to this source file.
+                    if (config.IsRoot)
+                    {
+                        analyzerOptionsBuilder.Clear();
+                        treeOptionsBuilder.Clear();
+                        diagnosticBuilder.Clear();
+                    }
+
                     int dirLength = config.NormalizedDirectory.Length;
                     // Leave '/' if the normalized directory ends with a '/'. This can happen if
                     // we're in a root directory (e.g. '/' or 'Z:/'). The section matching
@@ -119,7 +128,7 @@ namespace Microsoft.CodeAnalysis
                         if (matchers[sectionIndex]?.IsMatch(relativePath) == true)
                         {
                             var section = config.NamedSections[sectionIndex];
-                            addOptions(section, treeOptionsBuilder, analyzerOptionsBuilder, config.PathToFile);
+                            addOptions(section, treeOptionsBuilder, analyzerOptionsBuilder, diagnosticBuilder, config.PathToFile);
                         }
                     }
                 }
@@ -130,10 +139,11 @@ namespace Microsoft.CodeAnalysis
                 analyzerOptionsBuilder.Count > 0 ? analyzerOptionsBuilder.ToImmutable() : AnalyzerConfigOptions.EmptyDictionary,
                 diagnosticBuilder.ToImmutableAndFree());
 
-            void addOptions(
+            static void addOptions(
                 AnalyzerConfig.Section section,
                 TreeOptions.Builder treeBuilder,
                 AnalyzerOptions.Builder analyzerBuilder,
+                ArrayBuilder<Diagnostic> diagnosticBuilder,
                 string analyzerConfigPath)
             {
                 const string DiagnosticOptionPrefix = "dotnet_diagnostic.";


### PR DESCRIPTION
Walk the AnalyzerConfigDocuments from most nested to least nested. Check each applicable editorconfig for whether it is the root or not before continuing.

Fixes #37282