### PR TITLE
Skip tests requiring legacy EditorConfig

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/LegacyEditorConfigCondition.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/LegacyEditorConfigCondition.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Options.EditorConfig;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using Roslyn.Test.Utilities;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
     public sealed class LegacyEditorConfigCondition : ExecutionCondition
     {
-        // Run legacy .editorconfig tests until our infrastructure is ready to test the
+        // Skip legacy .editorconfig tests until our infrastructure is ready to test the
         // compiler support. Waiting for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/839836
-        public override bool ShouldSkip => false;
+        public override bool ShouldSkip => true;
 
         public override string SkipReason => "Test is only supported with our legacy .editorconfig support";
     }


### PR DESCRIPTION
Now that the integration test vm images have been updated with the latest preview build of 16.3 these tests are consistently failing in runs for branches dev16.3-preview1 and earlier.