### PR TITLE
Do not go back to syntax to determine if a source-property was an explicit implementation.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -485,7 +485,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal bool IsExpressionBodied => (_propertyFlags & SourcePropertySymbolFlags.IsExpressionBodied) != 0;
+        internal bool IsExpressionBodied
+            => (_propertyFlags & SourcePropertySymbolFlags.IsExpressionBodied) != 0;
 
         private void CheckInitializer(
             bool isAutoProperty,
@@ -735,7 +736,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal bool IsAutoProperty => (_propertyFlags & SourcePropertySymbolFlags.IsAutoProperty) != 0;
+        internal bool IsAutoProperty
+            => (_propertyFlags & SourcePropertySymbolFlags.IsAutoProperty) != 0;
 
         /// <summary>
         /// Backing field for automatically implemented property, or

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Condensed flags storing useful information about the <see cref="SourcePropertySymbol"/> 
         /// so that we do not have to go back to source to compute this data.
         /// </summary>
+        [Flags]
         private enum Flags : byte
         {
             IsExpressionBodied = 1 << 0,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -151,15 +151,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (isAutoProperty || hasInitializer)
             {
                 var hasGetSyntax = getSyntax != null;
-                var localIsAutoProperty = isAutoProperty && hasGetSyntax;
-                if (localIsAutoProperty)
+                var isAutoPropertyWithGetSyntax = isAutoProperty && hasGetSyntax;
+                if (isAutoPropertyWithGetSyntax)
                 {
                     _propertyFlags |= SourcePropertySymbolFlags.IsAutoProperty;
                 }
 
                 bool isGetterOnly = hasGetSyntax && setSyntax == null;
 
-                if (localIsAutoProperty && !IsStatic && !isGetterOnly)
+                if (isAutoPropertyWithGetSyntax && !IsStatic && !isGetterOnly)
                 {
                     if (ContainingType.IsReadOnly)
                     {
@@ -171,9 +171,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
 
-                if (localIsAutoProperty || hasInitializer)
+                if (isAutoPropertyWithGetSyntax || hasInitializer)
                 {
-                    if (localIsAutoProperty)
+                    if (isAutoPropertyWithGetSyntax)
                     {
                         //issue a diagnostic if the compiler generated attribute ctor is not found.
                         Binder.ReportUseSiteDiagnosticForSynthesizedAttribute(bodyBinder.Compilation,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -400,9 +400,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.ERR_AutoPropertyMustOverrideSet, location, this);
                 }
 
-                {
-                    CheckForFieldTargetedAttribute(syntax, diagnostics);
-                }
+                CheckForFieldTargetedAttribute(syntax, diagnostics);
             }
 
             CheckForBlockAndExpressionBody(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;


### PR DESCRIPTION
Fix for https://github.com/dotnet/roslyn/issues/37476

Sightly easier to review with whitespace diffs off.