### PR TITLE
EE: Do not trim comments from expression preceding a quote

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         }
 
         // TODO: https://github.com/dotnet/roslyn/issues/37536 
-        // This parsing is imprecise and amy result in bad expressions.
+        // This parsing is imprecise and may result in bad expressions.
         internal override string TrimAndGetFormatSpecifiers(string expression, out ReadOnlyCollection<string> formatSpecifiers)
         {
             expression = RemoveComments(expression);

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -34,6 +34,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return SyntaxFacts.IsWhitespace(c);
         }
 
+        // TODO: https://github.com/dotnet/roslyn/issues/37536 
+        // This parsing is imprecise and amy result in bad expressions.
         internal override string TrimAndGetFormatSpecifiers(string expression, out ReadOnlyCollection<string> formatSpecifiers)
         {
             expression = RemoveComments(expression);
@@ -47,7 +49,14 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var builder = pooledBuilder.Builder;
             var inMultilineComment = false;
             int length = expression.Length;
-            for (int i = 0; i < length; i++)
+
+            // Workaround for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849
+            // Do not remove any comments that might be in a string. 
+            // This won't work when there are quotes in the comment, but that's not that common.
+            int lastQuote = expression.LastIndexOf('"') + 1;
+            builder.Append(expression, 0, lastQuote);
+
+            for (int i = lastQuote; i < length; i++)
             {
                 var ch = expression[i];
                 if (inMultilineComment)

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
@@ -108,6 +108,14 @@ class C
 
             root = FormatResult("/**/a// Comment", value);
             Assert.Equal("a.F", GetChildren(root).Single().FullName);
+
+            // See https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849
+            root = FormatResult(@"""a//b/*"" // c", value);
+            Assert.Equal(@"(""a//b/*"").F", GetChildren(root).Single().FullName);
+
+            // incorrect - see https://github.com/dotnet/roslyn/issues/37536 
+            root = FormatResult(@"""a"" //""b", value);
+            Assert.Equal(@"(""a"" //""b).F", GetChildren(root).Single().FullName);
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         ' TODO https://github.com/dotnet/roslyn/issues/37536 
-        ' This parsing Is imprecise And amy result in bad expressions.
+        ' This parsing is imprecise and may result in bad expressions.
         Friend Overrides Function TrimAndGetFormatSpecifiers(expression As String, ByRef formatSpecifiers As ReadOnlyCollection(Of String)) As String
             expression = RemoveComments(expression)
             expression = RemoveFormatSpecifiers(expression, formatSpecifiers)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -39,6 +39,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Return SyntaxFacts.IsWhitespace(c)
         End Function
 
+        ' TODO https://github.com/dotnet/roslyn/issues/37536 
+        ' This parsing Is imprecise And amy result in bad expressions.
         Friend Overrides Function TrimAndGetFormatSpecifiers(expression As String, ByRef formatSpecifiers As ReadOnlyCollection(Of String)) As String
             expression = RemoveComments(expression)
             expression = RemoveFormatSpecifiers(expression, formatSpecifiers)
@@ -46,7 +48,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Private Shared Function RemoveComments(expression As String) As String
-            Dim index = expression.IndexOf("'"c)
+            ' Workaround for https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849
+            ' Do not remove any comments that might be in a string. 
+            ' This won't work when there are quotes in the comment, but that's not that common.
+            Dim lastQuote As Integer = expression.LastIndexOf(""""c) + 1
+
+            Dim index = expression.IndexOf("'"c, lastQuote)
             If index < 0 Then
                 Return expression
             End If

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/FullNameTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/FullNameTests.vb
@@ -96,6 +96,14 @@ End Class
             ' The result provider should never see a value like this in the "real-world"
             root = FormatResult("''a' Comment", value)
             Assert.Equal(".F", GetChildren(root).Single().FullName)
+
+            ' See https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849
+            root = FormatResult("""a'b"" ' c", value)
+            Assert.Equal("(""a'b"").F", GetChildren(root).Single().FullName)
+
+            ' incorrect - see https://github.com/dotnet/roslyn/issues/37536 
+            root = FormatResult("""a"" '""b", value)
+            Assert.Equal("(""a"" '""b).F", GetChildren(root).Single().FullName)
         End Sub
 
         <Fact>


### PR DESCRIPTION
Workaround to address https://dev.azure.com/devdiv/DevDiv/_workitems/edit/847849.

The real fix would be https://github.com/dotnet/roslyn/issues/37536 but it is much more involved.