### PR TITLE
Split liveshare handlers

### DIFF
--- a/src/Tools/ExternalAccess/LiveShare/Classification/RoslynClassificationService.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Classification/RoslynClassificationService.Exports.cs
@@ -30,42 +30,42 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Classification
     [ExportLanguageServiceFactory(typeof(ISyntaxClassificationService), StringConstants.CSharpLspLanguageName), Shared]
     internal class CSharpLspEditorClassificationFactoryService : ILanguageServiceFactory
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly CSharpLspClientServiceFactory _csharpLspClientServiceFactory;
         private readonly ClassificationTypeMap _classificationTypeMap;
         private readonly IThreadingContext _threadingContext;
 
         [ImportingConstructor]
-        public CSharpLspEditorClassificationFactoryService(RoslynLspClientServiceFactory roslynLspClientServiceFactory, ClassificationTypeMap classificationTypeMap, IThreadingContext threadingContext)
+        public CSharpLspEditorClassificationFactoryService(CSharpLspClientServiceFactory csharpLspClientServiceFactory, ClassificationTypeMap classificationTypeMap, IThreadingContext threadingContext)
         {
-            _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
+            _csharpLspClientServiceFactory = csharpLspClientServiceFactory ?? throw new ArgumentNullException(nameof(csharpLspClientServiceFactory));
             _classificationTypeMap = classificationTypeMap ?? throw new ArgumentNullException(nameof(classificationTypeMap));
             _threadingContext = threadingContext;
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
-            return new RoslynClassificationService(_roslynLspClientServiceFactory, languageServices.GetOriginalLanguageService<ISyntaxClassificationService>(), _classificationTypeMap, _threadingContext);
+            return new RoslynClassificationService(_csharpLspClientServiceFactory, languageServices.GetOriginalLanguageService<ISyntaxClassificationService>(), _classificationTypeMap, _threadingContext);
         }
     }
 
     [ExportLanguageServiceFactory(typeof(ISyntaxClassificationService), StringConstants.VBLspLanguageName), Shared]
     internal class VBLspEditorClassificationFactoryService : ILanguageServiceFactory
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly VisualBasicLspClientServiceFactory _vbLspClientServiceFactory;
         private readonly ClassificationTypeMap _classificationTypeMap;
         private readonly IThreadingContext _threadingContext;
 
         [ImportingConstructor]
-        public VBLspEditorClassificationFactoryService(RoslynLspClientServiceFactory roslynLspClientServiceFactory, ClassificationTypeMap classificationTypeMap, IThreadingContext threadingContext)
+        public VBLspEditorClassificationFactoryService(VisualBasicLspClientServiceFactory vbLspClientServiceFactory, ClassificationTypeMap classificationTypeMap, IThreadingContext threadingContext)
         {
-            _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
+            _vbLspClientServiceFactory = vbLspClientServiceFactory ?? throw new ArgumentNullException(nameof(vbLspClientServiceFactory));
             _classificationTypeMap = classificationTypeMap ?? throw new ArgumentNullException(nameof(classificationTypeMap));
             _threadingContext = threadingContext;
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
         {
-            return new RoslynClassificationService(_roslynLspClientServiceFactory, languageServices.GetOriginalLanguageService<ISyntaxClassificationService>(), _classificationTypeMap, _threadingContext);
+            return new RoslynClassificationService(_vbLspClientServiceFactory, languageServices.GetOriginalLanguageService<ISyntaxClassificationService>(), _classificationTypeMap, _threadingContext);
         }
     }
 }

--- a/src/Tools/ExternalAccess/LiveShare/Classification/RoslynClassificationService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Classification/RoslynClassificationService.cs
@@ -17,12 +17,12 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Classification
 {
     internal class RoslynClassificationService : ISyntaxClassificationService
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
         private readonly ISyntaxClassificationService _originalService;
         private readonly ClassificationTypeMap _classificationTypeMap;
         private readonly IThreadingContext _threadingContext;
 
-        public RoslynClassificationService(RoslynLspClientServiceFactory roslynLspClientServiceFactory, ISyntaxClassificationService originalService,
+        public RoslynClassificationService(AbstractLspClientServiceFactory roslynLspClientServiceFactory, ISyntaxClassificationService originalService,
             ClassificationTypeMap classificationTypeMap, IThreadingContext threadingContext)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));

--- a/src/Tools/ExternalAccess/LiveShare/CodeActions/RoslynCodeActionProvider.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/CodeActions/RoslynCodeActionProvider.Exports.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.CodeActions
     internal class CSharpLspCodeActionProvider : RoslynCodeActionProvider
     {
         [ImportingConstructor]
-        public CSharpLspCodeActionProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory, IDiagnosticAnalyzerService diagnosticAnalyzerService)
-            : base(roslynLspClientServiceFactory, diagnosticAnalyzerService)
+        public CSharpLspCodeActionProvider(CSharpLspClientServiceFactory csharpLspClientServiceFactory, IDiagnosticAnalyzerService diagnosticAnalyzerService)
+            : base(csharpLspClientServiceFactory, diagnosticAnalyzerService)
         {
         }
     }
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.CodeActions
     internal class VBLspCodeActionProvider : RoslynCodeActionProvider
     {
         [ImportingConstructor]
-        public VBLspCodeActionProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory, IDiagnosticAnalyzerService diagnosticAnalyzerService)
-            : base(roslynLspClientServiceFactory, diagnosticAnalyzerService)
+        public VBLspCodeActionProvider(VisualBasicLspClientServiceFactory vbLspClientServiceFactory, IDiagnosticAnalyzerService diagnosticAnalyzerService)
+            : base(vbLspClientServiceFactory, diagnosticAnalyzerService)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/CodeActions/RoslynCodeActionProvider.cs
+++ b/src/Tools/ExternalAccess/LiveShare/CodeActions/RoslynCodeActionProvider.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.CodeActions
 {
     internal class RoslynCodeActionProvider : CodeRefactoringProvider
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
         private readonly IDiagnosticAnalyzerService _diagnosticAnalyzerService;
 
-        public RoslynCodeActionProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory, IDiagnosticAnalyzerService diagnosticAnalyzerService)
+        public RoslynCodeActionProvider(AbstractLspClientServiceFactory roslynLspClientServiceFactory, IDiagnosticAnalyzerService diagnosticAnalyzerService)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
             _diagnosticAnalyzerService = diagnosticAnalyzerService ?? throw new ArgumentNullException(nameof(diagnosticAnalyzerService));

--- a/src/Tools/ExternalAccess/LiveShare/Completion/RoslynCompletionProvider.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Completion/RoslynCompletionProvider.Exports.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Completion
     internal class CSharpLspCompletionProvider : RoslynCompletionProvider
     {
         [ImportingConstructor]
-        public CSharpLspCompletionProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public CSharpLspCompletionProvider(CSharpLspClientServiceFactory csharpLspClientServiceFactory)
+            : base(csharpLspClientServiceFactory)
         {
         }
     }
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Completion
     internal class VBLspCompletionProvider : RoslynCompletionProvider
     {
         [ImportingConstructor]
-        public VBLspCompletionProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public VBLspCompletionProvider(VisualBasicLspClientServiceFactory vbLspClientServiceFactory)
+            : base(vbLspClientServiceFactory)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/Completion/RoslynCompletionProvider.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Completion/RoslynCompletionProvider.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Completion
 {
     internal class RoslynCompletionProvider : CommonCompletionProvider
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
 
-        public RoslynCompletionProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
+        public RoslynCompletionProvider(AbstractLspClientServiceFactory roslynLspClientServiceFactory)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
         }

--- a/src/Tools/ExternalAccess/LiveShare/Diagnostics/RoslynRemoteDiagnosticsService.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Diagnostics/RoslynRemoteDiagnosticsService.Exports.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Diagnostics
     internal class CSharpLspRemoteDiagnosticsService : RoslynRemoteDiagnosticsService
     {
         [ImportingConstructor]
-        public CSharpLspRemoteDiagnosticsService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public CSharpLspRemoteDiagnosticsService(CSharpLspClientServiceFactory csharpLspClientServiceFactory)
+            : base(csharpLspClientServiceFactory)
         {
         }
     }
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Diagnostics
     internal class VBLspRemoteDiagnosticsService : RoslynRemoteDiagnosticsService
     {
         [ImportingConstructor]
-        public VBLspRemoteDiagnosticsService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public VBLspRemoteDiagnosticsService(VisualBasicLspClientServiceFactory vbLspClientServiceFactory)
+            : base(vbLspClientServiceFactory)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/Diagnostics/RoslynRemoteDiagnosticsService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Diagnostics/RoslynRemoteDiagnosticsService.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Diagnostics
 {
     internal class RoslynRemoteDiagnosticsService : IRemoteDiagnosticsService
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
 
-        public RoslynRemoteDiagnosticsService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
+        public RoslynRemoteDiagnosticsService(AbstractLspClientServiceFactory roslynLspClientServiceFactory)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
         }

--- a/src/Tools/ExternalAccess/LiveShare/GotoDefinition/RoslynGotoDefinitionService.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/GotoDefinition/RoslynGotoDefinitionService.Exports.cs
@@ -13,17 +13,17 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.GotoDefinition
     internal class CSharpLspGotoDefinitionService : RoslynGotoDefinitionService
     {
         [ImportingConstructor]
-        public CSharpLspGotoDefinitionService(IStreamingFindUsagesPresenter streamingPresenter, RoslynLspClientServiceFactory roslynLspClientServiceFactory,
+        public CSharpLspGotoDefinitionService(IStreamingFindUsagesPresenter streamingPresenter, CSharpLspClientServiceFactory csharpLspClientServiceFactory,
             RemoteLanguageServiceWorkspace remoteWorkspace, IThreadingContext threadingContext)
-            : base(streamingPresenter, roslynLspClientServiceFactory, remoteWorkspace, threadingContext) { }
+            : base(streamingPresenter, csharpLspClientServiceFactory, remoteWorkspace, threadingContext) { }
     }
 
     [ExportLanguageService(typeof(IGoToDefinitionService), StringConstants.VBLspLanguageName), Shared]
     internal class VBLspGotoDefinitionService : RoslynGotoDefinitionService
     {
         [ImportingConstructor]
-        public VBLspGotoDefinitionService(IStreamingFindUsagesPresenter streamingPresenter, RoslynLspClientServiceFactory roslynLspClientServiceFactory,
+        public VBLspGotoDefinitionService(IStreamingFindUsagesPresenter streamingPresenter, VisualBasicLspClientServiceFactory vbLspClientServiceFactory,
             RemoteLanguageServiceWorkspace remoteWorkspace, IThreadingContext threadingContext)
-            : base(streamingPresenter, roslynLspClientServiceFactory, remoteWorkspace, threadingContext) { }
+            : base(streamingPresenter, vbLspClientServiceFactory, remoteWorkspace, threadingContext) { }
     }
 }

--- a/src/Tools/ExternalAccess/LiveShare/GotoDefinition/RoslynGotoDefinitionService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/GotoDefinition/RoslynGotoDefinitionService.cs
@@ -21,13 +21,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.GotoDefinition
     internal class RoslynGotoDefinitionService : IGoToDefinitionService
     {
         private readonly IStreamingFindUsagesPresenter _streamingPresenter;
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
         private readonly RemoteLanguageServiceWorkspace _remoteWorkspace;
         private readonly IThreadingContext _threadingContext;
 
         public RoslynGotoDefinitionService(
             IStreamingFindUsagesPresenter streamingPresenter,
-            RoslynLspClientServiceFactory roslynLspClientServiceFactory,
+            AbstractLspClientServiceFactory roslynLspClientServiceFactory,
             RemoteLanguageServiceWorkspace remoteWorkspace,
             IThreadingContext threadingContext)
         {

--- a/src/Tools/ExternalAccess/LiveShare/Highlights/RoslynDocumentHighlightsService.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Highlights/RoslynDocumentHighlightsService.Exports.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Highlights
     internal class CSharpLspDocumentHighlightsService : RoslynDocumentHighlightsService
     {
         [ImportingConstructor]
-        public CSharpLspDocumentHighlightsService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public CSharpLspDocumentHighlightsService(CSharpLspClientServiceFactory csharpLspClientServiceFactory)
+            : base(csharpLspClientServiceFactory)
         {
         }
     }
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Highlights
     internal class VBLspDocumentHighlightsService : RoslynDocumentHighlightsService
     {
         [ImportingConstructor]
-        public VBLspDocumentHighlightsService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public VBLspDocumentHighlightsService(VisualBasicLspClientServiceFactory vbLspClientServiceFactory)
+            : base(vbLspClientServiceFactory)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/Highlights/RoslynDocumentHighlightsService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Highlights/RoslynDocumentHighlightsService.cs
@@ -13,9 +13,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Highlights
 {
     internal class RoslynDocumentHighlightsService : IDocumentHighlightsService
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
 
-        public RoslynDocumentHighlightsService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
+        public RoslynDocumentHighlightsService(AbstractLspClientServiceFactory roslynLspClientServiceFactory)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
         }

--- a/src/Tools/ExternalAccess/LiveShare/Navigation/RoslynNavigationBarItemService.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Navigation/RoslynNavigationBarItemService.Exports.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Navigation
     internal class CSharpLspNavigationBarItemService : RoslynNavigationBarItemService
     {
         [ImportingConstructor]
-        protected CSharpLspNavigationBarItemService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        protected CSharpLspNavigationBarItemService(CSharpLspClientServiceFactory csharpLspClientServiceFactory)
+            : base(csharpLspClientServiceFactory)
         {
         }
     }
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Navigation
     internal class VBLspNavigationBarItemService : RoslynNavigationBarItemService
     {
         [ImportingConstructor]
-        protected VBLspNavigationBarItemService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        protected VBLspNavigationBarItemService(VisualBasicLspClientServiceFactory vbLspClientServiceFactory)
+            : base(vbLspClientServiceFactory)
         {
         }
     }
@@ -30,8 +30,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Navigation
     internal class TypeScriptLspNavigationBarItemService : RoslynNavigationBarItemService
     {
         [ImportingConstructor]
-        protected TypeScriptLspNavigationBarItemService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        protected TypeScriptLspNavigationBarItemService(TypeScriptLspClientServiceFactory typeScriptLspClientServiceFactory)
+            : base(typeScriptLspClientServiceFactory)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/Navigation/RoslynNavigationBarItemService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Navigation/RoslynNavigationBarItemService.cs
@@ -20,9 +20,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Navigation
 {
     internal class RoslynNavigationBarItemService : AbstractNavigationBarItemService
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
 
-        internal RoslynNavigationBarItemService(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
+        internal RoslynNavigationBarItemService(AbstractLspClientServiceFactory roslynLspClientServiceFactory)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
         }

--- a/src/Tools/ExternalAccess/LiveShare/Projects/RoslynRemoteProjectInfoProvider.cs
+++ b/src/Tools/ExternalAccess/LiveShare/Projects/RoslynRemoteProjectInfoProvider.cs
@@ -17,11 +17,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.Projects
     {
         private const string SystemUriSchemeExternal = "vslsexternal";
 
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly CSharpLspClientServiceFactory _roslynLspClientServiceFactory;
         private readonly RemoteLanguageServiceWorkspace _remoteLanguageServiceWorkspace;
 
         [ImportingConstructor]
-        public RoslynRemoteProjectInfoProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
+        public RoslynRemoteProjectInfoProvider(CSharpLspClientServiceFactory roslynLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
             _remoteLanguageServiceWorkspace = remoteLanguageServiceWorkspace ?? throw new ArgumentNullException(nameof(RemoteLanguageServiceWorkspace));

--- a/src/Tools/ExternalAccess/LiveShare/References/RoslynFindUsagesService.Exports..cs
+++ b/src/Tools/ExternalAccess/LiveShare/References/RoslynFindUsagesService.Exports..cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.References
     internal class CSharpLspFindUsagesService : RoslynFindUsagesService
     {
         [ImportingConstructor]
-        public CSharpLspFindUsagesService(RoslynLspClientServiceFactory roslynLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
-            : base(roslynLspClientServiceFactory, remoteLanguageServiceWorkspace)
+        public CSharpLspFindUsagesService(CSharpLspClientServiceFactory csharpLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
+            : base(csharpLspClientServiceFactory, remoteLanguageServiceWorkspace)
         {
         }
     }
@@ -20,8 +20,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.References
     internal class VBLspFindUsagesService : RoslynFindUsagesService
     {
         [ImportingConstructor]
-        public VBLspFindUsagesService(RoslynLspClientServiceFactory roslynLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
-            : base(roslynLspClientServiceFactory, remoteLanguageServiceWorkspace)
+        public VBLspFindUsagesService(VisualBasicLspClientServiceFactory vbLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
+            : base(vbLspClientServiceFactory, remoteLanguageServiceWorkspace)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/References/RoslynFindUsagesService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/References/RoslynFindUsagesService.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.References
 {
     internal class RoslynFindUsagesService : IFindUsagesService
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
         private readonly RemoteLanguageServiceWorkspace _remoteLanguageServiceWorkspace;
 
-        public RoslynFindUsagesService(RoslynLspClientServiceFactory roslynLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
+        public RoslynFindUsagesService(AbstractLspClientServiceFactory roslynLspClientServiceFactory, RemoteLanguageServiceWorkspace remoteLanguageServiceWorkspace)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
             _remoteLanguageServiceWorkspace = remoteLanguageServiceWorkspace ?? throw new ArgumentNullException(nameof(remoteLanguageServiceWorkspace));

--- a/src/Tools/ExternalAccess/LiveShare/RoslynLSPClientService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/RoslynLSPClientService.cs
@@ -11,16 +11,9 @@ using Microsoft.VisualStudio.LiveShare;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
 {
-    [Export]
-    [ExportCollaborationService(typeof(RoslynLSPClientLifeTimeService),
-                                Scope = SessionScope.Guest,
-                                Role = ServiceRole.LocalService,
-                                Features = "LspServices",
-                                CreationPriority = (int)ServiceRole.LocalService + 2000)]
-    internal class RoslynLspClientServiceFactory : ICollaborationServiceFactory
+    internal abstract class AbstractLspClientServiceFactory : ICollaborationServiceFactory
     {
-        private const string RoslynProviderName = "Roslyn";
-        private const string AnyProviderName = "any";
+        protected abstract string LanguageSpecificProviderName { get; }
 
         public ILanguageServerClient ActiveLanguageServerClient { get; private set; }
 
@@ -30,11 +23,19 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
 
             collaborationSession.RemoteServicesChanged += (sender, e) =>
             {
-                // VS will expose a roslyn LSP server and VSCode will expose a "any" LSP provider and both support roslyn languages.
-                var roslynLspServerProviderName = LanguageServicesUtils.GetLanguageServerProviderServiceName(RoslynProviderName);
-                var anyLspServerProviderName = LanguageServicesUtils.GetLanguageServerProviderServiceName(AnyProviderName);
+                // VS will expose a roslyn LSP server.
+                var roslynLspServerProviderName = LanguageServicesUtils.GetLanguageServerProviderServiceName(StringConstants.RoslynProviderName);
+                // Newer versions of VS will expose language specific LSP servers for Roslyn.
+                var languageSpecificLspServerProviderName = LanguageServicesUtils.GetLanguageServerProviderServiceName(LanguageSpecificProviderName);
+                // VSCode will expose a "any" LSP provider and both support roslyn languages.
+                var anyLspServerProviderName = LanguageServicesUtils.GetLanguageServerProviderServiceName(StringConstants.AnyProviderName);
 
-                if (collaborationSession.RemoteServiceNames.Contains(roslynLspServerProviderName))
+                // For VS, Preferentially use the language specific server when it's available, otherwise fall back to the generic roslyn server.
+                if (collaborationSession.RemoteServiceNames.Contains(languageSpecificLspServerProviderName))
+                {
+                    ActiveLanguageServerClient = languageServerGuestService.CreateLanguageServerClient(languageSpecificLspServerProviderName);
+                }
+                else if (collaborationSession.RemoteServiceNames.Contains(roslynLspServerProviderName))
                 {
                     ActiveLanguageServerClient = languageServerGuestService.CreateLanguageServerClient(roslynLspServerProviderName);
                 }
@@ -112,7 +113,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
             return Task.FromResult<ICollaborationService>(lifeTimeService);
         }
 
-        private class RoslynLSPClientLifeTimeService : ICollaborationService, IDisposable
+        protected class RoslynLSPClientLifeTimeService : ICollaborationService, IDisposable
         {
             public event EventHandler Disposed;
 
@@ -121,5 +122,38 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
                 Disposed?.Invoke(this, null);
             }
         }
+    }
+
+    [Export]
+    [ExportCollaborationService(typeof(RoslynLSPClientLifeTimeService),
+                                Scope = SessionScope.Guest,
+                                Role = ServiceRole.LocalService,
+                                Features = "LspServices",
+                                CreationPriority = (int)ServiceRole.LocalService + 2000)]
+    internal class CSharpLspClientServiceFactory : AbstractLspClientServiceFactory
+    {
+        protected override string LanguageSpecificProviderName => StringConstants.CSharpProviderName;
+    }
+
+    [Export]
+    [ExportCollaborationService(typeof(RoslynLSPClientLifeTimeService),
+                                Scope = SessionScope.Guest,
+                                Role = ServiceRole.LocalService,
+                                Features = "LspServices",
+                                CreationPriority = (int)ServiceRole.LocalService + 2000)]
+    internal class VisualBasicLspClientServiceFactory : AbstractLspClientServiceFactory
+    {
+        protected override string LanguageSpecificProviderName => StringConstants.VisualBasicProviderName;
+    }
+
+    [Export]
+    [ExportCollaborationService(typeof(RoslynLSPClientLifeTimeService),
+                                Scope = SessionScope.Guest,
+                                Role = ServiceRole.LocalService,
+                                Features = "LspServices",
+                                CreationPriority = (int)ServiceRole.LocalService + 2000)]
+    internal class TypeScriptLspClientServiceFactory : AbstractLspClientServiceFactory
+    {
+        protected override string LanguageSpecificProviderName => StringConstants.TypeScriptProviderName;
     }
 }

--- a/src/Tools/ExternalAccess/LiveShare/SignatureHelp/RoslynSignatureHelpProvider.Exports.cs
+++ b/src/Tools/ExternalAccess/LiveShare/SignatureHelp/RoslynSignatureHelpProvider.Exports.cs
@@ -11,8 +11,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
     internal class CSharpLspSignatureHelpProvider : RoslynSignatureHelpProvider
     {
         [ImportingConstructor]
-        public CSharpLspSignatureHelpProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public CSharpLspSignatureHelpProvider(CSharpLspClientServiceFactory csharpLspClientServiceFactory)
+            : base(csharpLspClientServiceFactory)
         {
         }
     }
@@ -22,8 +22,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
     internal class VBLspSignatureHelpProvider : RoslynSignatureHelpProvider
     {
         [ImportingConstructor]
-        public VBLspSignatureHelpProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
-            : base(roslynLspClientServiceFactory)
+        public VBLspSignatureHelpProvider(VisualBasicLspClientServiceFactory vbLspClientServiceFactory)
+            : base(vbLspClientServiceFactory)
         {
         }
     }

--- a/src/Tools/ExternalAccess/LiveShare/SignatureHelp/RoslynSignatureHelpProvider.cs
+++ b/src/Tools/ExternalAccess/LiveShare/SignatureHelp/RoslynSignatureHelpProvider.cs
@@ -16,9 +16,9 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
 {
     class RoslynSignatureHelpProvider : ISignatureHelpProvider
     {
-        private readonly RoslynLspClientServiceFactory _roslynLspClientServiceFactory;
+        private readonly AbstractLspClientServiceFactory _roslynLspClientServiceFactory;
 
-        public RoslynSignatureHelpProvider(RoslynLspClientServiceFactory roslynLspClientServiceFactory)
+        public RoslynSignatureHelpProvider(AbstractLspClientServiceFactory roslynLspClientServiceFactory)
         {
             _roslynLspClientServiceFactory = roslynLspClientServiceFactory ?? throw new ArgumentNullException(nameof(roslynLspClientServiceFactory));
         }

--- a/src/Tools/ExternalAccess/LiveShare/StringConstants.cs
+++ b/src/Tools/ExternalAccess/LiveShare/StringConstants.cs
@@ -11,6 +11,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
         // The service name for an LSP server implemented using Roslyn designed to be used with the LSP SDK client
         public const string RoslynLspSdkContractName = "RoslynLSPSDK";
 
+        // LSP server provider names.
+        public const string RoslynProviderName = "Roslyn";
+        public const string CSharpProviderName = "RoslynCSharp";
+        public const string VisualBasicProviderName = "RoslynVisualBasic";
+        public const string TypeScriptProviderName = "RoslynTypeScript";
+        public const string AnyProviderName = "any";
+
         public const string CSharpLspLanguageName = "C#_LSP";
         public const string CSharpLspContentTypeName = "C#_LSP";
         public const string TypeScriptLanguageName = "TypeScript";

--- a/src/VisualStudio/LiveShare/Impl/ClassificationsHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/ClassificationsHandler.Exports.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServices.LiveShare.CustomProtocol;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, RoslynMethods.ClassificationsName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynClassificationsHandler : ClassificationsHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, RoslynMethods.ClassificationsName)]
+    internal class CSharpClassificationsHandler : ClassificationsHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, RoslynMethods.ClassificationsName)]
+    internal class VisualBasicClassificationsHandler : ClassificationsHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, RoslynMethods.ClassificationsName)]
+    internal class TypeScriptClassificationsHandler : ClassificationsHandler
+    {
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/ClassificationsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/ClassificationsHandler.cs
@@ -19,7 +19,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     /// Note, this must return object instead of ClassificationSpan b/c liveshare uses dynamic to convert handler results.
     /// Unfortunately, ClassificationSpan is an internal type and cannot be defined in the external access layer.
     /// </summary>
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, RoslynMethods.ClassificationsName)]
     internal class ClassificationsHandler : ILspRequestHandler<ClassificationParams, object[], Solution>
     {
         public async Task<object[]> HandleAsync(ClassificationParams request, RequestContext<Solution> requestContext, CancellationToken cancellationToken)

--- a/src/VisualStudio/LiveShare/Impl/DiagnosticHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/DiagnosticHandler.Exports.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
@@ -9,6 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
     [Export(LiveShareConstants.RoslynContractName, typeof(ILspNotificationProvider))]
     [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.GetDocumentDiagnosticsName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
     internal class RoslynDiagnosticsHandler : DiagnosticsHandler
     {
         [ImportingConstructor]
@@ -18,6 +20,42 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         }
     }
 
+    [Export(LiveShareConstants.CSharpContractName, typeof(ILspNotificationProvider))]
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.GetDocumentDiagnosticsName)]
+    internal class CSharpDiagnosticsHandler : DiagnosticsHandler
+    {
+        [ImportingConstructor]
+        public CSharpDiagnosticsHandler(IDiagnosticService diagnosticService)
+            : base(diagnosticService)
+        {
+        }
+    }
+
+    [Export(LiveShareConstants.VisualBasicContractName, typeof(ILspNotificationProvider))]
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.GetDocumentDiagnosticsName)]
+    internal class VisualBasicDiagnosticsHandler : DiagnosticsHandler
+    {
+        [ImportingConstructor]
+        public VisualBasicDiagnosticsHandler(IDiagnosticService diagnosticService)
+            : base(diagnosticService)
+        {
+        }
+    }
+
+    [Export(LiveShareConstants.TypeScriptContractName, typeof(ILspNotificationProvider))]
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.GetDocumentDiagnosticsName)]
+    internal class TypeScriptDiagnosticsHandler : DiagnosticsHandler
+    {
+        [ImportingConstructor]
+        public TypeScriptDiagnosticsHandler(IDiagnosticService diagnosticService)
+            : base(diagnosticService)
+        {
+        }
+    }
+
+    /// <summary>
+    /// <see cref="LiveShareConstants.RoslynLSPSDKContractName"/> is only used for typescript.
+    /// </summary>
     [Export(LiveShareConstants.RoslynLSPSDKContractName, typeof(ILspNotificationProvider))]
     [ExportLspRequestHandler(LiveShareConstants.RoslynLSPSDKContractName, Methods.GetDocumentDiagnosticsName)]
     internal class RoslynLSPSDKDiagnosticsHandler : DiagnosticsHandler

--- a/src/VisualStudio/LiveShare/Impl/FindAllReferencesHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/FindAllReferencesHandler.Exports.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentReferencesName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynFindAllReferencesHandler : FindAllReferencesHandler
+    {
+        [ImportingConstructor]
+        public RoslynFindAllReferencesHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentReferencesName)]
+    internal class CSharpFindAllReferencesHandler : FindAllReferencesHandler
+    {
+        [ImportingConstructor]
+        public CSharpFindAllReferencesHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentReferencesName)]
+    internal class VisualBasicFindAllReferencesHandler : FindAllReferencesHandler
+    {
+        [ImportingConstructor]
+        public VisualBasicFindAllReferencesHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentReferencesName)]
+    internal class TypeScriptFindAllReferencesHandler : FindAllReferencesHandler
+    {
+        [ImportingConstructor]
+        public TypeScriptFindAllReferencesHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/FindAllReferencesHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/FindAllReferencesHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,12 +19,10 @@ using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, LSP.Methods.TextDocumentReferencesName)]
     internal class FindAllReferencesHandler : ILspRequestHandler<LSP.ReferenceParams, object[], Solution>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
         public FindAllReferencesHandler(IThreadingContext threadingContext)
         {
             _threadingContext = threadingContext;
@@ -50,7 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // This is not great for us and ideally we should ask for a Roslyn API where we can make this call without blocking the UI.
             if (VsTaskLibraryHelper.ServiceInstance != null)
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             }
 
             await findUsagesService.FindReferencesAsync(document, position, context).ConfigureAwait(false);

--- a/src/VisualStudio/LiveShare/Impl/GoToDefintionWithFarHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/GoToDefintionWithFarHandler.Exports.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentDefinitionName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynGoToDefinitionWithFarHandler : GotoDefinitionHandler
+    {
+        [ImportingConstructor]
+        public RoslynGoToDefinitionWithFarHandler([Import(AllowDefault = true)] IMetadataAsSourceFileService metadataAsSourceService) : base(metadataAsSourceService)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentDefinitionName)]
+    internal class CSharpGoToDefinitionWithFarHandler : GotoDefinitionHandler
+    {
+        [ImportingConstructor]
+        public CSharpGoToDefinitionWithFarHandler([Import(AllowDefault = true)] IMetadataAsSourceFileService metadataAsSourceService) : base(metadataAsSourceService)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentDefinitionName)]
+    internal class VisualBasicGoToDefinitionWithFarHandler : GotoDefinitionHandler
+    {
+        [ImportingConstructor]
+        public VisualBasicGoToDefinitionWithFarHandler([Import(AllowDefault = true)] IMetadataAsSourceFileService metadataAsSourceService) : base(metadataAsSourceService)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDefinitionName)]
+    internal class TypeScriptGoToDefinitionWithFarHandler : GotoDefinitionHandler
+    {
+        [ImportingConstructor]
+        public TypeScriptGoToDefinitionWithFarHandler([Import(AllowDefault = true)] IMetadataAsSourceFileService metadataAsSourceService) : base(metadataAsSourceService)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/GoToDefintionWithFarHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/GoToDefintionWithFarHandler.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     /// cone to the vslsexternal scheme.
     /// This lives in external access because it has a dependency on FAR, which requires the UI thread.
     /// </summary>
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, LSP.Methods.TextDocumentDefinitionName)]
     internal class GotoDefinitionHandler : ILspRequestHandler<LSP.TextDocumentPositionParams, object, Solution>
     {
         private readonly IMetadataAsSourceFileService _metadataAsSourceService;
@@ -31,7 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         // These languages don't provide an IGoToDefinitionService implementation that will return definitions. We'll use IFindUsagesService instead.
         private static readonly string[] s_findUsagesServiceLanguages = new string[] { LiveShareConstants.TypeScriptLanguageName };
 
-        [ImportingConstructor]
         public GotoDefinitionHandler([Import(AllowDefault = true)] IMetadataAsSourceFileService metadataAsSourceService)
         {
             this._metadataAsSourceService = metadataAsSourceService;

--- a/src/VisualStudio/LiveShare/Impl/LiveShareConstants.cs
+++ b/src/VisualStudio/LiveShare/Impl/LiveShareConstants.cs
@@ -9,5 +9,9 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
         // The service name for an LSP server implemented using Roslyn designed to be used with the LSP SDK client
         public const string RoslynLSPSDKContractName = "RoslynLSPSDK";
         public const string TypeScriptLanguageName = "TypeScript";
+
+        public const string CSharpContractName = "CSharp";
+        public const string VisualBasicContractName = "VisualBasic";
+        public const string TypeScriptContractName = "TypeScript";
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/LoadHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/LoadHandler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
@@ -7,12 +8,32 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.LoadName)]
     internal class LoadHandler : ILspRequestHandler, ILspRequestHandler<object, object>
     {
         public Task<object> HandleAsync(object request, RequestContext requestContext, CancellationToken cancellationToken)
         {
             return Task.FromResult<object>(null);
         }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.LoadName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynLoadHandler : LoadHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.LoadName)]
+    internal class CSharpLoadHandler : LoadHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.LoadName)]
+    internal class VisualBasicLoadHandler : LoadHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.LoadName)]
+    internal class TypeScriptLoadHandler : LoadHandler
+    {
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/PreviewCodeActionsHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/PreviewCodeActionsHandler.Exports.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.VisualStudio.LanguageServices.LiveShare.CustomProtocol;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, RoslynMethods.CodeActionPreviewName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynPreviewCodeActionsHandler : PreviewCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public RoslynPreviewCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService) : base(codeFixService, codeRefactoringService)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, RoslynMethods.CodeActionPreviewName)]
+    internal class CSharpPreviewCodeActionsHandler : PreviewCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public CSharpPreviewCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService) : base(codeFixService, codeRefactoringService)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, RoslynMethods.CodeActionPreviewName)]
+    internal class VisualBasicPreviewCodeActionsHandler : PreviewCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public VisualBasicPreviewCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService) : base(codeFixService, codeRefactoringService)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, RoslynMethods.CodeActionPreviewName)]
+    internal class TypeScriptPreviewCodeActionsHandler : PreviewCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public TypeScriptPreviewCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService) : base(codeFixService, codeRefactoringService)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/PreviewCodeActionsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/PreviewCodeActionsHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,16 +11,13 @@ using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.VisualStudio.LanguageServices.LiveShare.CustomProtocol;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, RoslynMethods.CodeActionPreviewName)]
     internal class PreviewCodeActionsHandler : CodeActionsHandlerBase, ILspRequestHandler<RunCodeActionParams, LSP.TextEdit[], Solution>
     {
-        [ImportingConstructor]
         public PreviewCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService)
             : base(codeFixService, codeRefactoringService)
         {

--- a/src/VisualStudio/LiveShare/Impl/ProjectsHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/ProjectsHandler.Exports.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServices.LiveShare.CustomProtocol;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, RoslynMethods.ProjectsName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynProjectsHandler : ProjectsHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, RoslynMethods.ProjectsName)]
+    internal class CSharpProjectsHandler : ProjectsHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, RoslynMethods.ProjectsName)]
+    internal class VisualBasicProjectsHandler : ProjectsHandler
+    {
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, RoslynMethods.ProjectsName)]
+    internal class TypeScriptProjectsHandler : ProjectsHandler
+    {
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/ProjectsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/ProjectsHandler.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.VisualStudio.LanguageServices.LiveShare.CustomProtocol;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
@@ -15,7 +13,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     /// <summary>
     /// TODO - Move to lower layer once the protocol converter is figured out.
     /// </summary>
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, RoslynMethods.ProjectsName)]
     internal class ProjectsHandler : ILspRequestHandler<object, object[], Solution>
     {
         public async Task<object[]> HandleAsync(object param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)

--- a/src/VisualStudio/LiveShare/Impl/RenameHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/RenameHandler.Exports.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentRenameName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynRenameHandler : RenameHandler
+    {
+        [ImportingConstructor]
+        public RoslynRenameHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentRenameName)]
+    internal class CSharpRenameHandler : RenameHandler
+    {
+        [ImportingConstructor]
+        public CSharpRenameHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentRenameName)]
+    internal class VisualBasicRenameHandler : RenameHandler
+    {
+        [ImportingConstructor]
+        public VisualBasicRenameHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentRenameName)]
+    internal class TypeScriptRenameHandler : RenameHandler
+    {
+        [ImportingConstructor]
+        public TypeScriptRenameHandler(IThreadingContext threadingContext) : base(threadingContext)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/RenameHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/RenameHandler.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,12 +13,10 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentRenameName)]
     internal class RenameHandler : ILspRequestHandler<RenameParams, WorkspaceEdit, Solution>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
         public RenameHandler(IThreadingContext threadingContext)
         {
             _threadingContext = threadingContext;

--- a/src/VisualStudio/LiveShare/Impl/RunCodeActionsHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/RunCodeActionsHandler.Exports.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LiveShare.LanguageServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.LiveShare
+{
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.WorkspaceExecuteCommandName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynRunCodeActionsHandler : RunCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public RoslynRunCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService, IThreadingContext threadingContext)
+            : base(codeFixService, codeRefactoringService, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.WorkspaceExecuteCommandName)]
+    internal class CSharpRunCodeActionsHandler : RunCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public CSharpRunCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService, IThreadingContext threadingContext)
+            : base(codeFixService, codeRefactoringService, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.WorkspaceExecuteCommandName)]
+    internal class VisualBasicRunCodeActionsHandler : RunCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public VisualBasicRunCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService, IThreadingContext threadingContext)
+            : base(codeFixService, codeRefactoringService, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.WorkspaceExecuteCommandName)]
+    internal class TypeScriptRunCodeActionsHandler : RunCodeActionsHandler
+    {
+        [ImportingConstructor]
+        public TypeScriptRunCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService, IThreadingContext threadingContext)
+            : base(codeFixService, codeRefactoringService, threadingContext)
+        {
+        }
+    }
+}

--- a/src/VisualStudio/LiveShare/Impl/RunCodeActionsHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/RunCodeActionsHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,12 +19,10 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     /// Run code actions handler.  Called when lightbulb invoked.
     /// TODO - Move to CodeAnalysis.LanguageServer once the UI thread dependency is removed.
     /// </summary>
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, LSP.Methods.WorkspaceExecuteCommandName)]
     internal class RunCodeActionsHandler : CodeActionsHandlerBase, ILspRequestHandler<LSP.ExecuteCommandParams, object, Solution>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
         public RunCodeActionsHandler(ICodeFixService codeFixService, ICodeRefactoringService codeRefactoringService, IThreadingContext threadingContext)
             : base(codeFixService, codeRefactoringService)
         {

--- a/src/VisualStudio/LiveShare/Impl/Shims/CodeActionsHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/CodeActionsHandlerShim.cs
@@ -14,11 +14,9 @@ using LiveShareCodeAction = Microsoft.VisualStudio.LiveShare.LanguageServices.Pr
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentCodeActionName)]
     internal class CodeActionsHandlerShim : AbstractLiveShareHandlerShim<CodeActionParams, object[]>
     {
-        [ImportingConstructor]
-        public CodeActionsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public CodeActionsHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.TextDocumentCodeActionName)
         {
         }
@@ -57,6 +55,43 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                     Title = codeAction.Title
                 };
             }
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentCodeActionName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynCodeActionsHandlerShim : CodeActionsHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynCodeActionsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentCodeActionName)]
+    internal class CSharpCodeActionsHandlerShim : CodeActionsHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpCodeActionsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentCodeActionName)]
+    internal class VisualBasicCodeActionsHandlerShim : CodeActionsHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicCodeActionsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentCodeActionName)]
+    internal class TypeScriptCodeActionsHandlerShim : CodeActionsHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptCodeActionsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/CompletionHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/CompletionHandlerShim.cs
@@ -9,12 +9,47 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentCompletionName)]
     internal class CompletionHandlerShim : AbstractLiveShareHandlerShim<CompletionParams, object>
     {
-        [ImportingConstructor]
-        public CompletionHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public CompletionHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.TextDocumentCompletionName)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentCompletionName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynCompletionHandlerShim : CompletionHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynCompletionHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentCompletionName)]
+    internal class CSharpCompletionHandlerShim : CompletionHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpCompletionHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentCompletionName)]
+    internal class VisualBasicCompletionHandlerShim : CompletionHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicCompletionHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentCompletionName)]
+    internal class TypeScriptCompletionHandlerShim : CompletionHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptCompletionHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/CompletionResolverHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/CompletionResolverHandlerShim.cs
@@ -9,12 +9,47 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentCompletionResolveName)]
     internal class CompletionResolverHandlerShim : AbstractLiveShareHandlerShim<CompletionItem, CompletionItem>
     {
-        [ImportingConstructor]
-        public CompletionResolverHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public CompletionResolverHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.TextDocumentCompletionResolveName)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentCompletionResolveName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynCompletionResolverHandlerShim : CompletionResolverHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynCompletionResolverHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentCompletionResolveName)]
+    internal class CSharpCompletionResolverHandlerShim : CompletionResolverHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpCompletionResolverHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentCompletionResolveName)]
+    internal class VisualBasicCompletionResolverHandlerShim : CompletionResolverHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicCompletionResolverHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentCompletionResolveName)]
+    internal class TypeScriptCompletionResolverHandlerShim : CompletionResolverHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptCompletionResolverHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/DocumentHighlightHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/DocumentHighlightHandlerShim.cs
@@ -9,12 +9,47 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentDocumentHighlightName)]
     internal class DocumentHighlightHandlerShim : AbstractLiveShareHandlerShim<TextDocumentPositionParams, DocumentHighlight[]>
     {
-        [ImportingConstructor]
-        public DocumentHighlightHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public DocumentHighlightHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.TextDocumentDocumentHighlightName)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentDocumentHighlightName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynDocumentHighlightHandlerShim : DocumentHighlightHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynDocumentHighlightHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentDocumentHighlightName)]
+    internal class CSharpDocumentHighlightHandlerShim : DocumentHighlightHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpDocumentHighlightHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentDocumentHighlightName)]
+    internal class VisualBasicDocumentHighlightHandlerShim : DocumentHighlightHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicDocumentHighlightHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDocumentHighlightName)]
+    internal class TypeScriptDocumentHighlightHandlerShim : DocumentHighlightHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptDocumentHighlightHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/DocumentSymbolsHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/DocumentSymbolsHandlerShim.cs
@@ -13,11 +13,9 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentDocumentSymbolName)]
     internal class DocumentSymbolsHandlerShim : AbstractLiveShareHandlerShim<DocumentSymbolParams, SymbolInformation[]>
     {
-        [ImportingConstructor]
-        public DocumentSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public DocumentSymbolsHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.TextDocumentDocumentSymbolName)
         {
         }
@@ -36,6 +34,43 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
             // Since hierarchicalSupport will never be true, it is safe to cast the response to SymbolInformation[]
             return response?.Select(obj => (SymbolInformation)obj).ToArray();
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentDocumentSymbolName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynDocumentSymbolsHandlerShim : DocumentSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynDocumentSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentDocumentSymbolName)]
+    internal class CSharpDocumentSymbolsHandlerShim : DocumentSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpDocumentSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentDocumentSymbolName)]
+    internal class VisualBasicDocumentSymbolsHandlerShim : DocumentSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicDocumentSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentDocumentSymbolName)]
+    internal class TypeScriptDocumentSymbolsHandlerShim : DocumentSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptDocumentSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/FindImplementationsHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FindImplementationsHandlerShim.cs
@@ -13,13 +13,11 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentImplementationName)]
     internal class FindImplementationsHandlerShim : AbstractLiveShareHandlerShim<TextDocumentPositionParams, object>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
-        public FindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+        public FindImplementationsHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
             : base(requestHandlers, Methods.TextDocumentImplementationName)
         {
             _threadingContext = threadingContext;
@@ -30,6 +28,43 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // TypeScript requires this call to be on the UI thread.
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return await base.HandleAsync(param, requestContext, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentImplementationName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynFindImplementationsHandlerShim : FindImplementationsHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentImplementationName)]
+    internal class CSharpFindImplementationsHandlerShim : FindImplementationsHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentImplementationName)]
+    internal class VisualBasicFindImplementationsHandlerShim : FindImplementationsHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentImplementationName)]
+    internal class TypeScriptFindImplementationsHandlerShim : FindImplementationsHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentHandlerShim.cs
@@ -13,13 +13,11 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentFormattingName)]
     internal class FormatDocumentHandlerShim : AbstractLiveShareHandlerShim<DocumentFormattingParams, TextEdit[]>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
-        public FormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+        public FormatDocumentHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
             : base(requestHandlers, Methods.TextDocumentFormattingName)
         {
             _threadingContext = threadingContext;
@@ -30,6 +28,43 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // To get the formatting options, TypeScript expects to be called on the UI thread.
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return await base.HandleAsync(param, requestContext, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentFormattingName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynFormatDocumentHandlerShim : FormatDocumentHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentFormattingName)]
+    internal class CSharpFormatDocumentHandlerShim : FormatDocumentHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentFormattingName)]
+    internal class VisualBasicFormatDocumentHandlerShim : FormatDocumentHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentFormattingName)]
+    internal class TypeScriptFormatDocumentHandlerShim : FormatDocumentHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentOnTypeHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentOnTypeHandlerShim.cs
@@ -13,13 +13,11 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentOnTypeFormattingName)]
     internal class FormatDocumentOnTypeHandlerShim : AbstractLiveShareHandlerShim<DocumentOnTypeFormattingParams, TextEdit[]>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
-        public FormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+        public FormatDocumentOnTypeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
             : base(requestHandlers, Methods.TextDocumentOnTypeFormattingName)
         {
             _threadingContext = threadingContext;
@@ -30,6 +28,43 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // To get the formatting options, TypeScript expects to be called on the UI thread.
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return await base.HandleAsync(param, requestContext, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentOnTypeFormattingName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentOnTypeFormattingName)]
+    internal class CSharpFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentOnTypeFormattingName)]
+    internal class VisualBasicFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentOnTypeFormattingName)]
+    internal class TypeScriptFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentRangeHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentRangeHandlerShim.cs
@@ -13,13 +13,11 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentRangeFormattingName)]
     internal class FormatDocumentRangeHandlerShim : AbstractLiveShareHandlerShim<DocumentRangeFormattingParams, TextEdit[]>
     {
         private readonly IThreadingContext _threadingContext;
 
-        [ImportingConstructor]
-        public FormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+        public FormatDocumentRangeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
             : base(requestHandlers, Methods.TextDocumentRangeFormattingName)
         {
             _threadingContext = threadingContext;
@@ -30,6 +28,43 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             // To get the formatting options, TypeScript expects to be called on the UI thread.
             await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return await base.HandleAsync(param, requestContext, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentRangeFormattingName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentRangeFormattingName)]
+    internal class CSharpFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentRangeFormattingName)]
+    internal class VisualBasicFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentRangeFormattingName)]
+    internal class TypeScriptFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        {
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Shims/InitializeHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/InitializeHandlerShim.cs
@@ -9,12 +9,47 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.InitializeName)]
     internal class InitializeHandlerShim : AbstractLiveShareHandlerShim<InitializeParams, InitializeResult>
     {
-        [ImportingConstructor]
-        public InitializeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public InitializeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.InitializeName)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.InitializeName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynInitializeHandlerShim : InitializeHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynInitializeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.InitializeName)]
+    internal class CSharpInitializeHandlerShim : InitializeHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpInitializeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.InitializeName)]
+    internal class VisualBasicInitializeHandlerShim : InitializeHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicInitializeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.InitializeName)]
+    internal class TypeScriptInitializeHandlerShim : InitializeHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptInitializeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/SignatureHelpHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/SignatureHelpHandlerShim.cs
@@ -9,12 +9,47 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentSignatureHelpName)]
     internal class SignatureHelpHandlerShim : AbstractLiveShareHandlerShim<TextDocumentPositionParams, SignatureHelp>
     {
-        [ImportingConstructor]
-        public SignatureHelpHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public SignatureHelpHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.TextDocumentSignatureHelpName)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentSignatureHelpName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynSignatureHelpHandlerShim : SignatureHelpHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynSignatureHelpHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.TextDocumentSignatureHelpName)]
+    internal class CSharpSignatureHelpHandlerShim : SignatureHelpHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpSignatureHelpHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.TextDocumentSignatureHelpName)]
+    internal class VisualBasicSignatureHelpHandlerShim : SignatureHelpHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicSignatureHelpHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentSignatureHelpName)]
+    internal class TypeScriptSignatureHelpHandlerShim : SignatureHelpHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptSignatureHelpHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/WorkspaceSymbolsHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/WorkspaceSymbolsHandlerShim.cs
@@ -9,12 +9,47 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.WorkspaceSymbolName)]
     internal class WorkspaceSymbolsHandlerShim : AbstractLiveShareHandlerShim<WorkspaceSymbolParams, SymbolInformation[]>
     {
-        [ImportingConstructor]
-        public WorkspaceSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+        public WorkspaceSymbolsHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
             : base(requestHandlers, Methods.WorkspaceSymbolName)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.WorkspaceSymbolName)]
+    [Obsolete("Used for backwards compatibility with old liveshare clients.")]
+    internal class RoslynWorkspaceSymbolsHandlerShim : WorkspaceSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public RoslynWorkspaceSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.CSharpContractName, Methods.WorkspaceSymbolName)]
+    internal class CSharpWorkspaceSymbolsHandlerShim : WorkspaceSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public CSharpWorkspaceSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.VisualBasicContractName, Methods.WorkspaceSymbolName)]
+    internal class VisualBasicWorkspaceSymbolsHandlerShim : WorkspaceSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public VisualBasicWorkspaceSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
+        {
+        }
+    }
+
+    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.WorkspaceSymbolName)]
+    internal class TypeScriptWorkspaceSymbolsHandlerShim : WorkspaceSymbolsHandlerShim
+    {
+        [ImportingConstructor]
+        public TypeScriptWorkspaceSymbolsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }


### PR DESCRIPTION
Export liveshare handlers on a per language basis and update the client to import the per language server.

Related PR - https://devdiv.visualstudio.com/DevDiv/_git/Cascade/pullrequest/193071

Might be easier to review the commits in order, the first changes the server side handler exports, the second changes the client implementation to retrieve them.