### PR TITLE
Delete some dead code in analyzer driver

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -780,12 +780,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private async Task GenerateCompilationEventsAndPopulateEventsCacheAsync(AnalysisScope analysisScope, AnalyzerDriver driver, CancellationToken cancellationToken)
         {
-#if SIMULATED_EVENT_QUEUE
-            await _analysisState.GenerateSimulatedCompilationEventsAsync(analysisScope, _compilation, _compilationData.GetOrCreateCachedSemanticModel, driver, cancellationToken).ConfigureAwait(false);
-#else
             GenerateCompilationEvents(analysisScope, cancellationToken);
             await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
-#endif
         }
 
         private void GenerateCompilationEvents(AnalysisScope analysisScope, CancellationToken cancellationToken)


### PR DESCRIPTION
`SIMULATED_EVENT_QUEUE` was an experimental approach for populating compilation event queue for IDE open file analysis. It is no longer been used or experimented.

Fixes #37434