### PR TITLE
Handle speculation for AsNewClause by generating an EqualsValue node

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GenerateConstructor/GenerateConstructorTests.vb
@@ -1919,5 +1919,26 @@ End Class",
     End Sub
 End Class", options:=options.MergeStyles(options.FieldNamesAreCamelCaseWithUnderscorePrefix, options.ParameterNamesAreCamelCaseWithPUnderscorePrefix, LanguageNames.VisualBasic))
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        <WorkItem(23807, "https://github.com/dotnet/roslyn/issues/23807")>
+        Public Async Function TestAsNewClause() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Class Test
+    Private field As New Test([|1|])
+End Class
+",
+"
+Class Test
+    Private field As New Test(1)
+    Private v As Integer
+
+    Public Sub New(v As Integer)
+        Me.v = v
+    End Sub
+End Class
+")
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -243,12 +243,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
                 End If
 
                 If newNode.Kind = SyntaxKind.AsNewClause Then
-                    ' Speculation is not supported for AsNewClauseSyntax nodes.
+                    ' Speculation is not supported for AsNewClauseSyntax nodes (see https://github.com/dotnet/roslyn/issues/15593).
                     ' Generate an EqualsValueSyntax node with the inner NewExpression of the AsNewClauseSyntax node for speculation.
+                    
+                    ' The SpeculationAnalyzer would do the work of creating the EqualsValueSyntax for us if we passed the AsNewClause,
+                    ' but we need to build it ourself so that we can locate the newTypeName node in the new tree. This way we can
+                    ' GetSymbolInfo for it.
 
                     Dim asNewClauseNode = DirectCast(newNode, AsNewClauseSyntax)
-                    Dim equalsValueNode = SyntaxFactory.EqualsValue(asNewClauseNode.NewExpression)
-                    newNode = asNewClauseNode.CopyAnnotationsTo(equalsValueNode)
+                    newNode = SyntaxFactory.EqualsValue(asNewClauseNode.NewExpression)
                     newTypeName = DirectCast(newNode.GetAnnotatedNodes(s_annotation).Single(), TypeSyntax)
                 End If
 

--- a/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -242,6 +242,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateConstructor
                     End If
                 End If
 
+                If newNode.Kind = SyntaxKind.AsNewClause Then
+                    ' Speculation is not supported for AsNewClauseSyntax nodes.
+                    ' Generate an EqualsValueSyntax node with the inner NewExpression of the AsNewClauseSyntax node for speculation.
+
+                    Dim asNewClauseNode = DirectCast(newNode, AsNewClauseSyntax)
+                    Dim equalsValueNode = SyntaxFactory.EqualsValue(asNewClauseNode.NewExpression)
+                    newNode = asNewClauseNode.CopyAnnotationsTo(equalsValueNode)
+                    newTypeName = DirectCast(newNode.GetAnnotatedNodes(s_annotation).Single(), TypeSyntax)
+                End If
+
                 Dim speculativeModel = SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(oldNode, newNode, document.SemanticModel)
                 If speculativeModel IsNot Nothing Then
                     Dim symbolInfo = speculativeModel.GetSymbolInfo(newTypeName.Parent, cancellationToken)


### PR DESCRIPTION
CreateSpeculativeSemanticModelForNode will create a speculativeModel from a generated EqualsValue node already, but the Type node we are searching for won't be part of the tree. So we generate the EqualsValue node instead and find the Type node so that we can get symbol information.

Fixes #23807