### PR TITLE
Couple of fixes in analyzer drive in presence of editorconfig configu…

### DIFF
--- a/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -1828,5 +1828,54 @@ namespace Microsoft.CodeAnalysis
                 context.ReportSuppression(Suppression.Create(_descriptor2, nonReportedDiagnostic));
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class AnalyzerWithNoLocationDiagnostics : DiagnosticAnalyzer
+        {
+            public AnalyzerWithNoLocationDiagnostics(bool isEnabledByDefault)
+            {
+                Descriptor = new DiagnosticDescriptor(
+                    "ID0001",
+                    "Title1",
+                    "Message1",
+                    "Category1",
+                    defaultSeverity: DiagnosticSeverity.Warning,
+                    isEnabledByDefault);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationAction(compilationContext =>
+                    compilationContext.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None)));
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class NamedTypeAnalyzerWithConfigurableEnabledByDefault : DiagnosticAnalyzer
+        {
+            public NamedTypeAnalyzerWithConfigurableEnabledByDefault(bool isEnabledByDefault)
+            {
+                Descriptor = new DiagnosticDescriptor(
+                    "ID0001",
+                    "Title1",
+                    "Message1",
+                    "Category1",
+                    defaultSeverity: DiagnosticSeverity.Warning,
+                    isEnabledByDefault);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterSymbolAction(
+                    context => context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Symbol.Locations[0])),
+                    SymbolKind.NamedType);
+            }
+        }
     }
 }

--- a/src/Test/Utilities/Portable/Diagnostics/ReportDiagnosticExtensions.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/ReportDiagnosticExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class ReportDiagnosticExtensions
+    {
+        public static string ToAnalyzerConfigString(this ReportDiagnostic reportDiagnostic)
+        {
+            return reportDiagnostic switch
+            {
+                ReportDiagnostic.Error => "error",
+                ReportDiagnostic.Warn => "warning",
+                ReportDiagnostic.Info => "suggestion",
+                ReportDiagnostic.Hidden => "silent",
+                ReportDiagnostic.Suppress => "none",
+                _ => throw ExceptionUtilities.Unreachable,
+            };
+        }
+    }
+}


### PR DESCRIPTION
…ration

Fixes #37876

1. For analyzer diagnostics with Location.None, we now apply diagnostic configuration based on editorconfig files, as long as there is at least one configuration entry and there is no mismatch between configuration entries in different editorconfig files.

2. Analyzers which are disabled by default are now properly enabled when there is any editorconfig entry for its reported descriptor(s) that enables them.