### PR TITLE
Restore constraint checking for reduced extension methods.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6324,15 +6324,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
+#nullable enable
         private MethodGroupResolution BindExtensionMethod(
             SyntaxNode expression,
             string methodName,
-            AnalyzedArguments analyzedArguments,
+            AnalyzedArguments? analyzedArguments,
             BoundExpression left,
             ImmutableArray<TypeWithAnnotations> typeArgumentsWithAnnotations,
             bool isMethodGroupConversion,
             RefKind returnRefKind,
-            TypeSymbol returnType)
+            TypeSymbol? returnType)
+#nullable disable
         {
             var firstResult = new MethodGroupResolution();
             AnalyzedArguments actualArguments = null;
@@ -6344,12 +6346,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 this.PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, expression, left, methodName, typeArgumentsWithAnnotations, diagnostics);
 
-                // Arguments will be null if the caller is resolving to the first method group that can accept
-                // that receiver, regardless of arguments, when the signature cannot
-                // be inferred. (In the case of nameof(o.M) or the error case of o.M = null; for instance.)
-                if (analyzedArguments == null && methodGroup.Methods.Count != 0)
+                // analyzedArguments will be null if the caller is resolving for error recovery to the first method group
+                // that can accept that receiver, regardless of arguments, when the signature cannot be inferred.
+                // (In the error case of nameof(o.M) or the error case of o.M = null; for instance.)
+                if (analyzedArguments == null)
                 {
-                    return new MethodGroupResolution(methodGroup, diagnostics.ToReadOnlyAndFree());
+                    if (expression == EnclosingNameofArgument)
+                    {
+                        for (int i = methodGroup.Methods.Count - 1; i >= 0; i--)
+                        {
+                            if ((object)methodGroup.Methods[i].ReduceExtensionMethod(left.Type, this.Compilation) == null)
+                                methodGroup.Methods.RemoveAt(i);
+                        }
+                    }
+
+                    if (methodGroup.Methods.Count != 0)
+                    {
+                        return new MethodGroupResolution(methodGroup, diagnostics.ToReadOnlyAndFree());
+                    }
                 }
 
                 if (methodGroup.Methods.Count == 0)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6324,17 +6324,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-#nullable enable
         private MethodGroupResolution BindExtensionMethod(
             SyntaxNode expression,
             string methodName,
-            AnalyzedArguments? analyzedArguments,
+            AnalyzedArguments analyzedArguments,
             BoundExpression left,
             ImmutableArray<TypeWithAnnotations> typeArgumentsWithAnnotations,
             bool isMethodGroupConversion,
             RefKind returnRefKind,
-            TypeSymbol? returnType)
-#nullable disable
+            TypeSymbol returnType)
         {
             var firstResult = new MethodGroupResolution();
             AnalyzedArguments actualArguments = null;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -883,7 +883,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool HadConstructedParameterFailedConstraintCheck(
             ConversionsBase conversions,
-            Compilation compilation,
+            CSharpCompilation compilation,
             DiagnosticBag diagnostics,
             Location location)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
@@ -231,8 +231,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 type = type.GetEnumUnderlyingType();
             }
 
-            bool hasGenerics = type.TupleUnderlyingTypeOrSelf().GetArity() > 0;
-
             // Short-circuit common cases.
             switch (type.SpecialType)
             {
@@ -255,12 +253,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SpecialType.System_TypedReference:
                 case SpecialType.System_ArgIterator:
                 case SpecialType.System_RuntimeArgumentHandle:
-                    return (ThreeState.False, hasGenerics);
+                    return (ThreeState.False, false);
                 case SpecialType.None:
                 default:
                     // CONSIDER: could provide cases for other common special types.
                     break; // Proceed with additional checks.
             }
+
+            bool hasGenerics = type.TupleUnderlyingTypeOrSelf().GetArity() > 0;
             switch (type.TypeKind)
             {
                 case TypeKind.Enum:

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -881,7 +881,7 @@ hasRelatedInterfaces:
                     // When there is no compilation, we are being invoked through the API IMethodSymbol.ReduceExtensionMethod(...).
                     // In that case we consider the unmanaged constraint to be satisfied as if we were compiling with the latest
                     // language version.  The net effect of this is that in some IDE scenarios completion might consider an
-                    // extension method to be applicable, but then when you try to use it the IDE tells you to upgrage your language version.
+                    // extension method to be applicable, but then when you try to use it the IDE tells you to upgrade your language version.
                     if (!(currentCompilation is null))
                     {
                         var csDiagnosticInfo = MessageID.IDS_FeatureUnmanagedConstructedTypes.GetFeatureAvailabilityDiagnosticInfoOpt(currentCompilation);

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool includeNullability,
             SyntaxNode typeSyntax,
             ImmutableArray<Location> elementLocations,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             DiagnosticBag diagnosticsOpt,
             DiagnosticBag nullabilityDiagnosticsOpt)
         {
@@ -505,13 +505,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool includeNullability,
             SyntaxNode typeSyntax,
             SeparatedSyntaxList<TypeSyntax> typeArgumentsSyntax, // may be omitted in synthesized invocations
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             ConsList<TypeSymbol> basesBeingResolved,
             DiagnosticBag diagnostics)
         {
             Debug.Assert(!type.IsTupleType);
             Debug.Assert(typeArgumentsSyntax.Count == 0 /*omitted*/ || typeArgumentsSyntax.Count == type.Arity);
-            Debug.Assert(currentCompilation is object);
 
             if (!RequiresChecking(type))
             {
@@ -646,7 +645,7 @@ hasRelatedInterfaces:
             this MethodSymbol method,
             ConversionsBase conversions,
             SyntaxNode syntaxNode,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             DiagnosticBag diagnostics)
         {
             if (!RequiresChecking(method))
@@ -677,7 +676,7 @@ hasRelatedInterfaces:
             this MethodSymbol method,
             ConversionsBase conversions,
             Location location,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             DiagnosticBag diagnostics)
         {
             if (!RequiresChecking(method))
@@ -707,7 +706,7 @@ hasRelatedInterfaces:
             NamedTypeSymbol type,
             ConversionsBase conversions,
             bool includeNullability,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder)
@@ -729,7 +728,7 @@ hasRelatedInterfaces:
             MethodSymbol method,
             ConversionsBase conversions,
             bool includeNullability,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
@@ -757,7 +756,7 @@ hasRelatedInterfaces:
         /// <param name="substitution">The map from type parameters to type arguments.</param>
         /// <param name="typeParameters">Containing symbol type parameters.</param>
         /// <param name="typeArguments">Containing symbol type arguments.</param>
-        /// <param name="currentCompilation">Improves error message detail.</param>
+        /// <param name="currentCompilation">Used to check availability of unmanaged constraint, and improves error message detail.</param>
         /// <param name="diagnosticsBuilder">Diagnostics.</param>
         /// <param name="nullabilityDiagnosticsBuilderOpt">Nullability warnings.</param>
         /// <param name="skipParameters">Parameters to skip.</param>
@@ -772,7 +771,7 @@ hasRelatedInterfaces:
             TypeMap substitution,
             ImmutableArray<TypeParameterSymbol> typeParameters,
             ImmutableArray<TypeWithAnnotations> typeArguments,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
@@ -814,14 +813,13 @@ hasRelatedInterfaces:
             TypeMap substitution,
             TypeParameterSymbol typeParameter,
             TypeWithAnnotations typeArgument,
-            Compilation currentCompilation,
+            CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
             HashSet<TypeParameterSymbol> ignoreTypeConstraintsDependentOnTypeParametersOpt)
         {
             Debug.Assert(substitution != null);
-            Debug.Assert(currentCompilation is object);
 
             // The type parameters must be original definitions of type parameters from the containing symbol.
             Debug.Assert(ReferenceEquals(typeParameter.ContainingSymbol, containingSymbol.OriginalDefinition));
@@ -880,13 +878,19 @@ hasRelatedInterfaces:
                 }
                 else if (managedKind == ManagedKind.UnmanagedWithGenerics)
                 {
-                    var csDiagnosticInfo = MessageID.IDS_FeatureUnmanagedConstructedTypes
-                        .GetFeatureAvailabilityDiagnosticInfoOpt((CSharpCompilation)currentCompilation);
-                    if (csDiagnosticInfo != null)
+                    // When there is no compilation, we are being invoked through the API IMethodSymbol.ReduceExtensionMethod(...).
+                    // In that case we consider the unmanaged constraint to be satisfied as if we were compiling with the latest
+                    // language version.  The net effect of this is that in some IDE scenarios completion might consider an
+                    // extension method to be applicable, but then when you try to use it the IDE tells you to upgrage your language version.
+                    if (!(currentCompilation is null))
                     {
-                        var typeParameterDiagnosticInfo = new TypeParameterDiagnosticInfo(typeParameter, csDiagnosticInfo);
-                        diagnosticsBuilder.Add(typeParameterDiagnosticInfo);
-                        return false;
+                        var csDiagnosticInfo = MessageID.IDS_FeatureUnmanagedConstructedTypes.GetFeatureAvailabilityDiagnosticInfoOpt(currentCompilation);
+                        if (csDiagnosticInfo != null)
+                        {
+                            var typeParameterDiagnosticInfo = new TypeParameterDiagnosticInfo(typeParameter, csDiagnosticInfo);
+                            diagnosticsBuilder.Add(typeParameterDiagnosticInfo);
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -676,7 +676,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If this is an extension method that can be applied to a receiver of the given type,
         /// returns a reduced extension method symbol thus formed. Otherwise, returns null.
         /// </summary>
-        public MethodSymbol ReduceExtensionMethod(TypeSymbol receiverType)
+        /// <param name="compilation">The compilation in which constraints should be checked.
+        /// Should not be null, but if it is null we consider the unmanaged constraint not to be satisfied.</param>
+        public MethodSymbol ReduceExtensionMethod(TypeSymbol receiverType, CSharpCompilation compilation)
         {
             if ((object)receiverType == null)
             {
@@ -688,7 +690,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
 
-            return ReducedExtensionMethodSymbol.Create(this, receiverType);
+            return ReducedExtensionMethodSymbol.Create(this, receiverType, compilation);
         }
 
         /// <summary>
@@ -1127,7 +1129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         IMethodSymbol IMethodSymbol.ReduceExtensionMethod(ITypeSymbol receiverType)
         {
-            return this.ReduceExtensionMethod(receiverType.EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>(nameof(receiverType)));
+            return this.ReduceExtensionMethod(receiverType.EnsureCSharpSymbolOrNull<ITypeSymbol, TypeSymbol>(nameof(receiverType)), compilation: null!);
         }
 
         ImmutableArray<IMethodSymbol> IMethodSymbol.ExplicitInterfaceImplementations

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -677,7 +677,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// returns a reduced extension method symbol thus formed. Otherwise, returns null.
         /// </summary>
         /// <param name="compilation">The compilation in which constraints should be checked.
-        /// Should not be null, but if it is null we consider the unmanaged constraint not to be satisfied.</param>
+        /// Should not be null, but if it is null we treat constraints as we would in the latest
+        /// language version.</param>
         public MethodSymbol ReduceExtensionMethod(TypeSymbol receiverType, CSharpCompilation compilation)
         {
             if ((object)receiverType == null)

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly ImmutableArray<TypeWithAnnotations> _typeArguments;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
 
-#nullable enable
         /// <summary>
         /// Return the extension method in reduced form if the extension method
         /// is applicable, and satisfies type parameter constraints, based on the
@@ -34,8 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         /// <param name="compilation">Compilation used to check constraints.
         /// The latest language version is assumed if this is null.</param>
-        public static MethodSymbol Create(MethodSymbol method, TypeSymbol receiverType, CSharpCompilation? compilation)
-#nullable disable
+        public static MethodSymbol Create(MethodSymbol method, TypeSymbol receiverType, CSharpCompilation compilation)
         {
             Debug.Assert(method.IsExtensionMethod && method.MethodKind != MethodKind.ReducedExtension);
             Debug.Assert(method.ParameterCount > 0);
@@ -102,7 +100,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _typeArguments = _typeMap.SubstituteTypes(reducedFrom.TypeArgumentsWithAnnotations);
         }
 
-#nullable enable
         /// <summary>
         /// If the extension method is applicable based on the "this" argument type, return
         /// the method constructed with the inferred type arguments. If the method is not an
@@ -110,9 +107,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// applicable, or if constraints when inferring type parameters from the "this" type
         /// are not satisfied, the return value is null.
         /// </summary>
-        /// <param name="compilation">Compilation used to check constraints.  Language version 7.3 is assumed if this is null.</param>
-        private static MethodSymbol InferExtensionMethodTypeArguments(MethodSymbol method, TypeSymbol thisType, CSharpCompilation? compilation, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
-#nullable disable
+        /// <param name="compilation">Compilation used to check constraints.  The latest language version is assumed if this is null.</param>
+        private static MethodSymbol InferExtensionMethodTypeArguments(MethodSymbol method, TypeSymbol thisType, CSharpCompilation compilation, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(method.IsExtensionMethod);
             Debug.Assert((object)thisType != null);

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// is applicable, and satisfies type parameter constraints, based on the
         /// "this" argument type. Otherwise, returns null.
         /// </summary>
-        /// <param name="compilation">Compilation used to check constraints.  Language version 7.3 is assumed if this is null.</param>
+        /// <param name="compilation">Compilation used to check constraints.
+        /// The latest language version is assumed if this is null.</param>
         public static MethodSymbol Create(MethodSymbol method, TypeSymbol receiverType, CSharpCompilation? compilation)
 #nullable disable
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NameOfTests.cs
@@ -842,9 +842,9 @@ public class Program
 }";
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
             compilation.VerifyDiagnostics(
-                // (14,20): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+                // (14,22): error CS1061: 'A' does not contain a definition for 'Extension' and no accessible extension method 'Extension' accepting a first argument of type 'A' could be found (are you missing a using directive or an assembly reference?)
                 //         Use(nameof(a.Extension));
-                Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "a.Extension").WithLocation(14, 20)
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Extension").WithArguments("A", "Extension").WithLocation(14, 22)
                 );
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);
@@ -996,9 +996,9 @@ public class Program
 ";
             var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
             compilation.VerifyDiagnostics(
-                // (16,20): error CS8093: Extension method groups are not allowed as an argument to 'nameof'.
+                // (16,22): error CS1061: 'A' does not contain a definition for 'Extension' and no accessible extension method 'Extension' accepting a first argument of type 'A' could be found (are you missing a using directive or an assembly reference?)
                 //         Use(nameof(a.Extension));
-                Diagnostic(ErrorCode.ERR_NameofExtensionMethod, "a.Extension").WithLocation(16, 20)
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Extension").WithArguments("A", "Extension").WithLocation(16, 22)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -1938,7 +1938,7 @@ static class E
 
             // Type not satisfying constraint.
             symbols = model.LookupSymbols(position, container: method.Parameters[1].Type, name: "F", includeReducedExtensionMethods: true);
-            CheckSymbolsUnordered(symbols, "void B.F<B>()");
+            CheckSymbolsUnordered(symbols);
 
             // Same tests as above but with position outside of
             // static class defining extension methods.
@@ -1978,7 +1978,7 @@ static class E
 
             // Type not satisfying constraint.
             symbols = model.LookupSymbols(position, container: method.Parameters[1].Type, name: "F", includeReducedExtensionMethods: true);
-            CheckSymbolsUnordered(symbols, "void B.F<B>()");
+            CheckSymbolsUnordered(symbols);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -475,7 +475,7 @@ namespace N1 {
             {
                 var type = global.GetTypeMember("C1");
                 var method = (MethodSymbol)global.GetTypeMember("C2").GetMember("M");
-                return method.ReduceExtensionMethod(type);
+                return method.ReduceExtensionMethod(type, null!);
             };
 
             var format = new SymbolDisplayFormat(
@@ -540,7 +540,7 @@ namespace N1 {
             {
                 var type = global.GetTypeMember("C1");
                 var method = (MethodSymbol)global.GetTypeMember("C2").GetMember("M");
-                return method.ReduceExtensionMethod(type);
+                return method.ReduceExtensionMethod(type, null!);
             };
 
             var format = new SymbolDisplayFormat(
@@ -596,7 +596,7 @@ namespace N1 {
             {
                 var type = global.GetTypeMember("C1");
                 var method = (MethodSymbol)global.GetTypeMember("C2").GetMember("M");
-                return method.ReduceExtensionMethod(type);
+                return method.ReduceExtensionMethod(type, null!);
             };
 
             var format = new SymbolDisplayFormat(

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -2842,7 +2842,7 @@ public struct MyStruct<T>
             reducedWithReceiver = extensionMethod.ReduceExtensionMethod(msi, null!);
             Assert.NotNull(reducedWithReceiver);
 
-            reducedWithReceiver = (MethodSymbol)(extensionMethod as IMethodSymbol).ReduceExtensionMethod(msi);
+            reducedWithReceiver = (MethodSymbol)((IMethodSymbol)extensionMethod).ReduceExtensionMethod(msi);
             Assert.NotNull(reducedWithReceiver);
 
 
@@ -2866,7 +2866,7 @@ public struct MyStruct<T>
             reducedWithReceiver = extensionMethod.ReduceExtensionMethod(msi, null!);
             Assert.NotNull(reducedWithReceiver);
 
-            reducedWithReceiver = (MethodSymbol)(extensionMethod as IMethodSymbol).ReduceExtensionMethod(msi);
+            reducedWithReceiver = (MethodSymbol)((IMethodSymbol)extensionMethod).ReduceExtensionMethod(msi);
             Assert.NotNull(reducedWithReceiver);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -2683,10 +2683,10 @@ S");
                 var genericExtension = type.GetMember<MethodSymbol>("Generic");
 
                 Assert.True(nonGenericExtension.IsExtensionMethod);
-                Assert.Throws<ArgumentNullException>(() => nonGenericExtension.ReduceExtensionMethod(receiverType: null));
+                Assert.Throws<ArgumentNullException>(() => nonGenericExtension.ReduceExtensionMethod(receiverType: null, compilation: null!));
 
                 Assert.True(genericExtension.IsExtensionMethod);
-                Assert.Throws<ArgumentNullException>(() => genericExtension.ReduceExtensionMethod(receiverType: null));
+                Assert.Throws<ArgumentNullException>(() => genericExtension.ReduceExtensionMethod(receiverType: null, compilation: null!));
             });
         }
 
@@ -2791,11 +2791,83 @@ class Program
 
             var int32Type = compilation.GetSpecialType(SpecialType.System_Int32);
 
-            var reducedWithReceiver = extensionMethod.ReduceExtensionMethod(int32Type);
+            var reducedWithReceiver = extensionMethod.ReduceExtensionMethod(int32Type, null!);
             Assert.True(reduced.IsExtensionMethod);
             Assert.Equal(reduced, reducedWithReceiver);
 
-            Assert.Null(reducedWithReceiver.ReduceExtensionMethod(int32Type));
+            Assert.Null(reducedWithReceiver.ReduceExtensionMethod(int32Type, null!));
+        }
+
+        [WorkItem(37780, "https://github.com/dotnet/roslyn/issues/37780")]
+        [Fact]
+        public void ReducedExtensionMethodVsUnmanagedConstraint()
+        {
+            var source1 =
+@"public static class C
+{
+    public static void M<T>(this T self) where T : unmanaged
+    {
+    }
+}";
+            var compilation1 = CreateCompilation(source1);
+            compilation1.VerifyDiagnostics();
+
+            var source2 =
+@"public class D
+{
+    static void M(MyStruct<int> s)
+    {
+        s.M();
+    }
+}
+public struct MyStruct<T>
+{
+    public T field;
+}
+";
+
+            var compilation2 = CreateCompilation(source2, references: new[] { new CSharpCompilationReference(compilation1) }, parseOptions: TestOptions.Regular8);
+            compilation2.VerifyDiagnostics();
+
+            var extensionMethod = compilation2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<MethodSymbol>("M");
+            Assert.True(extensionMethod.IsExtensionMethod);
+
+            var myStruct = (NamedTypeSymbol)compilation2.GlobalNamespace.GetMember<NamedTypeSymbol>("MyStruct");
+            var int32Type = compilation2.GetSpecialType(SpecialType.System_Int32);
+            var msi = myStruct.Construct(int32Type);
+
+            var reducedWithReceiver = extensionMethod.ReduceExtensionMethod(msi, compilation2);
+            Assert.NotNull(reducedWithReceiver);
+
+            reducedWithReceiver = extensionMethod.ReduceExtensionMethod(msi, null!);
+            Assert.NotNull(reducedWithReceiver);
+
+            reducedWithReceiver = (MethodSymbol)(extensionMethod as IMethodSymbol).ReduceExtensionMethod(msi);
+            Assert.NotNull(reducedWithReceiver);
+
+
+            compilation2 = CreateCompilation(source2, references: new[] { new CSharpCompilationReference(compilation1) }, parseOptions: TestOptions.Regular7);
+            compilation2.VerifyDiagnostics(
+                // (5,9): error CS8107: Feature 'unmanaged constructed types' is not available in C# 7.0. Please use language version 8.0 or greater.
+                //         s.M();
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "s.M").WithArguments("unmanaged constructed types", "8.0").WithLocation(5, 9)
+                );
+
+            extensionMethod = compilation2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<MethodSymbol>("M");
+            Assert.True(extensionMethod.IsExtensionMethod);
+
+            myStruct = (NamedTypeSymbol)compilation2.GlobalNamespace.GetMember<NamedTypeSymbol>("MyStruct");
+            int32Type = compilation2.GetSpecialType(SpecialType.System_Int32);
+            msi = myStruct.Construct(int32Type);
+
+            reducedWithReceiver = extensionMethod.ReduceExtensionMethod(msi, compilation2);
+            Assert.Null(reducedWithReceiver);
+
+            reducedWithReceiver = extensionMethod.ReduceExtensionMethod(msi, null!);
+            Assert.NotNull(reducedWithReceiver);
+
+            reducedWithReceiver = (MethodSymbol)(extensionMethod as IMethodSymbol).ReduceExtensionMethod(msi);
+            Assert.NotNull(reducedWithReceiver);
         }
 
         /// <summary>
@@ -3831,9 +3903,8 @@ public class BaseClass<TMember>
             var baseClass = model.GetTypeInfo(instance).Type;
             Assert.Equal("BaseClass<System.Int32>", baseClass.ToTestDisplayString());
 
-            var setMember = model.LookupSymbols(instance.Position, baseClass, "SetMember", includeReducedExtensionMethods: true).Single();
-            Assert.Equal("BaseClass<System.Int32> BaseClass<System.Int32>.SetMember<BaseClass<System.Int32>, TMember>(TMember NewValue)", setMember.ToTestDisplayString());
-            Assert.Contains(setMember, model.LookupSymbols(instance.Position, baseClass, includeReducedExtensionMethods: true));
+            Assert.Empty(model.LookupSymbols(instance.Position, baseClass, "SetMember", includeReducedExtensionMethods: true));
+            Assert.Empty(model.LookupSymbols(instance.Position, baseClass, includeReducedExtensionMethods: true).Where(s => s.Name == "SetMembers"));
         }
 
         [Fact]
@@ -3927,9 +3998,8 @@ public class BaseClass<TMember> : I1<TMember>
             var baseClass = model.GetTypeInfo(instance).Type;
             Assert.Equal("BaseClass<System.Int32>", baseClass.ToTestDisplayString());
 
-            var setMember = model.LookupSymbols(instance.Position, baseClass, "SetMember", includeReducedExtensionMethods: true).Single();
-            Assert.Equal("BaseClass<System.Int32> BaseClass<System.Int32>.SetMember<BaseClass<System.Int32>, TMember>(TMember NewValue)", setMember.ToTestDisplayString());
-            Assert.Contains(setMember, model.LookupSymbols(instance.Position, baseClass, includeReducedExtensionMethods: true));
+            Assert.Empty(model.LookupSymbols(instance.Position, baseClass, "SetMember", includeReducedExtensionMethods: true));
+            Assert.Empty(model.LookupSymbols(instance.Position, baseClass, includeReducedExtensionMethods: true).Where(s => s.Name == "SetMembers"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/RetargetingTests.cs
@@ -76,8 +76,8 @@ static class S2
             CheckTypes(sourceType, retargetingType);
 
             CheckMethods(sourceMethod, retargetingMethod);
-            var sourceReduced = sourceMethod.ReduceExtensionMethod(sourceType);
-            var retargetingReduced = retargetingMethod.ReduceExtensionMethod(retargetingType);
+            var sourceReduced = sourceMethod.ReduceExtensionMethod(sourceType, null!);
+            var retargetingReduced = retargetingMethod.ReduceExtensionMethod(retargetingType, null!);
             CheckReducedExtensionMethods(sourceReduced, retargetingReduced);
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10293,7 +10293,7 @@ class AnotherBuilder
                 matchingFilters: new List<CompletionItemFilter> { CompletionItemFilter.ClassFilter });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/37780"), Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CompletionShouldNotProvideExtensionMethodsIfTypeConstraintDoesNotMatch()
         {
             var markup = @"


### PR DESCRIPTION
Before C# 8, the reduction of an extension method would fail (return null) when the
method's constraints would not be satisfied.  But in C# 8 the unmanaged constraint requires
we know the language version, and therefore the compilation, to check.  That is not available
in `IMethodSymbol.ReduceExtensionMethod`.  So we dropped the constraint checking in #37022.
However this causes an unfortunate regression in the quality of the IDE experience.  So here we
restore the constraint checking, using the compilation's language version when available.
IMethodSymbol.ReduceExtensionMethod uses the C# 8 rules since it has no language version to check.
Fixes #37780