### PR TITLE
Replace ApplyPartialNgenOptimization with ApplyNgenOptimization

### DIFF
--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -29,8 +29,6 @@
   <PropertyGroup>
     <_DependentAssemblyVersionsFile>$(VisualStudioBuildPackagesDir)DependentAssemblyVersions.csv</_DependentAssemblyVersionsFile>
     <_OptimizedDependenciesDir>$(ArtifactsTmpDir)OptimizedDependencies\</_OptimizedDependenciesDir>
-    <_OptimizedNuGetPackageVersionSuffix Condition="'$(OfficialBuild)' != 'true'">vs-ci</_OptimizedNuGetPackageVersionSuffix>
-    <_OptimizedNuGetPackageVersionSuffix Condition="'$(OfficialBuild)' == 'true'">vs-$(VersionSuffixDateStamp)-$(VersionSuffixBuildOfTheDayPadded)</_OptimizedNuGetPackageVersionSuffix>
   </PropertyGroup>
 
   <!-- 
@@ -223,6 +221,11 @@
           Condition="'$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true'"
           DependsOnTargets="_CalculateDependenciesToInsert;_UnpackDependencies;ApplyOptimizations">
 
+    <PropertyGroup>
+      <_OptimizedNuGetPackageVersionSuffix Condition="'$(OfficialBuild)' != 'true'">vs-ci</_OptimizedNuGetPackageVersionSuffix>
+      <_OptimizedNuGetPackageVersionSuffix Condition="'$(OfficialBuild)' == 'true'">vs-$(VersionSuffixDateStamp)-$(VersionSuffixBuildOfTheDayPadded)</_OptimizedNuGetPackageVersionSuffix>
+    </PropertyGroup>
+    
     <MakeDir Directories="$(VisualStudioBuildPackagesDir)"/>
 
     <!-- Unsign assemblies that need to be unsigned but not optimized. -->

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -144,7 +144,7 @@
     -->
     <ItemGroup>
       <ExpectedDependency>
-        <_EffectiveOptimizeAssemblies Condition="'$(ApplyPartialNgenOptimization)' == 'true'">%(ExpectedDependency.OptimizeAssemblies)</_EffectiveOptimizeAssemblies>
+        <_EffectiveOptimizeAssemblies Condition="'$(ApplyNgenOptimization)' != ''">%(ExpectedDependency.OptimizeAssemblies)</_EffectiveOptimizeAssemblies>
       </ExpectedDependency>
       
       <_OptimizeAssembliesSplit Include="%(ExpectedDependency._EffectiveOptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" />

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -142,7 +142,7 @@
     -->
     <ItemGroup>
       <ExpectedDependency>
-        <_EffectiveOptimizeAssemblies Condition="'$(ApplyNgenOptimization)' != ''">%(ExpectedDependency.OptimizeAssemblies)</_EffectiveOptimizeAssemblies>
+        <_EffectiveOptimizeAssemblies Condition="'$(EnableNgenOptimization)' == 'true' and '$(ApplyNgenOptimization)' != ''">%(ExpectedDependency.OptimizeAssemblies)</_EffectiveOptimizeAssemblies>
       </ExpectedDependency>
       
       <_OptimizeAssembliesSplit Include="%(ExpectedDependency._EffectiveOptimizeAssemblies)" DependencyName="%(ExpectedDependency.Identity)" />

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -30,7 +30,7 @@
           DependsOnTargets="InitializeDesktopCompilerArtifacts">
 
     <ItemGroup>
-      <DesktopCompilerArtifact Condition="'%(DesktopCompilerArtifact.OverwriteNgenOptimizationData)' == 'true' and '$(ApplyPartialNgenOptimization)' == 'true'">
+      <DesktopCompilerArtifact Condition="'%(DesktopCompilerArtifact.OverwriteNgenOptimizationData)' == 'true' and '$(ApplyNgenOptimization)' != ''">
         <_OptimizeAssembly>$(IntermediateOutputPath)optimized\$([System.IO.Path]::GetFileName(%(DesktopCompilerArtifact.Identity)))</_OptimizeAssembly>
       </DesktopCompilerArtifact>
 
@@ -45,7 +45,7 @@
           DependsOnTargets="_CalculateDesktopCompilerArtifactsToOptimize"
           Inputs="@(DesktopCompilerArtifact)"
           Outputs="@(DesktopCompilerArtifact->'%(_OptimizeAssembly)')"
-          Condition="'$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true' and '$(ApplyPartialNgenOptimization)' == 'true'">
+          Condition="'$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true' and '$(ApplyNgenOptimization)' != ''">
 
     <Copy SourceFiles="%(DesktopCompilerArtifact.Identity)" DestinationFiles="%(DesktopCompilerArtifact._OptimizeAssembly)" Condition="'%(DesktopCompilerArtifact._OptimizeAssembly)' != ''">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.Setup.csproj
@@ -30,7 +30,7 @@
           DependsOnTargets="InitializeDesktopCompilerArtifacts">
 
     <ItemGroup>
-      <DesktopCompilerArtifact Condition="'%(DesktopCompilerArtifact.OverwriteNgenOptimizationData)' == 'true' and '$(ApplyNgenOptimization)' != ''">
+      <DesktopCompilerArtifact Condition="'%(DesktopCompilerArtifact.OverwriteNgenOptimizationData)' == 'true' and '$(EnableNgenOptimization)' == 'true' and '$(ApplyNgenOptimization)' != ''">
         <_OptimizeAssembly>$(IntermediateOutputPath)optimized\$([System.IO.Path]::GetFileName(%(DesktopCompilerArtifact.Identity)))</_OptimizeAssembly>
       </DesktopCompilerArtifact>
 
@@ -45,7 +45,7 @@
           DependsOnTargets="_CalculateDesktopCompilerArtifactsToOptimize"
           Inputs="@(DesktopCompilerArtifact)"
           Outputs="@(DesktopCompilerArtifact->'%(_OptimizeAssembly)')"
-          Condition="'$(Configuration)' == 'Release' and '$(ContinuousIntegrationBuild)' == 'true' and '$(ApplyNgenOptimization)' != ''">
+          Condition="'$(EnableNgenOptimization)' == 'true' and '$(ApplyNgenOptimization)' != ''">
 
     <Copy SourceFiles="%(DesktopCompilerArtifact.Identity)" DestinationFiles="%(DesktopCompilerArtifact._OptimizeAssembly)" Condition="'%(DesktopCompilerArtifact._OptimizeAssembly)' != ''">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites"/>


### PR DESCRIPTION
The ApplyPartialNgenOptimization property is an old name for ApplyNgenOptimization=partial and shouldn't be used anymore.

Fixes merging IBC data to inserted dependencies.