### PR TITLE
Some Inline Rename accessibility improvements

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
@@ -241,6 +241,7 @@
                 <Button Name="ApplyButton" Click="Apply_Click" IsDefault="True" MinWidth="75" MinHeight="23" Padding="10,1,10,1" Margin="0,8,0,0" HorizontalAlignment="Right"
                     ToolTip="{Binding ElementName=dashboard, Path=ApplyToolTip}"
                     Style="{DynamicResource {x:Static utilities:CodeAnalysisColors.ButtonStyleKey}}"
+                    Content="{Binding ElementName=dashboard, Path=ApplyRename}"
                     AutomationProperties.Name="{Binding ElementName=dashboard, Path=ApplyRename}"/>
             </StackPanel>
         </Border>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
@@ -115,7 +115,8 @@
                     VerticalAlignment="Center"
                     HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"
                     Click="CloseButton_Click"
-                    ToolTip="{Binding ElementName=dashboard, Path=CancelToolTip}"/>
+                    ToolTip="{Binding ElementName=dashboard, Path=CancelToolTip}"
+                    AutomationProperties.Name="{Binding ElementName=dashboard, Path=CancelRename}"/>
                 </Grid>
 
                 <!-- Display the new name if it has been adjusted, or instructional text if it has not. -->
@@ -239,9 +240,8 @@
 
                 <Button Name="ApplyButton" Click="Apply_Click" IsDefault="True" MinWidth="75" MinHeight="23" Padding="10,1,10,1" Margin="0,8,0,0" HorizontalAlignment="Right"
                     ToolTip="{Binding ElementName=dashboard, Path=ApplyToolTip}"
-                    Style="{DynamicResource {x:Static utilities:CodeAnalysisColors.ButtonStyleKey}}">
-                    <AccessText Text="{Binding ElementName=dashboard, Path=ApplyRename}" />
-                </Button>
+                    Style="{DynamicResource {x:Static utilities:CodeAnalysisColors.ButtonStyleKey}}"
+                    AutomationProperties.Name="{Binding ElementName=dashboard, Path=ApplyRename}"/>
             </StackPanel>
         </Border>
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new DashboardAutomationPeer(this);
+            return new DashboardAutomationPeer(this, _model.GetOriginalName());
         }
 
         private void DisconnectFromPresentationSource()

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -271,6 +271,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public string SearchInComments => EditorFeaturesResources.Include_comments;
         public string SearchInStrings => EditorFeaturesResources.Include_strings;
         public string ApplyRename => EditorFeaturesResources.Apply1;
+        public string CancelRename => EditorFeaturesResources.Cancel;
         public string PreviewChanges => EditorFeaturesResources.Preview_changes1;
         public string RenameInstructions => EditorFeaturesResources.Modify_any_highlighted_location_to_begin_renaming;
         public string ApplyToolTip { get { return EditorFeaturesResources.Apply3 + " (Enter)"; } }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -142,6 +142,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 _focusedElement = _tabNavigableChildren[current];
             }
 
+            while (!_focusedElement.IsVisible)
+            {
+                var current = _tabNavigableChildren.IndexOf(_focusedElement);
+                current = selector(current);
+                _focusedElement = _tabNavigableChildren[current];
+            }
+
             _focusedElement.Focus();
             ShowCaret();
         }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -142,6 +142,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 _focusedElement = _tabNavigableChildren[current];
             }
 
+            // We have found the next control in _tabNavigableChildren, but not all controls are
+            // visible in all sessions. For example, "Rename Overloads" only applies if there the
+            // symbol has overloads. Therefore, continue searching for the next control in
+            // _tabNavigableChildren that's actually valid in this session.
             while (!_focusedElement.IsVisible)
             {
                 var current = _tabNavigableChildren.IndexOf(_focusedElement);

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new DashboardAutomationPeer(this, _model.GetOriginalName());
+            return new DashboardAutomationPeer(this, _model.OriginalName);
         }
 
         private void DisconnectFromPresentationSource()

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardAutomationPeer.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardAutomationPeer.cs
@@ -10,8 +10,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
     /// </summary>
     internal class DashboardAutomationPeer : UserControlAutomationPeer
     {
-        public DashboardAutomationPeer(UserControl owner) : base(owner)
+        private string _identifier;
+
+        public DashboardAutomationPeer(UserControl owner, string identifier) : base(owner)
         {
+            _identifier = identifier;
         }
 
         protected override bool HasKeyboardFocusCore()
@@ -26,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         protected override string GetNameCore()
         {
-            return EditorFeaturesResources.An_inline_rename_session_is_active;
+            return string.Format(EditorFeaturesResources.An_inline_rename_session_is_active_for_identifier_0, _identifier);
         }
 
         protected override AutomationControlType GetAutomationControlTypeCore()

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardViewModel.cs
@@ -310,6 +310,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
+        public string GetOriginalName()
+        {
+            return _session.OriginalSymbolName;
+        }
+
         public void Dispose()
         {
             _session.ReplacementTextChanged -= OnReplacementTextChanged;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardViewModel.cs
@@ -310,10 +310,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        public string GetOriginalName()
-        {
-            return _session.OriginalSymbolName;
-        }
+        public string OriginalName => _session.OriginalSymbolName;
 
         public void Dispose()
         {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An inline rename session is active.
+        ///   Looks up a localized string similar to An inline rename session is active. Invoke inline rename again to access additional options..
         /// </summary>
         internal static string An_inline_rename_session_is_active {
             get {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -198,11 +198,11 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An inline rename session is active. Invoke inline rename again to access additional options..
+        ///   Looks up a localized string similar to An inline rename session is active for identifier &apos;{0}&apos;. Invoke inline rename again to access additional options..
         /// </summary>
-        internal static string An_inline_rename_session_is_active {
+        internal static string An_inline_rename_session_is_active_for_identifier_0 {
             get {
-                return ResourceManager.GetString("An_inline_rename_session_is_active", resourceCulture);
+                return ResourceManager.GetString("An_inline_rename_session_is_active_for_identifier_0", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An inline rename session is active for identifier &apos;{0}&apos;. Invoke inline rename again to access additional options..
+        ///   Looks up a localized string similar to An inline rename session is active for identifier &apos;{0}&apos;. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time..
         /// </summary>
         internal static string An_inline_rename_session_is_active_for_identifier_0 {
             get {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -755,7 +755,7 @@ Do you want to proceed?</value>
     <value>'{0}' declarations</value>
   </data>
   <data name="An_inline_rename_session_is_active_for_identifier_0" xml:space="preserve">
-    <value>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</value>
+    <value>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</value>
     <comment>For screenreaders. {0} is the identifier being renamed.</comment>
   </data>
   <data name="Inline_Rename_Conflict" xml:space="preserve">

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -754,9 +754,9 @@ Do you want to proceed?</value>
   <data name="_0_declarations" xml:space="preserve">
     <value>'{0}' declarations</value>
   </data>
-  <data name="An_inline_rename_session_is_active" xml:space="preserve">
-    <value>An inline rename session is active. Invoke inline rename again to access additional options.</value>
-    <comment>For screenreaders</comment>
+  <data name="An_inline_rename_session_is_active_for_identifier_0" xml:space="preserve">
+    <value>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</value>
+    <comment>For screenreaders. {0} is the identifier being renamed.</comment>
   </data>
   <data name="Inline_Rename_Conflict" xml:space="preserve">
     <value>Inline Rename Conflict</value>

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -755,7 +755,7 @@ Do you want to proceed?</value>
     <value>'{0}' declarations</value>
   </data>
   <data name="An_inline_rename_session_is_active" xml:space="preserve">
-    <value>An inline rename session is active</value>
+    <value>An inline rename session is active. Invoke inline rename again to access additional options.</value>
     <comment>For screenreaders</comment>
   </data>
   <data name="Inline_Rename_Conflict" xml:space="preserve">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Aplikují se změny.</target>
@@ -1223,11 +1228,6 @@ Chcete pokračovat?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'Deklarace symbolů {0}</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Relace přejmenování na řádku je aktivní.</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.cs.xlf
@@ -1225,8 +1225,8 @@ Chcete pokračovat?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Relace přejmenování na řádku je aktivní.</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Relace přejmenování na řádku je aktivní.</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -1225,8 +1225,8 @@ Möchten Sie fortfahren?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Eine Inline-Umbenennungssitzung ist aktiv.</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Eine Inline-Umbenennungssitzung ist aktiv.</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Änderungen werden übernommen</target>
@@ -1223,11 +1228,6 @@ Möchten Sie fortfahren?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'"{0}"-Deklarationen</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Eine Inline-Umbenennungssitzung ist aktiv.</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Aplicando cambios</target>
@@ -1223,11 +1228,6 @@ Do you want to proceed?</source>
         <source>'{0}' declarations</source>
         <target state="translated">'Declaraciones de "{0}"</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Una sesión de cambio de nombre en línea está activa</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -1225,8 +1225,8 @@ Do you want to proceed?</source>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Una sesión de cambio de nombre en línea está activa</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Una sesión de cambio de nombre en línea está activa</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Application des changements</target>
@@ -1223,11 +1228,6 @@ Voulez-vous continuer ?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'Déclarations '{0}'</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Une session de renommage inline est active</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -1225,8 +1225,8 @@ Voulez-vous continuer ?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Une session de renommage inline est active</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Une session de renommage inline est active</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Applicazione delle modifiche in corso</target>
@@ -1223,11 +1228,6 @@ Continuare?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'Dichiarazioni di '{0}'</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Una sessione di ridenominazione inline è attiva</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.it.xlf
@@ -1225,8 +1225,8 @@ Continuare?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Una sessione di ridenominazione inline è attiva</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Una sessione di ridenominazione inline è attiva</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">変更の適用</target>
@@ -1223,11 +1228,6 @@ Do you want to proceed?</source>
         <source>'{0}' declarations</source>
         <target state="translated">'{0}' の宣言</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">インラインの名前変更セッションがアクティブです</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ja.xlf
@@ -1225,8 +1225,8 @@ Do you want to proceed?</source>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">インラインの名前変更セッションがアクティブです</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">インラインの名前変更セッションがアクティブです</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">변경 내용 적용</target>
@@ -1223,11 +1228,6 @@ Do you want to proceed?</source>
         <source>'{0}' declarations</source>
         <target state="translated">'{0}' 선언</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">인라인 이름 바꾸기 세션이 활성 상태입니다.</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -1225,8 +1225,8 @@ Do you want to proceed?</source>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">인라인 이름 바꾸기 세션이 활성 상태입니다.</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">인라인 이름 바꾸기 세션이 활성 상태입니다.</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Stosowanie zmian</target>
@@ -1223,11 +1228,6 @@ Czy chcesz kontynuować?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'Deklaracje „{0}”</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Wbudowana sesja zmiany nazwy jest aktywna</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pl.xlf
@@ -1225,8 +1225,8 @@ Czy chcesz kontynuować?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Wbudowana sesja zmiany nazwy jest aktywna</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Wbudowana sesja zmiany nazwy jest aktywna</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -1225,8 +1225,8 @@ Deseja continuar?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Uma sessão de renomeação embutida está ativa</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Uma sessão de renomeação embutida está ativa</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Aplicando mudanças</target>
@@ -1223,11 +1228,6 @@ Deseja continuar?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'Declarações de '{0}'</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Uma sessão de renomeação embutida está ativa</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -1225,8 +1225,8 @@ Do you want to proceed?</source>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Встроенный сеанс переименования активен</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Встроенный сеанс переименования активен</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Применение изменений</target>
@@ -1223,11 +1228,6 @@ Do you want to proceed?</source>
         <source>'{0}' declarations</source>
         <target state="translated">'Объявления "{0}"</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Встроенный сеанс переименования активен</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">Değişiklikler uygulanıyor</target>
@@ -1223,11 +1228,6 @@ Devam etmek istiyor musunuz?</target>
         <source>'{0}' declarations</source>
         <target state="translated">'{0}' bildirimleri</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">Etkin bir satır içi yeniden adlandırma oturumu var</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.tr.xlf
@@ -1225,8 +1225,8 @@ Devam etmek istiyor musunuz?</target>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">Etkin bir satır içi yeniden adlandırma oturumu var</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">Etkin bir satır içi yeniden adlandırma oturumu var</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -1225,8 +1225,8 @@ Do you want to proceed?</source>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">一个内联的重命名会话处于活动状态</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">一个内联的重命名会话处于活动状态</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">应用更改</target>
@@ -1223,11 +1228,6 @@ Do you want to proceed?</source>
         <source>'{0}' declarations</source>
         <target state="translated">'“{0}”声明</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">一个内联的重命名会话处于活动状态</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -1225,8 +1225,8 @@ Do you want to proceed?</source>
         <note />
       </trans-unit>
       <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active</source>
-        <target state="translated">內嵌重新命名工作階段使用中</target>
+        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
+        <target state="needs-review-translation">內嵌重新命名工作階段使用中</target>
         <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../EditorFeaturesResources.resx">
     <body>
+      <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <note>For screenreaders. {0} is the identifier being renamed.</note>
+      </trans-unit>
       <trans-unit id="Applying_changes">
         <source>Applying changes</source>
         <target state="translated">正在套用變更</target>
@@ -1223,11 +1228,6 @@ Do you want to proceed?</source>
         <source>'{0}' declarations</source>
         <target state="translated">'{0}' 宣告</target>
         <note />
-      </trans-unit>
-      <trans-unit id="An_inline_rename_session_is_active">
-        <source>An inline rename session is active. Invoke inline rename again to access additional options.</source>
-        <target state="needs-review-translation">內嵌重新命名工作階段使用中</target>
-        <note>For screenreaders</note>
       </trans-unit>
       <trans-unit id="Inline_Rename_Conflict">
         <source>Inline Rename Conflict</source>

--- a/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
+++ b/src/EditorFeatures/Core/xlf/EditorFeaturesResources.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../EditorFeaturesResources.resx">
     <body>
       <trans-unit id="An_inline_rename_session_is_active_for_identifier_0">
-        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</source>
-        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options.</target>
+        <source>An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</source>
+        <target state="new">An inline rename session is active for identifier '{0}'. Invoke inline rename again to access additional options. You may continue to edit the identifier being renamed at any time.</target>
         <note>For screenreaders. {0} is the identifier being renamed.</note>
       </trans-unit>
       <trans-unit id="Applying_changes">


### PR DESCRIPTION
1. More descriptive text when an Inline Rename session begins to let the user know:
    - The name of the identifier being renamed
    - More options exist, and you can access them by invoking inline rename again
    - That the identifier being renamed can be edited at any time
2. Keyboard tabbing around the dashboard now skips invisible controls
3. The Apply and Cancel (X) buttons now read automation text correctly