### PR TITLE
Small cleanup.

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -36,8 +36,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 if (showSpeculativeT)
                 {
-                    var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
                     const string T = nameof(T);
                     context.AddItem(CommonCompletionItem.Create(
                         T, displayTextSuffix: "", CompletionItemRules.Default, glyph: Glyph.TypeParameter));

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -116,9 +116,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             //   |
 
             // class C {
-            //   public |
-
-            // class C {
             //   [Goo]
             //   |
 
@@ -129,6 +126,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // previous token.
             token = token.GetPreviousTokenIfTouchingWord(position);
 
+            // class C {
+            //   |
             if (token.IsKind(SyntaxKind.OpenBraceToken))
             {
                 if (token.Parent is BaseTypeDeclarationSyntax)

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -219,12 +219,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return false;
             }
 
+            validTypeDeclarations ??= SpecializedCollections.EmptySet<SyntaxKind>();
+
             if (!validTypeDeclarations.Contains(typeDecl.Kind()))
             {
                 return false;
             }
-
-            validTypeDeclarations ??= SpecializedCollections.EmptySet<SyntaxKind>();
 
             // Check many of the simple cases first.
             var leftToken = contextOpt != null
@@ -367,9 +367,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // class C {
             //   int i;
             //   |
-
-            // class C {
-            //   public |
 
             // class C {
             //   [Goo]


### PR DESCRIPTION
Found small issues when trying to look for solution to #37224

1. Removed a no longer needed variable `text`, it was needed to get `FilterSpan` before 4445deb5

1. The first overload of `IsMemberDeclarationContext` does not handle cases with modifiers, removed from comments.

No functional changes in this PR.