### PR TITLE
Add an integration test for #37623

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -566,7 +566,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return await GetAnalyzerSemanticDiagnosticsCoreAsync(model, filterSpan, analyzers, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<ImmutableArray<Diagnostic>> GetAnalyzerSemanticDiagnosticsCoreAsync(SemanticModel model, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
+        private async Task<ImmutableArray<Diagnostic>> GetAnalyzerSemanticDiagnosticsCoreAsync(SemanticModel model, TextSpan? filterSpan, ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken, bool forceCompletePartialTrees = true)
         {
             try
             {
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         cancellationToken.ThrowIfCancellationRequested();
 
                         (ImmutableArray<CompilationEvent> compilationEvents, bool hasSymbolStartActions) = await ComputeAnalyzerDiagnosticsAsync(pendingAnalysisScope, getPendingEvents, taskToken, cancellationToken).ConfigureAwait(false);
-                        if (hasSymbolStartActions)
+                        if (hasSymbolStartActions && forceCompletePartialTrees)
                         {
                             await processPartialSymbolLocationsAsync(compilationEvents, analysisScope).ConfigureAwait(false);
                         }
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             Task.Run(() =>
                             {
                                 var treeModel = _compilationData.GetOrCreateCachedSemanticModel(tree, _compilation, cancellationToken);
-                                return GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken);
+                                return GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken, forceCompletePartialTrees: false);
                             }, cancellationToken))).ConfigureAwait(false);
                     }
                     else
@@ -658,7 +658,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         {
                             cancellationToken.ThrowIfCancellationRequested();
                             var treeModel = _compilationData.GetOrCreateCachedSemanticModel(tree, _compilation, cancellationToken);
-                            await GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken).ConfigureAwait(false);
+                            await GetAnalyzerSemanticDiagnosticsCoreAsync(treeModel, filterSpan: null, analysisScope.Analyzers, cancellationToken, forceCompletePartialTrees: false).ConfigureAwait(false);
                         }
                     }
                 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpTyping.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpTyping.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpTyping : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpTyping(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpTyping))
+        {
+        }
+
+        [WpfFact, WorkItem(957250, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/957250")]
+        public void TypingInPartialType()
+        {
+            SetUpEditor(@"
+public partial class Test
+{
+    private int f;
+
+    static void Main(string[] args) { }
+    public void Noop()
+    {
+        f = 1;$$
+    }
+}
+");
+            var secondPartialDecl = @"
+public partial class Test
+{
+    int val1 = 1, val2 = 2;
+    public void TestA()
+    {
+        TestB();
+    }
+}
+";
+            var thirdPartialDecl = @"
+public partial class Test
+{
+    public void TestB()
+    {
+        int val1x = this.val1, val2x = this.val2;
+    }
+}";
+            VisualStudio.SolutionExplorer.AddFile(new ProjectUtils.Project(ProjectName), "PartialType2.cs", secondPartialDecl, open: false);
+            VisualStudio.SolutionExplorer.AddFile(new ProjectUtils.Project(ProjectName), "PartialType3.cs", thirdPartialDecl, open: false);
+
+            // Typing intermixed with explicit Wait operations to ensure that
+            // we trigger multiple open file analyses along with cancellations.
+            VisualStudio.Editor.SendKeys(VirtualKey.Enter);
+            Wait(seconds: 1);
+            VisualStudio.Editor.SendKeys("f = 1;");
+            Wait(seconds: 1);
+            VisualStudio.Editor.SendKeys(VirtualKey.Backspace);
+            VisualStudio.Editor.SendKeys(VirtualKey.Backspace);
+            Wait(seconds: 1);
+            VisualStudio.Editor.SendKeys("2;");
+
+            VisualStudio.Editor.Verify.TextContains(
+                @"
+public partial class Test
+{
+    private int f;
+
+    static void Main(string[] args) { }
+    public void Noop()
+    {
+        f = 1;
+        f = 2;
+    }
+}");
+        }
+    }
+}


### PR DESCRIPTION
Adds a typing integration test for https://github.com/dotnet/roslyn/pull/37623. Primary bug fixed in the PR: VSO [#957250](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/957250)

I verified that the test fails consistently without the fix in #37623 and passes consistently after the fix.

**NOTE:** https://github.com/dotnet/roslyn/pull/37638/commits/a9016164d74326db02f8596862e291a7e00d7e33 is just a cherry-pick from `release/dev16.3-preview2` branch. This is a test-only PR with https://github.com/dotnet/roslyn/pull/37638/commits/0d4753ecf0d9b3bffc6d7d8aeba2d02abb93b1ac as the only relevant commit.