### PR TITLE
Writing code to call a function using identifiers that don’t exist yet

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5644,6 +5644,49 @@ class C
                 state.AssertCompletionItemsContainAll({"Length"})
             End Using
         End Function
+
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        <MemberData(NameOf(AllCompletionImplementations))>
+        Public Async Function CompletingWithColonInMethodParametersWithNoInstanceToInsert(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+<Document><![CDATA[class C
+{
+    void M(string s)
+    {
+        N(10, $$);
+    }
+
+    void N(int id, string serviceName) {}
+}]]></Document>)
+
+                state.SendTypeChars("serviceN")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars(":")
+                Assert.Contains("N(10, serviceName:);", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        <MemberData(NameOf(AllCompletionImplementations))>
+        Public Async Function CompletingWithSpaceInMethodParametersWithNoInstanceToInsert(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+<Document><![CDATA[class C
+{
+    void M(string s)
+    {
+        N(10, $$);
+    }
+
+    void N(int id, string serviceName) {}
+}]]></Document>)
+
+                state.SendTypeChars("serviceN")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars(" ")
+                Assert.Contains("N(10, serviceName );", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
         Private Class MultipleChangeCompletionProvider
             Inherits CompletionProvider
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -254,10 +254,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             return Task.FromResult<TextChange?>(new TextChange(
                 selectedItem.Span,
-                // Do not insert colon on <Tab> so that user can complete out a variable name that does not currently exist.
-                // ch == null is to support the old completion only.
-                // Do not insert an extra colon if colon has been explicitly typed.
-                (ch == null || ch == '\t' || ch == ':') ? selectedItem.DisplayText : selectedItem.GetEntireDisplayText()));
+                // Insert extra colon if commiting with '(' only: "method(parameter:(" is preferred to "method(parameter(".
+                // In all other cases, do not add extra colon. Note that colon is already added if commiting with ':'.
+                ch == '(' ? selectedItem.GetEntireDisplayText() : selectedItem.DisplayText));
         }
     }
 }


### PR DESCRIPTION

Fixes https://github.com/dotnet/roslyn/issues/33667

Writing code to call a function using identifiers that don’t exist yet.

```
class Program
{
    static void Main ( string[] args )
    {
        var mySvc = new MyService(10, otherSvc, $$);
    }        
}

class MyService
{
    public MyService (int id, OtherService otherService, string name)
    {
    }
}

class OtherService
{
}
```

In this scenario I’ve just put the comma in the call to new MyService in Main. I now enter a variable name name that doesn’t exist yet. As soon as you hit space or a dot (because this is an object) then IS autocompletes to the name: parameter name. This isn’t what I wanted so I have to stop my typing, go back and correct to the variable (I haven’t defined yet) and then continue typing. In VS 2017 it doesn’t autocomplete to the parameter name. It does recognize that the parameter name is the best choice, it just doesn’t auto complete it.

**Expected by user**
`        var mySvc = new MyService(10, otherSvc, name);`
**Actual**
`        var mySvc = new MyService(10, otherSvc, name:);`