### PR TITLE
Explicitly call BindExpression in GetSpeculativeSymbolInfo, instead o…

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -192,9 +192,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             crefSymbols = default;
             position = CheckAndAdjustPosition(position);
             expression = SyntaxFactory.GetStandaloneExpression(expression);
-            var bindableNewExpression = GetBindableSyntaxNode(expression);
             binder = GetEnclosingBinder(position);
-            var boundRoot = Bind(binder, bindableNewExpression, _ignoredDiagnostics);
+            var boundRoot = binder.BindExpression(expression, _ignoredDiagnostics);
             return (BoundExpression)NullableWalker.AnalyzeAndRewriteSpeculation(position, boundRoot, binder, GetSnapshotManager(), takeNewSnapshots: false, newSnapshots: out _);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -2185,8 +2185,10 @@ class C
             }
         }
 
-        [Fact, WorkItem(37659, "https://github.com/dotnet/roslyn/issues/37659")]
-        public void InvalidCodeVar_GetsCorrectSymbol()
+        [InlineData("true")]
+        [InlineData("false")]
+        [Theory, WorkItem(37659, "https://github.com/dotnet/roslyn/issues/37659")]
+        public void InvalidCodeVar_GetsCorrectSymbol(string flagState)
         {
             var source = @"
 public class C
@@ -2199,34 +2201,21 @@ public class C
 }
 ";
 
-            var comp1 = CreateCompilation(source, parseOptions: TestOptions.Regular8.WithFeature("run-nullable-analysis"));
-            var comp2 = CreateCompilation(source, parseOptions: TestOptions.Regular8.WithFeature("run-nullable-analysis", "false"));
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8.WithFeature("run-nullable-analysis", flagState));
 
-            var syntaxTree1 = comp1.SyntaxTrees[0];
-            var root1 = syntaxTree1.GetRoot();
-            var model1 = comp1.GetSemanticModel(syntaxTree1);
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
 
-            var syntaxTree2 = comp2.SyntaxTrees[0];
-            var root2 = syntaxTree2.GetRoot();
-            var model2 = comp2.GetSemanticModel(syntaxTree2);
+            var sRef = root.DescendantNodes().OfType<IdentifierNameSyntax>().Where(n => n.Identifier.ValueText == "s").Single();
 
-            var sRef1 = root1.DescendantNodes().OfType<IdentifierNameSyntax>().Where(n => n.Identifier.ValueText == "s").Single();
-            var sRef2 = root2.DescendantNodes().OfType<IdentifierNameSyntax>().Where(n => n.Identifier.ValueText == "s").Single();
+            var info = model.GetSpeculativeSymbolInfo(sRef.Position, sRef, SpeculativeBindingOption.BindAsExpression);
 
-            var symbolInfo1 = model1.GetSpeculativeSymbolInfo(sRef1.Position, sRef1, SpeculativeBindingOption.BindAsExpression);
-            var symbolInfo2 = model2.GetSpeculativeSymbolInfo(sRef2.Position, sRef2, SpeculativeBindingOption.BindAsExpression);
-
-            verifySymbol(symbolInfo1);
-            verifySymbol(symbolInfo2);
-
-            void verifySymbol(SymbolInfo info)
-            {
-                IParameterSymbol symbol = (IParameterSymbol)info.Symbol;
-                Assert.True(info.CandidateSymbols.IsEmpty);
-                Assert.NotNull(symbol);
-                Assert.Equal("s", symbol.Name);
-                Assert.Equal(SpecialType.System_String, symbol.Type.SpecialType);
-            }
+            IParameterSymbol symbol = (IParameterSymbol)info.Symbol;
+            Assert.True(info.CandidateSymbols.IsEmpty);
+            Assert.NotNull(symbol);
+            Assert.Equal("s", symbol.Name);
+            Assert.Equal(SpecialType.System_String, symbol.Type.SpecialType);
         }
     }
 }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5571,6 +5571,29 @@ class C
             End Using
         End Function
 
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        <MemberData(NameOf(AllCompletionImplementations))>
+        Public Async Function CompletionBeforeVarWithEnableNullableReferenceAnalysisIDEFeatures(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateTestStateFromWorkspace(completionImplementation,
+                 <Workspace>
+                     <Project Language="C#" LanguageVersion="CSharp8" CommonReferences="true" AssemblyName="CSProj" Features="run-nullable-analysis">
+                         <Document><![CDATA[
+class C
+{
+    void M(string s)
+    {
+        s$$
+        var o = new object();
+    }
+}]]></Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.AssertCompletionItemsContainAll({"Length"})
+            End Using
+        End Function
         Private Class MultipleChangeCompletionProvider
             Inherits CompletionProvider
 


### PR DESCRIPTION
…f Bind, to be sure that we don't return type expression info instead of actual expression info.

Fixes https://github.com/dotnet/roslyn/issues/37659.
/cc @ivanbasov.