### PR TITLE
Fix InvalidOperationException in AbstractRemoveUnusedParametersAndVal…

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1288,21 +1288,21 @@ class C
 @"using System;
 using System.Threading.Tasks;
 
-public interface IFoo { event Action Fooed; }
+public interface I { event Action MyAction; }
 
 public sealed class C : IDisposable
 {
-    private readonly Task<IFoo> foo;
+    private readonly Task<I> task;
 
-    public C(Task<IFoo> [|foo|])
+    public C(Task<I> [|task|])
     {
-        this.foo = foo;
-        Task.Run(async () => (await foo).Fooed += fooed);
+        this.task = task;
+        Task.Run(async () => (await task).MyAction += myAction);
     }
 
-    private void fooed() { }
+    private void myAction() { }
 
-    public void Dispose() => foo.Result.Fooed -= fooed;
+    public void Dispose() => task.Result.MyAction -= myAction;
 }", options);
         }
 
@@ -1317,21 +1317,21 @@ public sealed class C : IDisposable
 @"using System;
 using System.Threading.Tasks;
 
-public interface IFoo { event Action Fooed; }
+public interface I { event Action MyAction; }
 
 public sealed class C : IDisposable
 {
-    private readonly Task<IFoo> foo;
+    private readonly Task<I> task;
 
-    public C(Task<IFoo> [|foo|])
+    public C(Task<I> [|task|])
     {
-        this.foo = foo;
-        Task.Run(async () => (await foo).Fooed += fooed);
+        this.task = task;
+        Task.Run(async () => (await task).MyAction += myAction);
     }
 
-    private void fooed() { }
+    private void myAction() { }
 
-    public void Dispose() => foo.Result.Fooed -= fooed;
+    public void Dispose() => task.Result.MyAction -= myAction;
 }", options);
         }
 

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1306,6 +1306,35 @@ public sealed class C : IDisposable
 }", options);
         }
 
+        [WorkItem(37326, "https://github.com/dotnet/roslyn/issues/37326")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task RegressionTest_ShouldReportUnusedParameter_02()
+        {
+            var options = Option(CodeStyleOptions.UnusedParameters,
+                new CodeStyleOption<UnusedParametersPreference>((UnusedParametersPreference)2, NotificationOption.Suggestion));
+
+            await TestDiagnosticMissingAsync(
+@"using System;
+using System.Threading.Tasks;
+
+public interface IFoo { event Action Fooed; }
+
+public sealed class C : IDisposable
+{
+    private readonly Task<IFoo> foo;
+
+    public C(Task<IFoo> [|foo|])
+    {
+        this.foo = foo;
+        Task.Run(async () => (await foo).Fooed += fooed);
+    }
+
+    private void fooed() { }
+
+    public void Dispose() => foo.Result.Fooed -= fooed;
+}", options);
+        }
+
         [WorkItem(36817, "https://github.com/dotnet/roslyn/issues/36817")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         public async Task ParameterWithoutName_NoDiagnostic()

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -280,15 +280,12 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 return false;
             }
 
-            switch (unusedParametersPreference)
+            if (unusedParametersPreference == UnusedParametersPreference.NonPublicMethods)
             {
-                case UnusedParametersPreference.AllMethods:
-                    return true;
-                case UnusedParametersPreference.NonPublicMethods:
-                    return !symbol.HasPublicResultantVisibility();
-                default:
-                    throw ExceptionUtilities.Unreachable;
+                return !symbol.HasPublicResultantVisibility();
             }
+
+            return true;
         }
 
         public static bool TryGetUnusedValuePreference(Diagnostic diagnostic, out UnusedValuePreference preference)


### PR DESCRIPTION
…uesDiagnosticAnalyzer.ShouldReportUnusedParameters

We recently changed the enum values for `UnusedParametersPreference` (see https://github.com/dotnet/roslyn/commit/ee61cc53ff02b55df8c9d756235c0e1085dafa4b), which seems to lead to this exception if customers had explicitly changed this option in the Tools Option page prior to that fix. I have changed the code to be much more defensive.

Fixes #37326