### PR TITLE
Support multiple insertion text property names

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 => new TCompletionItem
                 {
                     Label = item.DisplayText,
-                    InsertText = item.Properties.ContainsKey("InsertionText") ? item.Properties["InsertionText"] : item.DisplayText,
+                    InsertText = item.GetInsertionText(),
                     SortText = item.SortText,
                     FilterText = item.FilterText,
                     Kind = GetCompletionKind(item.Tags),

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionItemExtensions.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionItemExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Completion;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+
+    internal static class CompletionItemExtensions
+    {
+
+        // A list of the different property names that the insertion text of a completion item may be stored under.
+        private static readonly string[] InsertionTextPropertyNames = new string[] { "InsertionText", "InsertText" };
+
+        internal static string GetInsertionText(this CompletionItem item)
+        {
+            foreach (var insertionTextPropertyName in InsertionTextPropertyNames)
+            {
+                if (item.Properties.ContainsKey(insertionTextPropertyName))
+                {
+                    return item.Properties[insertionTextPropertyName];
+                }
+            }
+            return item.DisplayText;
+        }
+    }
+
+}


### PR DESCRIPTION
This change fixes a bug where if the guest invokes completion in a Live Share session in a ts file and selects an IntelliCode completion, the star will also be inserted (e.g.  console.★ log).

We were previously trying to extract the insertion text on the completion item by looking at the "InsertionText" property. TS IntelliCode uses "InsertionText" for their property name.

This same change was made in the Live Share code base and was never migrated to Roslyn. See [here](https://devdiv.visualstudio.com/DevDiv/_git/Cascade/pullrequest/189799?_a=overview). 