### PR TITLE
Remove inaccessible attributes when generating from the navigation bar

### DIFF
--- a/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
@@ -1103,5 +1103,42 @@ End Class
                     Item("P", Glyph.PropertyPublic, bolded:=True)}))
         End Function
 
+        <WpfFact, Trait(Traits.Feature, Traits.Features.NavigationBar), WorkItem(37621, "https://github.com/dotnet/roslyn/issues/37621")>
+        Public Async Function TestGenerateEventWithAttributedDelegateType() As Task
+            Await AssertGeneratedResultIsAsync(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <ProjectReference>LibraryWithInaccessibleAttribute</ProjectReference>
+                        <Document>
+Class C
+    Inherits BaseType
+End Class
+                        </Document>
+                    </Project>
+                    <Project Language="Visual Basic" Name="LibraryWithInaccessibleAttribute" CommonReferences="true">
+                        <Document><![CDATA[[
+Friend Class AttributeType
+    Inherits Attribute
+End Class
+
+Delegate Sub DelegateType(<AttributeType> parameterWithInaccessibleAttribute As Object)
+
+Public Class BaseType
+    Public Event E As DelegateType
+End Class
+                    ]]></Document></Project>
+                </Workspace>,
+                 String.Format(VBEditorResources._0_Events, "C"), "E",
+                <Result>
+Class C
+    Inherits BaseType
+
+    Private Sub C_E(parameterWithInaccessibleAttribute As Object) Handles Me.E
+
+    End Sub
+End Class
+                </Result>)
+        End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/NavigationBar/GenerateEventHandlerItem.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/GenerateEventHandlerItem.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                 explicitInterfaceImplementations:=Nothing,
                 name:=methodName,
                 typeParameters:=Nothing,
-                parameters:=delegateInvokeMethod.Parameters,
+                parameters:=delegateInvokeMethod.Parameters.WithAttributesToBeCopied(destinationType),
                 handlesExpressions:=ImmutableArray.Create(Of SyntaxNode)(handlesSyntax))
             methodSymbol = GeneratedSymbolAnnotation.AddAnnotationToSymbol(methodSymbol)
 

--- a/src/EditorFeatures/VisualBasic/NavigationBar/GenerateMethodItem.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/GenerateMethodItem.vb
@@ -27,7 +27,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
                 Return Nothing
             End If
 
-            Dim codeGenerationSymbol = GeneratedSymbolAnnotation.AddAnnotationToSymbol(CodeGenerationSymbolFactory.CreateMethodSymbol(methodToReplicate))
+            Dim codeGenerationSymbol = GeneratedSymbolAnnotation.AddAnnotationToSymbol(
+                CodeGenerationSymbolFactory.CreateMethodSymbol(
+                    methodToReplicate,
+                    parameters:=methodToReplicate.Parameters.WithAttributesToBeCopied(destinationType)))
 
             Return Await CodeGenerator.AddMethodDeclarationAsync(document.Project.Solution,
                                                                  destinationType,


### PR DESCRIPTION
When generating code from the navigation bar, we should remove inaccessible attributes, since there's no value in spitting code that won't build.

Fixes https://github.com/dotnet/roslyn/issues/37621 although perhaps not in the ideal way. We may also want to generally drop all nullable attributes when generating VB code, but that's being tracked by https://github.com/dotnet/roslyn/issues/30327 as there's some design questions still out.