### PR TITLE
Fix calls to WaitAndGetResult in Peek

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Peek/DefinitionPeekableItem.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/DefinitionPeekableItem.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                 var workspace = _peekableItem._workspace;
                 var solution = workspace.CurrentSolution;
                 var project = solution.GetProject(_peekableItem._projectId);
-                var compilation = project.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
+                var compilation = project.GetCompilationAsync(cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken);
 
                 var symbol = _peekableItem._symbolKey.Resolve(compilation, ignoreAssemblyKey: true, cancellationToken: cancellationToken).Symbol;
                 if (symbol == null)
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
                 if (!sourceLocations.Any())
                 {
                     // It's a symbol from metadata, so we want to go produce it from metadata
-                    var declarationFile = _peekableItem._metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, allowDecompilation: false, cancellationToken).WaitAndGetResult(cancellationToken);
+                    var declarationFile = _peekableItem._metadataAsSourceFileService.GetGeneratedFileAsync(project, symbol, allowDecompilation: false, cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken);
                     var peekDisplayInfo = new PeekResultDisplayInfo(declarationFile.DocumentTitle, declarationFile.DocumentTitle, declarationFile.DocumentTitle, declarationFile.DocumentTitle);
                     var identifierSpan = declarationFile.IdentifierLocation.GetLineSpan().Span;
                     var entityOfInterestSpan = PeekHelpers.GetEntityOfInterestSpan(symbol, workspace, declarationFile.IdentifierLocation, cancellationToken);


### PR DESCRIPTION
This is allowed to be called on the background thread (since that's how the editor API works), so let's mark it as such.