### PR TITLE
Update ownership of CompilerGeneratorTools to the compiler team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@ src/NuGet/ @dotnet/roslyn-infrastructure
 src/Scripting/ @dotnet/roslyn-interactive
 src/Setup/ @dotnet/roslyn-infrastructure
 src/Tools/ @dotnet/roslyn-infrastructure
+src/Tools/Source/CompilerGeneratorTools/ @dotnet/roslyn-compiler
 src/VisualStudio/ @dotnet/roslyn-ide
 src/Workspaces/ @dotnet/roslyn-ide
 


### PR DESCRIPTION
Otherwise the infrastructure team gets tagged and that's not useful.