### PR TITLE
Fix a couple bugs in ChangeNamespaceService 

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/SyncNamespace/SyncNamespaceTests_ChangeNamespace.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/SyncNamespace/SyncNamespaceTests_ChangeNamespace.cs
@@ -2070,5 +2070,230 @@ Public Class VBClass
 End Class";
             await TestChangeNamespaceAsync(code, expectedSourceOriginal, expectedSourceReference);
         }
+
+        [WorkItem(37891, "https://github.com/dotnet/roslyn/issues/37891")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSyncNamespace)]
+        public async Task ChangeNamespace_WithMemberAccessReferencesInOtherDocument()
+        {
+            var defaultNamespace = "A";
+            var declaredNamespace = "Foo.Bar.Baz";
+
+            var documentPath1 = CreateDocumentFilePath(new[] { "B", "C" }, "File1.cs");
+            var documentPath2 = CreateDocumentFilePath(Array.Empty<string>(), "File2.cs");
+            var code =
+$@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" FilePath=""{ProjectFilePath}"" RootNamespace=""{defaultNamespace}"" CommonReferences=""true"">
+        <Document Folders=""{documentPath1.folder}"" FilePath=""{documentPath1.filePath}""> 
+namespace [||]{declaredNamespace}
+{{
+    enum Enum1 
+    {{
+        A,
+        B,
+        C
+    }}
+}}</Document>
+<Document Folders=""{documentPath2.folder}"" FilePath=""{documentPath2.filePath}""> 
+namespace Foo
+{{
+    class RefClass
+    {{
+        Enum1 M1()
+        {{
+            return {declaredNamespace}.Enum1.A;
+        }}
+    }}
+}}</Document>
+    </Project>
+</Workspace>";
+
+            var expectedSourceOriginal =
+@"namespace A.B.C
+{
+    enum Enum1
+    {
+        A,
+        B,
+        C
+    }
+}";
+            var expectedSourceReference =
+@"
+using A.B.C;
+
+namespace Foo
+{
+    class RefClass
+    {
+        Enum1 M1()
+        {
+            return Enum1.A;
+        }
+    }
+}";
+            await TestChangeNamespaceAsync(code, expectedSourceOriginal, expectedSourceReference);
+        }
+
+        [WorkItem(37891, "https://github.com/dotnet/roslyn/issues/37891")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSyncNamespace)]
+        public async Task ChangeToGlobalNamespace_WithMemberAccessReferencesInOtherDocument()
+        {
+            var defaultNamespace = "";
+            var declaredNamespace = "Foo.Bar.Baz";
+
+            var documentPath1 = CreateDocumentFilePath(Array.Empty<string>(), "File1.cs");
+            var documentPath2 = CreateDocumentFilePath(Array.Empty<string>(), "File2.cs");
+            var code =
+$@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" FilePath=""{ProjectFilePath}"" RootNamespace=""{defaultNamespace}"" CommonReferences=""true"">
+        <Document Folders=""{documentPath1.folder}"" FilePath=""{documentPath1.filePath}""> 
+namespace [||]{declaredNamespace}
+{{
+    enum Enum1 
+    {{
+        A,
+        B,
+        C
+    }}
+}}</Document>
+<Document Folders=""{documentPath2.folder}"" FilePath=""{documentPath2.filePath}""> 
+namespace Foo
+{{
+    class RefClass
+    {{
+        Enum1 M1()
+        {{
+            return {declaredNamespace}.Enum1.A;
+        }}
+    }}
+}}</Document>
+    </Project>
+</Workspace>";
+
+            var expectedSourceOriginal =
+@"enum Enum1
+{
+    A,
+    B,
+    C
+}
+";
+            var expectedSourceReference =
+@"namespace Foo
+{
+    class RefClass
+    {
+        Enum1 M1()
+        {
+            return Enum1.A;
+        }
+    }
+}";
+            await TestChangeNamespaceAsync(code, expectedSourceOriginal, expectedSourceReference);
+        }
+
+        [WorkItem(37891, "https://github.com/dotnet/roslyn/issues/37891")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSyncNamespace)]
+        public async Task ChangeNamespace_WithMemberAccessReferencesInVBDocument()
+        {
+            var defaultNamespace = "A.B.C";
+            var declaredNamespace = "A.B.C.D";
+
+            var documentPath1 = CreateDocumentFilePath(Array.Empty<string>(), "File1.cs");
+            var code =
+$@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" FilePath=""{ProjectFilePath}"" RootNamespace=""{defaultNamespace}"" CommonReferences=""true"">
+        <Document Folders=""{documentPath1.folder}"" FilePath=""{documentPath1.filePath}""> 
+namespace [||]{declaredNamespace}
+{{
+    public enum Enum1
+    {{
+        A,
+        B,
+        C
+    }}
+}}</Document>
+    </Project>    
+<Project Language=""Visual Basic"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+Public Class VBClass
+    Sub M()
+        Dim x = A.B.C.D.Enum1.A
+    End Sub
+End Class</Document>
+    </Project>
+</Workspace>";
+
+            var expectedSourceOriginal =
+@"namespace A.B.C
+{
+    public enum Enum1
+    {
+        A,
+        B,
+        C
+    }
+}";
+            var expectedSourceReference =
+@"Public Class VBClass
+    Sub M()
+        Dim x = A.B.C.Enum1.A
+    End Sub
+End Class";
+            await TestChangeNamespaceAsync(code, expectedSourceOriginal, expectedSourceReference);
+        }
+
+        [WorkItem(37891, "https://github.com/dotnet/roslyn/issues/37891")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsSyncNamespace)]
+        public async Task ChangeToGlobalNamespace_WithMemberAccessReferencesInVBDocument()
+        {
+            var defaultNamespace = "";
+            var declaredNamespace = "A.B.C.D";
+
+            var documentPath1 = CreateDocumentFilePath(Array.Empty<string>(), "File1.cs");
+            var code =
+$@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" FilePath=""{ProjectFilePath}"" RootNamespace=""{defaultNamespace}"" CommonReferences=""true"">
+        <Document Folders=""{documentPath1.folder}"" FilePath=""{documentPath1.filePath}""> 
+namespace [||]{declaredNamespace}
+{{
+    public enum Enum1
+    {{
+        A,
+        B,
+        C
+    }}
+}}</Document>
+    </Project>    
+<Project Language=""Visual Basic"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+Public Class VBClass
+    Sub M()
+        Dim x = A.B.C.D.Enum1.A
+    End Sub
+End Class</Document>
+    </Project>
+</Workspace>";
+
+            var expectedSourceOriginal =
+@"public enum Enum1
+{
+    A,
+    B,
+    C
+}
+";
+            var expectedSourceReference =
+@"Public Class VBClass
+    Sub M()
+        Dim x = Enum1.A
+    End Sub
+End Class";
+            await TestChangeNamespaceAsync(code, expectedSourceOriginal, expectedSourceReference);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
@@ -202,7 +202,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeNamespace
             old = @new = nameRef;
             return false;
 
-            static bool TryGetGlobalQualifiedName(ImmutableArray<string> newNamespaceParts, SimpleNameSyntax nameNode, string? aliasQualifier, out SyntaxNode newNode)
+#nullable enable
+            static bool TryGetGlobalQualifiedName(ImmutableArray<string> newNamespaceParts, SimpleNameSyntax nameNode, string? aliasQualifier, out SyntaxNode? newNode)
             {
                 if (IsGlobalNamespace(newNamespaceParts))
                 {
@@ -216,6 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeNamespace
                 newNode = null;
                 return false;
             }
+#nullable restore
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -86,6 +86,9 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
         private static bool IsValidContainer(SyntaxNode container)
             => container is TCompilationUnitSyntax || container is TNamespaceDeclarationSyntax;
 
+        protected static bool IsGlobalNamespace(ImmutableArray<string> parts)
+            => parts.Length == 1 && parts[0].Length == 0;
+
         public override async Task<bool> CanChangeNamespaceAsync(Document document, SyntaxNode container, CancellationToken cancellationToken)
         {
             if (!IsValidContainer(container))

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -582,14 +582,15 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             return await Simplifier.ReduceAsync(formattedDocument, optionSet, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<Document> FixReferencingDocumentAsync(
+#nullable enable
+
+        private async Task<Document?> FixReferencingDocumentAsync(
             Document document,
             IEnumerable<LocationForAffectedSymbol> refLocations,
             string newNamespace,
             CancellationToken cancellationToken)
         {
             // Can't apply change to certain document, returns null to indicate this.
-            // e.g. Razor document (*.g.cs file, not *.cshtml)
             if (!document.CanApplyChange())
             {
                 return null;
@@ -625,6 +626,8 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
 
             return await Simplifier.ReduceAsync(formattedDocument, optionSet, cancellationToken).ConfigureAwait(false);
         }
+
+#nullable restore
 
         /// <summary>
         /// Fix each reference and return a collection of proper containers (innermost container


### PR DESCRIPTION
1. Exclude documents we can't change from referenced documents for change namespace #37521 
2. Fix the ChangeNamespaceService so the reference in the form of member access is handled correctly #37891