### PR TITLE
Deserialize to VSClientCapabilities

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/FindAllReferencesHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/FindAllReferencesHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
             await findUsagesService.FindReferencesAsync(document, position, context).ConfigureAwait(false);
 
-            if (requestContext?.ClientCapabilities?.ToObject<ClientCapabilities>()?.HasVisualStudioLspCapability() == true)
+            if (requestContext?.ClientCapabilities?.ToObject<VSClientCapabilities>()?.HasVisualStudioLspCapability() == true)
             {
                 return await GetReferenceGroupsAsync(request, context, cancellationToken).ConfigureAwait(false);
             }

--- a/src/VisualStudio/LiveShare/Impl/Shims/AbstractLiveShareHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/AbstractLiveShareHandlerShim.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public virtual Task<ResponseType> HandleAsync(RequestType param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            return ((IRequestHandler<RequestType, ResponseType>)LazyRequestHandler.Value).HandleRequestAsync(requestContext.Context, param, requestContext.ClientCapabilities?.ToObject<ClientCapabilities>(), cancellationToken);
+            return ((IRequestHandler<RequestType, ResponseType>)LazyRequestHandler.Value).HandleRequestAsync(requestContext.Context, param, requestContext.ClientCapabilities?.ToObject<VSClientCapabilities>(), cancellationToken);
         }
 
         protected Lazy<IRequestHandler, IRequestHandlerMetadata> GetRequestHandler(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, string methodName)

--- a/src/VisualStudio/LiveShare/Impl/Shims/DocumentSymbolsHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/DocumentSymbolsHandlerShim.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 
         public override async Task<SymbolInformation[]> HandleAsync(DocumentSymbolParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
         {
-            var clientCapabilities = requestContext.ClientCapabilities?.ToObject<ClientCapabilities>();
+            var clientCapabilities = requestContext.ClientCapabilities?.ToObject<VSClientCapabilities>();
             var hierarchicalSupport = clientCapabilities?.TextDocument?.DocumentSymbol?.HierarchicalDocumentSymbolSupport;
             if (hierarchicalSupport == true)
             {


### PR DESCRIPTION
Deserialize `ClientCapabilities` to `VSClientCapabilities` to get the available additional properties, e.g. `SupportsVisualStudioExtensions`.