### PR TITLE
Ensure SplitStringLiteralCommandHandler is ordered after the completion handler

### DIFF
--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
@@ -2,12 +2,14 @@
 
 using System.ComponentModel.Composition;
 using System.Threading;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -21,6 +23,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
     [Export(typeof(VSCommanding.ICommandHandler))]
     [ContentType(ContentTypeNames.CSharpContentType)]
     [Name(nameof(SplitStringLiteralCommandHandler))]
+    [Order(After = PredefinedCommandHandlerNames.Completion)]
+    [Order(After = PredefinedCompletionNames.CompletionCommandHandler)]
     internal partial class SplitStringLiteralCommandHandler : VSCommanding.ICommandHandler<ReturnKeyCommandArgs>
     {
         private readonly ITextUndoHistoryRegistry _undoHistoryRegistry;


### PR DESCRIPTION
Since we started using `RegexEmbeddedCompletionProvider`, we noticed a regression where completing on a suggestion, inserted a new line, instead of the suggestion. 

On VS for Mac, it seems that the command handlers are loaded in an order that causes that particular regression, and makes `SplitStringLiteralCommandHandler` the first one that is invoked. On Windows, this doesn't appear to be the problem. 

We filed our regression under: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/951939

Note: this same change was done here https://github.com/dotnet/roslyn/blob/5a12be6a4002fb2ffa3d8d2ecbe81d4bc30d213a/src/EditorFeatures/CSharp/BlockCommentEditing/BlockCommentEditingCommandHandler.cs#L23 to fix a similar problem. I've tested the fix manually by dropping the compiled DLL into our app package, and it does fix the problem. I'm happy to write more specific tests though, if anyone has a requirement/idea.