### PR TITLE
Create a UIContext triggered by projects in the VisualStudioWorkspace

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectExistsUIContextProviderLanguageService.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectExistsUIContextProviderLanguageService.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
+{
+    [ExportLanguageService(typeof(IProjectExistsUIContextProviderLanguageService), LanguageNames.CSharp), Shared]
+    internal sealed class CSharpProjectExistsUIContextProviderLanguageService : IProjectExistsUIContextProviderLanguageService
+    {
+        public UIContext GetUIContext()
+        {
+            return UIContext.FromUIContextGuid(Guids.CSharpProjectExistsInWorkspaceUIContext);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Guids.cs
+++ b/src/VisualStudio/Core/Def/Guids.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices
 {
@@ -22,6 +25,11 @@ namespace Microsoft.VisualStudio.LanguageServices
         public const string CSharpOrganizeIconIdString = "9420a4b2-b48b-449d-a4c0-335d6e864b82";
         public const string CSharpLibraryIdString = "58F1BAD0-2288-45b9-AC3A-D56398F7781D";
         public const string CSharpReplPackageIdString = "c5edd1ee-c43b-4360-9ce4-6b993ca12897";
+
+        /// <summary>
+        /// A <see cref="UIContext"/> that is set if there is a C# project in the <see cref="VisualStudioWorkspace"/>.
+        /// </summary>
+        public static readonly Guid CSharpProjectExistsInWorkspaceUIContext = new Guid("CA719A03-D55C-48F9-85DE-D934346E7F70");
 
         public const string CSharpProjectRootIdString = "C7FEDB89-B36D-4a62-93F4-DC7A95999921";
 
@@ -67,6 +75,11 @@ namespace Microsoft.VisualStudio.LanguageServices
         public const string VisualBasicDebuggerLanguageIdString = "3a12d0b8-c26c-11d0-b442-00a0244a1dd2";
         public const string VisualBasicLibraryIdString = "414AC972-9829-4b6a-A8D7-A08152FEB8AA";
         public const string VisualBasicOptionPageCodeStyleIdString = "10C168E1-3470-448A-A1AC-73D6BC070750";
+
+        /// <summary>
+        /// A <see cref="UIContext"/> that is set if there is a Visual Basic project in the <see cref="VisualStudioWorkspace"/>.
+        /// </summary>
+        public static readonly Guid VisualBasicProjectExistsInWorkspaceUIContext = new Guid("EEC3DF0D-6D3F-4544-ABF9-8E26E6A90275");
 
         public static readonly Guid VisualBasicPackageId = new Guid(VisualBasicPackageIdString);
         public static readonly Guid VisualBasicCompilerServiceId = new Guid(VisualBasicCompilerServiceIdString);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IProjectExistsUIContextProviderLanguageService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IProjectExistsUIContextProviderLanguageService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+{
+    /// <summary>
+    /// Implemented by an language that wants a <see cref="UIContext"/> to be activated when there is a project of a given language in the workspace.
+    /// </summary>
+    internal interface IProjectExistsUIContextProviderLanguageService : ILanguageService
+    {
+        UIContext GetUIContext();
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
@@ -99,6 +99,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 {
                     w.OnProjectAdded(projectInfo);
                 }
+
+                _visualStudioWorkspaceImpl.RefreshProjectExistsUIContextForLanguage(language);
             });
 
             // We do all these sets after the w.OnProjectAdded, as the setting of these properties is going to try to modify the workspace

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -111,6 +111,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Test.Utilities2" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.IntegrationTest.Utilities" />
+    <internalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.IntegrationTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ErrorList.UnitTests" WorkItem="https://github.com/dotnet/roslyn/issues/35081" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Next.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpProjectExistsUIContext.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpProjectExistsUIContext.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using Guids = Microsoft.VisualStudio.LanguageServices.Guids;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpProjectExistsUIContext : AbstractIntegrationTest
+    {
+        public CSharpProjectExistsUIContext(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
+        {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync().ConfigureAwait(true);
+            VisualStudio.SolutionExplorer.CreateSolution(nameof(CSharpProjectExistsUIContext));
+        }
+
+        [WpfFact]
+        public void ProjectContextChanges()
+        {
+            Assert.False(VisualStudio.Shell.IsUIContextActive(Guids.CSharpProjectExistsInWorkspaceUIContext));
+
+            VisualStudio.SolutionExplorer.AddProject(new ProjectUtils.Project("TestCSharpProject"), WellKnownProjectTemplates.ConsoleApplication, LanguageNames.CSharp);
+
+            Assert.True(VisualStudio.Shell.IsUIContextActive(Guids.CSharpProjectExistsInWorkspaceUIContext));
+
+            VisualStudio.SolutionExplorer.CloseSolution();
+
+            Assert.False(VisualStudio.Shell.IsUIContextActive(Guids.CSharpProjectExistsInWorkspaceUIContext));
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicProjectExistsUIContext.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicProjectExistsUIContext.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+using Guids = Microsoft.VisualStudio.LanguageServices.Guids;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class BasicProjectExistsUIContext : AbstractIntegrationTest
+    {
+        public BasicProjectExistsUIContext(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
+        {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync().ConfigureAwait(true);
+            VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicProjectExistsUIContext));
+        }
+
+        [WpfFact]
+        public void ProjectContextChanges()
+        {
+            Assert.False(VisualStudio.Shell.IsUIContextActive(Guids.VisualBasicProjectExistsInWorkspaceUIContext));
+
+            VisualStudio.SolutionExplorer.AddProject(new ProjectUtils.Project("TestVisualBasicProject"), WellKnownProjectTemplates.ConsoleApplication, LanguageNames.VisualBasic);
+
+            Assert.True(VisualStudio.Shell.IsUIContextActive(Guids.VisualBasicProjectExistsInWorkspaceUIContext));
+
+            VisualStudio.SolutionExplorer.CloseSolution();
+
+            Assert.False(VisualStudio.Shell.IsUIContextActive(Guids.VisualBasicProjectExistsInWorkspaceUIContext));
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
@@ -43,5 +43,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
                 return (bool)isProvisionalObject;
             });
+
+        public bool IsUIContextActive(Guid context)
+        {
+            return UIContext.FromUIContextGuid(context).IsActive;
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Shell_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Shell_OutOfProc.cs
@@ -26,5 +26,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public bool IsActiveTabProvisional()
             => _inProc.IsActiveTabProvisional();
+
+        public bool IsUIContextActive(Guid context)
+            => _inProc.IsUIContextActive(context);
     }
 }

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectExistsUIContextProviderLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectExistsUIContextProviderLanguageService.vb
@@ -1,0 +1,18 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Microsoft.VisualStudio.Shell
+
+Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
+    <ExportLanguageService(GetType(IProjectExistsUIContextProviderLanguageService), LanguageNames.VisualBasic), [Shared]>
+    Public Class VisualBasicProjectExistsUIContextProviderLanguageService
+        Implements IProjectExistsUIContextProviderLanguageService
+
+        Public Function GetUIContext() As UIContext Implements IProjectExistsUIContextProviderLanguageService.GetUIContext
+            Return UIContext.FromUIContextGuid(Guids.VisualBasicProjectExistsInWorkspaceUIContext)
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
Sometimes other features need to light up if there's a C# or VB project present. A good example is some of the test tooling: they don't want to load their components with Roslyn unless somebody is also using the test tooling, but you don't want to accidentally load Roslyn if somebody is using the test tooling only for C++.

Fixes https://devdiv.visualstudio.com/DevDiv/_queries/edit/844761/