### PR TITLE
LambdaRewriter.SubstituteTypeArguments should make progress (#37487)

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -938,12 +938,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 do
                 {
                     oldTypeArg = newTypeArg;
-                    newTypeArg = this.TypeMap.SubstituteType(typeArg);
-
-                    // When type substitution does not change the type, it is expected to return the very same object.
-                    // Therefore the loop is terminated when that type (as an object) does not change.
+                    newTypeArg = this.TypeMap.SubstituteType(oldTypeArg);
                 }
-                while ((object)oldTypeArg.Type != newTypeArg.Type);
+                while (!TypeSymbol.Equals(oldTypeArg.Type, newTypeArg.Type, TypeCompareKind.ConsiderEverything));
+
+                // When type substitution does not change the type, it is expected to return the very same object.
+                // Therefore the loop is terminated when that type (as an object) does not change.
+                Debug.Assert((object)oldTypeArg.Type == newTypeArg.Type);
 
                 // The types are the same, so the last pass performed no substitutions.
                 // Therefore the annotations ought to be the same too.


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/37456 in 16.2 by cherry-picking commit a0009846c2bafedf2524f41aea2792157615a210 (from PR https://github.com/dotnet/roslyn/pull/37487)