### PR TITLE
UseExplicitTupleName: Avoid NullRefException on Rest field

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseExplicitTupleName/UseExplicitTupleNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExplicitTupleName/UseExplicitTupleNameTests.cs
@@ -225,5 +225,48 @@ class C
     }
 }", new TestParameters(options: Option(CodeStyleOptions.PreferExplicitTupleNames, false, NotificationOption.Warning)));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTupleName)]
+        public async Task TestOnRestField()
+        {
+            string valueTuple8 = @"
+namespace System
+{
+    public struct ValueTuple<T1>
+    {
+        public T1 Item1;
+
+        public ValueTuple(T1 item1)
+        {
+        }
+    }
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> where TRest : struct
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+        public TRest Rest;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+        }
+    }
+}
+";
+            await TestDiagnosticMissingAsync(
+@"
+class C
+{
+    void M()
+    {
+        (int, int, int, int, int, int, int, int) x = default;
+        _ = x.[|Rest|];
+    }
+}" + valueTuple8);
+        }
     }
 }

--- a/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
             var field = fieldReferenceOperation.Field;
             if (field.ContainingType.IsTupleType)
             {
-                if (field.CorrespondingTupleField.Equals(field))
+                if (field.CorrespondingTupleField?.Equals(field) == true)
                 {
                     var namedField = GetNamedField(field.ContainingType, field, cancellationToken);
                     if (namedField != null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/23867