### PR TITLE
Update override completion for nullable reference support

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/LoadDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/LoadDirectiveCompletionProviderTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             return new LoadDirectiveCompletionProvider();
         }
 
-        protected override bool CompareItems(string actualItem, string expectedItem)
+        protected override IEqualityComparer<string> GetStringComparer()
         {
-            return actualItem.Equals(expectedItem, StringComparison.OrdinalIgnoreCase);
+            return StringComparer.OrdinalIgnoreCase;
         }
 
         private protected override Task VerifyWorkerAsync(

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ReferenceDirectiveCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ReferenceDirectiveCompletionProviderTests.cs
@@ -27,9 +27,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             return new ReferenceDirectiveCompletionProvider();
         }
 
-        protected override bool CompareItems(string actualItem, string expectedItem)
+        protected override IEqualityComparer<string> GetStringComparer()
         {
-            return actualItem.Equals(expectedItem, StringComparison.OrdinalIgnoreCase);
+            return StringComparer.OrdinalIgnoreCase;
         }
 
         private protected override Task VerifyWorkerAsync(

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -252,9 +252,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             }
         }
 
-        protected virtual bool CompareItems(string actualItem, string expectedItem)
+        protected bool CompareItems(string actualItem, string expectedItem)
         {
-            return actualItem.Equals(expectedItem);
+            return GetStringComparer().Equals(actualItem, expectedItem);
+        }
+
+        protected virtual IEqualityComparer<string> GetStringComparer()
+        {
+            return StringComparer.Ordinal;
         }
 
         private protected async Task VerifyItemExistsAsync(
@@ -404,6 +409,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             var service = GetCompletionService(workspace);
             var completionLlist = await GetCompletionListAsync(service, document, position, RoslynCompletion.CompletionTrigger.Invoke);
             var items = completionLlist.Items;
+
+            Assert.Contains(itemToCommit, items.Select(x => x.DisplayText), GetStringComparer());
             var firstItem = items.First(i => CompareItems(i.DisplayText, itemToCommit));
 
             if (service.GetTestAccessor().ExclusiveProviders?[0] is ICustomCommitCompletionProvider customCommitCompletionProvider)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.ItemGetter.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -24,7 +25,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 SymbolDisplayParameterOptions.IncludeExtensionThis |
                 SymbolDisplayParameterOptions.IncludeType |
                 SymbolDisplayParameterOptions.IncludeName |
-                SymbolDisplayParameterOptions.IncludeParamsRefOut);
+                SymbolDisplayParameterOptions.IncludeParamsRefOut)
+                .AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
             private readonly Document _document;
             private readonly SourceText _text;

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -37,6 +38,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         protected override Task<ISymbol> GenerateMemberAsync(ISymbol newOverriddenMember, INamedTypeSymbol newContainingType, Document newDocument, CompletionItem completionItem, CancellationToken cancellationToken)
         {
+            // Special case: if you are overriding object.ToString(), we will make the return value as non-nullable. The return was made nullable because
+            // are implementations out there that will return null, but that's not something we really want new implementations doing. We may need to consider
+            // expanding this behavior to other methods in the future; if that is the case then we would want there to be an attribute on the return type
+            // rather than updating this list, but for now there is no such attribute until we find more cases for it. See
+            // https://github.com/dotnet/roslyn/issues/30317 for some additional conversation about this design decision.
+            //
+            // We don't check if methodSymbol.ContainingType is object, in case you're overriding something that is itself an override
+            if (newOverriddenMember is IMethodSymbol methodSymbol &&
+                methodSymbol.Name == "ToString" &&
+                methodSymbol.Parameters.Length == 0)
+            {
+                newOverriddenMember = CodeGenerationSymbolFactory.CreateMethodSymbol(methodSymbol, returnType: methodSymbol.ReturnType.WithNullability(NullableAnnotation.NotAnnotated));
+            }
+
             // Figure out what to insert, and do it. Throw if we've somehow managed to get this far and can't.
             var syntaxFactory = newDocument.GetLanguageService<SyntaxGenerator>();
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -427,14 +427,15 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             string name = null,
             ImmutableArray<IParameterSymbol>? parameters = default,
             ImmutableArray<SyntaxNode> statements = default,
-            INamedTypeSymbol containingType = null)
+            INamedTypeSymbol containingType = null,
+            ITypeSymbol returnType = null)
         {
             return CreateMethodSymbol(
                 containingType,
                 attributes,
                 accessibility ?? method.DeclaredAccessibility,
                 modifiers ?? method.GetSymbolModifiers(),
-                method.GetReturnTypeWithAnnotatedNullability(),
+                returnType ?? method.GetReturnTypeWithAnnotatedNullability(),
                 method.RefKind,
                 explicitInterfaceImplementations,
                 name ?? method.Name,


### PR DESCRIPTION
- Ensure we show the ? in all the appropriate places
- Ensure we don't spit ? if we shouldn't
- Ensure we drop ? for the special case of the ToString return. See in-code comments for details.

Closes #30317. Note the original request in the bug isn't granted due to the extensive design discussion afterwards, but it fixes all the other problems.