### PR TITLE
Merge NullableAnnotation.NotApplicable and Disabled to None, and rename NullableFlowState.NotApplicable to None for consistency

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TopLevelFlowStateMaybeNull = 1 << 3,
             TopLevelNotAnnotated = 1 << 4,
             TopLevelAnnotated = 1 << 5,
-            TopLevelDisabled = TopLevelAnnotated | TopLevelNotAnnotated,
-            TopLevelAnnotationMask = TopLevelDisabled,
+            TopLevelNone = TopLevelAnnotated | TopLevelNotAnnotated,
+            TopLevelAnnotationMask = TopLevelNone,
 
             /// <summary>
             /// Captures the fact that consumers of the node already checked the state of the WasCompilerGenerated bit.
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     CodeAnalysis.NullableAnnotation.Annotated => BoundNodeAttributes.TopLevelAnnotated,
                     CodeAnalysis.NullableAnnotation.NotAnnotated => BoundNodeAttributes.TopLevelNotAnnotated,
-                    CodeAnalysis.NullableAnnotation.None => BoundNodeAttributes.TopLevelDisabled,
+                    CodeAnalysis.NullableAnnotation.None => BoundNodeAttributes.TopLevelNone,
                     var a => throw ExceptionUtilities.UnexpectedValue(a),
                 };
 
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundNodeAttributes.TopLevelAnnotated => CodeAnalysis.NullableAnnotation.Annotated,
                     BoundNodeAttributes.TopLevelNotAnnotated => CodeAnalysis.NullableAnnotation.NotAnnotated,
-                    BoundNodeAttributes.TopLevelDisabled => CodeAnalysis.NullableAnnotation.None,
+                    BoundNodeAttributes.TopLevelNone => CodeAnalysis.NullableAnnotation.None,
                     var mask => throw ExceptionUtilities.UnexpectedValue(mask)
                 };
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Top level nullability for the node. This should not be used by flow analysis.
         /// </summary>
-        [DebuggerHidden]
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected NullabilityInfo TopLevelNullability
         {
             get
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     CodeAnalysis.NullableAnnotation.Annotated => BoundNodeAttributes.TopLevelAnnotated,
                     CodeAnalysis.NullableAnnotation.NotAnnotated => BoundNodeAttributes.TopLevelNotAnnotated,
-                    CodeAnalysis.NullableAnnotation.Disabled => BoundNodeAttributes.TopLevelDisabled,
+                    CodeAnalysis.NullableAnnotation.None => BoundNodeAttributes.TopLevelDisabled,
                     var a => throw ExceptionUtilities.UnexpectedValue(a),
                 };
 
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundNodeAttributes.TopLevelAnnotated => CodeAnalysis.NullableAnnotation.Annotated,
                     BoundNodeAttributes.TopLevelNotAnnotated => CodeAnalysis.NullableAnnotation.NotAnnotated,
-                    BoundNodeAttributes.TopLevelDisabled => CodeAnalysis.NullableAnnotation.Disabled,
+                    BoundNodeAttributes.TopLevelDisabled => CodeAnalysis.NullableAnnotation.None,
                     var mask => throw ExceptionUtilities.UnexpectedValue(mask)
                 };
 

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1110,7 +1110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         CodeAnalysis.NullableAnnotation IMethodSymbol.ReceiverNullableAnnotation => ReceiverNullableAnnotation;
 
         protected virtual CodeAnalysis.NullableAnnotation ReceiverNullableAnnotation =>
-            RequiresInstanceReceiver ? CodeAnalysis.NullableAnnotation.NotAnnotated : CodeAnalysis.NullableAnnotation.NotApplicable;
+            RequiresInstanceReceiver ? CodeAnalysis.NullableAnnotation.NotAnnotated : CodeAnalysis.NullableAnnotation.None;
 
         IMethodSymbol IMethodSymbol.ReducedFrom
         {

--- a/src/Compilers/CSharp/Portable/Symbols/NullableAnnotationExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NullableAnnotationExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static NullabilityInfo ToNullabilityInfo(this CodeAnalysis.NullableAnnotation annotation, TypeSymbol type)
         {
-            if (annotation == CodeAnalysis.NullableAnnotation.NotApplicable)
+            if (annotation == CodeAnalysis.NullableAnnotation.None)
             {
                 return default;
             }
@@ -95,15 +95,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // A value type may be oblivious or not annotated depending on whether the type reference
                 // is from source or metadata. (Binding using the #nullable context only when setting the annotation
                 // to avoid checking IsValueType early.) The annotation is normalized here in the public API.
-                CSharp.NullableAnnotation.Oblivious => type.IsValueType ? CodeAnalysis.NullableAnnotation.NotAnnotated : CodeAnalysis.NullableAnnotation.Disabled,
+                CSharp.NullableAnnotation.Oblivious when  type.IsValueType => CodeAnalysis.NullableAnnotation.NotAnnotated,
+                CSharp.NullableAnnotation.Oblivious => CodeAnalysis.NullableAnnotation.None,
                 _ => throw ExceptionUtilities.UnexpectedValue(annotation)
             };
 
         internal static CSharp.NullableAnnotation ToInternalAnnotation(this CodeAnalysis.NullableAnnotation annotation) =>
             annotation switch
             {
-                CodeAnalysis.NullableAnnotation.NotApplicable => CSharp.NullableAnnotation.Oblivious,
-                CodeAnalysis.NullableAnnotation.Disabled => CSharp.NullableAnnotation.Oblivious,
+                CodeAnalysis.NullableAnnotation.None => CSharp.NullableAnnotation.Oblivious,
                 CodeAnalysis.NullableAnnotation.NotAnnotated => CSharp.NullableAnnotation.NotAnnotated,
                 CodeAnalysis.NullableAnnotation.Annotated => CSharp.NullableAnnotation.Annotated,
                 _ => throw ExceptionUtilities.UnexpectedValue(annotation)

--- a/src/Compilers/CSharp/Portable/Symbols/NullableFlowStateExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NullableFlowStateExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static CSharp.NullableFlowState ToInternalFlowState(this CodeAnalysis.NullableFlowState flowState) =>
             flowState switch
             {
-                CodeAnalysis.NullableFlowState.NotApplicable => CSharp.NullableFlowState.NotNull,
+                CodeAnalysis.NullableFlowState.None => CSharp.NullableFlowState.NotNull,
                 CodeAnalysis.NullableFlowState.NotNull => CSharp.NullableFlowState.NotNull,
                 CodeAnalysis.NullableFlowState.MaybeNull => CSharp.NullableFlowState.MaybeNull,
                 _ => throw ExceptionUtilities.UnexpectedValue(flowState)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -683,10 +683,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         CodeAnalysis.NullableAnnotation ITypeParameterSymbol.ReferenceTypeConstraintNullableAnnotation =>
             ReferenceTypeConstraintIsNullable switch
             {
-                false when !HasReferenceTypeConstraint => CodeAnalysis.NullableAnnotation.NotApplicable,
+                false when !HasReferenceTypeConstraint => CodeAnalysis.NullableAnnotation.None,
                 false => CodeAnalysis.NullableAnnotation.NotAnnotated,
                 true => CodeAnalysis.NullableAnnotation.Annotated,
-                null => CodeAnalysis.NullableAnnotation.Disabled,
+                null => CodeAnalysis.NullableAnnotation.None,
             };
 #pragma warning restore IDE0055 // Fix formatting
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -6377,7 +6377,7 @@ class C
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 underlyingType,
-                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable));
+                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None));
             Assert.True(tuple1.Equals(tuple2));
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString(includeNonNullable: true));
 
@@ -6390,7 +6390,7 @@ class C
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 underlyingType,
-                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.NotApplicable));
+                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.None));
             Assert.True(tuple1.Equals(tuple2));
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString(includeNonNullable: true));
         }
@@ -6415,7 +6415,7 @@ class C
             var e = Assert.Throws<ArgumentException>(() => comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations: CreateAnnotations(CodeAnalysis.NullableAnnotation.NotAnnotated, 8)));
             Assert.Contains(CodeAnalysisResources.TupleElementNullableAnnotationCountMismatch, e.Message);
 
-            tuple2 = comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations: CreateAnnotations(CodeAnalysis.NullableAnnotation.Disabled, 9));
+            tuple2 = comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations: CreateAnnotations(CodeAnalysis.NullableAnnotation.None, 9));
             Assert.True(TypeEquals(tuple1, tuple2, TypeCompareKind.IgnoreTupleNames));
             Assert.Equal("(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)", tuple2.ToTestDisplayString(includeNonNullable: true));
 
@@ -6446,7 +6446,7 @@ class C
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 elementTypes,
-                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable));
+                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None));
             Assert.True(tuple1.Equals(tuple2));
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString(includeNonNullable: true));
 
@@ -6459,7 +6459,7 @@ class C
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 elementTypes,
-                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.NotApplicable));
+                elementNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.None));
             Assert.True(tuple1.Equals(tuple2));
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString(includeNonNullable: true));
         }
@@ -6484,7 +6484,7 @@ class C
             var e = Assert.Throws<ArgumentException>(() => comp.CreateTupleTypeSymbol(elementTypes, elementNullableAnnotations: CreateAnnotations(CodeAnalysis.NullableAnnotation.NotAnnotated, 8)));
             Assert.Contains(CodeAnalysisResources.TupleElementNullableAnnotationCountMismatch, e.Message);
 
-            tuple2 = comp.CreateTupleTypeSymbol(elementTypes, elementNullableAnnotations: CreateAnnotations(CodeAnalysis.NullableAnnotation.Disabled, 9));
+            tuple2 = comp.CreateTupleTypeSymbol(elementTypes, elementNullableAnnotations: CreateAnnotations(CodeAnalysis.NullableAnnotation.None, 9));
             Assert.True(TypeEquals(tuple1, tuple2, TypeCompareKind.IgnoreTupleNames));
             Assert.Equal("(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)", tuple2.ToTestDisplayString(includeNonNullable: true));
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -2350,21 +2350,21 @@ public class C { public static FrameworkName Goo() { return null; }}";
 
             var arrayType = comp.CreateArrayTypeSymbol(elementType);
             Assert.Equal(1, arrayType.Rank);
-            Assert.Equal(CodeAnalysis.NullableAnnotation.Disabled, arrayType.ElementNullableAnnotation);
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, arrayType.ElementNullableAnnotation);
 
             Assert.Throws<ArgumentException>(() => comp.CreateArrayTypeSymbol(elementType, default));
             Assert.Throws<ArgumentException>(() => comp.CreateArrayTypeSymbol(elementType, 0));
 
             arrayType = comp.CreateArrayTypeSymbol(elementType, 1, default);
             Assert.Equal(1, arrayType.Rank);
-            Assert.Equal(CodeAnalysis.NullableAnnotation.Disabled, arrayType.ElementNullableAnnotation);
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, arrayType.ElementNullableAnnotation);
 
             Assert.Throws<ArgumentException>(() => comp.CreateArrayTypeSymbol(elementType, rank: default));
             Assert.Throws<ArgumentException>(() => comp.CreateArrayTypeSymbol(elementType, rank: 0));
 
             arrayType = comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: default);
             Assert.Equal(1, arrayType.Rank);
-            Assert.Equal(CodeAnalysis.NullableAnnotation.Disabled, arrayType.ElementNullableAnnotation);
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, arrayType.ElementNullableAnnotation);
         }
 
         [Fact]
@@ -2374,9 +2374,9 @@ public class C { public static FrameworkName Goo() { return null; }}";
             var comp = (Compilation)CSharpCompilation.Create("");
             var elementType = comp.GetSpecialType(SpecialType.System_Object);
 
-            Assert.Equal(CodeAnalysis.NullableAnnotation.Disabled, comp.CreateArrayTypeSymbol(elementType).ElementNullableAnnotation);
-            Assert.Equal(CodeAnalysis.NullableAnnotation.Disabled, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: CodeAnalysis.NullableAnnotation.NotApplicable).ElementNullableAnnotation);
-            Assert.Equal(CodeAnalysis.NullableAnnotation.Disabled, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: CodeAnalysis.NullableAnnotation.Disabled).ElementNullableAnnotation);
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType).ElementNullableAnnotation);
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: CodeAnalysis.NullableAnnotation.None).ElementNullableAnnotation);
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: CodeAnalysis.NullableAnnotation.None).ElementNullableAnnotation);
             Assert.Equal(CodeAnalysis.NullableAnnotation.NotAnnotated, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: CodeAnalysis.NullableAnnotation.NotAnnotated).ElementNullableAnnotation);
             Assert.Equal(CodeAnalysis.NullableAnnotation.Annotated, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation: CodeAnalysis.NullableAnnotation.Annotated).ElementNullableAnnotation);
         }
@@ -2580,7 +2580,7 @@ public class C { public static FrameworkName Goo() { return null; }}";
 
             var type = comp.CreateAnonymousTypeSymbol(memberTypes, memberNames);
             Assert.Equal("<anonymous type: System.Object P, System.String Q>", type.ToTestDisplayString(includeNonNullable: true));
-            AssertEx.Equal(new[] { CodeAnalysis.NullableAnnotation.Disabled, CodeAnalysis.NullableAnnotation.Disabled }, GetAnonymousTypeNullableAnnotations(type));
+            AssertEx.Equal(new[] { CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None }, GetAnonymousTypeNullableAnnotations(type));
 
             Assert.Throws<ArgumentException>(() => comp.CreateAnonymousTypeSymbol(memberTypes, memberNames, memberNullableAnnotations: ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotAnnotated)));
 
@@ -2611,7 +2611,7 @@ public class C { public static FrameworkName Goo() { return null; }}";
 
             var type = genericType.Construct(typeArguments, default);
             Assert.Equal("Pair<System.Object, System.String>", type.ToTestDisplayString(includeNonNullable: true));
-            AssertEx.Equal(new[] { CodeAnalysis.NullableAnnotation.Disabled, CodeAnalysis.NullableAnnotation.Disabled }, type.TypeArgumentNullableAnnotations);
+            AssertEx.Equal(new[] { CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None }, type.TypeArgumentNullableAnnotations);
 
             Assert.Throws<ArgumentException>(() => genericType.Construct(typeArguments, ImmutableArray<CodeAnalysis.NullableAnnotation>.Empty));
             Assert.Throws<ArgumentException>(() => genericType.Construct(ImmutableArray.Create<ITypeSymbol>(null, null), default));
@@ -2644,7 +2644,7 @@ public class C { public static FrameworkName Goo() { return null; }}";
 
             var type = genericMethod.Construct(typeArguments, default);
             Assert.Equal("void Program.M<System.Object, System.String>()", type.ToTestDisplayString(includeNonNullable: true));
-            AssertEx.Equal(new[] { CodeAnalysis.NullableAnnotation.Disabled, CodeAnalysis.NullableAnnotation.Disabled }, type.TypeArgumentNullableAnnotations);
+            AssertEx.Equal(new[] { CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None }, type.TypeArgumentNullableAnnotations);
 
             Assert.Throws<ArgumentException>(() => genericMethod.Construct(typeArguments, ImmutableArray<CodeAnalysis.NullableAnnotation>.Empty));
             Assert.Throws<ArgumentException>(() => genericMethod.Construct(ImmutableArray.Create<ITypeSymbol>(null, null), default));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -141,7 +141,7 @@ public class C
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -203,7 +203,7 @@ public class C
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -270,7 +270,7 @@ public class C
                 testMetadata: true,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
@@ -353,7 +353,7 @@ public class C
                 member => member.NullableAnnotation,
                 testMetadata: true,
                 PublicNullableAnnotation.NotAnnotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
@@ -448,9 +448,9 @@ public static class Ext
                 var c = compilation.GetTypeByMetadataName("C");
                 var members = c.GetMembers().OfType<IMethodSymbol>().Where(m => m.Name.StartsWith("M")).ToArray();
                 assertNullability(members,
-                    PublicNullableAnnotation.NotApplicable,
+                    PublicNullableAnnotation.None,
                     PublicNullableAnnotation.NotAnnotated,
-                    PublicNullableAnnotation.NotApplicable,
+                    PublicNullableAnnotation.None,
                     PublicNullableAnnotation.NotAnnotated);
 
                 var e = compilation.GetTypeByMetadataName("Ext");
@@ -460,7 +460,7 @@ public static class Ext
                     PublicNullableAnnotation.Annotated,
                     PublicNullableAnnotation.NotAnnotated,
                     PublicNullableAnnotation.Annotated,
-                    PublicNullableAnnotation.Disabled,
+                    PublicNullableAnnotation.None,
                     PublicNullableAnnotation.Annotated,
                     PublicNullableAnnotation.NotAnnotated,
                     PublicNullableAnnotation.Annotated);
@@ -536,7 +536,7 @@ public class C
                 method =>
                 {
                     Assert.Equal(method.ReturnNullableAnnotation, method.Parameters[0].NullableAnnotation);
-                    Assert.Equal(PublicNullableAnnotation.NotApplicable, method.ReceiverNullableAnnotation);
+                    Assert.Equal(PublicNullableAnnotation.None, method.ReceiverNullableAnnotation);
                     return method.ReturnNullableAnnotation;
                 },
                 testMetadata: false,
@@ -544,7 +544,7 @@ public class C
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -600,7 +600,7 @@ public class C
                 testMetadata: true,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated);
         }
 
@@ -652,7 +652,7 @@ public class C
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -711,8 +711,8 @@ public interface I<T, U, V>
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -770,7 +770,7 @@ public interface I
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -832,8 +832,8 @@ public interface IB<T, U, V>
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated);
@@ -883,8 +883,8 @@ public interface IB<T, U, V>
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated
@@ -934,8 +934,8 @@ class C
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated,
-                PublicNullableAnnotation.Disabled,
-                PublicNullableAnnotation.Disabled,
+                PublicNullableAnnotation.None,
+                PublicNullableAnnotation.None,
                 PublicNullableAnnotation.Annotated,
                 PublicNullableAnnotation.NotAnnotated,
                 PublicNullableAnnotation.Annotated

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -897,7 +897,7 @@ namespace Microsoft.CodeAnalysis
         /// Returns a new ArrayTypeSymbol representing an array type tied to the base types of the
         /// COR Library in this Compilation.
         /// </summary>
-        public IArrayTypeSymbol CreateArrayTypeSymbol(ITypeSymbol elementType, int rank = 1, NullableAnnotation elementNullableAnnotation = NullableAnnotation.NotApplicable)
+        public IArrayTypeSymbol CreateArrayTypeSymbol(ITypeSymbol elementType, int rank = 1, NullableAnnotation elementNullableAnnotation = NullableAnnotation.None)
         {
             return CommonCreateArrayTypeSymbol(elementType, rank, elementNullableAnnotation);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -7,7 +7,7 @@ Microsoft.CodeAnalysis.CommandLineArguments.GetPdbFilePath(string outputFileName
 Microsoft.CodeAnalysis.Compilation.CreateAnonymousTypeSymbol(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> memberTypes, System.Collections.Immutable.ImmutableArray<string> memberNames, System.Collections.Immutable.ImmutableArray<bool> memberIsReadOnly = default(System.Collections.Immutable.ImmutableArray<bool>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location> memberLocations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.NullableAnnotation> memberNullableAnnotations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.NullableAnnotation>)) -> Microsoft.CodeAnalysis.INamedTypeSymbol
 *REMOVED*Microsoft.CodeAnalysis.Compilation.CreateAnonymousTypeSymbol(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> memberTypes, System.Collections.Immutable.ImmutableArray<string> memberNames, System.Collections.Immutable.ImmutableArray<bool> memberIsReadOnly = default(System.Collections.Immutable.ImmutableArray<bool>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location> memberLocations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>)) -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.Compilation.CreateAnonymousTypeSymbol(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> memberTypes, System.Collections.Immutable.ImmutableArray<string> memberNames, System.Collections.Immutable.ImmutableArray<bool> memberIsReadOnly, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location> memberLocations) -> Microsoft.CodeAnalysis.INamedTypeSymbol
-Microsoft.CodeAnalysis.Compilation.CreateArrayTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol elementType, int rank = 1, Microsoft.CodeAnalysis.NullableAnnotation elementNullableAnnotation = Microsoft.CodeAnalysis.NullableAnnotation.NotApplicable) -> Microsoft.CodeAnalysis.IArrayTypeSymbol
+Microsoft.CodeAnalysis.Compilation.CreateArrayTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol elementType, int rank = 1, Microsoft.CodeAnalysis.NullableAnnotation elementNullableAnnotation = Microsoft.CodeAnalysis.NullableAnnotation.None) -> Microsoft.CodeAnalysis.IArrayTypeSymbol
 *REMOVED*Microsoft.CodeAnalysis.Compilation.CreateArrayTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol elementType, int rank = 1) -> Microsoft.CodeAnalysis.IArrayTypeSymbol
 Microsoft.CodeAnalysis.Compilation.CreateArrayTypeSymbol(Microsoft.CodeAnalysis.ITypeSymbol elementType, int rank) -> Microsoft.CodeAnalysis.IArrayTypeSymbol
 Microsoft.CodeAnalysis.Compilation.CreateTupleTypeSymbol(Microsoft.CodeAnalysis.INamedTypeSymbol underlyingType, System.Collections.Immutable.ImmutableArray<string> elementNames = default(System.Collections.Immutable.ImmutableArray<string>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location> elementLocations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.NullableAnnotation> elementNullableAnnotations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.NullableAnnotation>)) -> Microsoft.CodeAnalysis.INamedTypeSymbol
@@ -57,10 +57,9 @@ Microsoft.CodeAnalysis.NullabilityInfo.Annotation.get -> Microsoft.CodeAnalysis.
 Microsoft.CodeAnalysis.NullabilityInfo.Equals(Microsoft.CodeAnalysis.NullabilityInfo other) -> bool
 Microsoft.CodeAnalysis.NullabilityInfo.FlowState.get -> Microsoft.CodeAnalysis.NullableFlowState
 Microsoft.CodeAnalysis.NullableAnnotation
-Microsoft.CodeAnalysis.NullableAnnotation.Annotated = 3 -> Microsoft.CodeAnalysis.NullableAnnotation
-Microsoft.CodeAnalysis.NullableAnnotation.Disabled = 1 -> Microsoft.CodeAnalysis.NullableAnnotation
-Microsoft.CodeAnalysis.NullableAnnotation.NotAnnotated = 2 -> Microsoft.CodeAnalysis.NullableAnnotation
-Microsoft.CodeAnalysis.NullableAnnotation.NotApplicable = 0 -> Microsoft.CodeAnalysis.NullableAnnotation
+Microsoft.CodeAnalysis.NullableAnnotation.Annotated = 2 -> Microsoft.CodeAnalysis.NullableAnnotation
+Microsoft.CodeAnalysis.NullableAnnotation.None = 0 -> Microsoft.CodeAnalysis.NullableAnnotation
+Microsoft.CodeAnalysis.NullableAnnotation.NotAnnotated = 1 -> Microsoft.CodeAnalysis.NullableAnnotation
 Microsoft.CodeAnalysis.NullableContext
 Microsoft.CodeAnalysis.NullableContext.AnnotationsContextInherited = 8 -> Microsoft.CodeAnalysis.NullableContext
 Microsoft.CodeAnalysis.NullableContext.AnnotationsEnabled = 2 -> Microsoft.CodeAnalysis.NullableContext
@@ -78,7 +77,7 @@ Microsoft.CodeAnalysis.NullableContextOptions.Warnings = 1 -> Microsoft.CodeAnal
 Microsoft.CodeAnalysis.NullableContextOptionsExtensions
 Microsoft.CodeAnalysis.NullableFlowState
 Microsoft.CodeAnalysis.NullableFlowState.MaybeNull = 2 -> Microsoft.CodeAnalysis.NullableFlowState
-Microsoft.CodeAnalysis.NullableFlowState.NotApplicable = 0 -> Microsoft.CodeAnalysis.NullableFlowState
+Microsoft.CodeAnalysis.NullableFlowState.None = 0 -> Microsoft.CodeAnalysis.NullableFlowState
 Microsoft.CodeAnalysis.NullableFlowState.NotNull = 1 -> Microsoft.CodeAnalysis.NullableFlowState
 Microsoft.CodeAnalysis.SuppressionDescriptor
 Microsoft.CodeAnalysis.SuppressionDescriptor.Equals(Microsoft.CodeAnalysis.SuppressionDescriptor other) -> bool

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns the top-level nullability of the type arguments that have been substituted
         /// for the type parameters. If nothing has been substituted for a given type parameter,
-        /// then <see cref="NullableAnnotation.NotApplicable"/> is returned.
+        /// then <see cref="NullableAnnotation.None"/> is returned.
         /// </summary>
         ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations { get; }
 

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns the top-level nullability of the type arguments that have been substituted
         /// for the type parameters. If nothing has been substituted for a given type parameter,
-        /// then <see cref="NullableAnnotation.NotApplicable"/> is returned for that type argument.
+        /// then <see cref="NullableAnnotation.None"/> is returned for that type argument.
         /// </summary>
         ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations { get; }
 

--- a/src/Compilers/Core/Portable/Symbols/ITypeParameterSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeParameterSymbol.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// If <see cref="HasReferenceTypeConstraint"/> is true, returns the top-level nullability of the
         /// <c>class</c> constraint that was specified for the type parameter. If there was no <c>class</c>
-        /// constraint, this returns <see cref="NullableAnnotation.NotApplicable"/>.
+        /// constraint, this returns <see cref="NullableAnnotation.None"/>.
         /// </summary>
         NullableAnnotation ReferenceTypeConstraintNullableAnnotation { get; }
 

--- a/src/Compilers/Core/Portable/Symbols/NullableAnnotation.cs
+++ b/src/Compilers/Core/Portable/Symbols/NullableAnnotation.cs
@@ -13,13 +13,7 @@ namespace Microsoft.CodeAnalysis
         /// The expression has not been analyzed, or the syntax is
         /// not an expression (such as a statement).
         /// </summary>
-        NotApplicable = 0,
-        /// <summary>
-        /// The expression comes from a library not updated to C# 8
-        /// or nullable was disabled for the definition, and has no
-        /// nullability information. Analysis is disabled.
-        /// </summary>
-        Disabled,
+        None = 0,
         /// <summary>
         /// The expression is not annotated (does not have a ?).
         /// </summary>

--- a/src/Compilers/Core/Portable/Symbols/NullableAnnotation.cs
+++ b/src/Compilers/Core/Portable/Symbols/NullableAnnotation.cs
@@ -13,6 +13,17 @@ namespace Microsoft.CodeAnalysis
         /// The expression has not been analyzed, or the syntax is
         /// not an expression (such as a statement).
         /// </summary>
+        /// <remarks>
+        /// There are a few different reasons the expression could
+        /// have not been analyzed:
+        ///     1) The symbol producing the expression comes from
+        ///        a method that has not been annotated, such as
+        ///        invoking a C# 7.3 or earlier method, or a
+        ///        method in this compilation that is in a disabled
+        ///        context.
+        ///     2) Nullable is completely disabled in this
+        ///        compilation.
+        /// </remarks>
         None = 0,
         /// <summary>
         /// The expression is not annotated (does not have a ?).

--- a/src/Compilers/Core/Portable/Symbols/NullableFlowState.cs
+++ b/src/Compilers/Core/Portable/Symbols/NullableFlowState.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Syntax is not an expression, or was not analyzed.
         /// </summary>
-        NotApplicable = 0,
+        None = 0,
         /// <summary>
         /// Expression is not null.
         /// </summary>

--- a/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CompilationTestUtils.cs
@@ -316,8 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 var actualTypes = annotations.SelectAsArray(annotation =>
                     {
                         var typeInfo = model.GetTypeInfo(annotation.Expression);
-                        Assert.NotEqual(CodeAnalysis.NullableAnnotation.NotApplicable, typeInfo.Nullability.Annotation);
-                        Assert.NotEqual(CodeAnalysis.NullableFlowState.NotApplicable, typeInfo.Nullability.FlowState);
+                        Assert.NotEqual(CodeAnalysis.NullableFlowState.None, typeInfo.Nullability.FlowState);
                         // https://github.com/dotnet/roslyn/issues/35035: After refactoring symboldisplay, we should be able to just call something like typeInfo.Type.ToDisplayString(typeInfo.Nullability.FlowState, TypeWithState.TestDisplayFormat)
                         var type = TypeWithState.Create(
                             (TypeSymbol)(annotation.IsConverted ? typeInfo.ConvertedType : typeInfo.Type),

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -401,7 +401,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IArrayTypeSymbol_ElementNullableAnnotation As NullableAnnotation Implements IArrayTypeSymbol.ElementNullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -278,7 +278,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IEventSymbol_NullableAnnotation As NullableAnnotation Implements IEventSymbol.NullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -428,7 +428,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IFieldSymbol_NullableAnnotation As NullableAnnotation Implements IFieldSymbol.NullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -894,7 +894,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IMethodSymbol_ReceiverNullableAnnotation As NullableAnnotation Implements IMethodSymbol.ReceiverNullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 
@@ -997,7 +997,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IMethodSymbol_ReturnNullableAnnotation As NullableAnnotation Implements IMethodSymbol.ReturnNullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 
@@ -1009,7 +1009,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IMethodSymbol_TypeArgumentsNullableAnnotation As ImmutableArray(Of NullableAnnotation) Implements IMethodSymbol.TypeArgumentNullableAnnotations
             Get
-                Return Me.TypeArguments.SelectAsArray(Function(t) NullableAnnotation.NotApplicable)
+                Return Me.TypeArguments.SelectAsArray(Function(t) NullableAnnotation.None)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1146,7 +1146,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property TypeArgumentNullableAnnotations As ImmutableArray(Of NullableAnnotation) Implements INamedTypeSymbol.TypeArgumentNullableAnnotations
             Get
-                Return Me.TypeArgumentsNoUseSiteDiagnostics.SelectAsArray(Function(t) NullableAnnotation.NotApplicable)
+                Return Me.TypeArgumentsNoUseSiteDiagnostics.SelectAsArray(Function(t) NullableAnnotation.None)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ParameterSymbol.vb
@@ -294,7 +294,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IParameterSymbol_NullableAnnotation As NullableAnnotation Implements IParameterSymbol.NullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -527,7 +527,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IPropertySymbol_NullableAnnotation As NullableAnnotation Implements IPropertySymbol.NullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
@@ -391,7 +391,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ILocalSymbol_NullableAnnotation As NullableAnnotation Implements ILocalSymbol.NullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
@@ -363,7 +363,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeParameterSymbol_ReferenceTypeConstraintNullableAnnotation As NullableAnnotation Implements ITypeParameterSymbol.ReferenceTypeConstraintNullableAnnotation
             Get
-                Return NullableAnnotation.NotApplicable
+                Return NullableAnnotation.None
             End Get
         End Property
 
@@ -393,7 +393,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property ITypeParameterSymbol_ConstraintNullableAnnotations As ImmutableArray(Of NullableAnnotation) Implements ITypeParameterSymbol.ConstraintNullableAnnotations
             Get
-                Return Me.ConstraintTypesNoUseSiteDiagnostics.SelectAsArray(Function(t) NullableAnnotation.NotApplicable)
+                Return Me.ConstraintTypesNoUseSiteDiagnostics.SelectAsArray(Function(t) NullableAnnotation.None)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -7611,7 +7611,7 @@ End Module")
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 underlyingType,
-                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable))
+                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None))
             Assert.True(tuple1.Equals(tuple2))
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString())
 
@@ -7623,7 +7623,7 @@ End Module")
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 underlyingType,
-                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.NotApplicable))
+                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.None))
             Assert.True(tuple1.Equals(tuple2))
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString())
         End Sub
@@ -7645,7 +7645,7 @@ End Module")
             Dim ex = Assert.Throws(Of ArgumentException)(Function() comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations:=CreateAnnotations(CodeAnalysis.NullableAnnotation.NotAnnotated, 8)))
             Assert.Contains(CodeAnalysisResources.TupleElementNullableAnnotationCountMismatch, ex.Message)
 
-            tuple2 = comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations:=CreateAnnotations(CodeAnalysis.NullableAnnotation.Disabled, 9))
+            tuple2 = comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations:=CreateAnnotations(CodeAnalysis.NullableAnnotation.None, 9))
             Assert.True(TypeEquals(tuple1, tuple2, TypeCompareKind.IgnoreTupleNames))
             Assert.Equal("(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)", tuple2.ToTestDisplayString())
 
@@ -7672,7 +7672,7 @@ End Module")
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 elementTypes,
-                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable))
+                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None))
             Assert.True(tuple1.Equals(tuple2))
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString())
 
@@ -7684,7 +7684,7 @@ End Module")
 
             tuple2 = comp.CreateTupleTypeSymbol(
                 elementTypes,
-                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.NotApplicable))
+                elementNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.None))
             Assert.True(tuple1.Equals(tuple2))
             Assert.Equal("(System.Int32, System.String)", tuple2.ToTestDisplayString())
         End Sub
@@ -7706,7 +7706,7 @@ End Module")
             Dim ex = Assert.Throws(Of ArgumentException)(Function() comp.CreateTupleTypeSymbol(elementTypes, elementNullableAnnotations:=CreateAnnotations(CodeAnalysis.NullableAnnotation.NotAnnotated, 8)))
             Assert.Contains(CodeAnalysisResources.TupleElementNullableAnnotationCountMismatch, ex.Message)
 
-            tuple2 = comp.CreateTupleTypeSymbol(elementTypes, elementNullableAnnotations:=CreateAnnotations(CodeAnalysis.NullableAnnotation.Disabled, 9))
+            tuple2 = comp.CreateTupleTypeSymbol(elementTypes, elementNullableAnnotations:=CreateAnnotations(CodeAnalysis.NullableAnnotation.None, 9))
             Assert.True(TypeEquals(tuple1, tuple2, TypeCompareKind.IgnoreTupleNames))
             Assert.Equal("(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)", tuple2.ToTestDisplayString())
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -1526,7 +1526,6 @@ BC2014: the value '_' is invalid for option 'RootNamespace'
             Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType).ElementNullableAnnotation)
             Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=Nothing).ElementNullableAnnotation)
             Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.None).ElementNullableAnnotation)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.None).ElementNullableAnnotation)
             Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.NotAnnotated).ElementNullableAnnotation)
             Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.Annotated).ElementNullableAnnotation)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -1500,21 +1500,21 @@ BC2014: the value '_' is invalid for option 'RootNamespace'
 
             Dim arrayType = comp.CreateArrayTypeSymbol(elementType)
             Assert.Equal(1, arrayType.Rank)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, arrayType.ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, arrayType.ElementNullableAnnotation)
 
             Assert.Throws(Of ArgumentException)(Function() comp.CreateArrayTypeSymbol(elementType, Nothing))
             Assert.Throws(Of ArgumentException)(Function() comp.CreateArrayTypeSymbol(elementType, 0))
 
             arrayType = comp.CreateArrayTypeSymbol(elementType, 1, Nothing)
             Assert.Equal(1, arrayType.Rank)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, arrayType.ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, arrayType.ElementNullableAnnotation)
 
             Assert.Throws(Of ArgumentException)(Function() comp.CreateArrayTypeSymbol(elementType, rank:=Nothing))
             Assert.Throws(Of ArgumentException)(Function() comp.CreateArrayTypeSymbol(elementType, rank:=0))
 
             arrayType = comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=Nothing)
             Assert.Equal(1, arrayType.Rank)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, arrayType.ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, arrayType.ElementNullableAnnotation)
         End Sub
 
         <Fact()>
@@ -1523,12 +1523,12 @@ BC2014: the value '_' is invalid for option 'RootNamespace'
             Dim comp = DirectCast(VisualBasicCompilation.Create(""), Compilation)
             Dim elementType = comp.GetSpecialType(SpecialType.System_Object)
 
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, comp.CreateArrayTypeSymbol(elementType).ElementNullableAnnotation)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=Nothing).ElementNullableAnnotation)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.NotApplicable).ElementNullableAnnotation)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.Disabled).ElementNullableAnnotation)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.NotAnnotated).ElementNullableAnnotation)
-            Assert.Equal(CodeAnalysis.NullableAnnotation.NotApplicable, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.Annotated).ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType).ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=Nothing).ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.None).ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.None).ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.NotAnnotated).ElementNullableAnnotation)
+            Assert.Equal(CodeAnalysis.NullableAnnotation.None, comp.CreateArrayTypeSymbol(elementType, elementNullableAnnotation:=CodeAnalysis.NullableAnnotation.Annotated).ElementNullableAnnotation)
         End Sub
 
         <Fact()>
@@ -1706,13 +1706,13 @@ BC2014: the value '_' is invalid for option 'RootNamespace'
 
             Dim type = comp.CreateAnonymousTypeSymbol(memberTypes, memberNames)
             Assert.Equal("<anonymous type: Key P As System.Object, Key Q As System.String>", type.ToTestDisplayString())
-            AssertEx.Equal({CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable}, GetAnonymousTypeNullableAnnotations(type))
+            AssertEx.Equal({CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None}, GetAnonymousTypeNullableAnnotations(type))
 
             Assert.Throws(Of ArgumentException)(Function() comp.CreateAnonymousTypeSymbol(memberTypes, memberNames, memberNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotAnnotated)))
 
             type = comp.CreateAnonymousTypeSymbol(memberTypes, memberNames, memberNullableAnnotations:=ImmutableArray.Create(CodeAnalysis.NullableAnnotation.NotAnnotated, CodeAnalysis.NullableAnnotation.Annotated))
             Assert.Equal("<anonymous type: Key P As System.Object, Key Q As System.String>", type.ToTestDisplayString())
-            AssertEx.Equal({CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable}, GetAnonymousTypeNullableAnnotations(type))
+            AssertEx.Equal({CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None}, GetAnonymousTypeNullableAnnotations(type))
         End Sub
 
         Private Shared Function GetAnonymousTypeNullableAnnotations(type As ITypeSymbol) As ImmutableArray(Of CodeAnalysis.NullableAnnotation)
@@ -1734,14 +1734,14 @@ End Class"
 
             Dim type = genericType.Construct(typeArguments, Nothing)
             Assert.Equal("Pair(Of System.Object, System.String)", type.ToTestDisplayString())
-            AssertEx.Equal({CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable}, type.TypeArgumentNullableAnnotations)
+            AssertEx.Equal({CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None}, type.TypeArgumentNullableAnnotations)
 
             Assert.Throws(Of ArgumentException)(Function() genericType.Construct(typeArguments, ImmutableArray(Of CodeAnalysis.NullableAnnotation).Empty))
             Assert.Throws(Of ArgumentException)(Function() genericType.Construct(ImmutableArray.Create(Of ITypeSymbol)(Nothing, Nothing), Nothing))
 
             type = genericType.Construct(typeArguments, ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.NotAnnotated))
             Assert.Equal("Pair(Of System.Object, System.String)", type.ToTestDisplayString())
-            AssertEx.Equal({CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable}, type.TypeArgumentNullableAnnotations)
+            AssertEx.Equal({CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None}, type.TypeArgumentNullableAnnotations)
 
             ' Type arguments from C#.
             comp = CreateCSharpCompilation("")
@@ -1766,14 +1766,14 @@ End Class"
 
             Dim type = genericMethod.Construct(typeArguments, Nothing)
             Assert.Equal("Sub Program.M(Of System.Object, System.String)()", type.ToTestDisplayString())
-            AssertEx.Equal({CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable}, type.TypeArgumentNullableAnnotations)
+            AssertEx.Equal({CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None}, type.TypeArgumentNullableAnnotations)
 
             Assert.Throws(Of ArgumentException)(Function() genericMethod.Construct(typeArguments, ImmutableArray(Of CodeAnalysis.NullableAnnotation).Empty))
             Assert.Throws(Of ArgumentException)(Function() genericMethod.Construct(ImmutableArray.Create(Of ITypeSymbol)(Nothing, Nothing), Nothing))
 
             type = genericMethod.Construct(typeArguments, ImmutableArray.Create(CodeAnalysis.NullableAnnotation.Annotated, CodeAnalysis.NullableAnnotation.NotAnnotated))
             Assert.Equal("Sub Program.M(Of System.Object, System.String)()", type.ToTestDisplayString())
-            AssertEx.Equal({CodeAnalysis.NullableAnnotation.NotApplicable, CodeAnalysis.NullableAnnotation.NotApplicable}, type.TypeArgumentNullableAnnotations)
+            AssertEx.Equal({CodeAnalysis.NullableAnnotation.None, CodeAnalysis.NullableAnnotation.None}, type.TypeArgumentNullableAnnotations)
 
             ' Type arguments from C#.
             comp = CreateCSharpCompilation("")

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 var methodTypeParameter = GetMethodTypeParameter(type, cancellationToken);
                 return methodTypeParameter != null
                     ? methodTypeParameter
-                    : CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique)).WithNullability(NullableAnnotation.NotApplicable);
+                    : CodeGenerationSymbolFactory.CreateTypeParameterSymbol(NameGenerator.GenerateUniqueName("T", isUnique)).WithNullability(NullableAnnotation.None);
             }
 
             private ITypeParameterSymbol GetMethodTypeParameter(TypeSyntax type, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
                 // Strip off top-level nullability since we can't put top-level nullability into the base list. We will still include nested nullability
                 // if you're deriving some interface like IEnumerable<string?>.
-                BaseTypeOrInterfaceOpt = baseType.WithNullability(NullableAnnotation.NotApplicable);
+                BaseTypeOrInterfaceOpt = baseType.WithNullability(NullableAnnotation.None);
             }
 
             private bool GenerateStruct(TService service, SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/NullableExtensions.cs
@@ -41,8 +41,8 @@ namespace Microsoft.CodeAnalysis
             // TODO: call the compiler API once it's available
             switch (flowState)
             {
-                case NullableFlowState.NotApplicable:
-                    return typeSymbol.WithNullability(NullableAnnotation.NotApplicable);
+                case NullableFlowState.None:
+                    return typeSymbol.WithNullability(NullableAnnotation.None);
                 case NullableFlowState.NotNull:
                     return typeSymbol.WithNullability(NullableAnnotation.NotAnnotated);
                 case NullableFlowState.MaybeNull:
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis
             {
                 // For now, we'll return this while we transition the codebase over to these helpers. Eventually this should throw, since it means somebody got a type from
                 // the compiler API and didn't wrap it properly.
-                return NullableAnnotation.NotApplicable;
+                return NullableAnnotation.None;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/37441. @dotnet/roslyn-compiler for review. /cc @jasonmalinowski @ryzngard 