### PR TITLE
Disable interprocedural dataflow analysis for DisposableFieldsShouldB…

### DIFF
--- a/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CodeQuality;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.Operations;
@@ -209,6 +210,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
                     // We have a field reference for a disposable field.
                     // Check if it is being assigned a locally created disposable object.
+                    // PERF: Do not perform interprocedural analysis for this detection.
                     if (fieldReference.Parent is ISimpleAssignmentOperation simpleAssignmentOperation &&
                         simpleAssignmentOperation.Target == fieldReference)
                     {
@@ -217,6 +219,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                             if (_disposeAnalysisHelper.TryGetOrComputeResult(
                                 operationBlockStartContext, containingMethod,
                                 s_disposableFieldsShouldBeDisposedRule,
+                                InterproceduralAnalysisKind.None,
                                 trackInstanceFields: false,
                                 out _, out var pointsToAnalysisResult) &&
                                 pointsToAnalysisResult != null)
@@ -253,7 +256,9 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
                     // Perform dataflow analysis to compute dispose value of disposable fields at the end of dispose method.
                     if (_disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext, containingMethod,
-                        s_disposableFieldsShouldBeDisposedRule, trackInstanceFields: true,
+                        s_disposableFieldsShouldBeDisposedRule,
+                        InterproceduralAnalysisKind.ContextSensitive,
+                        trackInstanceFields: true,
                         disposeAnalysisResult: out var disposeAnalysisResult,
                         pointsToAnalysisResult: out var pointsToAnalysisResult))
                     {

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeAnalysisHelper.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeAnalysisHelper.cs
@@ -97,6 +97,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
             OperationBlockAnalysisContext context,
             IMethodSymbol containingMethod,
             DiagnosticDescriptor rule,
+            InterproceduralAnalysisKind interproceduralAnalysisKind,
             bool trackInstanceFields,
             out DisposeAnalysisResult disposeAnalysisResult,
             out PointsToAnalysisResult pointsToAnalysisResult,
@@ -112,6 +113,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                     disposeAnalysisResult = FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis.TryGetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
                         context.Options, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
                         exceptionPathsAnalysis: false, context.CancellationToken, out pointsToAnalysisResult,
+                        interproceduralAnalysisKind,
                         interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
                         defaultDisposeOwnershipTransferAtConstructor: true,
                         defaultDisposeOwnershipTransferAtMethodCall: true);
@@ -132,6 +134,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
             OperationBlockStartAnalysisContext context,
             IMethodSymbol containingMethod,
             DiagnosticDescriptor rule,
+            InterproceduralAnalysisKind interproceduralAnalysisKind,
             bool trackInstanceFields,
             out DisposeAnalysisResult disposeAnalysisResult,
             out PointsToAnalysisResult pointsToAnalysisResult,
@@ -147,6 +150,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                     disposeAnalysisResult = FlowAnalysis.DataFlow.DisposeAnalysis.DisposeAnalysis.TryGetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
                         context.Options, rule, _disposeOwnershipTransferLikelyTypes, trackInstanceFields,
                         exceptionPathsAnalysis: false, context.CancellationToken, out pointsToAnalysisResult,
+                        interproceduralAnalysisKind,
                         interproceduralAnalysisPredicateOpt: interproceduralAnalysisPredicateOpt,
                         defaultDisposeOwnershipTransferAtConstructor: true,
                         defaultDisposeOwnershipTransferAtMethodCall: true);

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
@@ -89,7 +89,9 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
             // Compute dispose dataflow analysis result for the operation block.
             if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockContext, containingMethod,
-                s_disposeObjectsBeforeLosingScopeRule, trackInstanceFields: false,
+                s_disposeObjectsBeforeLosingScopeRule,
+                InterproceduralAnalysisKind.ContextSensitive,
+                trackInstanceFields: false,
                 out var disposeAnalysisResult, out var pointsToAnalysisResult,
                 interproceduralAnalysisPredicateOpt))
             {


### PR DESCRIPTION
…eDisposedDiagnosticAnalyzer

This should fix the performance issues reported in VS feedback tickets [#672009](https://developercommunity.visualstudio.com/content/problem/672009/live-analysis-eats-up-memory-resulting-in-vs-crash.html) and [#672909](https://developercommunity.visualstudio.com/content/problem/672909/live-code-analysis-extremely-slow-and-vs-2019-cras.html).