### PR TITLE
Publish Ngen logs separately

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -145,6 +145,15 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Ngen Logs
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\ngen'
+      ArtifactName: 'NGen Logs'
+      publishLocation: Container
+    continueOnError: true
+    condition: succeeded()
+
   - task: PublishTestResults@2
     displayName: Publish xUnit Test Results
     inputs:


### PR DESCRIPTION
The NGEN log files are published inside our "Build Diagnostic Logs"
container today. That is regularly around 160MB in size of which the
NGEN logs take up ~700K.

Been working on some automation / processing that is specific to NGEN
log files. Downloading the other 159MB is fairly wasteful and slow for
this automation. Publishing the NGEN files separately so I can make this
automation more effecient.