### PR TITLE
VB DIM work

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -54164,5 +54164,242 @@ public interface I2 : I1
                 );
         }
 
+        [ConditionalFact(typeof(MonoOrCoreClrOnly))]
+        public void ImplicitImplementationOfNonPublicMethod_01()
+        {
+            var ilSource = @"
+.class interface public abstract auto ansi I1
+{
+  .method assembly hidebysig newslot strict virtual 
+          instance string  M() cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      ""I1.M""
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method I1::M
+
+  .method public hidebysig instance string 
+          Test() cil managed
+  {
+    // Code size       12 (0xc)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance string I1::M()
+    IL_0007:  stloc.0
+    IL_0008:  br.s       IL_000a
+
+    IL_000a:  ldloc.0
+    IL_000b:  ret
+  } // end of method I1::Test
+
+} // end of class I1
+
+.class public auto ansi beforefieldinit C0
+       extends System.Object
+       implements I1
+{
+  .method public hidebysig newslot virtual 
+          instance string  M() cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      ""C0.M""
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method C0::M
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method C0::.ctor
+
+} // end of class C0
+";
+
+            var source1 =
+@"
+class Test
+{
+    static void Main()
+    {
+        I1 x = new C0();
+        System.Console.WriteLine(x.Test());
+    }
+}
+";
+            var compilation1 = CreateCompilationWithIL(source1, ilSource, options: TestOptions.DebugExe, targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, expectedOutput: "C0.M");
+
+            var c0 = compilation1.GetTypeByMetadataName("C0");
+            var i1M = compilation1.GetMember<MethodSymbol>("I1.M");
+
+            Assert.Equal("System.String C0.M()", c0.FindImplementationForInterfaceMember(i1M).ToTestDisplayString());
+        }
+
+        [ConditionalFact(typeof(MonoOrCoreClrOnly))]
+        public void ImplicitImplementationOfNonPublicMethod_02()
+        {
+            var ilSource = @"
+.class interface public abstract auto ansi I1
+{
+  .method assembly hidebysig newslot strict virtual 
+          instance string  M() cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      ""I1.M""
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method I1::M
+
+  .method public hidebysig instance string 
+          Test() cil managed
+  {
+    // Code size       12 (0xc)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  callvirt   instance string I1::M()
+    IL_0007:  stloc.0
+    IL_0008:  br.s       IL_000a
+
+    IL_000a:  ldloc.0
+    IL_000b:  ret
+  } // end of method I1::Test
+
+} // end of class I1
+
+.class public auto ansi beforefieldinit C0
+       extends System.Object
+       implements I1
+{
+  .method public hidebysig newslot virtual 
+          instance string  M() cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      ""C0.M""
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method C0::M
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method C0::.ctor
+
+} // end of class C0
+";
+
+            var source1 =
+@"
+class Test : C0, I1
+{
+    static void Main()
+    {
+        I1 x = new Test();
+        System.Console.WriteLine(x.Test());
+    }
+}
+";
+            var compilation1 = CreateCompilationWithIL(source1, ilSource, options: TestOptions.DebugExe, targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, expectedOutput: "C0.M");
+
+            var test = compilation1.GetTypeByMetadataName("Test");
+            var i1M = compilation1.GetMember<MethodSymbol>("I1.M");
+
+            Assert.Equal("System.String C0.M()", test.FindImplementationForInterfaceMember(i1M).ToTestDisplayString());
+        }
+
+        [Fact]
+        public void ImplicitImplementationOfNonPublicMethod_03()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    internal string M()
+    {
+        return ""I1.M"";
+    }
+
+    public sealed string Test()
+    {
+        return M();
+    }
+}
+
+public class C0 : I1
+{
+    public virtual string M()
+    {
+        return ""C0.M"";
+    }
+}
+
+class Test : C0, I1
+{
+    static void Main()
+    {
+        I1 x = new Test();
+        System.Console.WriteLine(x.Test());
+    }
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugExe, targetFramework: TargetFramework.NetStandardLatest);
+
+            var i1M = compilation1.GetMember<MethodSymbol>("I1.M");
+            var c0 = compilation1.GetTypeByMetadataName("C0");
+            var test = compilation1.GetTypeByMetadataName("Test");
+
+            Assert.Equal("System.String C0.M()", c0.FindImplementationForInterfaceMember(i1M).ToTestDisplayString());
+            Assert.Equal("System.String C0.M()", test.FindImplementationForInterfaceMember(i1M).ToTestDisplayString());
+
+            compilation1.VerifyDiagnostics(
+                // (15,19): error CS8704: 'C0' does not implement interface member 'I1.M()'. 'C0.M()' cannot implicitly implement a non-public member.
+                // public class C0 : I1
+                Diagnostic(ErrorCode.ERR_ImplicitImplementationOfNonPublicInterfaceMember, "I1").WithArguments("C0", "I1.M()", "C0.M()").WithLocation(15, 19)
+                );
+        }
+
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -752,7 +752,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                              MethodAttributes.Final Or
                              MethodAttributes.Abstract Or
                              MethodAttributes.NewSlot)) =
-                        (MethodAttributes.Virtual Or MethodAttributes.Final)
+                        If(_containingType.IsInterface,
+                           MethodAttributes.Virtual Or MethodAttributes.Final Or MethodAttributes.Abstract,
+                           MethodAttributes.Virtual Or MethodAttributes.Final)
             End Get
         End Property
 
@@ -782,7 +784,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                                      MethodAttributes.NewSlot))
 
                 Return flagsToCheck = (MethodAttributes.Virtual Or MethodAttributes.NewSlot) OrElse
-                       (flagsToCheck = MethodAttributes.Virtual AndAlso _containingType.BaseTypeNoUseSiteDiagnostics Is Nothing)
+                       (Not _containingType.IsInterface AndAlso
+                        flagsToCheck = MethodAttributes.Virtual AndAlso _containingType.BaseTypeNoUseSiteDiagnostics Is Nothing)
             End Get
         End Property
 
@@ -795,7 +798,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 '
                 ' This means that a virtual method without NewSlot flag in a type that doesn't have a base
                 ' is a new virtual method and doesn't override anything.
-                Return (_flags And MethodAttributes.Virtual) <> 0 AndAlso
+                Return Not _containingType.IsInterface AndAlso
+                       (_flags And MethodAttributes.Virtual) <> 0 AndAlso
                        (_flags And MethodAttributes.NewSlot) = 0 AndAlso
                        _containingType.BaseTypeNoUseSiteDiagnostics IsNot Nothing
             End Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -363,6 +363,7 @@ DoneWithErrorReporting:
                             resultKind = LookupResult.WorseResultKind(resultKind, lookup.Kind)
                             If Not binder.IsAccessible(foundMember, useSiteDiagnostics) Then
                                 resultKind = LookupResult.WorseResultKind(resultKind, LookupResultKind.Inaccessible) ' we specified IgnoreAccessibility above.
+                                Binder.ReportDiagnostic(diagBag, implementedMemberSyntax, binder.GetInaccessibleErrorInfo(foundMember))
                             End If
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -208,7 +208,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     ' Note that in metadata, you can encounter methods that are static (shared) or non-virtual 
                     ' (for example TLBIMP VtblGap members), even though you can't define those in source.
                     Return sym.ContainingType.IsInterfaceType() AndAlso
-                           Not sym.IsShared AndAlso
+                           Not sym.IsShared AndAlso Not sym.IsNotOverridable AndAlso
                            (sym.IsMustOverride OrElse sym.IsOverridable)
                 Case Else
                     Return False

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             End Get
         End Property
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35820")>
+        <Fact>
         <WorkItem(35820, "https://github.com/dotnet/roslyn/issues/35820")>
         Public Sub MethodImplementation_01()
 
@@ -2915,7 +2915,7 @@ BC30389: 'I1.T1' is not accessible in this context because it is 'Private Protec
 </error>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35820")>
+        <Fact>
         <WorkItem(35820, "https://github.com/dotnet/roslyn/issues/35820")>
         Public Sub PropertyImplementation_001()
 
@@ -2940,7 +2940,7 @@ End Class
             Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
             comp1.AssertTheseDiagnostics(
 <errors>
-BC30149: Class 'C' must implement 'P1' for interface 'I1'.
+BC30149: Class 'C' must implement 'Property P1 As Integer' for interface 'I1'.
     Implements I1
                ~~
 </errors>
@@ -6580,7 +6580,7 @@ BC31103: 'Get' accessor of property 'P1' is not accessible.
 </error>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35820")>
+        <Fact>
         <WorkItem(35820, "https://github.com/dotnet/roslyn/issues/35820")>
         Public Sub PropertyImplementation_089()
 
@@ -6605,7 +6605,7 @@ End Class
             Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
             comp1.AssertTheseDiagnostics(
 <errors>
-BC30149: Class 'C' must implement 'P1' for interface 'I1'.
+BC30149: Class 'C' must implement 'ReadOnly Property P1 As Integer' for interface 'I1'.
     Implements I1
                ~~
 </errors>
@@ -7846,7 +7846,7 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Frie
 </error>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35820")>
+        <Fact>
         <WorkItem(35820, "https://github.com/dotnet/roslyn/issues/35820")>
         Public Sub PropertyImplementation_122()
 
@@ -7871,7 +7871,7 @@ End Class
             Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
             comp1.AssertTheseDiagnostics(
 <errors>
-BC30149: Class 'C' must implement 'P1' for interface 'I1'.
+BC30149: Class 'C' must implement 'WriteOnly Property P1 As Integer' for interface 'I1'.
     Implements I1
                ~~
 </errors>
@@ -9114,7 +9114,7 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Frie
 </error>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35820")>
+        <Fact>
         <WorkItem(35820, "https://github.com/dotnet/roslyn/issues/35820")>
         Public Sub EventImplementation_01()
 
@@ -9139,7 +9139,7 @@ End Class
             Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
             comp1.AssertTheseDiagnostics(
 <errors>
-BC30149: Class 'C' must implement 'P1' for interface 'I1'.
+BC30149: Class 'C' must implement 'Event P1 As Action' for interface 'I1'.
     Implements I1
                ~~
 </errors>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -280,9 +280,11 @@ End Class
 
             Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
 
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect an error: 'I1.M1' is inaccessible due to its protection level 
             comp1.AssertTheseDiagnostics(
 <errors>
+BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Friend'.
+    Sub M1() Implements I1.M1
+                        ~~~~~
 </errors>
             )
         End Sub
@@ -333,6 +335,9 @@ End Class
 BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected'.
             i2.M1()
             ~~~~~
+BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected'.
+    Sub M1() Implements I1.M1
+                        ~~~~~
 </error>)
 #End If
         End Sub
@@ -384,6 +389,9 @@ End Class
 BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected Friend'.
             i2.M1()
             ~~~~~
+BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected Friend'.
+    Sub M1() Implements I1.M1
+                        ~~~~~
 </error>)
 #End If
         End Sub
@@ -415,9 +423,11 @@ End Class
 
             Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
 
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect an error: 'I1.M1' is inaccessible due to its protection level 
             comp1.AssertTheseDiagnostics(
 <errors>
+BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Private Protected'.
+    Sub M1() Implements I1.M1
+                        ~~~~~
 </errors>
             )
         End Sub
@@ -1262,6 +1272,9 @@ End Class
 BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected'.
             i2.M1()
             ~~~~~
+BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected'.
+    Sub M1() Implements I1.M1
+                        ~~~~~
 </error>)
         End Sub
 
@@ -1309,6 +1322,9 @@ End Class
 BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected Friend'.
             i2.M1()
             ~~~~~
+BC30390: 'I1.Sub M1()' is not accessible in this context because it is 'Protected Friend'.
+    Sub M1() Implements I1.M1
+                        ~~~~~
 </error>)
         End Sub
 
@@ -3189,14 +3205,21 @@ End Class
 Public Class C2
     Implements I1
 
-    Property P1 As Integer Implements I1.P1
+    Property P1 As Integer Implements I1.P1 ' 2
 End Class
 ]]></file>
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Property P1 As Integer Implements I1.P1 ' 2
+                                      ~~~~~
+</expected>)
         End Sub
 
         <Fact>
@@ -3335,6 +3358,9 @@ C.P1.Set", Nothing), verify:=VerifyOnMonoOrCoreClr)
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             i2.P1 += 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
 </error>)
 #End If
         End Sub
@@ -3509,6 +3535,9 @@ C.P1.Set", Nothing), verify:=VerifyOnMonoOrCoreClr)
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             i2.P1 += 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
 </error>)
 #End If
         End Sub
@@ -3660,14 +3689,21 @@ End Class
 Public Class C2
     Implements I1
 
-    Property P1 As Integer Implements I1.P1
+    Property P1 As Integer Implements I1.P1 ' 2
 End Class
 ]]></file>
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Property P1 As Integer Implements I1.P1 ' 2
+                                      ~~~~~
+</expected>)
         End Sub
 
         <Fact>
@@ -6352,6 +6388,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             i2.P1 += 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
 </error>)
         End Sub
 
@@ -6487,6 +6526,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             i2.P1 += 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
 </error>)
         End Sub
 
@@ -6837,14 +6879,21 @@ End Class
 Public Class C2
     Implements I1
 
-    Readonly Property P1 As Integer Implements I1.P1
+    Readonly Property P1 As Integer Implements I1.P1 ' 2
 End Class
 ]]></file>
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Readonly Property P1 As Integer Implements I1.P1
+                                               ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Readonly Property P1 As Integer Implements I1.P1 ' 2
+                                               ~~~~~
+</expected>)
         End Sub
 
         <Fact>
@@ -6896,6 +6945,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             Dim x = i2.P1
                     ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Readonly Property P1 As Integer Implements I1.P1
+                                               ~~~~~
 </error>)
 #End If
         End Sub
@@ -6949,6 +7001,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             Dim x = i2.P1
                     ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Readonly Property P1 As Integer Implements I1.P1
+                                               ~~~~~
 </error>)
 #End If
         End Sub
@@ -6982,14 +7037,21 @@ End Class
 Public Class C2
     Implements I1
 
-    Readonly Property P1 As Integer Implements I1.P1
+    Readonly Property P1 As Integer Implements I1.P1 ' 2
 End Class
 ]]></file>
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Readonly Property P1 As Integer Implements I1.P1
+                                               ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Readonly Property P1 As Integer Implements I1.P1 ' 2
+                                               ~~~~~
+</expected>)
         End Sub
 
         <Fact>
@@ -7798,6 +7860,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             Dim x = i2.P1
                     ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Readonly Property P1 As Integer Implements I1.P1
+                                               ~~~~~
 </error>)
         End Sub
 
@@ -7843,6 +7908,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             Dim x = i2.P1
                     ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Readonly Property P1 As Integer Implements I1.P1
+                                               ~~~~~
 </error>)
         End Sub
 
@@ -8105,8 +8173,16 @@ End Class
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Writeonly Property P1 As Integer Implements I1.P1
+                                                ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
+</expected>
+            )
         End Sub
 
         <Fact>
@@ -8157,6 +8233,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             i2.P1 = 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Writeonly Property P1 As Integer Implements I1.P1
+                                                ~~~~~
 </error>)
 #End If
         End Sub
@@ -8209,6 +8288,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             i2.P1 = 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Writeonly Property P1 As Integer Implements I1.P1
+                                                ~~~~~
 </error>)
 #End If
         End Sub
@@ -8247,8 +8329,15 @@ End Class
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Writeonly Property P1 As Integer Implements I1.P1
+                                                ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
+</expected>)
         End Sub
 
         <Fact>
@@ -9066,6 +9155,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             i2.P1 = 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
 </error>)
         End Sub
 
@@ -9111,6 +9203,9 @@ End Class
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             i2.P1 = 1
             ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Property P1 As Integer Implements I1.P1
+                                      ~~~~~
 </error>)
         End Sub
 
@@ -9401,8 +9496,15 @@ End Class
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Custom Event P1 As System.Action Implements I1.P1
+                                                ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
+    Event P1 As System.Action Implements I1.P1
+                                         ~~~~~
+</expected>)
         End Sub
 
         <Fact>
@@ -9464,6 +9566,9 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             RemoveHandler i2.P1, Nothing
                           ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Custom Event P1 As System.Action Implements I1.P1
+                                                ~~~~~
 </error>)
 #End If
         End Sub
@@ -9527,6 +9632,9 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Frie
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             RemoveHandler i2.P1, Nothing
                           ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Custom Event P1 As System.Action Implements I1.P1
+                                                ~~~~~
 </error>)
 #End If
         End Sub
@@ -9569,8 +9677,16 @@ End Class
 </compilation>
 
             Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
-            ' https://github.com/dotnet/roslyn/issues/35824 - Expect two errors: 'I1.P1' is inaccessible due to its protection level 
-            comp1.AssertTheseDiagnostics()
+            comp1.AssertTheseDiagnostics(
+<expected>
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Custom Event P1 As System.Action Implements I1.P1
+                                                ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
+    Event P1 As System.Action Implements I1.P1
+                                         ~~~~~
+</expected>
+            )
         End Sub
 
         <Fact>
@@ -10514,6 +10630,9 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
             RemoveHandler i2.P1, Nothing
                           ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected'.
+    Event P1 As System.Action Implements I1.P1
+                                         ~~~~~
 </error>)
         End Sub
 
@@ -10563,6 +10682,9 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Frie
 BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
             RemoveHandler i2.P1, Nothing
                           ~~~~~
+BC30389: 'I1.P1' is not accessible in this context because it is 'Protected Friend'.
+    Event P1 As System.Action Implements I1.P1
+                                         ~~~~~
 </error>)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -176,7 +176,7 @@ End Class
             CompileAndVerify(comp1, expectedOutput:=If(ExecutionConditionUtil.IsMonoOrCoreClr, "C.M1", Nothing), verify:=VerifyOnMonoOrCoreClr)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub MethodImplementation_05()
 
@@ -213,7 +213,7 @@ BC30149: Class 'C' must implement 'Sub M1()' for interface 'I1'.
             )
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub MethodImplementation_06()
 
@@ -3073,7 +3073,7 @@ End Class
 C.P1.Set", Nothing), verify:=VerifyOnMonoOrCoreClr)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub PropertyImplementation_005()
 
@@ -3110,7 +3110,7 @@ BC30149: Class 'C' must implement 'Property P1 As Integer' for interface 'I1'.
             )
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub PropertyImplementation_006()
 
@@ -6728,7 +6728,7 @@ End Class
             CompileAndVerify(comp1, expectedOutput:=If(ExecutionConditionUtil.IsMonoOrCoreClr, "C.P1.Get", Nothing), verify:=VerifyOnMonoOrCoreClr)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub PropertyImplementation_093()
 
@@ -6765,7 +6765,7 @@ BC30149: Class 'C' must implement 'ReadOnly Property P1 As Integer' for interfac
             )
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub PropertyImplementation_094()
 
@@ -7992,7 +7992,7 @@ End Class
             CompileAndVerify(comp1, expectedOutput:=If(ExecutionConditionUtil.IsMonoOrCoreClr, "C.P1.Set", Nothing), verify:=VerifyOnMonoOrCoreClr)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub PropertyImplementation_126()
 
@@ -8029,7 +8029,7 @@ BC30149: Class 'C' must implement 'WriteOnly Property P1 As Integer' for interfa
             )
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub PropertyImplementation_127()
 
@@ -9276,7 +9276,7 @@ End Class
 C.P1.Remove", Nothing), verify:=VerifyOnMonoOrCoreClr)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub EventImplementation_05()
 
@@ -9313,7 +9313,7 @@ BC30149: Class 'C' must implement 'Event P1 As Action' for interface 'I1'.
             )
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/35823")>
+        <Fact>
         <WorkItem(35823, "https://github.com/dotnet/roslyn/issues/35823")>
         Public Sub EventImplementation_06()
 


### PR DESCRIPTION
- Do not require to implement a method representing a re-abstraction of an interface method from base interface. Closes #35823.
- Enable tests verifying that class is required to implement a virtual interface method. Closes #35820.
- Report an attempt to implement an inaccessible interface member. Closes #35824.