### PR TITLE
Don't drop a token passed to a syntax factory method.

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/MethodDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/MethodDeclarationSyntax.cs
@@ -34,7 +34,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             BlockSyntax body,
             SyntaxToken semicolonToken)
         {
-            return SyntaxFactory.MethodDeclaration(attributeLists, modifiers, returnType, explicitInterfaceSpecifier, identifier, typeParameterList, parameterList, constraintClauses, body, null, default(SyntaxToken));
+            return SyntaxFactory.MethodDeclaration(
+                attributeLists,
+                modifiers,
+                returnType,
+                explicitInterfaceSpecifier,
+                identifier,
+                typeParameterList,
+                parameterList,
+                constraintClauses,
+                body,
+                null,
+                semicolonToken);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -542,5 +542,35 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var syntaxNode3 = SyntaxFactory.ParseExpression("x is object??y").NormalizeWhitespace();
             Assert.Equal("x is object ?? y", syntaxNode3.ToFullString());
         }
+
+        [Fact]
+        [WorkItem(37467, "https://github.com/dotnet/roslyn/issues/37467")]
+        public void TestUnnecessarySemicolon()
+        {
+            //public static MethodDeclarationSyntax MethodDeclaration(
+            //    SyntaxList<AttributeListSyntax> attributeLists,
+            //    SyntaxTokenList modifiers,
+            //    TypeSyntax returnType,
+            //    ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier,
+            //    SyntaxToken identifier,
+            //    TypeParameterListSyntax typeParameterList,
+            //    ParameterListSyntax parameterList,
+            //    SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
+            //    BlockSyntax body,
+            //    SyntaxToken semicolonToken)
+            var syntaxNode = SyntaxFactory.MethodDeclaration(
+                attributeLists: default,
+                modifiers: default,
+                returnType: SyntaxFactory.ParseTypeName("int[]"),
+                explicitInterfaceSpecifier: default,
+                identifier: SyntaxFactory.Identifier("M"),
+                typeParameterList: default,
+                parameterList: SyntaxFactory.ParseParameterList("()"),
+                constraintClauses: default,
+                body: (BlockSyntax)SyntaxFactory.ParseStatement("{}"),
+                semicolonToken: SyntaxFactory.Token(SyntaxKind.SemicolonToken)
+                );
+            Assert.Equal("int[]M(){};", syntaxNode.ToFullString());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -547,17 +547,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [WorkItem(37467, "https://github.com/dotnet/roslyn/issues/37467")]
         public void TestUnnecessarySemicolon()
         {
-            //public static MethodDeclarationSyntax MethodDeclaration(
-            //    SyntaxList<AttributeListSyntax> attributeLists,
-            //    SyntaxTokenList modifiers,
-            //    TypeSyntax returnType,
-            //    ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier,
-            //    SyntaxToken identifier,
-            //    TypeParameterListSyntax typeParameterList,
-            //    ParameterListSyntax parameterList,
-            //    SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses,
-            //    BlockSyntax body,
-            //    SyntaxToken semicolonToken)
             var syntaxNode = SyntaxFactory.MethodDeclaration(
                 attributeLists: default,
                 modifiers: default,


### PR DESCRIPTION
Fixes #37467

@dotnet/roslyn-compiler May I please have a couple of reviews for this one-line bug fix for 16.3?
