### PR TITLE
Annotate SymbolInfo and TypeInfo

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -20,7 +22,7 @@ namespace Microsoft.CodeAnalysis
         /// still be that case that we have one or more "best guesses" as to what symbol was
         /// intended. These best guesses are available via the CandidateSymbols property.
         /// </summary>
-        public ISymbol Symbol { get; }
+        public ISymbol? Symbol { get; }
 
         /// <summary>
         /// If the expression did not successfully resolve to a symbol, but there were one or more
@@ -71,7 +73,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        internal SymbolInfo(ISymbol symbol, ImmutableArray<ISymbol> candidateSymbols, CandidateReason candidateReason)
+        internal SymbolInfo(ISymbol? symbol, ImmutableArray<ISymbol> candidateSymbols, CandidateReason candidateReason)
             : this()
         {
             this.Symbol = symbol;
@@ -79,7 +81,7 @@ namespace Microsoft.CodeAnalysis
 
 #if DEBUG
             const NamespaceKind NamespaceKindNamespaceGroup = (NamespaceKind)0;
-            Debug.Assert((object)symbol == null || symbol.Kind != SymbolKind.Namespace || ((INamespaceSymbol)symbol).NamespaceKind != NamespaceKindNamespaceGroup);
+            Debug.Assert(symbol is null || symbol.Kind != SymbolKind.Namespace || ((INamespaceSymbol)symbol).NamespaceKind != NamespaceKindNamespaceGroup);
             foreach (var item in _candidateSymbols)
             {
                 Debug.Assert(item.Kind != SymbolKind.Namespace || ((INamespaceSymbol)item).NamespaceKind != NamespaceKindNamespaceGroup);
@@ -89,7 +91,7 @@ namespace Microsoft.CodeAnalysis
             this.CandidateReason = candidateReason;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SymbolInfo && Equals((SymbolInfo)obj);
         }

--- a/src/Compilers/Core/Portable/Compilation/TypeInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/TypeInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Roslyn.Utilities;
 
@@ -14,7 +16,7 @@ namespace Microsoft.CodeAnalysis
         /// have a type, null is returned. If the type could not be determined due to an error, then
         /// an IErrorTypeSymbol is returned.
         /// </summary>
-        public ITypeSymbol Type { get; }
+        public ITypeSymbol? Type { get; }
 
         /// <summary>
         /// The top-level nullability information of the expression represented by the syntax node.
@@ -25,7 +27,7 @@ namespace Microsoft.CodeAnalysis
         /// The type of the expression after it has undergone an implicit conversion. If the type
         /// did not undergo an implicit conversion, returns the same as Type.
         /// </summary>
-        public ITypeSymbol ConvertedType { get; }
+        public ITypeSymbol? ConvertedType { get; }
 
         /// <summary>
         /// The top-level nullability of the expression after it has undergone an implicit conversion.
@@ -34,7 +36,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public NullabilityInfo ConvertedNullability { get; }
 
-        internal TypeInfo(ITypeSymbol type, ITypeSymbol convertedType, NullabilityInfo nullability, NullabilityInfo convertedNullability)
+        internal TypeInfo(ITypeSymbol? type, ITypeSymbol? convertedType, NullabilityInfo nullability, NullabilityInfo convertedNullability)
             : this()
         {
             this.Type = type;
@@ -51,7 +53,7 @@ namespace Microsoft.CodeAnalysis
                 && this.ConvertedNullability.Equals(other.ConvertedNullability);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TypeInfo && this.Equals((TypeInfo)obj);
         }


### PR DESCRIPTION
I am leaving some constructors of SymbolInfo as taking a non-null symbol, since it appears callers do actually try to use SymbolInfo.None in those cases. As the compiler is annotated it may be necessary to change.