### PR TITLE
Analyzer driver performance fixes for IDE open file analysis

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private void FreeDeclarationDataMap_NoLock(Dictionary<int, DeclarationAnalyzerStateData> declarationDataMapOpt)
             {
-                if (declarationDataMapOpt != null)
+                if (declarationDataMapOpt is object)
                 {
                     declarationDataMapOpt.Clear();
                     _currentlyAnalyzingDeclarationsMapPool.Free(declarationDataMapOpt);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.PerAnalyzerState.cs
@@ -199,14 +199,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 _lazySyntaxTreesWithAnalysisData[tree] = AnalyzerStateData.FullyProcessedInstance;
             }
 
+            private Dictionary<int, DeclarationAnalyzerStateData> EnsureDeclarationDataMap_NoLock(ISymbol symbol, Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap)
+            {
+                Debug.Assert(_pendingDeclarations[symbol] == declarationDataMap);
+
+                if (declarationDataMap == null)
+                {
+                    declarationDataMap = _currentlyAnalyzingDeclarationsMapPool.Allocate();
+                    _pendingDeclarations[symbol] = declarationDataMap;
+                }
+
+                return declarationDataMap;
+            }
+
             private bool TryStartAnalyzingDeclaration_NoLock(ISymbol symbol, int declarationIndex, out DeclarationAnalyzerStateData state)
             {
-                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
-                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                if (!_pendingDeclarations.TryGetValue(symbol, out var declarationDataMap))
                 {
                     state = null;
                     return false;
                 }
+
+                declarationDataMap = EnsureDeclarationDataMap_NoLock(symbol, declarationDataMap);
 
                 if (declarationDataMap.TryGetValue(declarationIndex, out state))
                 {
@@ -229,14 +243,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private void MarkDeclarationProcessed_NoLock(ISymbol symbol, int declarationIndex)
             {
-                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
-                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                if (!_pendingDeclarations.TryGetValue(symbol, out var declarationDataMap))
                 {
                     return;
                 }
 
-                DeclarationAnalyzerStateData state;
-                if (declarationDataMap.TryGetValue(declarationIndex, out state))
+                declarationDataMap = EnsureDeclarationDataMap_NoLock(symbol, declarationDataMap);
+
+                if (declarationDataMap.TryGetValue(declarationIndex, out var state))
                 {
                     FreeDeclarationAnalyzerState_NoLock(state);
                 }
@@ -246,18 +260,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private void MarkDeclarationsProcessed_NoLock(ISymbol symbol)
             {
-                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
-                if (_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                if (_pendingDeclarations.TryGetValue(symbol, out var declarationDataMap))
                 {
                     FreeDeclarationDataMap_NoLock(declarationDataMap);
                     _pendingDeclarations.Remove(symbol);
                 }
             }
 
-            private void FreeDeclarationDataMap_NoLock(Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap)
+            private void FreeDeclarationDataMap_NoLock(Dictionary<int, DeclarationAnalyzerStateData> declarationDataMapOpt)
             {
-                declarationDataMap.Clear();
-                _currentlyAnalyzingDeclarationsMapPool.Free(declarationDataMap);
+                if (declarationDataMapOpt != null)
+                {
+                    declarationDataMapOpt.Clear();
+                    _currentlyAnalyzingDeclarationsMapPool.Free(declarationDataMapOpt);
+                }
             }
 
             private void FreeDeclarationAnalyzerState_NoLock(DeclarationAnalyzerStateData state)
@@ -299,14 +315,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private bool IsDeclarationComplete_NoLock(ISymbol symbol, int declarationIndex)
             {
-                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
-                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                if (!_pendingDeclarations.TryGetValue(symbol, out var declarationDataMap))
                 {
                     return true;
                 }
 
-                DeclarationAnalyzerStateData state;
-                if (!declarationDataMap.TryGetValue(declarationIndex, out state))
+                if (declarationDataMap == null ||
+                    !declarationDataMap.TryGetValue(declarationIndex, out var state))
                 {
                     return false;
                 }
@@ -316,13 +331,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             private bool AreDeclarationsProcessed_NoLock(ISymbol symbol, int declarationsCount)
             {
-                Dictionary<int, DeclarationAnalyzerStateData> declarationDataMap;
-                if (!_pendingDeclarations.TryGetValue(symbol, out declarationDataMap))
+                Debug.Assert(declarationsCount > 0);
+                if (!_pendingDeclarations.TryGetValue(symbol, out var declarationDataMap))
                 {
                     return true;
                 }
 
-                return declarationDataMap.Count == declarationsCount &&
+                return declarationDataMap?.Count == declarationsCount &&
                     declarationDataMap.Values.All(state => state.StateKind == StateKind.FullyProcessed);
             }
 
@@ -429,7 +444,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             actionCounts.HasAnyExecutableCodeActions)
                         {
                             needsAnalysis = true;
-                            _pendingDeclarations[symbol] = _currentlyAnalyzingDeclarationsMapPool.Allocate();
+                            _pendingDeclarations[symbol] = null;
                         }
 
                         if (actionCounts.SymbolStartActionsCount > 0 && (!skipSymbolAnalysis || !skipDeclarationAnalysis))

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -354,11 +354,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var diagnostics = ImmutableArray<Diagnostic>.Empty;
             var analysisScope = new AnalysisScope(_compilation, analyzers, _analysisOptions.ConcurrentAnalysis, categorizeDiagnostics: true);
-            Func<AsyncQueue<CompilationEvent>> getEventQueue = () =>
-               GetPendingEvents(analyzers, includeSourceEvents: true, includeNonSourceEvents: true, cancellationToken);
+            Func<ImmutableArray<CompilationEvent>> getPendingEvents = () =>
+                _analysisState.GetPendingEvents(analyzers, includeSourceEvents: true, includeNonSourceEvents: true, cancellationToken);
 
             // Compute the analyzer diagnostics for the given analysis scope.
-            await ComputeAnalyzerDiagnosticsAsync(analysisScope, getEventQueue, newTaskToken: 0, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await ComputeAnalyzerDiagnosticsAsync(analysisScope, getPendingEvents, newTaskToken: 0, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // Return computed non-local diagnostics for the given analysis scope.
             return _analysisResultBuilder.GetDiagnostics(analysisScope, getLocalDiagnostics: false, getNonLocalDiagnostics: true);
@@ -512,10 +512,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     var pendingAnalysisScope = pendingAnalyzers.Length < analyzers.Length ? analysisScope.WithAnalyzers(pendingAnalyzers) : analysisScope;
 
-                    Func<AsyncQueue<CompilationEvent>> getEventQueue = () => s_EmptyEventQueue;
-
                     // Compute the analyzer diagnostics for the pending analysis scope.
-                    await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getEventQueue, taskToken, cancellationToken).ConfigureAwait(false);
+                    await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEventsOpt: null, taskToken, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Return computed analyzer diagnostics for the given analysis scope.
@@ -581,7 +579,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     var pendingAnalysisScope = pendingAnalyzers.Length < analyzers.Length ? analysisScope.WithAnalyzers(pendingAnalyzers) : analysisScope;
 
-                    Func<AsyncQueue<CompilationEvent>> getEventQueue = () => GetPendingEvents(analyzers, model.SyntaxTree, cancellationToken);
+                    Func<ImmutableArray<CompilationEvent>> getPendingEvents = () => _analysisState.GetPendingEvents(analyzers, model.SyntaxTree, cancellationToken);
 
                     // Compute the analyzer diagnostics for the given analysis scope.
                     // We need to loop till symbol analysis is complete for any partial symbols being processed for other tree diagnostic requests.
@@ -589,7 +587,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
-                        (ImmutableArray<CompilationEvent> compilationEvents, bool hasSymbolStartActions) = await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getEventQueue, taskToken, cancellationToken).ConfigureAwait(false);
+                        (ImmutableArray<CompilationEvent> compilationEvents, bool hasSymbolStartActions) = await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEvents, taskToken, cancellationToken).ConfigureAwait(false);
                         if (hasSymbolStartActions)
                         {
                             await processPartialSymbolLocationsAsync(compilationEvents, analysisScope).ConfigureAwait(false);
@@ -651,7 +649,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             Task.Run(() =>
                             {
                                 var treeModel = _compilationData.GetOrCreateCachedSemanticModel(tree, _compilation, cancellationToken);
-                                return GetAnalyzerSemanticDiagnosticsAsync(treeModel, filterSpan: null, cancellationToken);
+                                return GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken);
                             }, cancellationToken))).ConfigureAwait(false);
                     }
                     else
@@ -660,14 +658,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         {
                             cancellationToken.ThrowIfCancellationRequested();
                             var treeModel = _compilationData.GetOrCreateCachedSemanticModel(tree, _compilation, cancellationToken);
-                            await GetAnalyzerSemanticDiagnosticsAsync(treeModel, filterSpan: null, cancellationToken).ConfigureAwait(false);
+                            await GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken).ConfigureAwait(false);
                         }
                     }
                 }
             }
         }
 
-        private async Task<(ImmutableArray<CompilationEvent> events, bool hasSymbolStartActions)> ComputeAnalyzerDiagnosticsAsync(AnalysisScope analysisScope, Func<AsyncQueue<CompilationEvent>> getEventQueue, int newTaskToken, CancellationToken cancellationToken)
+        private async Task<(ImmutableArray<CompilationEvent> events, bool hasSymbolStartActions)> ComputeAnalyzerDiagnosticsAsync(AnalysisScope analysisScope, Func<ImmutableArray<CompilationEvent>> getPendingEventsOpt, int newTaskToken, CancellationToken cancellationToken)
         {
             try
             {
@@ -686,11 +684,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    ImmutableArray<CompilationEvent> compilationEvents = await GenerateCompilationEventsAndPopulateEventsCacheAsync(analysisScope, driver, cancellationToken).ConfigureAwait(false);
+                    await GenerateCompilationEventsAndPopulateEventsCacheAsync(analysisScope, driver, cancellationToken).ConfigureAwait(false);
 
                     // Track if this task was suspended by another tree diagnostics request for the same tree.
                     // If so, we wait for the high priority requests to complete before restarting analysis.
                     bool suspendend;
+                    var pendingEvents = ImmutableArray<CompilationEvent>.Empty;
                     do
                     {
                         suspendend = false;
@@ -712,11 +711,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                         {
                                             try
                                             {
-                                                AsyncQueue<CompilationEvent> eventQueue = null;
+                                                AsyncQueue<CompilationEvent> eventQueue = s_EmptyEventQueue;
                                                 try
                                                 {
                                                     // Get event queue with pending events to analyze.
-                                                    eventQueue = getEventQueue();
+                                                    if (getPendingEventsOpt != null)
+                                                    {
+                                                        pendingEvents = getPendingEventsOpt();
+                                                        eventQueue = CreateEventsQueue(pendingEvents);
+                                                    }
 
                                                     linkedCancellationToken.ThrowIfCancellationRequested();
 
@@ -762,7 +765,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         }
                     } while (suspendend);
 
-                    return (compilationEvents, hasSymbolStartActions: driver?.HasSymbolStartedActions ?? false);
+                    return (pendingEvents, hasSymbolStartActions: driver?.HasSymbolStartedActions(analysisScope) ?? false);
                 }
                 finally
                 {
@@ -775,13 +778,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private async Task<ImmutableArray<CompilationEvent>> GenerateCompilationEventsAndPopulateEventsCacheAsync(AnalysisScope analysisScope, AnalyzerDriver driver, CancellationToken cancellationToken)
+        private async Task GenerateCompilationEventsAndPopulateEventsCacheAsync(AnalysisScope analysisScope, AnalyzerDriver driver, CancellationToken cancellationToken)
         {
 #if SIMULATED_EVENT_QUEUE
             await _analysisState.GenerateSimulatedCompilationEventsAsync(analysisScope, _compilation, _compilationData.GetOrCreateCachedSemanticModel, driver, cancellationToken).ConfigureAwait(false);
 #else
             GenerateCompilationEvents(analysisScope, cancellationToken);
-            return await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
+            await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
 #endif
         }
 
@@ -800,7 +803,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private async Task<ImmutableArray<CompilationEvent>> PopulateEventsCacheAsync(CancellationToken cancellationToken)
+        private async Task PopulateEventsCacheAsync(CancellationToken cancellationToken)
         {
             if (_compilation.EventQueue.Count > 0)
             {
@@ -812,15 +815,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     var compilationEvents = DequeueGeneratedCompilationEvents();
                     await _analysisState.OnCompilationEventsGeneratedAsync(compilationEvents, driver, cancellationToken).ConfigureAwait(false);
-                    return compilationEvents;
                 }
                 finally
                 {
                     FreeDriver(driver);
                 }
             }
-
-            return ImmutableArray<CompilationEvent>.Empty;
         }
 
         private ImmutableArray<CompilationEvent> DequeueGeneratedCompilationEvents()
@@ -1077,33 +1077,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        private AsyncQueue<CompilationEvent> GetPendingEvents(ImmutableArray<DiagnosticAnalyzer> analyzers, SyntaxTree tree, CancellationToken cancellationToken)
+        private AsyncQueue<CompilationEvent> CreateEventsQueue(ImmutableArray<CompilationEvent> compilationEvents)
         {
-            var eventQueue = _eventQueuePool.Allocate();
-            Debug.Assert(!eventQueue.IsCompleted);
-            Debug.Assert(eventQueue.Count == 0);
-
-            foreach (var compilationEvent in _analysisState.GetPendingEvents(analyzers, tree, cancellationToken))
+            if (compilationEvents.IsEmpty)
             {
-                eventQueue.TryEnqueue(compilationEvent);
+                return s_EmptyEventQueue;
             }
 
-            return eventQueue;
-        }
-
-        private AsyncQueue<CompilationEvent> GetPendingEvents(
-            ImmutableArray<DiagnosticAnalyzer> analyzers,
-            bool includeSourceEvents,
-            bool includeNonSourceEvents,
-            CancellationToken cancellationToken)
-        {
-            Debug.Assert(includeSourceEvents || includeNonSourceEvents);
-
             var eventQueue = _eventQueuePool.Allocate();
             Debug.Assert(!eventQueue.IsCompleted);
             Debug.Assert(eventQueue.Count == 0);
 
-            foreach (var compilationEvent in _analysisState.GetPendingEvents(analyzers, includeSourceEvents, includeNonSourceEvents, cancellationToken))
+            foreach (var compilationEvent in compilationEvents)
             {
                 eventQueue.TryEnqueue(compilationEvent);
             }


### PR DESCRIPTION
IDE analyzer host invokes [CompilationWithAnalyzers.GetAnalyzerSemanticDiagnosticsAsync](http://source.roslyn.io/#q=CompilationWithAnalyzers.GetAnalyzerSemanticDiagnosticsAsync) APIs to compute open file semantic diagnostics. This PR performs the following optimizations on this code path:
1. `AnalysisState.PerAnalyzerState`: Delay allocations of per-symbol dictionary values stored in `_pendingDeclarations` map until we actually start analyzing the first declaration for the symbol. This avoids unncessary allocation overhead on the dictionary pool from which these dictionaries are allocated.
2. `CompilationWithAnalyzers` and `AnalyzerDriver`: Ensure that we force complete partial type trees only for symbol start analyzer(s) in the original analysis scope for which diagnostics were requested. Our current logic force completed partial tree diagnostics for all analyzers if at least one of the analyzer is a symbol start analyzer, which is always true as IDE already has few symbol start analyzers.

Addresses VS Feedback performance issues [#922802](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/922802) and [#922837](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/922837)

**NOTE:** ~~This PR currently targets master branch, but we need to decide if this meets the current 16.3 bar as the code changes are in the compiler layer, even though the affected code path/APIs are only ever invoked during IDE open file analysis.~~ Retargeted to `features/compilerNext` based on offline discussion.