### PR TITLE
Syntax factory for switch statement adds parens when needed.

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -8190,18 +8190,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     }
 
 
-    /// <summary>Creates a new SwitchStatementSyntax instance.</summary>
-    public static SwitchStatementSyntax SwitchStatement(ExpressionSyntax expression, SyntaxList<SwitchSectionSyntax> sections)
-    {
-      return SyntaxFactory.SwitchStatement(SyntaxFactory.Token(SyntaxKind.SwitchKeyword), default(SyntaxToken), expression, default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.OpenBraceToken), sections, SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
-    }
-
-    /// <summary>Creates a new SwitchStatementSyntax instance.</summary>
-    public static SwitchStatementSyntax SwitchStatement(ExpressionSyntax expression)
-    {
-      return SyntaxFactory.SwitchStatement(SyntaxFactory.Token(SyntaxKind.SwitchKeyword), default(SyntaxToken), expression, default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.OpenBraceToken), default(SyntaxList<SwitchSectionSyntax>), SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
-    }
-
     /// <summary>Creates a new SwitchSectionSyntax instance.</summary>
     public static SwitchSectionSyntax SwitchSection(SyntaxList<SwitchLabelSyntax> labels, SyntaxList<StatementSyntax> statements)
     {

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2429,7 +2429,7 @@
     </FactoryComment>
   </Node>
 
-  <Node Name="SwitchStatementSyntax" Base="StatementSyntax">
+  <Node Name="SwitchStatementSyntax" Base="StatementSyntax" SkipConvenienceFactories="true">
     <Kind Name="SwitchStatement"/>
     <Field Name="SwitchKeyword" Type="SyntaxToken">
       <Kind Name="SwitchKeyword"/>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2531,6 +2531,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             return EventDeclaration(attributeLists, modifiers, eventKeyword, type, explicitInterfaceSpecifier, identifier, accessorList: null, semicolonToken);
         }
 
+        /// <summary>Creates a new SwitchStatementSyntax instance.</summary>
+        public static SwitchStatementSyntax SwitchStatement(ExpressionSyntax expression, SyntaxList<SwitchSectionSyntax> sections)
+        {
+            bool needsParens = !(expression is TupleExpressionSyntax);
+            var openParen = needsParens ? SyntaxFactory.Token(SyntaxKind.OpenParenToken) : default;
+            var closeParen = needsParens ? SyntaxFactory.Token(SyntaxKind.CloseParenToken) : default;
+            return SyntaxFactory.SwitchStatement(
+                SyntaxFactory.Token(SyntaxKind.SwitchKeyword),
+                openParen,
+                expression,
+                closeParen,
+                SyntaxFactory.Token(SyntaxKind.OpenBraceToken),
+                sections,
+                SyntaxFactory.Token(SyntaxKind.CloseBraceToken));
+        }
+
+        /// <summary>Creates a new SwitchStatementSyntax instance.</summary>
+        public static SwitchStatementSyntax SwitchStatement(ExpressionSyntax expression)
+        {
+            return SyntaxFactory.SwitchStatement(expression, default(SyntaxList<SwitchSectionSyntax>));
+        }
+
         // BACK COMPAT OVERLOAD DO NOT MODIFY
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static SyntaxTree ParseSyntaxTree(

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/GreenNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/GreenNodeTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 using InternalSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax;
 
@@ -34,6 +32,42 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 return node;
             }
+        }
+
+        [Fact, WorkItem(33685, "https://github.com/dotnet/roslyn/issues/33685")]
+        public void ConvenienceSwitchStatementFactoriesAddParensWhenNeeded_01()
+        {
+            var expression = SyntaxFactory.ParseExpression("x");
+            var sw1 = SyntaxFactory.SwitchStatement(expression);
+            Assert.Equal(SyntaxKind.OpenParenToken, sw1.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.CloseParenToken, sw1.CloseParenToken.Kind());
+            var sw2 = SyntaxFactory.SwitchStatement(expression, default);
+            Assert.Equal(SyntaxKind.OpenParenToken, sw2.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.CloseParenToken, sw2.CloseParenToken.Kind());
+        }
+
+        [Fact, WorkItem(33685, "https://github.com/dotnet/roslyn/issues/33685")]
+        public void ConvenienceSwitchStatementFactoriesAddParensWhenNeeded_02()
+        {
+            var expression = SyntaxFactory.ParseExpression("(x)");
+            var sw1 = SyntaxFactory.SwitchStatement(expression);
+            Assert.Equal(SyntaxKind.OpenParenToken, sw1.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.CloseParenToken, sw1.CloseParenToken.Kind());
+            var sw2 = SyntaxFactory.SwitchStatement(expression, default);
+            Assert.Equal(SyntaxKind.OpenParenToken, sw2.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.CloseParenToken, sw2.CloseParenToken.Kind());
+        }
+
+        [Fact, WorkItem(33685, "https://github.com/dotnet/roslyn/issues/33685")]
+        public void ConvenienceSwitchStatementFactoriesOmitParensWhenPossible()
+        {
+            var expression = SyntaxFactory.ParseExpression("(1, 2)");
+            var sw1 = SyntaxFactory.SwitchStatement(expression);
+            Assert.True(sw1.OpenParenToken == default);
+            Assert.True(sw1.CloseParenToken == default);
+            var sw2 = SyntaxFactory.SwitchStatement(expression, default);
+            Assert.True(sw2.OpenParenToken == default);
+            Assert.True(sw2.CloseParenToken == default);
         }
     }
 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Model/TreeType.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/Model/TreeType.cs
@@ -12,6 +12,9 @@ namespace CSharpSyntaxGenerator
         [XmlAttribute]
         public string Base;
 
+        [XmlAttribute]
+        public string SkipConvenienceFactories;
+
         [XmlElement]
         public Comment TypeComment;
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -1625,9 +1625,13 @@ namespace CSharpSyntaxGenerator
             {
                 var node = nodes[i];
                 this.WriteRedFactory(node);
-                this.WriteRedFactoryWithNoAutoCreatableTokens(node);
-                this.WriteRedMinimalFactory(node);
-                this.WriteRedMinimalFactory(node, withStringNames: true);
+                bool skipConvenienceFactories = node.SkipConvenienceFactories != null && string.Compare(node.SkipConvenienceFactories, "true", true) == 0;
+                if (!skipConvenienceFactories)
+                {
+                    this.WriteRedFactoryWithNoAutoCreatableTokens(node);
+                    this.WriteRedMinimalFactory(node);
+                    this.WriteRedMinimalFactory(node, withStringNames: true);
+                }
                 this.WriteKindConverters(node);
             }
 


### PR DESCRIPTION
Fixes #33685

/cc @jcouv @agocke 
