### PR TITLE
Run naming styles on closed files

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyleDiagnosticAnalyzerBase.cs
@@ -44,8 +44,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
         // see https://github.com/dotnet/roslyn/issues/14061
         protected abstract ImmutableArray<TLanguageKindEnum> SupportedSyntaxKinds { get; }
 
-        public override bool OpenFileOnly(OptionSet options) => true;
-
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterCompilationStartAction(CompilationStartAction);
 

--- a/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractOptionsSerializationService.cs
@@ -6,12 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
-using System.Xml.Linq;
-using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Execution


### PR DESCRIPTION
Our best guess is we ran naming styles on open files only for two reasons:

1. At the time, we only supported .editorconfig in-proc, so out of proc wouldn't have used the right settings.
2. Even if we were running in-proc, there might have been performance issues since we were running across a lot of files.

Neither of these concerns apply at this point: we now support .editorconfig out of proc (both in the legacy path and the new path) and since we're already running other analyzers that use .editorconfig,
the cost of processing it will exist regardless.

Fixes #15760