### PR TITLE
Reduce memory consumption for string concatenation from O(n^2) to O(n)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -90,8 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindTupleBinaryOperatorNestedInfo(node, kind, left, right, diagnostics);
             }
 
-            int ignored = 0;
-            BoundExpression comparison = BindSimpleBinaryOperator(node, diagnostics, left, right, ref ignored);
+            BoundExpression comparison = BindSimpleBinaryOperator(node, diagnostics, left, right);
             switch (comparison)
             {
                 case BoundLiteral _:

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3202,7 +3202,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants..
+        ///   Looks up a localized string similar to Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants..
         /// </summary>
         internal static string ERR_ConstantStringTooLong {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4856,7 +4856,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Alignment value has a magnitude that may result in a large formatted string</value>
   </data>
   <data name="ERR_ConstantStringTooLong" xml:space="preserve">
-    <value>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</value>
+    <value>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</value>
   </data>
   <data name="ERR_TupleTooFewElements" xml:space="preserve">
     <value>Tuple must contain at least two elements.</value>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -8891,8 +8891,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Délka řetězcové konstanty přesahuje aktuální limit paměti. Zkuste řetězec rozdělit do několika konstant.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Délka řetězcové konstanty přesahuje aktuální limit paměti. Zkuste řetězec rozdělit do několika konstant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -8891,8 +8891,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Die Länge der Zeichenfolgenkonstante überschreitet das aktuelle Speicherlimit. Versuchen Sie, die Zeichenfolge in mehrere Konstanten aufzuteilen.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Die Länge der Zeichenfolgenkonstante überschreitet das aktuelle Speicherlimit. Versuchen Sie, die Zeichenfolge in mehrere Konstanten aufzuteilen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -8893,8 +8893,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">La longitud de la constante de cadena supera el límite de memoria actual. Pruebe dividiendo la cadena en varias constantes.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">La longitud de la constante de cadena supera el límite de memoria actual. Pruebe dividiendo la cadena en varias constantes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -8892,8 +8892,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">La longueur de la constante de chaîne dépasse la limite de mémoire actuelle. Essayez de fractionner la chaîne en plusieurs constantes.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">La longueur de la constante de chaîne dépasse la limite de mémoire actuelle. Essayez de fractionner la chaîne en plusieurs constantes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -8891,8 +8891,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">La lunghezza della costante di stringa supera il limite di memoria corrente. Provare a dividere la stringa in più costanti.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">La lunghezza della costante di stringa supera il limite di memoria corrente. Provare a dividere la stringa in più costanti.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -8891,8 +8891,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">文字列定数の長さが現在のメモリの制限を超えています。文字列を複数の定数に分割してください。</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">文字列定数の長さが現在のメモリの制限を超えています。文字列を複数の定数に分割してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -8891,8 +8891,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">문자열 상수의 길이가 현재 메모리 제한을 초과합니다. 문자열을 여러 상수로 분할해 보세요.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">문자열 상수의 길이가 현재 메모리 제한을 초과합니다. 문자열을 여러 상수로 분할해 보세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -8891,8 +8891,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Długość stałej typu String przekracza bieżący limit pamięci. Spróbuj podzielić ciąg na wiele stałych.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Długość stałej typu String przekracza bieżący limit pamięci. Spróbuj podzielić ciąg na wiele stałych.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -8891,8 +8891,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">O comprimento da constante de cadeia de caracteres excede o limite de memória atual.  Tente dividir a cadeia de caracteres em várias constantes.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">O comprimento da constante de cadeia de caracteres excede o limite de memória atual.  Tente dividir a cadeia de caracteres em várias constantes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -8893,8 +8893,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Длина строковой константы превышает текущий предельный объем памяти. Попробуйте разбить строку на несколько констант.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Длина строковой константы превышает текущий предельный объем памяти. Попробуйте разбить строку на несколько констант.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -8892,8 +8892,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Dize Uzunluğu sabiti geçerli hafıza sınırını aşıyor. Dizeyi birden fazla sabit içine bölmeyi deneyin.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Dize Uzunluğu sabiti geçerli hafıza sınırını aşıyor. Dizeyi birden fazla sabit içine bölmeyi deneyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -8927,8 +8927,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">字符串常量的长度超出了当前内存限制。请尝试将字符串拆分成多个常量。</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">字符串常量的长度超出了当前内存限制。请尝试将字符串拆分成多个常量。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -8891,8 +8891,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">字串常數的長度超過目前的記憶體限制。請嘗試將字串分割成多個常數。</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">字串常數的長度超過目前的記憶體限制。請嘗試將字串分割成多個常數。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_TupleTooFewElements">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -3023,6 +3024,35 @@ class C
                 //         const int F = c.Sum(o => F);
                 Diagnostic(ErrorCode.ERR_CircConstValue, "F").WithArguments("F").WithLocation(8, 34)
                 );
+        }
+
+        [Fact]
+        public void TestLargeStringConcatenation()
+        {
+            // When the compiler folds string concatenations using an O(n^2) algorithm, this program cannot be
+            // compiled within ordinary memory bounds.  However, when the compiler uses an O(n) algorithm, it can.
+            string source0 = @"
+class C
+{
+    static void Main()
+    {
+        string s =
+""BEGIN "" +
+";
+            string source1 = @"
+""END"";
+        System.Console.WriteLine(System.Linq.Enumerable.Sum(s, c => (int)c));
+    }
+}
+";
+            StringBuilder source = new StringBuilder();
+            source.Append(source0);
+            for (int i = 0; i < 5000; i++)
+            {
+                source.Append(@"""Lorem ipsum dolor sit amet"" + "", consectetur adipiscing elit, sed"" + "" do eiusmod tempor incididunt"" + "" ut labore et dolore magna aliqua. "" +" + "\n");
+            }
+            source.Append(source1);
+            CompileAndVerify(source.ToString(), expectedOutput: "58430604");
         }
     }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -10843,5 +10843,68 @@ public class C {
             Assert.Equal("?", type.ToTestDisplayString());
             Assert.True(type.IsErrorType());
         }
+
+        [Fact, WorkItem(529600, "DevDiv"), WorkItem(7398, "https://github.com/dotnet/roslyn/issues/7398")]
+        public void Bug529600()
+        {
+            // History of this bug:  When constant folding a long sequence of string concatentations, there is
+            // an intermediate constant value for every left-hand operand.  So the total memory consumed to
+            // compute the whole concatenation was O(n^2).  The compiler would simply perform this work and
+            // eventually run out of memory, simply crashing with no useful diagnostic.  Later, the concatenation
+            // implementation was instrumented so it would detect when it was likely to run out of memory soon,
+            // and would instead report a diagnostic at the last step.  This test was added to demonstrate that
+            // we produced a diagnostic.  However, the compiler still consumed O(n^2) memory for the
+            // concatenation and this test used to consume so much memory that it would cause other tests running
+            // in parallel to fail because they might not have enough memory to succeed.  So the test was
+            // disabled and eventually removed.  The compiler would still crash with programs constaining large
+            // string concatenations, so the underlying problem had not been addressed.  Now we have revised the
+            // implementation of constant folding so that it requires O(n) memory. As a consequence this test now
+            // runs very quickly and does not consume gobs of memory.
+            string source = $@"
+class M
+{{
+    static void Main()
+    {{}}
+    const string C0 = ""{new string('0', 65000)}"";
+    const string C1 = C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 +
+                      C0;
+     const string C2 = C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                      C1;
+}}
+";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (28,68): error CS8095: Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.
+                //                       C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 +
+                Diagnostic(ErrorCode.ERR_ConstantStringTooLong, "C1").WithLocation(28, 68)
+                );
+        }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/RopeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/RopeTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Collections
+{
+    public class RopeTests
+    {
+        private static string[] longStrings = new[]
+        {
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.  ",
+            "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.  ",
+            "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.  ",
+            "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.  ",
+            // So true
+        };
+        private static Rope[] longRopes = longStrings.Select(s => Rope.ForString(s)).ToArray();
+
+        private static string[] shortStrings = new[]
+        {
+            "abcd", "efgh", "ijkl", "mnop", "qrst", "uvwx", "yz01", "2345", "6789"
+        };
+        private static Rope[] shortRopes = shortStrings.Select(s => Rope.ForString(s)).ToArray();
+
+        private static Rope[] someRopes = shortRopes.Concat(longRopes).ToArray();
+        private static string[] someStrings = shortStrings.Concat(longStrings).ToArray();
+
+        [Fact]
+        public void Empty()
+        {
+            Rope r = Rope.Empty;
+            Assert.Equal(0, r.Length);
+            Assert.Equal(string.Empty, r.ToString());
+            Assert.Equal(r, Rope.ForString(string.Empty));
+            Assert.Equal(Rope.ForString(string.Empty), r);
+        }
+
+        [Fact]
+        public void EmptyConcatenation()
+        {
+            foreach (var rope in someRopes)
+            {
+                Assert.Same(rope, Rope.Concat(rope, Rope.Empty));
+                Assert.Same(rope, Rope.Concat(Rope.Empty, rope));
+            }
+        }
+
+        [Fact]
+        public void ForString()
+        {
+            foreach (var s in someStrings)
+            {
+                Assert.Equal(s, Rope.ForString(s).ToString());
+            }
+        }
+
+        [Fact]
+        public void Concatenation()
+        {
+            foreach (var r1 in someRopes)
+            {
+                foreach (var r2 in someRopes)
+                {
+                    foreach (var r3 in someRopes)
+                    {
+                        Rope c1 = Rope.Concat(r1, Rope.Concat(r2, r3));
+                        Rope c2 = Rope.Concat(Rope.Concat(r1, r2), r3);
+                        Assert.Equal(c1, c2); // associative
+                        Assert.Equal(c1.GetHashCode(), c2.GetHashCode());
+                        string s = r1.ToString() + r2.ToString() + r3.ToString();
+                        Assert.Equal(c1.ToString(), s);
+                        Assert.Equal(c2.ToString(), s);
+                        Rope c3 = Rope.ForString(s);
+                        Assert.Equal(c1.GetHashCode(), c3.GetHashCode());
+                        Assert.Equal(c1, c3);
+                        Assert.Equal(c2, c3);
+                        Assert.Equal(c3.ToString(), s);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ForNullString()
+        {
+            Assert.Throws<ArgumentNullException>(() => { Rope.ForString(null); });
+        }
+
+        [Fact]
+        public void ConcatNull()
+        {
+            foreach (var r in someRopes)
+            {
+                Assert.Throws<ArgumentNullException>(() => { Rope.Concat(r, null); });
+                Assert.Throws<ArgumentNullException>(() => { Rope.Concat(null, r); });
+            }
+        }
+
+        [Fact]
+        public void Overflow()
+        {
+            Rope r = Rope.ForString("x");
+            Rope all = r;
+            Assert.Equal(1, all.Length);
+            for (int i = 1; i < 31; i++)
+            {
+                r = Rope.Concat(r, r);
+                all = Rope.Concat(all, r);
+                Assert.Equal(1 << i, r.Length);
+                Assert.Equal((1 << (i + 1)) - 1, all.Length);
+            }
+
+            Assert.Equal(int.MaxValue, all.Length);
+            var waferThinMint = Rope.ForString("y");
+            Assert.Throws<OverflowException>(() => Rope.Concat(all, waferThinMint));
+            Assert.Throws<OverflowException>(() => Rope.Concat(waferThinMint, all));
+            Assert.Throws<OverflowException>(() => Rope.Concat(all, all));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Collections/Rope.cs
+++ b/src/Compilers/Core/Portable/Collections/Rope.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -16,6 +18,7 @@ namespace Microsoft.CodeAnalysis
         public abstract override string ToString();
         public abstract int Length { get; }
         protected abstract IEnumerable<char> GetChars();
+        private Rope() { }
 
         /// <summary>
         /// A rope can wrap a simple string.
@@ -65,6 +68,7 @@ namespace Microsoft.CodeAnalysis
 
             return true;
         }
+
         public override int GetHashCode()
         {
             int result = Length;
@@ -77,7 +81,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// A rope that wraps a simple string.
         /// </summary>
-        private class StringRope : Rope
+        private sealed class StringRope : Rope
         {
             private readonly string _value;
             public StringRope(string value) => _value = value;
@@ -89,7 +93,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// A rope that represents the concatenation of two ropes.
         /// </summary>
-        private class ConcatRope : Rope
+        private sealed class ConcatRope : Rope
         {
             private readonly Rope _left, _right;
             public override int Length { get; }

--- a/src/Compilers/Core/Portable/Collections/Rope.cs
+++ b/src/Compilers/Core/Portable/Collections/Rope.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A representation of a string of characters that requires O(1) extra space to concatenate two ropes.
+    /// </summary>
+    internal abstract class Rope
+    {
+        public static readonly Rope Empty = ForString("");
+        public abstract override string ToString();
+        public abstract int Length { get; }
+        protected abstract IEnumerable<char> GetChars();
+
+        /// <summary>
+        /// A rope can wrap a simple string.
+        /// </summary>
+        public static Rope ForString(string s)
+        {
+            if (s == null)
+                throw new ArgumentNullException(nameof(s));
+
+            return new StringRope(s);
+        }
+
+        /// <summary>
+        /// A rope can be formed from the concatenation of two ropes.
+        /// </summary>
+        public static Rope Concat(Rope r1, Rope r2)
+        {
+            if (r1 == null)
+                throw new ArgumentNullException(nameof(r1));
+
+            if (r2 == null)
+                throw new ArgumentNullException(nameof(r2));
+
+            return
+                r1.Length == 0 ? r2 :
+                r2.Length == 0 ? r1 :
+                checked(r1.Length + r2.Length < 32) ? ForString(r1.ToString() + r2.ToString()) :
+                new ConcatRope(r1, r2);
+        }
+
+        /// <summary>
+        /// Two ropes are "the same" if they represent the same sequence of characters.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Rope other) || Length != other.Length)
+                return false;
+            if (Length == 0)
+                return true;
+            var chars0 = GetChars().GetEnumerator();
+            var chars1 = other.GetChars().GetEnumerator();
+            while (chars0.MoveNext() && chars1.MoveNext())
+            {
+                if (chars0.Current != chars1.Current)
+                    return false;
+            }
+
+            return true;
+        }
+        public override int GetHashCode()
+        {
+            int result = Length;
+            foreach (char c in GetChars())
+                result = Hash.Combine((int)c, result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// A rope that wraps a simple string.
+        /// </summary>
+        private class StringRope : Rope
+        {
+            private readonly string _value;
+            public StringRope(string value) => _value = value;
+            public override string ToString() => _value;
+            public override int Length => _value.Length;
+            protected override IEnumerable<char> GetChars() => _value;
+        }
+
+        /// <summary>
+        /// A rope that represents the concatenation of two ropes.
+        /// </summary>
+        private class ConcatRope : Rope
+        {
+            private readonly Rope _left, _right;
+            public override int Length { get; }
+
+            public ConcatRope(Rope left, Rope right)
+            {
+                _left = left;
+                _right = right;
+                Length = checked(left.Length + right.Length);
+            }
+
+            public override string ToString()
+            {
+                var psb = PooledStringBuilder.GetInstance();
+                var stack = new Stack<Rope>();
+                stack.Push(this);
+                while (stack.Count != 0)
+                {
+                    switch (stack.Pop())
+                    {
+                        case StringRope s:
+                            psb.Builder.Append(s.ToString());
+                            break;
+                        case ConcatRope c:
+                            stack.Push(c._right);
+                            stack.Push(c._left);
+                            break;
+                        case var v:
+                            throw ExceptionUtilities.UnexpectedValue(v.GetType().Name);
+                    }
+                }
+
+                return psb.ToStringAndFree();
+            }
+
+            protected override IEnumerable<char> GetChars()
+            {
+                var stack = new Stack<Rope>();
+                stack.Push(this);
+                while (stack.Count != 0)
+                {
+                    switch (stack.Pop())
+                    {
+                        case StringRope s:
+                            foreach (var c in s.ToString())
+                                yield return c;
+                            break;
+                        case ConcatRope c:
+                            stack.Push(c._right);
+                            stack.Push(c._left);
+                            break;
+                        case var v:
+                            throw ExceptionUtilities.UnexpectedValue(v.GetType().Name);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -35,6 +35,8 @@ namespace Microsoft.CodeAnalysis
         internal abstract SpecialType SpecialType { get; }
 
         public virtual string StringValue { get { throw new InvalidOperationException(); } }
+        internal virtual Rope RopeValue { get { throw new InvalidOperationException(); } }
+
         public virtual bool BooleanValue { get { throw new InvalidOperationException(); } }
 
         public virtual sbyte SByteValue { get { throw new InvalidOperationException(); } }
@@ -94,6 +96,12 @@ namespace Microsoft.CodeAnalysis
                 return Null;
             }
 
+            return new ConstantValueString(value);
+        }
+
+        internal static ConstantValue CreateFromRope(Rope value)
+        {
+            Debug.Assert(value != null);
             return new ConstantValueString(value);
         }
 

--- a/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
+++ b/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
@@ -85,6 +85,14 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
+            internal override Rope RopeValue
+            {
+                get
+                {
+                    return null;
+                }
+            }
+
             // all instances of this class are singletons
             public override bool Equals(ConstantValue other)
             {
@@ -112,9 +120,16 @@ namespace Microsoft.CodeAnalysis
 
         private sealed class ConstantValueString : ConstantValue
         {
-            private readonly string _value;
+            private readonly Rope _value;
 
             public ConstantValueString(string value)
+            {
+                // we should have just one Null regardless string or object.
+                System.Diagnostics.Debug.Assert(value != null, "null strings should be represented as Null constant.");
+                _value = Rope.ForString(value);
+            }
+
+            public ConstantValueString(Rope value)
             {
                 // we should have just one Null regardless string or object.
                 System.Diagnostics.Debug.Assert(value != null, "null strings should be represented as Null constant.");
@@ -138,6 +153,14 @@ namespace Microsoft.CodeAnalysis
             {
                 get
                 {
+                    return _value.ToString();
+                }
+            }
+
+            internal override Rope RopeValue
+            {
+                get
+                {
                     return _value;
                 }
             }
@@ -149,7 +172,7 @@ namespace Microsoft.CodeAnalysis
 
             public override bool Equals(ConstantValue other)
             {
-                return base.Equals(other) && _value == other.StringValue;
+                return base.Equals(other) && _value.Equals(other.RopeValue);
             }
 
             internal override string GetValueToDisplay()

--- a/src/Compilers/Core/Portable/SwitchConstantValueHelper.cs
+++ b/src/Compilers/Core/Portable/SwitchConstantValueHelper.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis
                             return constant.UInt64Value.GetHashCode();
 
                         case ConstantValueTypeDiscriminator.String:
-                            return constant.StringValue.GetHashCode();
+                            return constant.RopeValue.GetHashCode();
                     }
                 }
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
@@ -173,7 +173,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 binary = DirectCast(child, BinaryExpressionSyntax)
             Loop
 
-            Dim compoundStringLength As Integer = 0
             Dim left As BoundExpression = BindValue(child, diagnostics, propagateIsOperandOfConditionalBranch)
 
             Do
@@ -184,8 +183,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 left = BindBinaryOperator(binary, left, right, binary.OperatorToken.Kind,
                                           OverloadResolution.MapBinaryOperatorKind(binary.Kind),
                                           If(binary Is node, isOperandOfConditionalBranch, propagateIsOperandOfConditionalBranch),
-                                          diagnostics,
-                                          compoundStringLength:=compoundStringLength)
+                                          diagnostics)
 
                 child = binary
             Loop While child IsNot node
@@ -201,8 +199,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             preliminaryOperatorKind As BinaryOperatorKind,
             isOperandOfConditionalBranch As Boolean,
             diagnostics As DiagnosticBag,
-            Optional isSelectCase As Boolean = False,
-            <[In], Out> Optional ByRef compoundStringLength As Integer = 0
+            Optional isSelectCase As Boolean = False
         ) As BoundExpression
 
             Debug.Assert(left.IsValue)
@@ -498,7 +495,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Not (left.HasErrors OrElse right.HasErrors) Then
                 Dim integerOverflow As Boolean = False
                 Dim divideByZero As Boolean = False
-                Dim compoundLengthOutOfLimit As Boolean = False
+                Dim lengthOutOfLimit As Boolean = False
 
                 value = OverloadResolution.TryFoldConstantBinaryOperator(operatorKind,
                                                                          left,
@@ -506,16 +503,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                          operatorResultType,
                                                                          integerOverflow,
                                                                          divideByZero,
-                                                                         compoundLengthOutOfLimit,
-                                                                         compoundStringLength)
+                                                                         lengthOutOfLimit)
 
                 If value IsNot Nothing Then
                     If divideByZero Then
                         Debug.Assert(value.IsBad)
                         ReportDiagnostic(diagnostics, node, ErrorFactory.ErrorInfo(ERRID.ERR_ZeroDivide))
-                    ElseIf compoundLengthOutOfLimit Then
+                    ElseIf lengthOutOfLimit Then
                         Debug.Assert(value.IsBad)
-                        ReportDiagnostic(diagnostics, node, ErrorFactory.ErrorInfo(ERRID.ERR_ConstantStringTooLong))
+                        ReportDiagnostic(diagnostics, right.Syntax, ErrorFactory.ErrorInfo(ERRID.ERR_ConstantStringTooLong))
                     ElseIf (value.IsBad OrElse integerOverflow) Then
                         ' Overflows are reported regardless of the value of OptionRemoveIntegerOverflowChecks, Dev10 behavior.
                         ReportDiagnostic(diagnostics, node, ErrorFactory.ErrorInfo(ERRID.ERR_ExpressionOverflow1, operatorResultType))

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
@@ -349,13 +349,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim intOverflow As Boolean = False
             Dim divideByZero As Boolean = False
-            Dim compoundLengthOutOfLimit As Boolean = False
+            Dim lengthOutOfLimit As Boolean = False
 
-            Dim constant = OverloadResolution.TryFoldConstantBinaryOperator(binaryOpKind, left, right, resultType, intOverflow, divideByZero, compoundLengthOutOfLimit)
+            Dim constant = OverloadResolution.TryFoldConstantBinaryOperator(binaryOpKind, left, right, resultType, intOverflow, divideByZero, lengthOutOfLimit)
             If constant IsNot Nothing AndAlso
                 Not divideByZero AndAlso
                 Not (intOverflow And isChecked) AndAlso
-                Not compoundLengthOutOfLimit Then
+                Not lengthOutOfLimit Then
 
                 Debug.Assert(Not constant.IsBad)
                 Return New BoundLiteral(syntax, constant, resultType)

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -2440,7 +2440,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants..
+        '''  Looks up a localized string similar to Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants..
         '''</summary>
         Friend ReadOnly Property ERR_ConstantStringTooLong() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5331,7 +5331,7 @@
     <value>Unused import statement</value>
   </data>
   <data name="ERR_ConstantStringTooLong" xml:space="preserve">
-    <value>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</value>
+    <value>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</value>
   </data>
   <data name="ERR_LanguageVersion" xml:space="preserve">
     <value>Visual Basic {0} does not support {1}.</value>

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.cs.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Délka řetězcové konstanty přesahuje aktuální limit paměti. Zkuste řetězec rozdělit do několika konstant.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Délka řetězcové konstanty přesahuje aktuální limit paměti. Zkuste řetězec rozdělit do několika konstant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.de.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Die Länge der Zeichenfolgenkonstante überschreitet das aktuelle Speicherlimit. Versuchen Sie, die Zeichenfolge in mehrere Konstanten aufzuteilen.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Die Länge der Zeichenfolgenkonstante überschreitet das aktuelle Speicherlimit. Versuchen Sie, die Zeichenfolge in mehrere Konstanten aufzuteilen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.es.xlf
@@ -8760,8 +8760,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">La longitud de la constante de cadena supera el límite de memoria actual. Pruebe dividiendo la cadena en varias constantes.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">La longitud de la constante de cadena supera el límite de memoria actual. Pruebe dividiendo la cadena en varias constantes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.fr.xlf
@@ -8760,8 +8760,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">La longueur de la constante de chaîne dépasse la limite de mémoire actuelle. Essayez de fractionner la chaîne en plusieurs constantes.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">La longueur de la constante de chaîne dépasse la limite de mémoire actuelle. Essayez de fractionner la chaîne en plusieurs constantes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.it.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">La lunghezza della costante di stringa supera il limite di memoria corrente. Provare a dividere la stringa in più costanti.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">La lunghezza della costante di stringa supera il limite di memoria corrente. Provare a dividere la stringa in più costanti.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ja.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">文字列定数の長さが現在のメモリの制限を超えています。文字列を複数の定数に分割してください。</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">文字列定数の長さが現在のメモリの制限を超えています。文字列を複数の定数に分割してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ko.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">문자열 상수의 길이가 현재 메모리 제한을 초과합니다. 문자열을 여러 상수로 분할해 보세요.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">문자열 상수의 길이가 현재 메모리 제한을 초과합니다. 문자열을 여러 상수로 분할해 보세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pl.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Długość stałej typu String przekracza bieżący limit pamięci. Spróbuj podzielić ciąg na wiele stałych.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Długość stałej typu String przekracza bieżący limit pamięci. Spróbuj podzielić ciąg na wiele stałych.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.pt-BR.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">O comprimento da constante de cadeia de caracteres excede o limite de memória atual.  Tente dividir a cadeia de caracteres em várias constantes.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">O comprimento da constante de cadeia de caracteres excede o limite de memória atual.  Tente dividir a cadeia de caracteres em várias constantes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.ru.xlf
@@ -8760,8 +8760,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Длина строковой константы превышает текущий предельный объем памяти. Попробуйте разбить строку на несколько констант.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Длина строковой константы превышает текущий предельный объем памяти. Попробуйте разбить строку на несколько констант.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.tr.xlf
@@ -8760,8 +8760,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">Dize Uzunluğu sabiti geçerli hafıza sınırını aşıyor. Dizeyi birden fazla sabit içine bölmeyi deneyin.</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">Dize Uzunluğu sabiti geçerli hafıza sınırını aşıyor. Dizeyi birden fazla sabit içine bölmeyi deneyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hans.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">字符串常量的长度超出了当前内存限制。请尝试将字符串拆分成多个常量。</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">字符串常量的长度超出了当前内存限制。请尝试将字符串拆分成多个常量。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
+++ b/src/Compilers/VisualBasic/Portable/xlf/VBResources.zh-Hant.xlf
@@ -8759,8 +8759,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ConstantStringTooLong">
-        <source>Length of String constant exceeds current memory limit.  Try splitting the string into multiple constants.</source>
-        <target state="translated">字串常數的長度超過目前的記憶體限制。請嘗試將字串分割成多個常數。</target>
+        <source>Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.</source>
+        <target state="needs-review-translation">字串常數的長度超過目前的記憶體限制。請嘗試將字串分割成多個常數。</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_LanguageVersion">

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.IO
+Imports System.Text
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.SpecialType
@@ -1417,6 +1418,88 @@ BC42038: This expression will always evaluate to Nothing (due to null propagatio
                         Throw ExceptionUtilities.UnexpectedValue(i)
                 End Select
             Next
+        End Sub
+
+        <Fact, WorkItem(529600, "DevDiv"), WorkItem(37572, "https://github.com/dotnet/roslyn/issues/37572")>
+        Public Sub Bug529600()
+
+            Dim compilationDef =
+<compilation>
+    <file name="a.vb">
+Module M
+    Sub Main()
+    End Sub
+
+    Const c0 = "<%= New String("0"c, 65000) %>"
+
+    Const C1=C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + C0 + 
+             C0
+
+    Const C2=C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + C1 + 
+             C1
+
+End Module
+    </file>
+</compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilation(compilationDef)
+
+            Dim err = compilation.GetDiagnostics().Single()
+
+            Assert.Equal(ERRID.ERR_ConstantStringTooLong, err.Code)
+            Assert.Equal("Length of String constant resulting from concatenation exceeds System.Int32.MaxValue.  Try splitting the string into multiple constants.", err.GetMessage(EnsureEnglishUICulture.PreferredOrNull))
+        End Sub
+
+        <Fact, WorkItem(37572, "https://github.com/dotnet/roslyn/issues/37572")>
+        Public Sub TestLargeStringConcatenation()
+
+            Dim mid = New StringBuilder()
+            For i As Integer = 0 To 4999
+                mid.Append("""Lorem ipsum dolor sit amet"" + "", consectetur adipiscing elit, sed"" + "" do eiusmod tempor incididunt"" + "" ut labore et dolore magna aliqua. "" +" + vbCrLf)
+            Next
+            Dim compilationDef =
+<compilation>
+    <file name="a.vb">
+Module M
+    Sub Main()
+        Dim s As String = "BEGIN "+
+        <%= mid.ToString() %> "END"
+        System.Console.WriteLine(System.Linq.Enumerable.Sum(s, Function(c As Char) System.Convert.ToInt32(c)))
+    End Sub
+End Module
+    </file>
+</compilation>
+            Dim compilation = CompilationUtils.CreateCompilation(compilationDef, options:=TestOptions.ReleaseExe)
+            compilation.VerifyDiagnostics()
+            CompileAndVerify(compilation, expectedOutput:="58430604")
         End Sub
 
     End Class


### PR DESCRIPTION
Fixes #7398
Fixes #37572
Relates to https://github.com/aspnet/Razor/issues/614 and many other customer accomodations that are no longer needed.

History of this bug:  When constant folding a long sequence of string concatentations, there is an intermediate constant value for every left-hand operand.  So the total memory consumed to compute the whole concatenation was *O(n^2)*.  The compiler would simply perform this work and eventually run out of memory, simply crashing with no useful diagnostic.  Later, the concatenation implementation was instrumented so it would detect when it was likely to run out of memory soon, and would instead report a diagnostic at the last step. See https://github.com/dotnet/roslyn/commit/f177077665a5bef862014f1898b961d1759c9248.  Test `Bug529600()` was added to demonstrate that we produced a diagnostic.  However, the compiler still consumed *O(n^2)* memory for the concatenation and this test used to consume so much memory that it would cause other tests running in parallel to fail because they might not have enough memory to succeed.  So the test was disabled and eventually removed.  The compiler would still crash with programs containing large string concatenations, or consume huge amounts of memory and take a long time before reporting a diagnostic, so the underlying problem had not been addressed.

Here we have revised the implementation of constant folding string concatenations so that it requires *O(n)* memory and remove the old instrumentation.  As a consequence the test `Bug529600()` now runs very quickly and does not consume gobs of memory.
