### PR TITLE
Mark M.VS.LanguageServer.Client as a private package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -245,6 +245,7 @@
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Language.Intellisense" />
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Language.NavigateTo.Interfaces" />
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Language.StandardClassification" />
+    <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.LanguageServer.Client" />
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.OLE.Interop" />
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Progression.CodeSchema" />
     <PrivateVisualStudioPackage Include="Microsoft.VisualStudio.Progression.Common" />


### PR DESCRIPTION
New VS dependency should be marked as a private package.