### PR TITLE
Fix using statements to use correct copy of PooledObjects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RunningDocumentTableEventTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RunningDocumentTableEventTracker.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;


### PR DESCRIPTION
The Microsoft.CodeAnalysis.FlowAnalysis.Utilities assembly which we consume accidentally made it's copy of the PooledObjects helper public. That copy has a different namespace, so by using the wrong namespace we were pulling in that assembly's copy rather than using the copy we have in our assembly. This causes us to do an early assembly load when it's absolutely not necessary.