### PR TITLE
Revert test workarounds/skip for IDE diagnostic configuration code fixes

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureCodeStyle/BooleanCodeStyleOptionConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureCodeStyle/BooleanCodeStyleOptionConfigurationTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configurati
     public abstract partial class BooleanCodeStyleOptionConfigurationTests : AbstractSuppressionDiagnosticTest
     {
         protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
-        => TestWorkspace.CreateCSharp(initialMarkup, parameters.parseOptions, parameters.compilationOptions);
+            => TestWorkspace.CreateCSharp(initialMarkup, parameters.parseOptions, parameters.compilationOptions);
 
         protected override string GetLanguage() => LanguageNames.CSharp;
 
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configurati
         internal override Tuple<DiagnosticAnalyzer, IConfigurationFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
         {
             return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
-                        new CSharpUseObjectInitializerDiagnosticAnalyzer(), new ConfigureCodeStyleOptionCodeFixProvider(performExperimentCheck: false));
+                        new CSharpUseObjectInitializerDiagnosticAnalyzer(), new ConfigureCodeStyleOptionCodeFixProvider());
         }
 
         public class TrueConfigurationTests : BooleanCodeStyleOptionConfigurationTests

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureCodeStyle/EnumCodeStyleOptionConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureCodeStyle/EnumCodeStyleOptionConfigurationTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configurati
                 }
              */
             return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
-                        new CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer(), new ConfigureCodeStyleOptionCodeFixProvider(performExperimentCheck: false));
+                        new CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer(), new ConfigureCodeStyleOptionCodeFixProvider());
         }
 
         public class UnusedLocalVariableConfigurationTests : EnumCodeStyleOptionConfigurationTests

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureCodeStyle/MultipleCodeStyleOptionConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureCodeStyle/MultipleCodeStyleOptionConfigurationTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configurati
                 csharp_style_var_when_type_is_apparent                
              */
             return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
-                        new CSharpUseExplicitTypeDiagnosticAnalyzer(), new ConfigureCodeStyleOptionCodeFixProvider(performExperimentCheck: false));
+                        new CSharpUseExplicitTypeDiagnosticAnalyzer(), new ConfigureCodeStyleOptionCodeFixProvider());
         }
 
         public class VarElsewhere_TrueConfigurationTests : MultipleCodeStyleOptionConfigurationTests

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configurati
         internal override Tuple<DiagnosticAnalyzer, IConfigurationFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
         {
             return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
-                        new CSharpUseObjectInitializerDiagnosticAnalyzer(), new ConfigureSeverityLevelCodeFixProvider(performExperimentCheck: false));
+                        new CSharpUseObjectInitializerDiagnosticAnalyzer(), new ConfigureSeverityLevelCodeFixProvider());
         }
 
         public class NoneConfigurationTests : CodeStyleOptionBasedSeverityConfigurationTests

--- a/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/DotNetDiagnosticSeverityBasedSeverityConfigurationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/Configuration/ConfigureSeverity/DotNetDiagnosticSeverityBasedSeverityConfigurationTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Configurati
         internal override Tuple<DiagnosticAnalyzer, IConfigurationFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
         {
             return new Tuple<DiagnosticAnalyzer, IConfigurationFixProvider>(
-                        new CustomDiagnosticAnalyzer(), new ConfigureSeverityLevelCodeFixProvider(performExperimentCheck: false));
+                        new CustomDiagnosticAnalyzer(), new ConfigureSeverityLevelCodeFixProvider());
         }
 
         public class NoneConfigurationTests : DotNetDiagnosticSeverityBasedSeverityConfigurationTests

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureCodeStyle/BooleanCodeStyleOptionConfigurationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureCodeStyle/BooleanCodeStyleOptionConfigurationTests.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Config
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(ByVal workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)
-            Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New VisualBasicUseObjectInitializerDiagnosticAnalyzer(), New ConfigureCodeStyleOptionCodeFixProvider(performExperimentCheck:=False))
+            Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New VisualBasicUseObjectInitializerDiagnosticAnalyzer(), New ConfigureCodeStyleOptionCodeFixProvider())
         End Function
 
         Public Class TrueConfigurationTests

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/CodeStyleOptionBasedSeverityConfigurationTests.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Config
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(ByVal workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)
-            Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New VisualBasicUseObjectInitializerDiagnosticAnalyzer(), New ConfigureSeverityLevelCodeFixProvider(performExperimentCheck:=False))
+            Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New VisualBasicUseObjectInitializerDiagnosticAnalyzer(), New ConfigureSeverityLevelCodeFixProvider())
         End Function
 
         Public Class NoneConfigurationTests

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/DotNetDiagnosticSeverityBasedSeverityConfigurationTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/Configuration/ConfigureSeverity/DotNetDiagnosticSeverityBasedSeverityConfigurationTests.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Config
         End Function
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(ByVal workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)
-            Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New CustomDiagnosticAnalyzer(), New ConfigureSeverityLevelCodeFixProvider(performExperimentCheck:=False))
+            Return New Tuple(Of DiagnosticAnalyzer, IConfigurationFixProvider)(New CustomDiagnosticAnalyzer(), New ConfigureSeverityLevelCodeFixProvider())
         End Function
 
         Public Class NoneConfigurationTests

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CodeFixes.Suppression;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.EditorConfig;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
@@ -53,6 +54,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
 
         private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
+            // Bail out if NativeEditorConfigSupport experiment is not enabled.
+            if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
+            {
+                return ImmutableArray<CodeFix>.Empty;
+            }
+
             var result = ArrayBuilder<CodeFix>.GetInstance();
             foreach (var diagnostic in diagnostics)
             {

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -26,19 +26,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
     {
         private static readonly ImmutableArray<bool> s_boolValues = ImmutableArray.Create(true, false);
 
-        private readonly bool _performExperimentCheck;
-
-        public ConfigureCodeStyleOptionCodeFixProvider()
-            : this(performExperimentCheck: true)
-        {
-        }
-
-        // Internal for test purpose.
-        internal ConfigureCodeStyleOptionCodeFixProvider(bool performExperimentCheck)
-        {
-            _performExperimentCheck = performExperimentCheck;
-        }
-
         public bool IsFixableDiagnostic(Diagnostic diagnostic)
         {
             // We only offer fix for configurable code style diagnostics which have one of more editorconfig based storage locations.
@@ -60,16 +47,15 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
             => null;
 
         public Task<ImmutableArray<CodeFix>> GetFixesAsync(Document document, TextSpan span, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
-            => Task.FromResult(GetConfigurations(document.Project, diagnostics, _performExperimentCheck, cancellationToken));
+            => Task.FromResult(GetConfigurations(document.Project, diagnostics, cancellationToken));
 
         public Task<ImmutableArray<CodeFix>> GetFixesAsync(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
-            => Task.FromResult(GetConfigurations(project, diagnostics, _performExperimentCheck, cancellationToken));
+            => Task.FromResult(GetConfigurations(project, diagnostics, cancellationToken));
 
-        private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, bool performExperimentCheck, CancellationToken cancellationToken)
+        private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
             // Bail out if NativeEditorConfigSupport experiment is not enabled.
-            if (performExperimentCheck &&
-                !EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
+            if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
             {
                 return ImmutableArray<CodeFix>.Empty;
             }

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.CodeFixes.Suppression;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Options.EditorConfig;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
@@ -54,12 +53,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
 
         private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
-            // Bail out if NativeEditorConfigSupport experiment is not enabled.
-            if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
-            {
-                return ImmutableArray<CodeFix>.Empty;
-            }
-
             var result = ArrayBuilder<CodeFix>.GetInstance();
             foreach (var diagnostic in diagnostics)
             {

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes.Suppression;
-using Microsoft.CodeAnalysis.Options.EditorConfig;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
@@ -42,12 +41,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 
         private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
-            // Bail out if NativeEditorConfigSupport experiment is not enabled.
-            if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
-            {
-                return ImmutableArray<CodeFix>.Empty;
-            }
-
             var result = ArrayBuilder<CodeFix>.GetInstance();
             foreach (var diagnostic in diagnostics)
             {

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes.Suppression;
+using Microsoft.CodeAnalysis.Options.EditorConfig;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using static Microsoft.CodeAnalysis.CodeActions.CodeAction;
@@ -41,6 +42,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
 
         private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
+            // Bail out if NativeEditorConfigSupport experiment is not enabled.
+            if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
+            {
+                return ImmutableArray<CodeFix>.Empty;
+            }
+
             var result = ArrayBuilder<CodeFix>.GetInstance();
             foreach (var diagnostic in diagnostics)
             {

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureSeverity/ConfigureSeverityLevelCodeFixProvider.cs
@@ -26,19 +26,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
                 (nameof(EditorConfigSeverityStrings.Warning), EditorConfigSeverityStrings.Warning),
                 (nameof(EditorConfigSeverityStrings.Error), EditorConfigSeverityStrings.Error));
 
-        private readonly bool _performExperimentCheck;
-
-        public ConfigureSeverityLevelCodeFixProvider()
-            : this(performExperimentCheck: true)
-        {
-        }
-
-        // Internal for test purpose.
-        internal ConfigureSeverityLevelCodeFixProvider(bool performExperimentCheck)
-        {
-            _performExperimentCheck = performExperimentCheck;
-        }
-
         // We only offer fix for configurable diagnostics.
         // Also skip suppressed diagnostics defensively, though the code fix engine should ideally never call us for suppressed diagnostics.
         public bool IsFixableDiagnostic(Diagnostic diagnostic)
@@ -48,16 +35,15 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureSeverity
             => null;
 
         public Task<ImmutableArray<CodeFix>> GetFixesAsync(Document document, TextSpan span, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
-            => Task.FromResult(GetConfigurations(document.Project, diagnostics, _performExperimentCheck, cancellationToken));
+            => Task.FromResult(GetConfigurations(document.Project, diagnostics, cancellationToken));
 
         public Task<ImmutableArray<CodeFix>> GetFixesAsync(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
-            => Task.FromResult(GetConfigurations(project, diagnostics, _performExperimentCheck, cancellationToken));
+            => Task.FromResult(GetConfigurations(project, diagnostics, cancellationToken));
 
-        private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, bool performExperimentCheck, CancellationToken cancellationToken)
+        private static ImmutableArray<CodeFix> GetConfigurations(Project project, IEnumerable<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
             // Bail out if NativeEditorConfigSupport experiment is not enabled.
-            if (performExperimentCheck &&
-                !EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
+            if (!EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport(project.Solution.Workspace))
             {
                 return ImmutableArray<CodeFix>.Empty;
             }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -492,13 +492,12 @@ public class P2 { }");
                 "Generate new type...",
                 "Remove unused variable",
                 "Configure or Suppress issues",
-                // https://github.com/dotnet/roslyn/issues/36330
-                //"Configure CS0168 severity",
-                //"None",
-                //"Silent",
-                //"Suggestion",
-                //"Warning",
-                //"Error",
+                "Configure CS0168 severity",
+                "None",
+                "Silent",
+                "Suggestion",
+                "Warning",
+                "Error",
                 "Suppress CS0168",
                 "in Source"
             };
@@ -540,13 +539,12 @@ namespace NS
                 "Generate new type...",
                 "Goober - using N;",
                 "Configure or Suppress issues",
-                // https://github.com/dotnet/roslyn/issues/36330
-                //"Configure CS0168 severity",
-                //"None",
-                //"Silent",
-                //"Suggestion",
-                //"Warning",
-                //"Error",
+                "Configure CS0168 severity",
+                "None",
+                "Silent",
+                "Suggestion",
+                "Warning",
+                "Error",
                 "Suppress CS0168",
                 "in Source",
             };
@@ -583,13 +581,12 @@ class Program
                 "Extract Method",
                 generateImplicitTitle,
                 "Configure or Suppress issues",
-                // https://github.com/dotnet/roslyn/issues/36330
-                //"Configure CS0612 severity",
-                //"None",
-                //"Silent",
-                //"Suggestion",
-                //"Warning",
-                //"Error",
+                "Configure CS0612 severity",
+                "None",
+                "Silent",
+                "Suggestion",
+                "Warning",
+                "Error",
                 "Suppress CS0612",
                 "in Source",
             };
@@ -647,7 +644,7 @@ public class Program
 
         }
 
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/36330"), Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsConfiguration)]
         public void ConfigureCodeStyleOptionValueAndSeverity()
         {
             SetUpEditor(@"


### PR DESCRIPTION
Now that `EditorConfigDocumentOptionsProviderFactory.ShouldUseNativeEditorConfigSupport` is defaulted to true for everyone, we can remove the unit test workarounds and also unskip the integration test for it. Note that the first two commits are just reverts of workarounds added to prior PR that enabled these configuration fixes.

Fixes #36330