### PR TITLE
Consume construction with nullable in type inferrer

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -378,7 +378,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
 
             if (token.IsKind(SyntaxKind.QuestionToken)
-                && (token.Parent.IsKind(SyntaxKind.ConditionalExpression) || token.Parent is TypeSyntax))
+                && (token.Parent.IsKind(SyntaxKind.ConditionalExpression) || token.Parent is TypeSyntax)
+                && !token.Parent.Parent.IsKind(SyntaxKind.TypeArgumentList))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -62,6 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             TestNormalizeExpression("(IList<int>)args", "(IList<int>)args");
             TestNormalizeExpression("(IList<IList<int>>)args", "(IList<IList<int>>)args");
+
+            TestNormalizeExpression("(IList<string?>)args", "(IList<string?>)args");
         }
 
         private void TestNormalizeExpression(string text, string expected)

--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1623,7 +1623,7 @@ for (string? s = [|Goo()|]; ; ) { }", "global::System.String?");
             await TestInMethodAsync(@"foreach (int v in [|Goo()|]) { }", "global::System.Collections.Generic.IEnumerable<global::System.Int32>");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36046"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/37309"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
         public async Task TestForEachNullableElements()
         {
             await TestInMethodAsync(
@@ -2508,7 +2508,7 @@ class C
             await TestAsync(text, "global::System.Threading.Tasks.Task<global::System.Int32>");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36046"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
         public async Task TestAwaitTaskOfTNullableValue()
         {
             var text =
@@ -3031,7 +3031,7 @@ class C
             await TestAsync(text, "global::Program", testNode: false);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36046"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/37310"), Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
         public async Task TestInferringThroughGenericFunctionWithNullableReturn()
         {
             var text =

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -618,7 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return method;
                 }
 
-                // TODO: pass nullability once https://github.com/dotnet/roslyn/issues/36046 is fixed
+                // TODO: pass nullability once https://github.com/dotnet/roslyn/issues/37310 is fixed
                 var typeArguments = method.ConstructedFrom.TypeParameters
                     .Select(tp => (bestMap.GetValueOrDefault(tp) ?? tp).WithoutNullability()).ToArray();
                 return method.ConstructedFrom.Construct(typeArguments);
@@ -1219,8 +1219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var type = this.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
 
-                // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                return variableTypes.Select(v => new TypeInferenceInfo(type.Construct(v.InferredType.WithoutNullability())));
+                return variableTypes.Select(v => new TypeInferenceInfo(type.ConstructWithNullability(v.InferredType)));
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInForStatement(ForStatementSyntax forStatement, ExpressionSyntax expressionOpt = null, SyntaxToken? previousToken = null)
@@ -1702,8 +1701,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         this.Compilation.ObjectType;
                                 }
 
-                                // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                                return CreateResult(ienumerableType.Construct(typeArg.WithoutNullability()));
+                                return CreateResult(ienumerableType.ConstructWithNullability(typeArg));
                             }
                         }
                     }
@@ -1882,8 +1880,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return CreateResult(task);
                 }
 
-                // TODO: pass along nullability to Construct when https://github.com/dotnet/roslyn/issues/36046 is fixed.
-                return types.Select(t => t.InferredType.SpecialType == SpecialType.System_Void ? new TypeInferenceInfo(task) : new TypeInferenceInfo(taskOfT.Construct(t.InferredType.WithoutNullability())));
+                return types.Select(t => t.InferredType.SpecialType == SpecialType.System_Void ? new TypeInferenceInfo(task) : new TypeInferenceInfo(taskOfT.ConstructWithNullability(t.InferredType)));
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInYieldStatement(YieldStatementSyntax yieldStatement, SyntaxToken? previousToken = null)

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
@@ -26,8 +26,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public override ImmutableArray<ITypeSymbol> TypeArguments => _typeArguments;
 
-        // TODO: implement this once INamedTypeSymbol.Construct is fixed in https://github.com/dotnet/roslyn/issues/36046
-        public override ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations => _typeArguments.SelectAsArray(t => NullableAnnotation.NotAnnotated);
+        public override ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations => _typeArguments.SelectAsArray(t => t.GetNullability());
 
         public override int Arity => _constructedFrom.Arity;
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -599,8 +599,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static INamedTypeSymbol TryConstruct(this INamedTypeSymbol type, ITypeSymbol[] typeArguments)
         {
-            // TODO: pass along nullability once https://github.com/dotnet/roslyn/issues/36046 is fixed
-            return typeArguments.Length > 0 ? type.Construct(typeArguments.Select(t => t.WithoutNullability()).ToArray()) : type;
+            return typeArguments.Length > 0 ? type.ConstructWithNullability(typeArguments) : type;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.CompilationTypeGenerator.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.CompilationTypeGenerator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             public ITypeSymbol Construct(INamedTypeSymbol namedType, ITypeSymbol[] typeArguments)
             {
-                return namedType.Construct(typeArguments);
+                return namedType.ConstructWithNullability(typeArguments);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.SubstituteTypesVisitor.cs
@@ -87,8 +87,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return symbol;
                 }
 
-                // TODO: pass nullability to the substituted arguments once https://github.com/dotnet/roslyn/issues/36046 is fixed
-                return _typeGenerator.Construct(symbol.OriginalDefinition, substitutedArguments.Select(t => t.WithoutNullability()).ToArray()).WithNullability(symbol.GetNullability());
+                return _typeGenerator.Construct(symbol.OriginalDefinition, substitutedArguments.ToArray()).WithNullability(symbol.GetNullability());
             }
 
             public override ITypeSymbol VisitArrayType(IArrayTypeSymbol symbol)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (iequatableType != null)
             {
-                // TODO: pass the nullability to Construct once https://github.com/dotnet/roslyn/issues/36046 is fixed
+                // It's correct to throw out nullability here -- if you have a field of type Foo? and it implements IEquatable, it's still implementing IEquatable<Foo>.
                 var constructed = iequatableType.Construct(memberType.WithoutNullability());
                 return memberType.AllInterfaces.Contains(constructed);
             }

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
@@ -110,5 +110,10 @@ namespace Microsoft.CodeAnalysis
 
         public static ITypeSymbol GetTypeWithAnnotatedNullability(this ILocalSymbol localSymbol)
             => localSymbol.Type.WithNullability(localSymbol.NullableAnnotation);
+
+        public static INamedTypeSymbol ConstructWithNullability(this INamedTypeSymbol typeSymbol, params ITypeSymbol[] typeArguments)
+        {
+            return typeSymbol.Construct(typeArguments.SelectAsArray(t => t.WithoutNullability()), typeArguments.SelectAsArray(t => t.GetNullability()));
+        }
     }
 }


### PR DESCRIPTION
This consists of two parts:

1. Fixing a compiler bug in NormalizeWhitespace that I hit while trying to test the second part and
2. Updating the type inferrer and the appropriate tests.