### PR TITLE
Move to a new Windows pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - job: Windows_Desktop_Unit_Tests
   pool:
     name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2017.Open
+    queue: BuildPool.Windows.10.Amd64.Open
   strategy:
     maxParallel: 4
     matrix:


### PR DESCRIPTION
One possible cause of our git clone issues is it seems to be specific to
the Windows 2017 pool. Trying out a new pool to see if the issues stop
reproducing there.

Further this pool doesn't have Visual Studio installed hence will
force our clean build scenarios