### PR TITLE
Add CI telemetry for bootstrap build and test

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -610,20 +610,36 @@ try {
     InstallDotNetSdk $global:_DotNetInstallDir "2.1.503"
   }
 
-  if ($bootstrap) {
-    $bootstrapDir = Make-BootstrapBuild -force32:$test32
+  try
+  {
+    if ($bootstrap) {
+      $bootstrapDir = Make-BootstrapBuild -force32:$test32
+    }
+  }
+  catch
+  {
+      echo "##vso[task.logissue type=error](NETCORE_ENGINEERING_TELEMETRY=Build) Build failed"
+      throw $_
   }
 
   if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -or $testCoreClr) {
-    BuildSolution
+      BuildSolution
   }
 
   if ($ci -and $build -and $msbuildEngine -eq "vs") {
     SetVisualStudioBootstrapperBuildArgs
   }
 
-  if ($testDesktop -or $testVsi -or $testIOperation) {
-    TestUsingOptimizedRunner
+  try
+  {
+    if ($testDesktop -or $testVsi -or $testIOperation) {
+      TestUsingOptimizedRunner
+    }
+  }
+  catch
+  {
+      echo "##vso[task.logissue type=error](NETCORE_ENGINEERING_TELEMETRY=Test) Tests failed"
+      throw $_
   }
 
   if ($launch) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -618,12 +618,12 @@ try {
   }
   catch
   {
-      echo "##vso[task.logissue type=error](NETCORE_ENGINEERING_TELEMETRY=Build) Build failed"
-      throw $_
+    echo "##vso[task.logissue type=error](NETCORE_ENGINEERING_TELEMETRY=Build) Build failed"
+    throw $_
   }
 
   if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -or $testCoreClr) {
-      BuildSolution
+    BuildSolution
   }
 
   if ($ci -and $build -and $msbuildEngine -eq "vs") {
@@ -638,8 +638,8 @@ try {
   }
   catch
   {
-      echo "##vso[task.logissue type=error](NETCORE_ENGINEERING_TELEMETRY=Test) Tests failed"
-      throw $_
+    echo "##vso[task.logissue type=error](NETCORE_ENGINEERING_TELEMETRY=Test) Tests failed"
+    throw $_
   }
 
   if ($launch) {


### PR DESCRIPTION
This should allow us to query the azure event API to figure out if a particular run failed because of failure to build or test failure. This should help us categorize the causes of CI flakiness and drive it down.