### PR TITLE
Don't show nullability information in quick info if it's not enabled

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -6591,5 +6591,26 @@ class X
                 MainDescription($"({FeaturesResources.local_variable}) string s"),
                 NullabilityAnalysis(""));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task NullableNotShownInNullableDisableContextEvenIfAnalysisIsRunning()
+        {
+            var options = TestOptions.Regular8.WithFeature(CompilerFeatureFlags.RunNullableAnalysis, "true");
+            await TestWithOptionsAsync(options,
+@"#nullable disable
+
+using System.Collections.Generic;
+
+class X
+{
+    void N()
+    {
+        string s = """";
+        string s2 = $$s;
+    }
+}",
+                MainDescription($"({FeaturesResources.local_variable}) string s"),
+                NullabilityAnalysis(""));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
@@ -56,6 +56,14 @@ namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
                 return default;
             }
 
+            // If the user doesn't have nullable enabled, don't show anything. For now we're not trying to be more precise if the user has just annotations or just
+            // warnings. If the user has annotations off then things that are oblivious might become non-null (which is a lie) and if the user has warnings off then
+            // that probably implies they're not actually trying to know if their code is correct. We can revisit this if we have specific user scenarios.
+            if (semanticModel.GetNullableContext(token.SpanStart) != NullableContext.Enabled)
+            {
+                return default;
+            }
+
             var syntaxFacts = workspace.Services.GetLanguageServices(semanticModel.Language).GetRequiredService<ISyntaxFactsService>();
             var bindableParent = syntaxFacts.GetBindableParent(token);
             var symbolInfo = semanticModel.GetSymbolInfo(bindableParent, cancellationToken);


### PR DESCRIPTION
We don't have this scenario fully polished and it can often be more confusing because the information shown won't always be useful or accurate.

Fixes https://github.com/dotnet/roslyn/issues/37314