### PR TITLE
LambdaRewriter.SubstituteTypeArguments should make progress

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -938,7 +938,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 do
                 {
                     oldTypeArg = newTypeArg;
-                    newTypeArg = this.TypeMap.SubstituteType(typeArg);
+                    newTypeArg = this.TypeMap.SubstituteType(oldTypeArg);
 
                     // When type substitution does not change the type, it is expected to return the very same object.
                     // Therefore the loop is terminated when that type (as an object) does not change.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -939,11 +939,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     oldTypeArg = newTypeArg;
                     newTypeArg = this.TypeMap.SubstituteType(oldTypeArg);
-
-                    // When type substitution does not change the type, it is expected to return the very same object.
-                    // Therefore the loop is terminated when that type (as an object) does not change.
                 }
-                while ((object)oldTypeArg.Type != newTypeArg.Type);
+                while (!TypeSymbol.Equals(oldTypeArg.Type, newTypeArg.Type, TypeCompareKind.ConsiderEverything));
+
+                // When type substitution does not change the type, it is expected to return the very same object.
+                // Therefore the loop is terminated when that type (as an object) does not change.
+                Debug.Assert((object)oldTypeArg.Type == newTypeArg.Type);
 
                 // The types are the same, so the last pass performed no substitutions.
                 // Therefore the annotations ought to be the same too.


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/37456

@gafter Looking back at https://github.com/dotnet/roslyn/pull/35284, I still think the use of reference equality is correct, but I want to check with you in case you think we should return to the original `.Equals(..., ConsiderEverything)` comparison.