### PR TITLE
Backported fix for #37584 to 16.3-preview2

### DIFF
--- a/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
@@ -496,6 +496,47 @@ class C
 
         #region Attributes
         [Fact]
+        [WorkItem(37584, "https://github.com/dotnet/roslyn/issues/37584")]
+        public async Task TestMissingEmptyMember()
+        {
+            var testText = @"
+using System;
+public class Class1
+{
+    [][||]
+}";
+            await TestMissingAsync<MethodDeclarationSyntax>(testText);
+        }
+
+        [Fact]
+        [WorkItem(37584, "https://github.com/dotnet/roslyn/issues/37584")]
+        public async Task TestMissingEmptyMember2()
+        {
+            var testText = @"
+using System;
+public class Class1
+{
+    [||]// Comment 
+    []
+}";
+            await TestMissingAsync<MethodDeclarationSyntax>(testText);
+        }
+
+        [Fact]
+        [WorkItem(37584, "https://github.com/dotnet/roslyn/issues/37584")]
+        public async Task TestEmptyAttributeList()
+        {
+            var testText = @"
+using System;
+public class Class1
+{
+    {|result:[]
+    [||]void a() {}|}
+}";
+            await TestAsync<MethodDeclarationSyntax>(testText);
+        }
+
+        [Fact]
         [WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")]
         public async Task TestClimbLeftEdgeBeforeAttribute()
         {

--- a/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
@@ -270,7 +270,13 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                 var endOfAttributeLists = attributeList.Last().Span.End;
                 var afterAttributesToken = root.FindTokenOnRightOfPosition(endOfAttributeLists);
 
-                return TextSpan.FromBounds(afterAttributesToken.Span.Start, node.Span.End);
+                var endOfNode = node.Span.End;
+                var startOfTokenAfterAttributes = afterAttributesToken.Span.Start;
+                var startOfNodeWithoutAttributes = endOfNode >= startOfTokenAfterAttributes
+                    ? afterAttributesToken.Span.Start
+                    : endOfNode;
+
+                return TextSpan.FromBounds(startOfNodeWithoutAttributes, endOfNode);
             }
 
             return node.Span;


### PR DESCRIPTION
Customer and scenario info
=============================
**Who is impacted by this bug?**
Typing for C#/VB developers which leads to erroneous broken code 

**Bugs fixed**
Fixes #37584

**What is the customer scenario and impact of the bug?**
Typing in C#/VB source files such that the file has syntax errors leads to the underlying exception firing in shared code refactoring service.

**What is the workaround?**
None

**How was the bug found?**
Dogfooding

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
This is a regression from previous inserted Roslyn bits. We have been building on a core refactoring service that will be shared by all the C#/VB refactorings for improved discoverability of refactorings. This service is backed by large number of unit tests for existing refactorings, but the scenario failing here is erroneous broken code while typing.

**Testing**
We have added the necessary regression tests for this bug in this PR.