### PR TITLE
Fix trailing whitespace and superfluous blank lines in generated GlobalSuppressions.cs

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixAllTests.cs
@@ -368,9 +368,9 @@ class Class2
 </Workspace>";
 
                     var addedGlobalSuppressions = $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:Class1.Method~System.Int32"")]
@@ -471,9 +471,9 @@ class Class2
 </Workspace>";
 
                     var addedGlobalSuppressions = $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:Class1.Method~System.Int32"")]
@@ -575,9 +575,9 @@ class Class2
 </Workspace>";
 
                     var addedGlobalSuppressionsProject1 = $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:Class1.Method~System.Int32"")]
@@ -588,9 +588,9 @@ class Class2
 ".Replace("<", "&lt;").Replace(">", "&gt;");
 
                     var addedGlobalSuppressionsProject2 = $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:Class1.Method~System.Int32"")]
@@ -698,9 +698,9 @@ class Class2
 </Workspace>";
 
                 var addedGlobalSuppressions = $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""NoLocationDiagnostic"", ""NoLocationDiagnostic:NoLocationDiagnostic"", Justification = ""{FeaturesResources.Pending}"")]"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTest_FixAllTests.cs
@@ -367,8 +367,8 @@ class Class2
     </Project>
 </Workspace>";
 
-                    var addedGlobalSuppressions = $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+                    var addedGlobalSuppressions =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -470,8 +470,8 @@ class Class2
     </Project>
 </Workspace>";
 
-                    var addedGlobalSuppressions = $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+                    var addedGlobalSuppressions =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -574,8 +574,8 @@ class Class2
     </Project>
 </Workspace>";
 
-                    var addedGlobalSuppressionsProject1 = $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+                    var addedGlobalSuppressionsProject1 =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -587,8 +587,8 @@ class Class2
 
 ".Replace("<", "&lt;").Replace(">", "&gt;");
 
-                    var addedGlobalSuppressionsProject2 = $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+                    var addedGlobalSuppressionsProject2 =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -697,8 +697,8 @@ class Class2
     </Project>
 </Workspace>";
 
-                var addedGlobalSuppressions = $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+                var addedGlobalSuppressions =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -808,8 +808,8 @@ class Class
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public async Task GeneratedCodeShouldNotHaveTrailingWhitespace()
                 {
-                    var expected = $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+                    var expected =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -881,8 +881,7 @@ using System;
         int x = 0;
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -924,8 +923,7 @@ using System;
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -973,8 +971,7 @@ namespace N1
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1025,8 +1022,7 @@ namespace N
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1077,8 +1073,7 @@ namespace N
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1134,8 +1129,7 @@ namespace N
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1194,8 +1188,7 @@ namespace N
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1225,8 +1218,7 @@ namespace N
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1277,8 +1269,7 @@ namespace N
         }
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1320,8 +1311,7 @@ class Class
 {
     [|int field = 0;|]
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1362,8 +1352,7 @@ enum E
     Field2
     |]
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1399,8 +1388,7 @@ class Class
 {
     int [|field = 0|], field2 = 1;
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1447,8 +1435,7 @@ class Class
         remove { }
     }|]
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1497,8 +1484,7 @@ class Class { }
 [|class Class2|] { }
 ]]>
         </Document>
-        <Document FilePath=""GlobalSuppressions.cs""><![CDATA[
-// This file is used by Code Analysis to maintain SuppressMessage
+        <Document FilePath=""GlobalSuppressions.cs""><![CDATA[// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1509,8 +1495,7 @@ class Class { }
     </Project>
 </Workspace>";
                     var expectedText =
-                        $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1546,8 +1531,7 @@ class Class { }
     </Project>
 </Workspace>";
                     var expectedText =
-                        $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1579,8 +1563,7 @@ using System;
 class Class { }
 ]]>
         </Document>
-         <Document FilePath=""GlobalSuppressions2.cs""><![CDATA[
-// This file is used by Code Analysis to maintain SuppressMessage
+         <Document FilePath=""GlobalSuppressions2.cs""><![CDATA[// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1591,8 +1574,7 @@ class Class { }
     </Project>
 </Workspace>";
                     var expectedText =
-                        $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -1997,8 +1979,7 @@ class Class
         int x = 0;
     }
 }",
-            $@"
-// This file is used by Code Analysis to maintain SuppressMessage
+$@"// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -868,6 +868,34 @@ using System;
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                public async Task GeneratedCodeShouldNotHaveMoreThanOneTrailingBlankLine()
+                {
+                    var expected =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class"")]
+";
+
+                    var lines = Regex.Split(expected, "\r?\n");
+                    Assert.False(string.IsNullOrWhiteSpace(lines[lines.Length - 2]));
+
+                    await TestAsync(
+            @"
+using System;
+
+[|class Class|]
+{
+    int Method()
+    {
+        int x = 0;
+    }
+}", expected);
+                }
+
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public async Task TestSuppressionOnSimpleType()
                 {
                     await TestAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -815,7 +815,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class"")]
-
 ";
 
                     Assert.All(Regex.Split(expected, "\r?\n"), line => Assert.False(HasTrailingWhitespace(line)));
@@ -848,7 +847,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class"")]
-
 ";
 
                     var lines = Regex.Split(expected, "\r?\n");
@@ -915,7 +913,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -957,7 +954,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""namespace"", Target = ""~N:N"")]
-
 ", index: 1);
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1005,7 +1001,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:N1.N2.Class"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1056,7 +1051,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:N.Generic`1.Class"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1107,7 +1101,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1163,7 +1156,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method(System.Int32,System.Char@)~System.Int32"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1222,7 +1214,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
-
 ");
                 }
 
@@ -1252,7 +1243,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method``1(``0)~System.Int32"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1303,7 +1293,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~P:N.Generic.Class.Property"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1345,7 +1334,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~F:Class.field"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1386,7 +1374,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:E"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1422,7 +1409,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~F:Class.field"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1469,7 +1455,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~E:Class.SampleEvent"")]
-
 ");
 
                     // Also verify that the added attribute does indeed suppress the diagnostic.
@@ -1530,7 +1515,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class2"")]
-
 ";
 
                     await TestAsync(initialMarkup, expectedText);
@@ -1565,7 +1549,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class2"")]
-
 ";
 
                     await TestAsync(initialMarkup, expectedText);
@@ -1609,7 +1592,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class2"")]
-
 ";
 
                     await TestAsync(initialMarkup, expectedText);
@@ -1642,7 +1624,6 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
 [assembly: SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class2"")]
-
 ";
 
                     await TestAsync(initialMarkup, expectedText);
@@ -2013,7 +1994,6 @@ $@"// This file is used by Code Analysis to maintain SuppressMessage
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""NoLocationDiagnostic"", ""NoLocationDiagnostic:NoLocationDiagnostic"", Justification = ""{FeaturesResources.Pending}"")]
-
 ");
             }
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -806,6 +806,7 @@ class Class
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [WorkItem(37529, "https://github.com/dotnet/roslyn/issues/37529")]
                 public async Task GeneratedCodeShouldNotHaveTrailingWhitespace()
                 {
                     var expected =
@@ -838,6 +839,7 @@ using System;
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [WorkItem(37529, "https://github.com/dotnet/roslyn/issues/37529")]
                 public async Task GeneratedCodeShouldNotHaveLeadingBlankLines()
                 {
                     var expected =
@@ -866,6 +868,7 @@ using System;
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                [WorkItem(37529, "https://github.com/dotnet/roslyn/issues/37529")]
                 public async Task GeneratedCodeShouldNotHaveMoreThanOneTrailingBlankLine()
                 {
                     var expected =
@@ -1472,10 +1475,10 @@ public class SampleEventArgs
 
 class Class
 {
-    // Declare the delegate (if using non-generic pattern). 
+    // Declare the delegate (if using non-generic pattern).
     public delegate void SampleEventHandler(object sender, SampleEventArgs e);
 
-    // Declare the event. 
+    // Declare the event.
     [|public event SampleEventHandler SampleEvent|]
     {
         add { }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -853,9 +853,9 @@ using System;
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class"")]
@@ -896,9 +896,9 @@ using System;
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""namespace"", Target = ""~N:N"")]
@@ -945,9 +945,9 @@ namespace N1
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:N1.N2.Class"")]
@@ -997,9 +997,9 @@ namespace N
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:N.Generic`1.Class"")]
@@ -1049,9 +1049,9 @@ namespace N
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
@@ -1106,9 +1106,9 @@ namespace N
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method(System.Int32,System.Char@)~System.Int32"")]
@@ -1166,9 +1166,9 @@ namespace N
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method~System.Int32"")]
@@ -1197,9 +1197,9 @@ namespace N
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~M:N.Generic`1.Class.Method``1(``0)~System.Int32"")]
@@ -1249,9 +1249,9 @@ namespace N
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~P:N.Generic.Class.Property"")]
@@ -1292,9 +1292,9 @@ class Class
     [|int field = 0;|]
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~F:Class.field"")]
@@ -1334,9 +1334,9 @@ enum E
     |]
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:E"")]
@@ -1371,9 +1371,9 @@ class Class
     int [|field = 0|], field2 = 1;
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~F:Class.field"")]
@@ -1419,9 +1419,9 @@ class Class
     }|]
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""member"", Target = ""~E:Class.SampleEvent"")]
@@ -1469,9 +1469,9 @@ class Class { }
 ]]>
         </Document>
         <Document FilePath=""GlobalSuppressions.cs""><![CDATA[
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
@@ -1481,9 +1481,9 @@ class Class { }
 </Workspace>";
                     var expectedText =
                         $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
@@ -1518,9 +1518,9 @@ class Class { }
 </Workspace>";
                     var expectedText =
                         $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class2"")]
@@ -1551,9 +1551,9 @@ class Class { }
 ]]>
         </Document>
          <Document FilePath=""GlobalSuppressions2.cs""><![CDATA[
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
@@ -1563,9 +1563,9 @@ class Class { }
 </Workspace>";
                     var expectedText =
                         $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""<Pending>"", Scope = ""type"", Target = ""Class"")]
@@ -1969,9 +1969,9 @@ class Class
     }
 }",
             $@"
-// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""NoLocationDiagnostic"", ""NoLocationDiagnostic:NoLocationDiagnostic"", Justification = ""{FeaturesResources.Pending}"")]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Suppression/SuppressionTests.cs
@@ -839,6 +839,35 @@ using System;
                 }
 
                 [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
+                public async Task GeneratedCodeShouldNotHaveLeadingBlankLines()
+                {
+                    var expected =
+$@"// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification = ""{FeaturesResources.Pending}"", Scope = ""type"", Target = ""~T:Class"")]
+
+";
+
+                    var lines = Regex.Split(expected, "\r?\n");
+                    Assert.False(string.IsNullOrWhiteSpace(lines.First()));
+
+                    await TestAsync(
+            @"
+using System;
+
+[|class Class|]
+{
+    int Method()
+    {
+        int x = 0;
+    }
+}", expected);
+                }
+
+                [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSuppression)]
                 public async Task TestSuppressionOnSimpleType()
                 {
                     await TestAsync(

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -981,9 +981,9 @@ Imports System
     End Sub
 End Class]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""type"", Target:=""~T:Class1"")>
@@ -1019,9 +1019,9 @@ Imports System
     End Class
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""namespace"", Target:=""~N:N"")>
@@ -1061,9 +1061,9 @@ Namespace N1
     End Namespace
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""type"", Target:=""~T:N1.N2.Class1"")>
@@ -1105,9 +1105,9 @@ Namespace N
     End Class
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""type"", Target:=""~T:N.Generic`1.Class1"")>
@@ -1149,9 +1149,9 @@ Namespace N
     End Class
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method"")>
@@ -1197,9 +1197,9 @@ Namespace N
     End Class
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method(System.Int32,System.Int32@)"")>
@@ -1249,9 +1249,9 @@ Namespace N
     End Class
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""member"", Target:=""~M:N.Generic`1.Class1.Method``1(``0,System.Int32@)"")>
@@ -1299,9 +1299,9 @@ Namespace N
     End Class
 End Namespace]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""member"", Target:=""~P:N.Generic.C.P"")>
@@ -1339,9 +1339,9 @@ Class C
 	[|Private ReadOnly F As Integer|]
 End Class]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""member"", Target:=""~F:C.F"")>
@@ -1395,9 +1395,9 @@ Class C
 	End Event
 End Class]]>
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""member"", Target:=""~E:C.SampleEvent"")>
@@ -1457,9 +1457,9 @@ End Class
 End Class]]>
                             </Document>
                             <Document FilePath="GlobalSuppressions.vb"><![CDATA[
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="Class1")>
@@ -1469,9 +1469,9 @@ End Class]]>
                     </Workspace>
 
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""<Pending>"", Scope:=""type"", Target:=""Class1"")>
@@ -1506,9 +1506,9 @@ End Class
                     </Workspace>
 
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""{FeaturesResources.Pending}"", Scope:=""type"", Target:=""~T:Class2"")>
@@ -1539,9 +1539,9 @@ End Class
 ]]>
                             </Document>
                             <Document FilePath="GlobalSuppressions2.vb"><![CDATA[
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage("InfoDiagnostic", "InfoDiagnostic:InfoDiagnostic", Justification:="<Pending>", Scope:="type", Target:="Class1")>
@@ -1551,9 +1551,9 @@ End Class
                     </Workspace>
 
                     Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage 
+' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
-' Project-level suppressions either have no target or are given 
+' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
 
 <Assembly: Diagnostics.CodeAnalysis.SuppressMessage(""InfoDiagnostic"", ""InfoDiagnostic:InfoDiagnostic"", Justification:=""<Pending>"", Scope:=""type"", Target:=""Class1"")>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Suppression/SuppressionTests.vb
@@ -980,8 +980,8 @@ Imports System
         Dim x
     End Sub
 End Class]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1018,8 +1018,8 @@ Imports System
         End Sub
     End Class
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1060,8 +1060,8 @@ Namespace N1
         End Class
     End Namespace
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1104,8 +1104,8 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1148,8 +1148,8 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1196,8 +1196,8 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1248,8 +1248,8 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1298,8 +1298,8 @@ Namespace N
         End Class
     End Class
 End Namespace]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1338,8 +1338,8 @@ Imports System
 Class C
 	[|Private ReadOnly F As Integer|]
 End Class]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1394,8 +1394,8 @@ Class C
 		End RemoveHandler
 	End Event
 End Class]]>
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1456,8 +1456,7 @@ End Class
 [|Class Class2|]
 End Class]]>
                             </Document>
-                            <Document FilePath="GlobalSuppressions.vb"><![CDATA[
-' This file is used by Code Analysis to maintain SuppressMessage
+                            <Document FilePath="GlobalSuppressions.vb"><![CDATA[' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1468,8 +1467,8 @@ End Class]]>
                         </Project>
                     </Workspace>
 
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1505,8 +1504,8 @@ End Class
                         </Project>
                     </Workspace>
 
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1538,8 +1537,7 @@ Class Class3
 End Class
 ]]>
                             </Document>
-                            <Document FilePath="GlobalSuppressions2.vb"><![CDATA[
-' This file is used by Code Analysis to maintain SuppressMessage
+                            <Document FilePath="GlobalSuppressions2.vb"><![CDATA[' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.
@@ -1550,8 +1548,8 @@ End Class
                         </Project>
                     </Workspace>
 
-                    Dim expected = $"
-' This file is used by Code Analysis to maintain SuppressMessage
+                    Dim expected =
+$"' This file is used by Code Analysis to maintain SuppressMessage
 ' attributes that are applied to this project.
 ' Project-level suppressions either have no target or are given
 ' a specific target and scoped to a namespace, type, member, etc.

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         private const string s_globalSuppressionsFileName = "GlobalSuppressions";
         private const string s_suppressionsFileCommentTemplate =
 @"
-{0} This file is used by Code Analysis to maintain SuppressMessage 
+{0} This file is used by Code Analysis to maintain SuppressMessage
 {0} attributes that are applied to this project.
-{0} Project-level suppressions either have no target or are given 
+{0} Project-level suppressions either have no target or are given
 {0} a specific target and scoped to a namespace, type, member, etc.
 
 ";

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.cs
@@ -20,8 +20,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
         public const string SuppressMessageAttributeName = "System.Diagnostics.CodeAnalysis.SuppressMessage";
         private const string s_globalSuppressionsFileName = "GlobalSuppressions";
         private const string s_suppressionsFileCommentTemplate =
-@"
-{0} This file is used by Code Analysis to maintain SuppressMessage
+@"{0} This file is used by Code Analysis to maintain SuppressMessage
 {0} attributes that are applied to this project.
 {0} Project-level suppressions either have no target or are given
 {0} a specific target and scoped to a namespace, type, member, etc.

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 // current implementation of engine gives higher priority on new line operations over space operations if
                 // two are conflicting.
-                // ex) new line operation says add 1 line between tokens, and 
+                // ex) new line operation says add 1 line between tokens, and
                 //     space operation says give 1 space between two tokens (basically means remove new lines)
                 //     then, engine will pick new line operation and ignore space operation
 
@@ -276,15 +276,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                         || currentToken.Kind() == SyntaxKind.OpenBraceToken) ? 1 : 0;
 
                 case SyntaxKind.CloseBracketToken:
-                    // Assembly and module-level attributes followed by non-attributes should have
-                    // a blank line after them.
+                    // Assembly and module-level attributes followed by non-attributes should have a blank line after
+                    // them, unless it's the end of the file which will already have a blank line.
                     if (previousToken.Parent is AttributeListSyntax parent)
                     {
                         if (parent.Target != null &&
                             (parent.Target.Identifier.IsKindOrHasMatchingText(SyntaxKind.AssemblyKeyword) ||
                              parent.Target.Identifier.IsKindOrHasMatchingText(SyntaxKind.ModuleKeyword)))
                         {
-                            if (!(currentToken.Parent is AttributeListSyntax))
+                            if (!currentToken.IsKind(SyntaxKind.EndOfFileToken) && !(currentToken.Parent is AttributeListSyntax))
                             {
                                 return 2;
                             }

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddAttributesTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddAttributesTests.cs
@@ -60,7 +60,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGeneration
             await TestAsync(
 string.Empty,
 @"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-
 ");
         }
 
@@ -71,7 +70,6 @@ string.Empty,
 @"[assembly: System.Reflection.AssemblyName(""Test"")]",
 @"[assembly: System.Reflection.AssemblyName(""Test"")]
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-
 ");
         }
     }


### PR DESCRIPTION
Fixes #37529

Each thing is fixed with a pair of commits, one to add the failing test and the next to make all tests pass again.