### PR TITLE
Don't include unchangeable references as renamable references

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.FindSymbols
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
     Partial Public Class FindReferencesTests
@@ -2187,5 +2188,52 @@ public class D { }
 
         End Function
 
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(963225, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/963225")>
+        Public Async Function TestNamedType_WithUnchangeableDocument_IgnoreUnchangeableDocument(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class {|Definition:$$C|}
+        {
+        }
+        </Document>
+        <Document CanApplyChange="false">
+        class D
+        {
+            private C c;
+        }
+        </Document>
+    </Project>
+</Workspace>
+
+            ' testKind.StreamingFeature doesn't support providing FindReferencesSearchOptions
+            Await TestAPI(input, host, options:=FindReferencesSearchOptions.Default.WithIgnoreUnchangeableDocuments(True))
+        End Function
+
+        <WpfTheory, CombinatorialData, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WorkItem(963225, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/963225")>
+        Public Async Function TestNamedType_WithUnchangeableDocument_NotIgnoreUnchangeableDocument(host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class {|Definition:$$C|}
+        {
+        }
+        </Document>
+        <Document CanApplyChange="false">
+        class D
+        {
+            private [|C|] c;
+        }
+        </Document>
+    </Project>
+</Workspace>
+
+            ' testKind.StreamingFeature doesn't support providing FindReferencesSearchOptions
+            Await TestAPI(input, host, options:=FindReferencesSearchOptions.Default.WithIgnoreUnchangeableDocuments(False))
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -6187,6 +6187,37 @@ End Class
             End Using
         End Sub
 
+        <WorkItem(963225, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/963225")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameShouldIgnoreUnchangeableDocument()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#">
+                        <Document>
+                            class [|$$A|]
+                            {
+                                void M()
+                                {
+                                    [|A|] a = new [|A|]();
+                                }
+                            }
+                        </Document>
+                        <Document CanApplyChange="false">
+                            class B
+                            {
+                                void M()
+                                {
+                                    {|stmt:A|} a;
+                                }
+                            }
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="C")
+
+                result.AssertLabeledSpansAre("stmt", "A", RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
+
 #Region "Rename in strings/comments"
 
         <WorkItem(700923, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/700923"), WorkItem(700925, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/700925")>

--- a/src/EditorFeatures/TestUtilities/Utilities/TestDocumentServiceProvider.cs
+++ b/src/EditorFeatures/TestUtilities/Utilities/TestDocumentServiceProvider.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    internal class TestDocumentServiceProvider : IDocumentServiceProvider
+    {
+        public TestDocumentServiceProvider(bool canApplyChange = true, bool supportDiagnostics = true)
+        {
+            DocumentOperationService = new TestDocumentOperationService()
+            {
+                CanApplyChange = canApplyChange,
+                SupportDiagnostics = supportDiagnostics
+            };
+        }
+
+        public IDocumentOperationService DocumentOperationService { get; }
+
+        public TService GetService<TService>() where TService : class, IDocumentService
+        {
+            if (DocumentOperationService is TService service)
+            {
+                return service;
+            }
+
+            return default;
+        }
+
+        private class TestDocumentOperationService : IDocumentOperationService
+        {
+            public TestDocumentOperationService()
+            {
+            }
+
+            public bool CanApplyChange { get; set; }
+            public bool SupportDiagnostics { get; set; }
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -745,12 +745,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
 
             var testDocumentServiceProvider = GetDocumentServiceProvider(documentElement);
-            if (documentServiceProvider != null && testDocumentServiceProvider != null)
-            {
-                AssertEx.Fail("A non-null documentServiceProvider is provided when creating TestWorkspace from XML, which might conflict with the valued provided by individual document.");
-            }
 
-            documentServiceProvider = testDocumentServiceProvider;
+            if (documentServiceProvider == null)
+            {
+                documentServiceProvider = testDocumentServiceProvider;
+            }
+            else if (testDocumentServiceProvider != null)
+            {
+                AssertEx.Fail("A non-null documentServiceProvider is provided when creating TestWorkspace from XML, which might conflict with the valued provided in document attributes.");
+            }
 
             return new TestHostDocument(
                 exportProvider, languageServiceProvider, textBuffer, filePath, cursorPosition, spans, codeKind, folders, isLinkFile, documentServiceProvider);

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -744,8 +744,31 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 filePathToTextBufferMap.Add(filePath, textBuffer);
             }
 
+            var testDocumentServiceProvider = GetDocumentServiceProvider(documentElement);
+            if (documentServiceProvider != null && testDocumentServiceProvider != null)
+            {
+                AssertEx.Fail("A non-null documentServiceProvider is provided when creating TestWorkspace from XML, which might conflict with the valued provided by individual document.");
+            }
+
+            documentServiceProvider = testDocumentServiceProvider;
+
             return new TestHostDocument(
                 exportProvider, languageServiceProvider, textBuffer, filePath, cursorPosition, spans, codeKind, folders, isLinkFile, documentServiceProvider);
+        }
+
+        private static TestDocumentServiceProvider GetDocumentServiceProvider(XElement documentElement)
+        {
+            var canApplyChange = (bool?)documentElement.Attribute("CanApplyChange");
+            var supportDiagnostics = (bool?)documentElement.Attribute("SupportDiagnostics");
+
+            if (canApplyChange == null && supportDiagnostics == null)
+            {
+                return null;
+            }
+
+            return new TestDocumentServiceProvider(
+                canApplyChange ?? true,
+                supportDiagnostics ?? true);
         }
 
         private static string GetFilePath(

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchOptions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis.FindSymbols.Finders;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -26,16 +24,30 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// </summary>
         public bool AssociatePropertyReferencesWithSpecificAccessor { get; }
 
+        /// <summary>
+        /// Exclude references in unchangeable documents from search results.
+        /// i.e. when a document's corresponding <see cref="IDocumentOperationService.CanApplyChange()"/> returns <c>false</c>.
+        /// </summary>
+        public bool IgnoreUnchangeableDocuments { get; }
+
         public FindReferencesSearchOptions(
-            bool associatePropertyReferencesWithSpecificAccessor)
+            bool associatePropertyReferencesWithSpecificAccessor,
+            bool ignoreUnchangeableDocuments = false)
         {
             AssociatePropertyReferencesWithSpecificAccessor = associatePropertyReferencesWithSpecificAccessor;
+            IgnoreUnchangeableDocuments = ignoreUnchangeableDocuments;
         }
 
         public FindReferencesSearchOptions WithAssociatePropertyReferencesWithSpecificAccessor(
             bool associatePropertyReferencesWithSpecificAccessor)
         {
-            return new FindReferencesSearchOptions(associatePropertyReferencesWithSpecificAccessor);
+            return new FindReferencesSearchOptions(associatePropertyReferencesWithSpecificAccessor, this.IgnoreUnchangeableDocuments);
+        }
+
+        public FindReferencesSearchOptions WithIgnoreUnchangeableDocuments(
+            bool ignoreUnchangeableDocuments)
+        {
+            return new FindReferencesSearchOptions(this.AssociatePropertyReferencesWithSpecificAccessor, ignoreUnchangeableDocuments);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -720,13 +721,23 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
                 : SpecializedTasks.EmptyImmutableArray<Project>();
         }
 
-        public override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
+        public async override Task<ImmutableArray<Document>> DetermineDocumentsToSearchAsync(
             ISymbol symbol, Project project, IImmutableSet<Document> documents,
             FindReferencesSearchOptions options, CancellationToken cancellationToken)
         {
-            return symbol is TSymbol && CanFind((TSymbol)symbol)
-                ? DetermineDocumentsToSearchAsync((TSymbol)symbol, project, documents, options, cancellationToken)
-                : SpecializedTasks.EmptyImmutableArray<Document>();
+            if (symbol is TSymbol targetSymbol && CanFind(targetSymbol))
+            {
+                var documentsToSearch = await DetermineDocumentsToSearchAsync(targetSymbol, project, documents, options, cancellationToken).ConfigureAwait(false);
+
+                if (options.IgnoreUnchangeableDocuments)
+                {
+                    documentsToSearch = documentsToSearch.WhereAsArray(d => d.CanApplyChange());
+                }
+
+                return documentsToSearch;
+            }
+
+            return ImmutableArray<Document>.Empty;
         }
 
         public override Task<ImmutableArray<FinderLocation>> FindReferencesInDocumentAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_FindRenamableReferences.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols.Finders;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -29,7 +26,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     documents,
                     ReferenceFinders.DefaultRenameReferenceFinders,
                     streamingProgress,
-                    FindReferencesSearchOptions.Default,
+                    FindReferencesSearchOptions.Default.WithIgnoreUnchangeableDocuments(true),
                     cancellationToken);
 
                 await engine.FindReferencesAsync(symbolAndProjectId).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteArguments.cs
@@ -15,18 +15,20 @@ namespace Microsoft.CodeAnalysis.Remote
     internal class SerializableFindReferencesSearchOptions
     {
         public bool AssociatePropertyReferencesWithSpecificAccessor;
+        public bool IgnoreUnchangeableDocuments;
 
         public static SerializableFindReferencesSearchOptions Dehydrate(FindReferencesSearchOptions options)
         {
             return new SerializableFindReferencesSearchOptions
             {
-                AssociatePropertyReferencesWithSpecificAccessor = options.AssociatePropertyReferencesWithSpecificAccessor
+                AssociatePropertyReferencesWithSpecificAccessor = options.AssociatePropertyReferencesWithSpecificAccessor,
+                IgnoreUnchangeableDocuments = options.IgnoreUnchangeableDocuments
             };
         }
 
         public FindReferencesSearchOptions Rehydrate()
         {
-            return new FindReferencesSearchOptions(AssociatePropertyReferencesWithSpecificAccessor);
+            return new FindReferencesSearchOptions(AssociatePropertyReferencesWithSpecificAccessor, IgnoreUnchangeableDocuments);
         }
     }
 


### PR DESCRIPTION
Fix feedback https://developercommunity.visualstudio.com/content/problem/682938/csharperenametrackingcodefixprovider-encountered-a.html

I tried an alternative approach @jasonmalinowski suggested, i.e. creating a more general helper like
```cs
Solution ExcludeDisallowedChange(Solution oldSolution, Solution newSolution);
```
However, simply replacing the text/syntax in new document with the one from old one doesn't seem to work, because later when we apply the change, it just check the ref equality of the old and new DocumentState in `GetChangedDocuments`. So I ended up having the "fixed" document still being flagged as changed.

---

@CyrusNajmabadi @heejaechang The repro I have is to rename a type referenced in a .cshtml file, when the cshtml file is not opened in editor. In that scenario, the corresponding .g.cs document contains an auto-generated syntax tree that has the reference, which is then found by SymbolFinder. The part I don't quite understand is that it seems whenever the .cshtml is opened, it's added to the project on the fly and removed when closed, as a result for the .g.cs file, the one with auto-gen syntax tree is replaced with one with empty tree when cshtml is opened (and replaced back when it's closed). Is this how Razor works? 

That said, it seems FAR can handle this regardless of whether cshtml is opened nor not, do you know where it is implemented? It seems to be a different path from `FindReferencesSearchEngine.FindReferencesAsync` that is used by `SymbolFinder.FindRenamableReferencesAsync`? If possible, I'd rather fix this by making rename use whatever implementation that supports FAR.