### PR TITLE
Enable debugging/EnC integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
@@ -34,8 +34,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
             VisualStudio.SolutionExplorer.AddProject(testProj, WellKnownProjectTemplates.ConsoleApplication, LanguageNames.VisualBasic);
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void UpdateActiveStatementLeafNode()
         {
@@ -68,8 +67,7 @@ End Module
             VisualStudio.Debugger.CheckExpression("names(1)", "String", "\"bar\"");
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void AddTryCatchAroundActiveStatement()
         {
@@ -99,8 +97,7 @@ End Try");
             VisualStudio.Editor.Verify.CurrentLineText("End Try");
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void EditLambdaExpression()
         {
@@ -134,8 +131,7 @@ End Module");
             VisualStudio.ErrorList.Verify.NoBuildErrors();
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void EnCWhileDebuggingFromImmediateWindow()
         {
@@ -200,8 +196,7 @@ End Module
             VisualStudio.Workspace.WaitForAsyncOperations(Helper.HangMitigatingTimeout, FeatureAttribute.Workspace);
         }
 
-        // Also https://github.com/dotnet/roslyn/issues/36763
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void MultiProjectDebuggingWhereNotAllModulesAreLoaded()
         {
@@ -214,8 +209,7 @@ End Module
             VisualStudio.ErrorList.Verify.NoErrors();
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void LocalsWindowUpdatesAfterLocalGetsItsTypeUpdatedDuringEnC()
         {
@@ -240,8 +234,7 @@ End Module
             VisualStudio.LocalsWindow.Verify.CheckEntry("goo", "Single", "10");
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void LocalsWindowUpdatesCorrectlyDuringEnC()
         {
@@ -276,8 +269,7 @@ End Module
             VisualStudio.LocalsWindow.Verify.CheckEntry("lLng", "Long", "444");
         }
 
-        // Also "https://github.com/dotnet/roslyn/issues/37689")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         [Trait(Traits.Feature, Traits.Features.DebuggingEditAndContinue)]
         public void WatchWindowUpdatesCorrectlyDuringEnC()
         {

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExpressionEvaluator.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExpressionEvaluator.cs
@@ -65,7 +65,7 @@ Module Module1
 End Module");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         public void ValidateLocalsWindow()
         {
             VisualStudio.Debugger.Go(waitForBreakMode: true);
@@ -93,7 +93,7 @@ End Module");
             VisualStudio.LocalsWindow.Verify.CheckEntry("myMulticastDelegate", "System.MulticastDelegate", "Nothing");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         public void EvaluatePrimitiveValues()
         {
             VisualStudio.Debugger.Go(waitForBreakMode: true);
@@ -114,14 +114,14 @@ End Module");
             VisualStudio.Debugger.CheckExpression("(Function(val)(val+val))(1)", "Integer", "2");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         public void EvaluateInvalidExpressions()
         {
             VisualStudio.Debugger.Go(waitForBreakMode: true);
             VisualStudio.Debugger.CheckExpression("myNonsense", "", "error BC30451: 'myNonsense' is not declared. It may be inaccessible due to its protection level.");
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/35965")]
+        [WpfFact()]
         public void StateMachineTypeParameters()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -419,7 +419,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         private static void WaitForDesignMode(EnvDTE.DTE dte)
         {
-#if TODO// https://github.com/dotnet/roslyn/issues/35965
             // This delay was originally added to address test failures in BasicEditAndContinue. When running
             // multiple tests in sequence, situations were observed where the Edit and Continue state was not reset:
             //
@@ -453,7 +452,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     throw new TimeoutException("Failed to enter design mode in a timely manner.");
                 }
             }
-#endif
         }
 
         private void CloseSolution()


### PR DESCRIPTION
The recent failures for BasicEnC integration tests were because of the test image updating to 16.3 preview1. The changes in the vs-deps branches were waiting on this update and we can enable these tests again in these branches.

Closes #35965
Closes #37689