### PR TITLE
Replace obsolete vbNewLine

### DIFF
--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -10536,7 +10536,7 @@ BC31086: 'Public Overrides Sub F1()' cannot override 'Public Sub F1()' because i
     IL_0006:  ret
   }
 }
-]]>.Value.Replace(vbLf, vbNewLine)
+]]>.Value.Replace(vbLf, vbCrLf)
 
         <WorkItem(528982, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528982")>
         <Fact()>


### PR DESCRIPTION
When I run `build.cmd`, I get the following error:

> C:\code\roslyn\src\Compilers\VisualBasic\Test\Symbol\SymbolsTests\SymbolErrorTests.vb(10539,25): error BC40000: 'Public Const vbNewLine As String' is obsolete: 'For a carriage return and line feed, use vbCrLf.  For the current platform's newline, use System.Environment.NewLine.'. [C:\code\roslyn\src\Compilers\VisualBasic\Test\Symbol\Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.vbproj]

This change fixes that.