### PR TITLE
Update MS.CA.EditorFeatures2.UnitTests splitting

### DIFF
--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -300,7 +300,7 @@ namespace RunTests
                 // bottleneck.  Can adjust as we get real data.
                 if (name == "Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.dll" ||
                     name == "Microsoft.CodeAnalysis.EditorFeatures.UnitTests.dll" ||
-                    name == "Roslyn.Services.Editor.UnitTests2.dll" ||
+                    name == "Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" ||
                     name == "Microsoft.VisualStudio.LanguageServices.UnitTests.dll" ||
                     name == "Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.dll" ||
                     name == "Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.dll")


### PR DESCRIPTION
This DLL should be marked for splitting in our test runner. When we did
the great assembly rename though this was missed. Fixing.