### PR TITLE
Consume the new compiler API for comparing symbols without nullability

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -1177,7 +1177,7 @@ class Class
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/36044"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task TestGenericAssignmentWithNestedNullableReferenceTypeBeingAssignedTo()
         {
             // Here, we are asserting that the return type of the generated method is T, effectively discarding

--- a/src/Workspaces/Core/Portable/Utilities/NullableHelpers/AllNullabilityIgnoringSymbolComparer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/NullableHelpers/AllNullabilityIgnoringSymbolComparer.cs
@@ -8,7 +8,6 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// A comparer that compares symbols but ignores nullability, both top-level and nested.
     /// </summary>
-    /// <remarks>This is not implemented correctly, which is being tracked by https://github.com/dotnet/roslyn/issues/36044</remarks>
     internal sealed class AllNullabilityIgnoringSymbolComparer : IEqualityComparer<ISymbol>
     {
         public static readonly IEqualityComparer<ISymbol> Instance = new AllNullabilityIgnoringSymbolComparer();
@@ -21,9 +20,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (x is ITypeSymbol xTypeSymbol && y is ITypeSymbol yTypeSymbol)
             {
-                // TODO: also ignore nested nullability. Right now there is no compiler API to do this, but it's being tracked in https://github.com/dotnet/roslyn/issues/35933.
-                // The fixing of this code will be tracked by https://github.com/dotnet/roslyn/issues/36044 and tests can then be unskipped there.
-                return xTypeSymbol.WithoutNullability().Equals(yTypeSymbol.WithoutNullability());
+                return xTypeSymbol.WithoutNullability().Equals(yTypeSymbol.WithoutNullability(), SymbolEqualityComparer.Default);
             }
 
             return object.Equals(x, y);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36044