### PR TITLE
TypeImportCompletionItem.GetCompletionDescriptionAsync should not return null

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionItem.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 }
             }
 
-            return null;
+            return CompletionDescription.Empty;
         }
 
         private static string GetAritySuffix(int arity)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/36381
At least I could not find other provider returning null.

@genlu please let me know if you see an option to add a unit test here.