### PR TITLE
🚧 Remove broken PackageReference heuristic and prevent incorrect framework assembly references

### DIFF
--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -308,7 +308,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 foreach (var reference in p.MetadataReferences)
                 {
                     if (reference is PortableExecutableReference peReference &&
-                        !IsInPackagesDirectory(peReference) &&
+                        IsDirectReferenceAllowed(peReference) &&
                         seenReferences.Add(peReference))
                     {
                         result.Add((p.Id, peReference));
@@ -355,31 +355,17 @@ namespace Microsoft.CodeAnalysis.AddImport
         }
 
         /// <summary>
-        /// We ignore references that are in a directory that contains the names "Packages".
-        /// These directories are most likely the ones produced by NuGet, and we don't want
-        /// to offer to add .dll reference manually for dlls that are part of NuGet packages.
-        /// 
-        /// Note that this is only a heuristic (though a good one), and we should remove this
-        /// when we can get an API from NuGet that tells us if a reference is actually provided
-        /// by a nuget packages.
-        /// 
-        /// This heuristic will do the right thing in practically all cases for all. It 
-        /// prevents the very unpleasant experience of us offering to add a direct metadata 
-        /// reference to something that should only be referenced as a nuget package.
-        ///
-        /// It does mean that if the following is true:
-        /// You have a project that has a non-nuget metadata reference to something in a "packages"
-        /// directory, and you are in another project that uses a type name that would have matched
-        /// an accessible type from that dll. then we will not offer to add that .dll reference to
-        /// that other project.
-        /// 
-        /// However, that would be an exceedingly uncommon case that is degraded.  Whereas we're 
-        /// vastly improved in the common case. This is a totally acceptable and desirable outcome
-        /// for such a heuristic.
+        /// Determines whether a direct reference is allowed to an assembly which appears as a reference in another
+        /// project.
         /// </summary>
-        private bool IsInPackagesDirectory(PortableExecutableReference reference)
+        private bool IsDirectReferenceAllowed(PortableExecutableReference reference)
         {
-            return PathUtilities.ContainsPathComponent(reference.FilePath, "packages", ignoreCase: true);
+            // Direct references to assemblies in NuGet packages and framework targeting packs are not allowed. NuGet
+            // package references require <PackageReference>, and framework targeting packs require
+            // <FrameworkReference>. However, we do not currently have the ability to determine whether or not an
+            // assembly is located in one of these locations, so we do not allow direct assembly references in this
+            // feature at this time.
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
See #37246

🚧 I'm expecting tests to fail in CI that I need to mark as skipped...