### PR TITLE
Fix typing crash during open file analysis

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return await GetAnalyzerSemanticDiagnosticsCoreAsync(model, filterSpan, analyzers, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<ImmutableArray<Diagnostic>> GetAnalyzerSemanticDiagnosticsCoreAsync(SemanticModel model, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
+        private async Task<ImmutableArray<Diagnostic>> GetAnalyzerSemanticDiagnosticsCoreAsync(SemanticModel model, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken, bool forceCompletePartialTrees = true)
         {
             try
             {
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         cancellationToken.ThrowIfCancellationRequested();
 
                         (ImmutableArray<CompilationEvent> compilationEvents, bool hasSymbolStartActions) = await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEvents, taskToken, cancellationToken).ConfigureAwait(false);
-                        if (hasSymbolStartActions)
+                        if (hasSymbolStartActions && forceCompletePartialTrees)
                         {
                             await processPartialSymbolLocationsAsync(compilationEvents, analysisScope).ConfigureAwait(false);
                         }
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             Task.Run(() =>
                             {
                                 var treeModel = _compilationData.GetOrCreateCachedSemanticModel(tree, _compilation, cancellationToken);
-                                return GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken);
+                                return GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken, forceCompletePartialTrees: false);
                             }, cancellationToken))).ConfigureAwait(false);
                     }
                     else
@@ -658,7 +658,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         {
                             cancellationToken.ThrowIfCancellationRequested();
                             var treeModel = _compilationData.GetOrCreateCachedSemanticModel(tree, _compilation, cancellationToken);
-                            await GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken).ConfigureAwait(false);
+                            await GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken, forceCompletePartialTrees: false).ConfigureAwait(false);
                         }
                     }
                 }


### PR DESCRIPTION
Customer and scenario info
============================

**Who is impacted by this bug?**
Typing in C#/VB projects.
**NOTE:** This change only affects the IDE open file analysis code path. [CompilationWithAnalyzers.GetAnalyzerSemanticDiagnosticsAsync](http://source.roslyn.io/#q=GetAnalyzerSemanticDiagnosticsAsync) is never invoked from the batch compiler.

**Bugs Fixed**
Fixes P0 VSO bugs [#957250](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/957250) and [#957243](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/957243)
Fixes #37567

**What is the customer scenario and impact of the bug?**
C#/VB developers typing in a source file with partial types that have partial type declarations across multiple files. When cancellation is triggered while typing, it leads to a crash with stack overflow exception.

**What is the workaround?**
None.

**How was the bug found?**
Crashes seen in RPS/DDRIT test failures

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
My previous PR #37303 to improve IDE open file analysis performance led to a functional regression where attempting to compute open file diagnostics for a partial type leads to recursive attempt to force complete all partial trees, which in turn attempt force completion of original tree. In presence of cancellation request, this leads to a stack overflow and VS crash. The fix here ensures that we don't attempt partial tree analysis when invoked in context of partial analysis itself.

**Testing**
I have manually verified the crash before the fix and verified it does not repro after the fix. I am working on adding an integration test for the scenario with a follow-up commit/PR.