### PR TITLE
Fix speculation of AsNewClause in Rename Rewriter

### DIFF
--- a/src/EditorFeatures/Test2/Rename/VisualBasic/DeclarationConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/DeclarationConflictTests.vb
@@ -1242,5 +1242,30 @@ End Class
                 result.AssertLabeledSpansAre("local0", type:=RelatedLocationType.UnresolvedConflict)
             End Using
         End Sub
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(941271, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/941271")>
+        Public Sub AsNewClauseSpeculationResolvesConflicts()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="Visual Basic" CommonReferences="true">
+                            <Document>
+                                Public Class Main
+                                    Private T As {|class0:$$Test|} = Nothing
+                                End Class
+
+                                Public Class {|class1:Test|}
+                                    Private Rnd As New {|classConflict:Random|}
+                                End Class
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Random")
+
+                result.AssertLabeledSpansAre("class0", "Random", RelatedLocationType.ResolvedReferenceConflict)
+                result.AssertLabeledSpansAre("class1", "Random", RelatedLocationType.ResolvedReferenceConflict)
+                result.AssertLabeledSpansAre("classConflict", "System.Random", type:=RelatedLocationType.ResolvedNonReferenceConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -198,6 +198,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
 
                 Me._speculativeModel = GetSemanticModelForNode(speculativeNewNode, Me._semanticModel)
                 Debug.Assert(_speculativeModel IsNot Nothing, "expanding a syntax node which cannot be speculated?")
+
+                ' There are cases when we change the type of node to make speculation work (e.g.,
+                ' for AsNewClauseSyntax), so getting the newNode from the _speculativeModel 
+                ' ensures the final node replacing the original node is found.
+                probableRenameNode = Me._speculativeModel.SyntaxTree.GetRoot(_cancellationToken).GetAnnotatedNodes(Of SyntaxNode)(annotation).First()
+                speculativeNewNode = Me._speculativeModel.SyntaxTree.GetRoot(_cancellationToken).GetAnnotatedNodes(Of SyntaxNode)(annotationForSpeculativeNode).First()
+
                 Dim renamedNode = MyBase.Visit(probableRenameNode)
 
                 If Not ReferenceEquals(renamedNode, probableRenameNode) Then


### PR DESCRIPTION
Another case of building a SpeculativeModel from an AsNewClause and the tree being speculating on being generated from an EqualsValue node. Causing the nodes being speculated on to not exist in the tree.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/941271