### PR TITLE
workspace.TryApplyChanges should respect changes to DefaultNamespace

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -266,6 +266,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 case ApplyChangesKind.RemoveAdditionalDocument:
                 case ApplyChangesKind.AddAnalyzerConfigDocument:
                 case ApplyChangesKind.RemoveAnalyzerConfigDocument:
+                case ApplyChangesKind.ChangeProjectInfo:
                     return true;
 
                 case ApplyChangesKind.ChangeDocument:

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -468,6 +468,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 case ApplyChangesKind.AddAnalyzerConfigDocument:
                 case ApplyChangesKind.RemoveAnalyzerConfigDocument:
                 case ApplyChangesKind.ChangeAnalyzerConfigDocument:
+                case ApplyChangesKind.ChangeProjectInfo:
                     return true;
 
                 default:

--- a/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/MSBuildWorkspace.cs
@@ -237,6 +237,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 case ApplyChangesKind.RemoveProjectReference:
                 case ApplyChangesKind.AddAnalyzerReference:
                 case ApplyChangesKind.RemoveAnalyzerReference:
+                case ApplyChangesKind.ChangeProjectInfo:
                     return true;
                 default:
                     return false;

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ Microsoft.CodeAnalysis.AdditionalDocument
 Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.ApplyChangesKind.AddAnalyzerConfigDocument = 17 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeAnalyzerConfigDocument = 19 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.ApplyChangesKind.ChangeDefaultNamespace = 20 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.ApplyChangesKind.RemoveAnalyzerConfigDocument = 18 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.Project.AddAnalyzerConfigDocument(string name, Microsoft.CodeAnalysis.Text.SourceText text, System.Collections.Generic.IEnumerable<string> folders = null, string filePath = null) -> Microsoft.CodeAnalysis.TextDocument
 Microsoft.CodeAnalysis.Project.AnalyzerConfigDocuments.get -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.AnalyzerConfigDocument>
@@ -91,6 +92,7 @@ virtual Microsoft.CodeAnalysis.FileTextLoader.CreateText(System.IO.Stream stream
 virtual Microsoft.CodeAnalysis.Workspace.ApplyAnalyzerConfigDocumentAdded(Microsoft.CodeAnalysis.DocumentInfo info, Microsoft.CodeAnalysis.Text.SourceText text) -> void
 virtual Microsoft.CodeAnalysis.Workspace.ApplyAnalyzerConfigDocumentRemoved(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 virtual Microsoft.CodeAnalysis.Workspace.ApplyAnalyzerConfigDocumentTextChanged(Microsoft.CodeAnalysis.DocumentId id, Microsoft.CodeAnalysis.Text.SourceText text) -> void
+virtual Microsoft.CodeAnalysis.Workspace.ApplyDefaultNamespaceChanged(Microsoft.CodeAnalysis.ProjectId projectId, string defaultNamespace) -> void
 virtual Microsoft.CodeAnalysis.Workspace.CanApplyCompilationOptionChange(Microsoft.CodeAnalysis.CompilationOptions oldOptions, Microsoft.CodeAnalysis.CompilationOptions newOptions, Microsoft.CodeAnalysis.Project project) -> bool
 virtual Microsoft.CodeAnalysis.Workspace.CloseAnalyzerConfigDocument(Microsoft.CodeAnalysis.DocumentId documentId) -> void
 virtual Microsoft.CodeAnalysis.Workspace.GetAnalyzerConfigDocumentName(Microsoft.CodeAnalysis.DocumentId documentId) -> string

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ Microsoft.CodeAnalysis.AdditionalDocument
 Microsoft.CodeAnalysis.AnalyzerConfigDocument
 Microsoft.CodeAnalysis.ApplyChangesKind.AddAnalyzerConfigDocument = 17 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.ApplyChangesKind.ChangeAnalyzerConfigDocument = 19 -> Microsoft.CodeAnalysis.ApplyChangesKind
-Microsoft.CodeAnalysis.ApplyChangesKind.ChangeDefaultNamespace = 20 -> Microsoft.CodeAnalysis.ApplyChangesKind
+Microsoft.CodeAnalysis.ApplyChangesKind.ChangeProjectInfo = 20 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.ApplyChangesKind.RemoveAnalyzerConfigDocument = 18 -> Microsoft.CodeAnalysis.ApplyChangesKind
 Microsoft.CodeAnalysis.Project.AddAnalyzerConfigDocument(string name, Microsoft.CodeAnalysis.Text.SourceText text, System.Collections.Generic.IEnumerable<string> folders = null, string filePath = null) -> Microsoft.CodeAnalysis.TextDocument
 Microsoft.CodeAnalysis.Project.AnalyzerConfigDocuments.get -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.AnalyzerConfigDocument>

--- a/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis
         ChangeDocumentInfo = 16,
         AddAnalyzerConfigDocument = 17,
         RemoveAnalyzerConfigDocument = 18,
-        ChangeAnalyzerConfigDocument = 19
+        ChangeAnalyzerConfigDocument = 19,
+        ChangeDefaultNamespace = 20
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ApplyChangesKind.cs
@@ -25,6 +25,6 @@ namespace Microsoft.CodeAnalysis
         AddAnalyzerConfigDocument = 17,
         RemoveAnalyzerConfigDocument = 18,
         ChangeAnalyzerConfigDocument = 19,
-        ChangeDefaultNamespace = 20
+        ChangeProjectInfo = 20
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1196,6 +1196,12 @@ namespace Microsoft.CodeAnalysis
                 throw new NotSupportedException(WorkspacesResources.Changing_compilation_options_is_not_supported);
             }
 
+            if (projectChanges.OldProject.DefaultNamespace != projectChanges.NewProject.DefaultNamespace
+                && !this.CanApplyChange(ApplyChangesKind.ChangeProjectInfo))
+            {
+                throw new NotSupportedException(WorkspacesResources.Changing_project_properties_is_not_supported);
+            }
+
             if (projectChanges.OldProject.ParseOptions != projectChanges.NewProject.ParseOptions
                 && !this.CanApplyChange(ApplyChangesKind.ChangeParseOptions)
                 && !this.CanApplyParseOptionChange(

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1576,7 +1576,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string? defaultNamespace)
         {
-            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeDefaultNamespace));
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeProjectInfo));
             this.OnDefaultNamespaceChanged(projectId, defaultNamespace);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1325,6 +1325,12 @@ namespace Microsoft.CodeAnalysis
                 this.ApplyParseOptionsChanged(projectChanges.ProjectId, projectChanges.NewProject.ParseOptions!);
             }
 
+            // changed default namespace
+            if (projectChanges.OldProject.DefaultNamespace != projectChanges.NewProject.DefaultNamespace)
+            {
+                this.ApplyDefaultNamespaceChanged(projectChanges.ProjectId, projectChanges.NewProject.DefaultNamespace);
+            }
+
             // removed project references
             foreach (var removedProjectReference in projectChanges.GetRemovedProjectReferences())
             {
@@ -1561,6 +1567,17 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeCompilationOptions));
             this.OnCompilationOptionsChanged(projectId, options);
+        }
+
+        /// <summary>
+        /// This method is called during <see cref="TryApplyChanges(Solution)"/> to change the default namespace.
+        ///
+        /// Override this method to implement the capability of changing default namespace.
+        /// </summary>
+        protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string defaultNamespace)
+        {
+            Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeDefaultNamespace));
+            this.OnDefaultNamespaceChanged(projectId, defaultNamespace);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1574,7 +1574,7 @@ namespace Microsoft.CodeAnalysis
         ///
         /// Override this method to implement the capability of changing default namespace.
         /// </summary>
-        protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string defaultNamespace)
+        protected virtual void ApplyDefaultNamespaceChanged(ProjectId projectId, string? defaultNamespace)
         {
             Debug.Assert(CanApplyChange(ApplyChangesKind.ChangeDefaultNamespace));
             this.OnDefaultNamespaceChanged(projectId, defaultNamespace);

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -646,5 +646,17 @@ language: LanguageNames.CSharp);
             Assert.NotNull(service);
             Assert.Equal(service.GetType(), typeof(DefaultDocumentTextDifferencingService));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestChangeDefaultNamespace_TryApplyChanges()
+        {
+            using var ws = new AdhocWorkspace();
+            var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).WithDefaultNamespace("OriginalName").Id;
+
+            var newName = "ChangedName";
+            var newSolution = ws.CurrentSolution.WithProjectDefaultNamespace(projectId, newName);
+            Assert.True(ws.TryApplyChanges(newSolution));
+            Assert.Equal(newName, ws.CurrentSolution.Projects.First(p => p.Id == projectId).DefaultNamespace);
+        }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
@@ -20,19 +20,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var changedDoc = originalDoc.WithText(SourceText.From("new"));
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_documents_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_documents_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -47,18 +36,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var changedDoc = originalDoc.WithName(newName);
             Assert.Equal(newName, changedDoc.Name);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -75,18 +54,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("A", changedDoc.Folders[0]);
             Assert.Equal("B", changedDoc.Folders[1]);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -102,18 +71,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var changedDoc = originalDoc.WithFilePath(newPath);
             Assert.Equal(newPath, changedDoc.FilePath);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -128,18 +87,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var changedDoc = originalDoc.WithSourceCodeKind(SourceCodeKind.Script);
             Assert.Equal(SourceCodeKind.Script, changedDoc.SourceCodeKind);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(changedDoc.Project.Solution);
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(changedDoc.Project.Solution));
+            Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, exception.Message);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -151,19 +100,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var newName = "ChangedName";
             var newSolution = ws.CurrentSolution.WithProjectDefaultNamespace(projectId, newName);
 
-            NotSupportedException e = null;
-            try
-            {
-                ws.TryApplyChanges(newSolution);
-
-            }
-            catch (NotSupportedException x)
-            {
-                e = x;
-            }
-
-            Assert.NotNull(e);
-            Assert.Equal(WorkspacesResources.Changing_project_properties_is_not_supported, e.Message);
+            var exception = Assert.Throws<NotSupportedException>(() => ws.TryApplyChanges(newSolution));
+            Assert.Equal(WorkspacesResources.Changing_project_properties_is_not_supported, exception.Message);
         }
 
         private class NoChangesAllowedWorkspace : Workspace

--- a/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
@@ -142,6 +142,30 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(WorkspacesResources.Changing_document_property_is_not_supported, e.Message);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestChangeDefaultNamespace_TryApplyChanges_Throws()
+        {
+            using var ws = new NoChangesAllowedWorkspace();
+            var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).WithDefaultNamespace("OriginalName").Id;
+
+            var newName = "ChangedName";
+            var newSolution = ws.CurrentSolution.WithProjectDefaultNamespace(projectId, newName);
+
+            NotSupportedException e = null;
+            try
+            {
+                ws.TryApplyChanges(newSolution);
+
+            }
+            catch (NotSupportedException x)
+            {
+                e = x;
+            }
+
+            Assert.NotNull(e);
+            Assert.Equal(WorkspacesResources.Changing_project_properties_is_not_supported, e.Message);
+        }
+
         private class NoChangesAllowedWorkspace : Workspace
         {
             public NoChangesAllowedWorkspace(HostServices services, string workspaceKind = "Custom")


### PR DESCRIPTION
This is a follow up PR to https://github.com/dotnet/roslyn/pull/35486

In the original PR, the default namespace APIs were made public but the `TryApplyChanges` method of the workspace wouldn't respect it. As a result, we needed to use a [reflection workaround in OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn/blob/master/src/OmniSharp.Roslyn/OmniSharpWorkspace.cs#L478-L492).

This PR ensures that default namespace change is propagated via `TryApplyChanges`.