### PR TITLE
Do not fade code for IDE0016 (UseThrowExpressionDiagnosticId)

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
@@ -45,9 +45,10 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
-        public async Task TestOnIf()
+        [WorkItem(38136, "https://github.com/dotnet/roslyn/pull/38136")]
+        public async Task TestMissingOnIf()
         {
-            await TestInRegularAndScriptAsync(
+            await TestMissingInRegularAndScriptAsync(
 @"using System;
 
 class C
@@ -57,15 +58,6 @@ class C
         [|if|] (s == null)
             throw new ArgumentNullException(nameof(s));
         _s = s;
-    }
-}",
-@"using System;
-
-class C
-{
-    void M(string s)
-    {
-        _s = s ?? throw new ArgumentNullException(nameof(s));
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests_FixAllTests.cs
@@ -91,9 +91,9 @@ class C
 {
     void M(string s, string t)
     {
-        {|FixAllInDocument:if|} (s == null)
+        if (s == null)
         {
-            throw new ArgumentNullException(nameof(s));
+            {|FixAllInDocument:throw new ArgumentNullException(nameof(s));|}
         }
 
         if (t == null)
@@ -132,9 +132,9 @@ class C
             throw new ArgumentNullException(nameof(s));
         }
 
-        {|FixAllInDocument:if|} (t == null)
+        if (t == null)
         {
-            throw new ArgumentNullException(nameof(t));
+            {|FixAllInDocument:throw new ArgumentNullException(nameof(t));|}
         }
 
         _s = s;

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -6,8 +6,8 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.UseThrowExpression
 {
@@ -33,12 +33,32 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
     internal abstract class AbstractUseThrowExpressionDiagnosticAnalyzer :
         AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
+        internal const string UseThrowExpressionFixableDiagnosticId = IDEDiagnosticIds.UseThrowExpressionDiagnosticId + "_Fixable";
+
+        private static readonly LocalizableString s_title = new LocalizableResourceString(nameof(FeaturesResources.Use_throw_expression), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly LocalizableString s_message = new LocalizableResourceString(nameof(FeaturesResources.Null_check_can_be_simplified), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+
+        private static readonly DiagnosticDescriptor s_descriptor = CreateDescriptorWithId(
+            IDEDiagnosticIds.UseThrowExpressionDiagnosticId,
+            s_title,
+            s_message);
+        private static readonly DiagnosticDescriptor s_fixableDescriptor = CreateDescriptorWithId(
+            UseThrowExpressionFixableDiagnosticId,
+            s_title,
+            s_message,
+            isConfigurable: false);
+
         protected AbstractUseThrowExpressionDiagnosticAnalyzer()
-            : base(IDEDiagnosticIds.UseThrowExpressionDiagnosticId,
-                   CodeStyleOptions.PreferThrowExpression,
-                   new LocalizableResourceString(nameof(FeaturesResources.Use_throw_expression), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-                   new LocalizableResourceString(nameof(FeaturesResources.Null_check_can_be_simplified), FeaturesResources.ResourceManager, typeof(FeaturesResources)))
+            : base(GetSupportedDescriptorsWithOptions())
         {
+        }
+
+        private static ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption> GetSupportedDescriptorsWithOptions()
+        {
+            var builder = ImmutableDictionary.CreateBuilder<DiagnosticDescriptor, IPerLanguageOption>();
+            builder.Add(s_descriptor, CodeStyleOptions.PreferThrowExpression);
+            builder.Add(s_fixableDescriptor, CodeStyleOptions.PreferThrowExpression);
+            return builder.ToImmutable();
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
@@ -95,7 +115,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             }
 
             var option = optionSet.GetOption(CodeStyleOptions.PreferThrowExpression, throwStatementSyntax.Language);
-            if (!option.Value)
+            if (!option.Value || option.Notification.Severity == ReportDiagnostic.Suppress)
             {
                 return;
             }
@@ -143,29 +163,13 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 throwOperation.Exception.Syntax.GetLocation(),
                 assignmentExpression.Value.Syntax.GetLocation());
 
+            // Report a configurable diagnostic on the throw statement span.
             context.ReportDiagnostic(
-                DiagnosticHelper.Create(Descriptor, throwStatementSyntax.GetLocation(), option.Notification.Severity, additionalLocations: allLocations, properties: null));
+                DiagnosticHelper.Create(s_descriptor, throwStatementSyntax.GetLocation(), option.Notification.Severity, additionalLocations: allLocations, properties: null));
 
-            // Fade out the rest of the if that surrounds the 'throw' exception.
-
-            var tokenBeforeThrow = throwStatementSyntax.GetFirstToken().GetPreviousToken();
-            var tokenAfterThrow = throwStatementSyntax.GetLastToken().GetNextToken();
+            // Report a non-configurable hidden fixable diagnostic on the "if" span so the code fix can be invoked from anywhere inside the "if" span.
             context.ReportDiagnostic(
-                Diagnostic.Create(UnnecessaryWithSuggestionDescriptor,
-                    Location.Create(syntaxTree, TextSpan.FromBounds(
-                        ifOperation.Syntax.SpanStart,
-                        tokenBeforeThrow.Span.End)),
-                    additionalLocations: allLocations));
-
-            if (ifOperation.Syntax.Span.End > tokenAfterThrow.Span.Start)
-            {
-                context.ReportDiagnostic(
-                    Diagnostic.Create(UnnecessaryWithSuggestionDescriptor,
-                        Location.Create(syntaxTree, TextSpan.FromBounds(
-                            tokenAfterThrow.Span.Start,
-                            ifOperation.Syntax.Span.End)),
-                        additionalLocations: allLocations));
-            }
+                Diagnostic.Create(s_fixableDescriptor, ifOperation.Syntax.GetLocation(), additionalLocations: allLocations));
         }
 
         private static bool ValueIsAccessed(SemanticModel semanticModel, IConditionalOperation ifOperation, IBlockOperation containingBlock, ISymbol localOrParameter, IExpressionStatementOperation expressionStatement, IAssignmentOperation assignmentExpression)

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -145,27 +145,6 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
 
             context.ReportDiagnostic(
                 DiagnosticHelper.Create(Descriptor, throwStatementSyntax.GetLocation(), option.Notification.Severity, additionalLocations: allLocations, properties: null));
-
-            // Fade out the rest of the if that surrounds the 'throw' exception.
-
-            var tokenBeforeThrow = throwStatementSyntax.GetFirstToken().GetPreviousToken();
-            var tokenAfterThrow = throwStatementSyntax.GetLastToken().GetNextToken();
-            context.ReportDiagnostic(
-                Diagnostic.Create(UnnecessaryWithSuggestionDescriptor,
-                    Location.Create(syntaxTree, TextSpan.FromBounds(
-                        ifOperation.Syntax.SpanStart,
-                        tokenBeforeThrow.Span.End)),
-                    additionalLocations: allLocations));
-
-            if (ifOperation.Syntax.Span.End > tokenAfterThrow.Span.Start)
-            {
-                context.ReportDiagnostic(
-                    Diagnostic.Create(UnnecessaryWithSuggestionDescriptor,
-                        Location.Create(syntaxTree, TextSpan.FromBounds(
-                            tokenAfterThrow.Span.Start,
-                            ifOperation.Syntax.Span.End)),
-                        additionalLocations: allLocations));
-            }
         }
 
         private static bool ValueIsAccessed(SemanticModel semanticModel, IConditionalOperation ifOperation, IBlockOperation containingBlock, ISymbol localOrParameter, IExpressionStatementOperation expressionStatement, IAssignmentOperation assignmentExpression)

--- a/src/Features/Core/Portable/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
         }
 
         public override ImmutableArray<string> FixableDiagnosticIds
-            => ImmutableArray.Create(IDEDiagnosticIds.UseThrowExpressionDiagnosticId);
+            => ImmutableArray.Create(AbstractUseThrowExpressionDiagnosticAnalyzer.UseThrowExpressionFixableDiagnosticId);
 
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 var throwStatementExpression = root.FindNode(diagnostic.AdditionalLocations[1].SourceSpan);
                 var assignmentValue = root.FindNode(diagnostic.AdditionalLocations[2].SourceSpan);
 
-                // First, remote the if-statement entirely.
+                // First, remove the if-statement entirely.
                 editor.RemoveNode(ifStatement);
 
                 // Now, update the assignment value to go from 'a' to 'a ?? throw ...'.

--- a/src/Features/Core/Portable/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/UseThrowExpressionCodeFixProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
         }
 
         public override ImmutableArray<string> FixableDiagnosticIds
-            => ImmutableArray.Create(AbstractUseThrowExpressionDiagnosticAnalyzer.UseThrowExpressionFixableDiagnosticId);
+            => ImmutableArray.Create(IDEDiagnosticIds.UseThrowExpressionDiagnosticId);
 
         internal sealed override CodeFixCategory CodeFixCategory => CodeFixCategory.CodeStyle;
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 var throwStatementExpression = root.FindNode(diagnostic.AdditionalLocations[1].SourceSpan);
                 var assignmentValue = root.FindNode(diagnostic.AdditionalLocations[2].SourceSpan);
 
-                // First, remove the if-statement entirely.
+                // First, remote the if-statement entirely.
                 editor.RemoveNode(ifStatement);
 
                 // Now, update the assignment value to go from 'a' to 'a ?? throw ...'.


### PR DESCRIPTION
Fixes #27213

Analyzer recommends using throw expression for null checks instead of throw statement within an if statement with null check. We used to fade the entire if statement for discoverability and increased code fix span, but this was undesirable as we want to fade only unnecessary or dead code. Instead, we now generate a hidden non-configurable fixable diagnostic for the increased code fix span and do not generate any fading.