### PR TITLE
completion unit test for reduce extension method does not check type constraints

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10293,7 +10293,7 @@ class AnotherBuilder
                 matchingFilters: new List<CompletionItemFilter> { CompletionItemFilter.ClassFilter });
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/37780"), Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CompletionShouldNotProvideExtensionMethodsIfTypeConstraintDoesNotMatch()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10253,7 +10253,6 @@ class AnotherBuilder
                 matchingFilters: new List<CompletionItemFilter> { CompletionItemFilter.FieldFilter });
         }
 
-
         [Fact, Trait(Traits.Feature, Traits.Features.TargetTypedCompletion)]
         public async Task TestTargetTypeFilter_NotOnObjectMembers()
         {
@@ -10292,6 +10291,34 @@ class AnotherBuilder
             await VerifyItemExistsAsync(
                 markup, "C",
                 matchingFilters: new List<CompletionItemFilter> { CompletionItemFilter.ClassFilter });
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CompletionShouldNotProvideExtensionMethodsIfTypeConstraintDoesNotMatch()
+        {
+            var markup = @"
+public static class Ext
+{
+    public static void DoSomething<T>(this T thing, string s) where T : class, I
+    { 
+    }
+}
+
+public interface I 
+{
+}
+
+public class C
+{
+    public void M(string s)
+    {
+        this.$$
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "M");
+            await VerifyItemExistsAsync(markup, "Equals");
+            await VerifyItemIsAbsentAsync(markup, "DoSomething", displayTextSuffix: "<>");
         }
     }
 }


### PR DESCRIPTION
Unit tests for https://github.com/dotnet/roslyn/issues/37780
Feel free to either update the PR with a fix or cherry pick the test into a new PR with the fix