### PR TITLE
Use AnalyzerConfigOptionsProvider when available

### DIFF
--- a/src/CodeStyle/Core/Analyzers/AbstractFormattingAnalyzer.cs
+++ b/src/CodeStyle/Core/Analyzers/AbstractFormattingAnalyzer.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.IO;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.CodeStyle
@@ -27,8 +26,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         protected override void InitializeWorker(AnalysisContext context)
         {
-            var codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager();
-            context.RegisterSyntaxTreeAction(c => AnalyzeSyntaxTree(c, codingConventionsManager));
+            context.RegisterSyntaxTreeAction(c =>
+            {
+                var codingConventionsManager = new AnalyzerConfigCodingConventionsManager(c.Tree, c.Options);
+                AnalyzeSyntaxTree(c, codingConventionsManager);
+            });
         }
 
         protected abstract OptionSet ApplyFormattingOptions(OptionSet optionSet, ICodingConventionContext codingConventionContext);

--- a/src/CodeStyle/Core/Analyzers/AnalyzerConfigCodingConventionsContext.cs
+++ b/src/CodeStyle/Core/Analyzers/AnalyzerConfigCodingConventionsContext.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.CodingConventions;
+
+namespace Microsoft.CodeAnalysis
+{
+    public class AnalyzerConfigCodingConventionsContext : ICodingConventionContext, ICodingConventionsSnapshot
+    {
+        private static readonly Func<object, string, string?> TryGetAnalyzerConfigValue;
+
+        private readonly object _analyzerConfigOptions;
+
+        static AnalyzerConfigCodingConventionsContext()
+        {
+            TryGetAnalyzerConfigValue = CreateTryGetAnalyzerConfigValueAccessor();
+
+            static Func<object, string, string?> CreateTryGetAnalyzerConfigValueAccessor()
+            {
+                var analyzerConfigOptions = typeof(AnalyzerOptions).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions", throwOnError: false, ignoreCase: false);
+                var method = analyzerConfigOptions?.GetRuntimeMethod("TryGetValue", new[] { typeof(string), typeof(string).MakeByRefType() });
+                if (method is null)
+                {
+                    return (_1, _2) => null;
+                }
+
+                var instance = Expression.Parameter(typeof(object), "instance");
+                var key = Expression.Parameter(typeof(string), "key");
+                var value = Expression.Variable(typeof(string), "value");
+                var accessor = Expression.Lambda<Func<object, string, string>>(
+                    Expression.Block(
+                        typeof(string),
+                        new[] { value },
+                        Expression.Call(
+                            Expression.Convert(instance, analyzerConfigOptions),
+                            method,
+                            key,
+                            value),
+                        value),
+                    instance,
+                    key);
+                return accessor.Compile();
+            }
+        }
+
+        public AnalyzerConfigCodingConventionsContext(object analyzerConfigOptions)
+        {
+            _analyzerConfigOptions = analyzerConfigOptions;
+        }
+
+        public ICodingConventionsSnapshot CurrentConventions => this;
+
+        IUniversalCodingConventions ICodingConventionsSnapshot.UniversalConventions => throw new NotSupportedException();
+        IReadOnlyDictionary<string, object> ICodingConventionsSnapshot.AllRawConventions => throw new NotSupportedException();
+        int ICodingConventionsSnapshot.Version => 0;
+
+        event CodingConventionsChangedAsyncEventHandler ICodingConventionContext.CodingConventionsChangedAsync
+        {
+            add { }
+            remove { }
+        }
+
+        public void Dispose()
+        {
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task WriteConventionValueAsync(string conventionName, string conventionValue, CancellationToken cancellationToken)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            throw new NotSupportedException();
+        }
+
+        bool ICodingConventionsSnapshot.TryGetConventionValue<T>(string conventionName, [MaybeNullWhen(returnValue: false)] out T conventionValue)
+        {
+            if (typeof(T) != typeof(string))
+            {
+                conventionValue = default!;
+                return false;
+            }
+
+            conventionValue = (T)(object?)TryGetAnalyzerConfigValue(_analyzerConfigOptions, conventionName)!;
+            return conventionValue is object;
+        }
+    }
+}

--- a/src/CodeStyle/Core/Analyzers/AnalyzerConfigCodingConventionsManager.cs
+++ b/src/CodeStyle/Core/Analyzers/AnalyzerConfigCodingConventionsManager.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.CodingConventions;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal class AnalyzerConfigCodingConventionsManager : ICodingConventionsManager
+    {
+        private static readonly Func<AnalyzerOptions, object?> GetAnalyzerConfigOptionsProvider;
+        private static readonly Func<object, SyntaxTree, object> GetAnalyzerConfigOptions;
+
+        private readonly SyntaxTree _tree;
+        private readonly AnalyzerOptions _options;
+        private readonly ICodingConventionsManager? _codingConventionsManager;
+
+        static AnalyzerConfigCodingConventionsManager()
+        {
+            GetAnalyzerConfigOptionsProvider = CreateAnalyzerConfigOptionsProviderAccessor();
+            GetAnalyzerConfigOptions = CreateAnalyzerConfigOptionsAccessor();
+
+            static Func<AnalyzerOptions, object?> CreateAnalyzerConfigOptionsProviderAccessor()
+            {
+                var property = typeof(AnalyzerOptions).GetTypeInfo().GetDeclaredProperty("AnalyzerConfigOptionsProvider");
+                if (property is null)
+                {
+                    return _ => null;
+                }
+
+                var options = Expression.Parameter(typeof(AnalyzerOptions), "options");
+                var accessor = Expression.Lambda<Func<AnalyzerOptions, object>>(
+                    Expression.Call(options, property.GetMethod),
+                    options);
+                return accessor.Compile();
+            }
+
+            static Func<object, SyntaxTree, object> CreateAnalyzerConfigOptionsAccessor()
+            {
+                var analyzerConfigOptionsProvider = typeof(AnalyzerOptions).GetTypeInfo().Assembly.GetType("Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider", throwOnError: false, ignoreCase: false);
+                var method = analyzerConfigOptionsProvider?.GetRuntimeMethod("GetOptions", new[] { typeof(SyntaxTree) });
+                if (method is null)
+                {
+                    return (_1, _2) => throw new NotImplementedException();
+                }
+
+                var provider = Expression.Parameter(typeof(object), "provider");
+                var tree = Expression.Parameter(typeof(SyntaxTree), "tree");
+                var accessor = Expression.Lambda<Func<object, SyntaxTree, object>>(
+                    Expression.Call(
+                        Expression.Convert(provider, analyzerConfigOptionsProvider),
+                        method,
+                        tree),
+                    provider,
+                    tree);
+                return accessor.Compile();
+            }
+        }
+
+        public AnalyzerConfigCodingConventionsManager(SyntaxTree tree, AnalyzerOptions options)
+        {
+            _tree = tree;
+            _options = options;
+            if (GetAnalyzerConfigOptionsProvider(options) is null)
+            {
+                _codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager();
+            }
+        }
+
+        public Task<ICodingConventionContext> GetConventionContextAsync(string filePathContext, CancellationToken cancellationToken)
+        {
+            if (_codingConventionsManager is object)
+            {
+                return _codingConventionsManager.GetConventionContextAsync(filePathContext, cancellationToken);
+            }
+
+            var analyzerConfigOptionsProvider = GetAnalyzerConfigOptionsProvider(_options);
+            var analyzerConfigOptions = GetAnalyzerConfigOptions(analyzerConfigOptionsProvider!, _tree);
+            return Task.FromResult<ICodingConventionContext>(new AnalyzerConfigCodingConventionsContext(analyzerConfigOptions));
+        }
+    }
+}

--- a/src/CodeStyle/Core/CodeFixes/FormattingCodeFixProvider.cs
+++ b/src/CodeStyle/Core/CodeFixes/FormattingCodeFixProvider.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.CodingConventions;
 
 namespace Microsoft.CodeAnalysis.CodeStyle
@@ -62,7 +61,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             // in testing requires manual handling of .editorconfig.
             if (File.Exists(document.FilePath ?? document.Name))
             {
-                var codingConventionsManager = CodingConventionsManagerFactory.CreateCodingConventionsManager();
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var codingConventionsManager = new AnalyzerConfigCodingConventionsManager(tree, document.Project.AnalyzerOptions);
                 var codingConventionContext = await codingConventionsManager.GetConventionContextAsync(document.FilePath ?? document.Name, cancellationToken).ConfigureAwait(false);
                 options = ApplyFormattingOptions(options, codingConventionContext);
             }


### PR DESCRIPTION
This pull request updates the NuGet formatting analyzer to use `AnalyzerConfigOptionsProvider` instead of Microsoft.VisualStudio.CodingConventions whenever the analyzers are used with Roslyn 3.3+. The new options provider overwhelmingly outperforms the .editorconfig implementation in Visual Studio, so we are expecting performance gains of nearly 50% across the build for solutions using this analyzer.