### PR TITLE
Simplify readonly MetadataAsSource

### DIFF
--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -1734,6 +1734,42 @@ Public Structure S <IsReadOnlyAttribute>
 End Structure");
         }
 
+
+        [WorkItem(34650, "https://github.com/dotnet/roslyn/issues/34650")]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task TestReadOnlyMethod_InReadOnlyStruct()
+        {
+            var metadataSource = @"
+public readonly struct S
+{
+    public void M() {}
+}
+";
+            var symbolName = "S.M";
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, metadataLanguageVersion: "Preview",
+                expected: $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+public readonly struct S
+{{
+    public void [|M|]();
+}}");
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, metadataLanguageVersion: "Preview",
+                expected: $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+' {CodeAnalysisResources.InMemoryAssembly}
+#End Region
+
+Imports System.Runtime.CompilerServices
+
+<IsReadOnlyAttribute>
+Public Structure S
+    Public Sub [|M|]()
+End Structure");
+        }
+
         [WorkItem(34650, "https://github.com/dotnet/roslyn/issues/34650")]
         [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
         public async Task TestStructProperty_ReadOnly()
@@ -1825,6 +1861,41 @@ public struct S
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
+Public Structure S
+    Public ReadOnly Property [|P|] As Integer
+End Structure");
+        }
+
+        [WorkItem(34650, "https://github.com/dotnet/roslyn/issues/34650")]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task TestReadOnlyStructProperty_ReadOnlyGet()
+        {
+            var metadataSource = @"
+public readonly struct S
+{
+    public readonly int P { get; }
+}
+";
+            var symbolName = "S.P";
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, metadataLanguageVersion: "Preview",
+                expected: $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+public readonly struct S
+{{
+    public int [|P|] {{ get; }}
+}}");
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, metadataLanguageVersion: "Preview",
+                expected: $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+' {CodeAnalysisResources.InMemoryAssembly}
+#End Region
+
+Imports System.Runtime.CompilerServices
+
+<IsReadOnlyAttribute>
 Public Structure S
     Public ReadOnly Property [|P|] As Integer
 End Structure");
@@ -2033,6 +2104,44 @@ public struct S
 
 Imports System
 
+Public Structure S
+    Public Event [|E|] As Action
+End Structure");
+        }
+
+        [WorkItem(34650, "https://github.com/dotnet/roslyn/issues/34650")]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task TestReadOnlyStruct_ReadOnlyEvent()
+        {
+            var metadataSource = @"
+public readonly struct S
+{
+    public event System.Action E { add {} remove {} }
+}
+";
+            var symbolName = "S.E";
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, metadataLanguageVersion: "Preview",
+                expected: $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+using System;
+
+public readonly struct S
+{{
+    public event Action [|E|];
+}}");
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, metadataLanguageVersion: "Preview",
+                expected: $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+' {CodeAnalysisResources.InMemoryAssembly}
+#End Region
+
+Imports System
+Imports System.Runtime.CompilerServices
+
+<IsReadOnlyAttribute>
 Public Structure S
     Public Event [|E|] As Action
 End Structure");

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -1606,7 +1606,7 @@ End Class";
 
         [WorkItem(34650, "https://github.com/dotnet/roslyn/issues/34650")]
         [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
-        public async Task TestReadOnlyStruct()
+        public async Task TestReadOnlyStruct_ReadOnlyField()
         {
             var metadataSource = @"
 public readonly struct S
@@ -1632,6 +1632,36 @@ public readonly struct [|S|]
 Imports System.Runtime.CompilerServices
 
 <IsReadOnlyAttribute>
+Public Structure [|S|]
+    Public ReadOnly i As Integer
+End Structure");
+        }
+
+        [WorkItem(34650, "https://github.com/dotnet/roslyn/issues/34650")]
+        [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]
+        public async Task TestStruct_ReadOnlyField()
+        {
+            var metadataSource = @"
+public struct S
+{
+    public readonly int i;
+}
+";
+            var symbolName = "S";
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.CSharp, $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+// {CodeAnalysisResources.InMemoryAssembly}
+#endregion
+
+public struct [|S|]
+{{
+    public readonly int i;
+}}");
+
+            await GenerateAndVerifySourceAsync(metadataSource, symbolName, LanguageNames.VisualBasic, $@"#Region ""{FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null""
+' {CodeAnalysisResources.InMemoryAssembly}
+#End Region
+
 Public Structure [|S|]
     Public ReadOnly i As Integer
 End Structure");

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/EventGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/EventGenerator.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // If one accessor is readonly and the other one is not,
                     // the event is malformed and cannot be properly displayed.
                     // See https://github.com/dotnet/roslyn/issues/34213
-                    if (@event.AddMethod?.IsReadOnly == true)
+                    if (@event.AddMethod?.IsReadOnly == true && !@event.ContainingType.IsReadOnly)
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
                     }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/EventGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/EventGenerator.cs
@@ -204,6 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // If one accessor is readonly and the other one is not,
                     // the event is malformed and cannot be properly displayed.
                     // See https://github.com/dotnet/roslyn/issues/34213
+                    // Don't show the readonly modifier if the containing type is already readonly
                     if (@event.AddMethod?.IsReadOnly == true && !@event.ContainingType.IsReadOnly)
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
                     }
 
-                    if (method.IsReadOnly)
+                    if (method.IsReadOnly && (method.ContainingSymbol as INamedTypeSymbol)?.IsReadOnly != true)
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
                     }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
@@ -195,6 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
                     }
 
+                    // Don't show the readonly modifier if the containing type is already readonly
+                    // ContainingSymbol is used to guard against methods which are not members of their ContainingType (e.g. lambdas and local functions)
                     if (method.IsReadOnly && (method.ContainingSymbol as INamedTypeSymbol)?.IsReadOnly != true)
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // because of the boxing requirement in order to call the method.
                     // therefore it seems like a small oversight to leave out the keyword for an explicit impl from metadata.
                     var hasAllReadOnlyAccessors = property.GetMethod?.IsReadOnly != false && property.SetMethod?.IsReadOnly != false;
-                    if (hasAllReadOnlyAccessors)
+                    if (hasAllReadOnlyAccessors && !property.ContainingType.IsReadOnly)
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
                     }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/PropertyGenerator.cs
@@ -367,6 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // because of the boxing requirement in order to call the method.
                     // therefore it seems like a small oversight to leave out the keyword for an explicit impl from metadata.
                     var hasAllReadOnlyAccessors = property.GetMethod?.IsReadOnly != false && property.SetMethod?.IsReadOnly != false;
+                    // Don't show the readonly modifier if the containing type is already readonly
                     if (hasAllReadOnlyAccessors && !property.ContainingType.IsReadOnly)
                     {
                         tokens.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));


### PR DESCRIPTION
I felt that including the 'readonly' keyword when the containing type is already readonly introduces too much noise. Note that:

1. by design we already don't emit the readonly attribute on methods/properties/events within readonly structs for a similar reason (attributes excessively increase the size).
2. we already have a similar behavior for Quick Info (show the 'readonly' modifier on the method/property/event only if the containing type is not readonly)

Before (many members omitted for brevity):
<img width="433" alt="readonly-mas-1" src="https://user-images.githubusercontent.com/5833655/61908307-3ff04c00-aee4-11e9-810b-0c09ee872db3.PNG">

After:
<img width="377" alt="readonly-mas-2" src="https://user-images.githubusercontent.com/5833655/61908932-b04b9d00-aee5-11e9-8776-462d7dee35a4.PNG">
