### PR TITLE
Bail out from couple of IDE analyzers in presence of OperationKind.None operations

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedMembers/RemoveUnusedMembersTests.vb
@@ -1578,5 +1578,42 @@ Public Module B
     End Sub
 End Module")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(33142, "https://github.com/dotnet/roslyn/issues/33142")>
+        Public Async Function XmlLiteral_NoDiagnostic() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Public Class C
+    Public Sub Foo()
+        Dim xml = <tag><%= Me.M() %></tag>
+    End Sub
+
+    Private Function [|M|]() As Integer
+        Return 42
+    End Function
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)>
+        <WorkItem(33142, "https://github.com/dotnet/roslyn/issues/33142")>
+        Public Async Function Attribute_Diagnostic() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Class C
+    <MyAttribute>
+    Private Function [|M|]() As Integer
+        Return 42
+    End Function
+End Class
+
+Public Class MyAttribute
+    Inherits System.Attribute
+End Class",
+"Public Class C
+End Class
+
+Public Class MyAttribute
+    Inherits System.Attribute
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.vb
@@ -113,5 +113,18 @@ Partial Class C
     End Sub
 End Class")
         End Function
+
+        <WorkItem(37988, "https://github.com/dotnet/roslyn/issues/37988")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)>
+        Public Async Function XmlLiteral_NoDiagnostic() As Task
+            Await TestDiagnosticMissingAsync(
+$"Public Class C
+    Sub M([|param|] As System.Xml.Linq.XElement)
+        Dim a = param.<Test>
+        Dim b = param.@Test
+        Dim c = param...<Test>
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -152,18 +152,39 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 Action<ISymbol, ValueUsageInfo> onSymbolUsageFound = OnSymbolUsage;
                 compilationStartContext.RegisterSymbolStartAction(symbolStartContext =>
                 {
-                    var hasInvalidOrDynamicOperation = false;
+                    var hasUnsupportedOperation = false;
                     symbolStartContext.RegisterOperationAction(AnalyzeMemberReferenceOperation, OperationKind.FieldReference, OperationKind.MethodReference, OperationKind.PropertyReference, OperationKind.EventReference);
                     symbolStartContext.RegisterOperationAction(AnalyzeFieldInitializer, OperationKind.FieldInitializer);
                     symbolStartContext.RegisterOperationAction(AnalyzeInvocationOperation, OperationKind.Invocation);
                     symbolStartContext.RegisterOperationAction(AnalyzeNameOfOperation, OperationKind.NameOf);
                     symbolStartContext.RegisterOperationAction(AnalyzeObjectCreationOperation, OperationKind.ObjectCreation);
-                    symbolStartContext.RegisterOperationAction(_ => hasInvalidOrDynamicOperation = true, OperationKind.Invalid,
+
+                    // We bail out reporting diagnostics for named types if it contains following kind of operations:
+                    //  1. Invalid operations, i.e. erroneous code:
+                    //     We do so to ensure that we don't report false positives during editing scenarios in the IDE, where the user
+                    //     is still editing code and fixing unresolved references to symbols, such as overload resolution errors.
+                    //  2. Dynamic operations, where we do not know the exact member being referenced at compile time.
+                    //  3. Operations with OperationKind.None which are not operation root nodes. Attributes
+                    //     generate operation blocks with root operation with OperationKind.None, and we don't want to bail out for them.
+                    symbolStartContext.RegisterOperationAction(_ => hasUnsupportedOperation = true, OperationKind.Invalid,
                         OperationKind.DynamicIndexerAccess, OperationKind.DynamicInvocation, OperationKind.DynamicMemberReference, OperationKind.DynamicObjectCreation);
-                    symbolStartContext.RegisterSymbolEndAction(symbolEndContext => OnSymbolEnd(symbolEndContext, hasInvalidOrDynamicOperation));
+                    symbolStartContext.RegisterOperationAction(AnalyzeOperationNone, OperationKind.None);
+
+                    symbolStartContext.RegisterSymbolEndAction(symbolEndContext => OnSymbolEnd(symbolEndContext, hasUnsupportedOperation));
 
                     // Register custom language-specific actions, if any.
                     _analyzer.HandleNamedTypeSymbolStart(symbolStartContext, onSymbolUsageFound);
+
+                    return;
+
+                    void AnalyzeOperationNone(OperationAnalysisContext context)
+                    {
+                        if (context.Operation.Kind == OperationKind.None &&
+                            context.Operation.Parent != null)
+                        {
+                            hasUnsupportedOperation = true;
+                        }
+                    }
                 }, SymbolKind.NamedType);
             }
 
@@ -339,14 +360,9 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                 OnSymbolUsage(constructor, ValueUsageInfo.Read);
             }
 
-            private void OnSymbolEnd(SymbolAnalysisContext symbolEndContext, bool hasInvalidOrDynamicOperation)
+            private void OnSymbolEnd(SymbolAnalysisContext symbolEndContext, bool hasUnsupportedOperation)
             {
-                // We bail out reporting diagnostics for named types if it contains following kind of operations:
-                //  1. Invalid operations, i.e. erroneous code:
-                //     We do so to ensure that we don't report false positives during editing scenarios in the IDE, where the user
-                //     is still editing code and fixing unresolved references to symbols, such as overload resolution errors.
-                //  2. Dynamic operations, where we do not know the exact member being referenced at compile time.
-                if (hasInvalidOrDynamicOperation)
+                if (hasUnsupportedOperation)
                 {
                     return;
                 }

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
                 /// <summary>
                 /// Indicates if the operation block has an <see cref="IDelegateCreationOperation"/> or an <see cref="IAnonymousFunctionOperation"/>.
-                /// We use this value in <see cref="ShouldAnalyze(IOperation, ISymbol)"/> to determine whether to bail from analysis or not.
+                /// We use this value in <see cref="ShouldAnalyze(IOperation, ISymbol, ref bool)"/> to determine whether to bail from analysis or not.
                 /// </summary>
                 private bool _hasDelegateCreationOrAnonymousFunction;
 
@@ -38,13 +38,13 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 ///     2. Delegate passed as an argument to an invocation or object creation.
                 ///     3. Delegate added to an array or wrapped within a tuple.
                 ///     4. Delegate converted to a non-delegate type.
-                /// We use this value in <see cref="ShouldAnalyze(IOperation, ISymbol)"/> to determine whether to bail from analysis or not.
+                /// We use this value in <see cref="ShouldAnalyze(IOperation, ISymbol, ref bool)"/> to determine whether to bail from analysis or not.
                 /// </summary>
                 private bool _hasDelegateEscape;
 
                 /// <summary>
                 /// Indicates if the operation block has an <see cref="IInvalidOperation"/>.
-                /// We use this value in <see cref="ShouldAnalyze(IOperation, ISymbol)"/> to determine whether to bail from analysis or not.
+                /// We use this value in <see cref="ShouldAnalyze(IOperation, ISymbol, ref bool)"/> to determine whether to bail from analysis or not.
                 /// </summary>
                 private bool _hasInvalidOperation;
 
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 /// assignments of parameters/locals to other parameters/locals of delegate types,
                 /// and then delegate invocations through parameter/locals.
                 /// For the remaining unknown ones, we conservatively mark the operation as leading to
-                /// delegate escape, and corresponding bail out from flow analysis in <see cref="ShouldAnalyze(IOperation, ISymbol)"/>.
+                /// delegate escape, and corresponding bail out from flow analysis in <see cref="ShouldAnalyze(IOperation, ISymbol, ref bool)"/>.
                 /// This function checks the operation tree shape in context of
                 /// an <see cref="IDelegateCreationOperation"/> or an <see cref="IAnonymousFunctionOperation"/>.
                 /// </summary>
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 /// assignments of parameters/locals to other parameters/locals of delegate types,
                 /// and then delegate invocations through parameter/locals.
                 /// For the remaining unknown ones, we conservatively mark the operation as leading to
-                /// delegate escape, and corresponding bail out from flow analysis in <see cref="ShouldAnalyze(IOperation, ISymbol)"/>.
+                /// delegate escape, and corresponding bail out from flow analysis in <see cref="ShouldAnalyze(IOperation, ISymbol, ref bool)"/>.
                 /// This function checks the operation tree shape in context of
                 /// an <see cref="IParameterReferenceOperation"/> or an <see cref="ILocalReferenceOperation"/>
                 /// of delegate type.
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                 /// Method invoked in <see cref="AnalyzeOperationBlockEnd(OperationBlockAnalysisContext)"/>
                 /// for each operation block to determine if we should analyze the operation block or bail out.
                 /// </summary>
-                private bool ShouldAnalyze(IOperation operationBlock, ISymbol owningSymbol)
+                private bool ShouldAnalyze(IOperation operationBlock, ISymbol owningSymbol, ref bool hasOperationNoneDescendant)
                 {
                     switch (operationBlock.Kind)
                     {
@@ -337,6 +337,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                             {
                                 // Workaround for https://github.com/dotnet/roslyn/issues/32100
                                 // Bail out in presence of OperationKind.None - not implemented IOperation.
+                                hasOperationNoneDescendant = true;
                                 return false;
                             }
 
@@ -414,9 +415,9 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     try
                     {
                         // Flag indicating if we found an operation block where all symbol writes were used. 
-                        AnalyzeUnusedValueAssignments(context, isComputingUnusedParams, symbolUsageResultsBuilder, out var hasBlockWithAllUsedWrites);
+                        AnalyzeUnusedValueAssignments(context, isComputingUnusedParams, symbolUsageResultsBuilder, out var hasBlockWithAllUsedWrites, out var hasOperationNoneDescendant);
 
-                        AnalyzeUnusedParameters(context, isComputingUnusedParams, symbolUsageResultsBuilder, hasBlockWithAllUsedWrites);
+                        AnalyzeUnusedParameters(context, isComputingUnusedParams, symbolUsageResultsBuilder, hasBlockWithAllUsedWrites, hasOperationNoneDescendant);
                     }
                     finally
                     {
@@ -428,13 +429,15 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     OperationBlockAnalysisContext context,
                     bool isComputingUnusedParams,
                     PooledHashSet<SymbolUsageResult> symbolUsageResultsBuilder,
-                    out bool hasBlockWithAllUsedSymbolWrites)
+                    out bool hasBlockWithAllUsedSymbolWrites,
+                    out bool hasOperationNoneDescendant)
                 {
                     hasBlockWithAllUsedSymbolWrites = false;
+                    hasOperationNoneDescendant = false;
 
                     foreach (var operationBlock in context.OperationBlocks)
                     {
-                        if (!ShouldAnalyze(operationBlock, context.OwningSymbol))
+                        if (!ShouldAnalyze(operationBlock, context.OwningSymbol, ref hasOperationNoneDescendant))
                         {
                             continue;
                         }
@@ -641,13 +644,15 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                     OperationBlockAnalysisContext context,
                     bool isComputingUnusedParams,
                     PooledHashSet<SymbolUsageResult> symbolUsageResultsBuilder,
-                    bool hasBlockWithAllUsedSymbolWrites)
+                    bool hasBlockWithAllUsedSymbolWrites,
+                    bool hasOperationNoneDescendant)
                 {
                     // Process parameters for the context's OwningSymbol that are unused across all operation blocks.
 
                     // Bail out cases:
-                    //  1. Skip analysis if we are not computing unused parameters based on user's option preference.
-                    if (!isComputingUnusedParams)
+                    //  1. Skip analysis if we are not computing unused parameters based on user's option preference or have
+                    //     a descendant operation with OperatioKind.None (not yet implemented operation).
+                    if (!isComputingUnusedParams || hasOperationNoneDescendant)
                     {
                         return;
                     }


### PR DESCRIPTION
1. https://github.com/dotnet/roslyn/commit/49806932395686a392efea1236e2edd1b066c6f2: Bail out for unused parameters analyzer. Fixes #37988
2. https://github.com/dotnet/roslyn/commit/8a8629cbfd00c25456f43014d1061d9700ea0e0b: Bail out for unused private members analyzer. Fixes #33142