### PR TITLE
Show code instead of designer if the designer is not installed

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -25,10 +27,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     /// <summary>
     /// The base class of both the Roslyn editor factories.
     /// </summary>
-    internal abstract partial class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactoryNotify
+    internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactoryNotify
     {
         private readonly IComponentModel _componentModel;
-        private Microsoft.VisualStudio.OLE.Interop.IServiceProvider _oleServiceProvider;
+        private Microsoft.VisualStudio.OLE.Interop.IServiceProvider? _oleServiceProvider;
         private bool _encoding;
 
         protected AbstractEditorFactory(IComponentModel componentModel)
@@ -52,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         public int CreateEditorInstance(
             uint grfCreateDoc,
             string pszMkDocument,
-            string pszPhysicalView,
+            string? pszPhysicalView,
             IVsHierarchy vsHierarchy,
             uint itemid,
             IntPtr punkDocDataExisting,
@@ -72,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 ? "Code"
                 : pszPhysicalView;
 
-            IVsTextBuffer textBuffer = null;
+            IVsTextBuffer? textBuffer = null;
 
             // Is this document already open? If so, let's see if it's a IVsTextBuffer we should re-use. This allows us
             // to properly handle multiple windows open for the same document.
@@ -177,7 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return VSConstants.S_OK;
         }
 
-        private string GetWinFormsLoaderName(IVsHierarchy vsHierarchy)
+        private string? GetWinFormsLoaderName(IVsHierarchy vsHierarchy)
         {
             const string LoaderName = "Microsoft.VisualStudio.Design.Serialization.CodeDom.VSCodeDomDesignerLoader";
             const string NewLoaderName = "Microsoft.VisualStudio.Design.Core.Serialization.CodeDom.VSCodeDomDesignerLoader";
@@ -221,7 +223,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return LoaderName;
         }
 
-        public int MapLogicalView(ref Guid rguidLogicalView, out string pbstrPhysicalView)
+        public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)
         {
             pbstrPhysicalView = null;
 
@@ -283,7 +285,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var workspace = _componentModel.GetService<VisualStudioWorkspace>();
             var solution = workspace.CurrentSolution;
 
-            ProjectId projectIdToAddTo = null;
+            ProjectId? projectIdToAddTo = null;
 
             foreach (var projectId in solution.ProjectIds)
             {
@@ -308,7 +310,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             var documentId = DocumentId.CreateNewId(projectIdToAddTo);
             var forkedSolution = solution.AddDocument(DocumentInfo.Create(documentId, filePath, loader: new FileTextLoader(filePath, defaultEncoding: null), filePath: filePath));
-            var addedDocument = forkedSolution.GetDocument(documentId);
+            var addedDocument = forkedSolution.GetDocument(documentId)!;
 
             var rootToFormat = addedDocument.GetSyntaxRootSynchronously(cancellationToken);
             var documentOptions = ThreadHelper.JoinableTaskFactory.Run(() => addedDocument.GetOptionsAsync(cancellationToken));


### PR DESCRIPTION
See dotnet/winforms-designer#458

This avoids showing an error page when the designer package is not installed, but doesn't prevent the "View designer" command from showing in Solution Explorer (the command will just show code in this case).