### PR TITLE
Adjust sequence point on await foreach and using declaration

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -229,7 +229,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundStatement InstrumentForEachStatement(BoundForEachStatement original, BoundStatement rewritten)
         {
             var forEachSyntax = (CommonForEachStatementSyntax)original.Syntax;
-            BoundSequencePointWithSpan foreachKeywordSequencePoint = new BoundSequencePointWithSpan(forEachSyntax, null, forEachSyntax.ForEachKeyword.Span);
+            var span = forEachSyntax.AwaitKeyword != default
+                ? TextSpan.FromBounds(forEachSyntax.AwaitKeyword.Span.Start, forEachSyntax.ForEachKeyword.Span.End)
+                : forEachSyntax.ForEachKeyword.Span;
+
+            var foreachKeywordSequencePoint = new BoundSequencePointWithSpan(forEachSyntax, null, span);
             return new BoundStatementList(forEachSyntax,
                                             ImmutableArray.Create<BoundStatement>(foreachKeywordSequencePoint,
                                                                                 base.InstrumentForEachStatement(original, rewritten)));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -2498,7 +2498,7 @@ public class C
     IL_000c:  br         IL_009a
     // sequence point: {
     IL_0011:  nop
-    // sequence point: foreach
+    // sequence point: await foreach
     IL_0012:  nop
     // sequence point: new C()
     IL_0013:  ldarg.0
@@ -4208,7 +4208,7 @@ class C
     IL_0012:  ldarg.0
     IL_0013:  newobj     ""Collection<int>..ctor()""
     IL_0018:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
-    // sequence point: foreach
+    // sequence point: await foreach
     IL_001d:  nop
     // sequence point: c
     IL_001e:  ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -1989,7 +1989,7 @@ public class C
                 );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         [WorkItem(32316, "https://github.com/dotnet/roslyn/issues/32316")]
         public void TestPatternBasedDisposal_InstanceMethod_UsingDeclaration()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitUsingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using ICSharpCode.Decompiler.DebugInfo;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -2014,7 +2015,176 @@ public class C
 ";
             var comp = CreateCompilationWithTasksExtensions(new[] { source, s_interfaces }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+            var verifier = CompileAndVerify(comp, expectedOutput: "using dispose_start dispose_end return");
+
+            // Sequence point higlights `await using ...`
+            verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      303 (0x12f)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                object V_2,
+                System.Runtime.CompilerServices.ValueTaskAwaiter V_3,
+                System.Threading.Tasks.ValueTask V_4,
+                C.<Main>d__0 V_5,
+                System.Exception V_6)
+  // sequence point: <hidden>
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<Main>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    // sequence point: <hidden>
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_000c
+    IL_000a:  br.s       IL_0011
+    IL_000c:  br         IL_0091
+    // sequence point: {
+    IL_0011:  nop
+    // sequence point: {
+    IL_0012:  nop
+    // sequence point: await using var x = new C();
+    IL_0013:  ldarg.0
+    IL_0014:  newobj     ""C..ctor()""
+    IL_0019:  stfld      ""C C.<Main>d__0.<x>5__1""
+    // sequence point: <hidden>
+    IL_001e:  ldarg.0
+    IL_001f:  ldnull
+    IL_0020:  stfld      ""object C.<Main>d__0.<>s__2""
+    IL_0025:  ldarg.0
+    IL_0026:  ldc.i4.0
+    IL_0027:  stfld      ""int C.<Main>d__0.<>s__3""
+    .try
+    {
+      // sequence point: System.Console.Write(""using "");
+      IL_002c:  ldstr      ""using ""
+      IL_0031:  call       ""void System.Console.Write(string)""
+      IL_0036:  nop
+      // sequence point: <hidden>
+      IL_0037:  leave.s    IL_0043
+    }
+    catch object
+    {
+      // sequence point: <hidden>
+      IL_0039:  stloc.2
+      IL_003a:  ldarg.0
+      IL_003b:  ldloc.2
+      IL_003c:  stfld      ""object C.<Main>d__0.<>s__2""
+      IL_0041:  leave.s    IL_0043
+    }
+    // sequence point: <hidden>
+    IL_0043:  ldarg.0
+    IL_0044:  ldfld      ""C C.<Main>d__0.<x>5__1""
+    IL_0049:  brfalse.s  IL_00b5
+    IL_004b:  ldarg.0
+    IL_004c:  ldfld      ""C C.<Main>d__0.<x>5__1""
+    IL_0051:  callvirt   ""System.Threading.Tasks.ValueTask C.DisposeAsync()""
+    IL_0056:  stloc.s    V_4
+    IL_0058:  ldloca.s   V_4
+    IL_005a:  call       ""System.Runtime.CompilerServices.ValueTaskAwaiter System.Threading.Tasks.ValueTask.GetAwaiter()""
+    IL_005f:  stloc.3
+    // sequence point: <hidden>
+    IL_0060:  ldloca.s   V_3
+    IL_0062:  call       ""bool System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted.get""
+    IL_0067:  brtrue.s   IL_00ad
+    IL_0069:  ldarg.0
+    IL_006a:  ldc.i4.0
+    IL_006b:  dup
+    IL_006c:  stloc.0
+    IL_006d:  stfld      ""int C.<Main>d__0.<>1__state""
+    // async: yield
+    IL_0072:  ldarg.0
+    IL_0073:  ldloc.3
+    IL_0074:  stfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_0079:  ldarg.0
+    IL_007a:  stloc.s    V_5
+    IL_007c:  ldarg.0
+    IL_007d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<Main>d__0.<>t__builder""
+    IL_0082:  ldloca.s   V_3
+    IL_0084:  ldloca.s   V_5
+    IL_0086:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ValueTaskAwaiter, C.<Main>d__0>(ref System.Runtime.CompilerServices.ValueTaskAwaiter, ref C.<Main>d__0)""
+    IL_008b:  nop
+    IL_008c:  leave      IL_012e
+    // async: resume
+    IL_0091:  ldarg.0
+    IL_0092:  ldfld      ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_0097:  stloc.3
+    IL_0098:  ldarg.0
+    IL_0099:  ldflda     ""System.Runtime.CompilerServices.ValueTaskAwaiter C.<Main>d__0.<>u__1""
+    IL_009e:  initobj    ""System.Runtime.CompilerServices.ValueTaskAwaiter""
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldc.i4.m1
+    IL_00a6:  dup
+    IL_00a7:  stloc.0
+    IL_00a8:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_00ad:  ldloca.s   V_3
+    IL_00af:  call       ""void System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult()""
+    IL_00b4:  nop
+    // sequence point: <hidden>
+    IL_00b5:  ldarg.0
+    IL_00b6:  ldfld      ""object C.<Main>d__0.<>s__2""
+    IL_00bb:  stloc.2
+    IL_00bc:  ldloc.2
+    IL_00bd:  brfalse.s  IL_00da
+    IL_00bf:  ldloc.2
+    IL_00c0:  isinst     ""System.Exception""
+    IL_00c5:  stloc.s    V_6
+    IL_00c7:  ldloc.s    V_6
+    IL_00c9:  brtrue.s   IL_00cd
+    IL_00cb:  ldloc.2
+    IL_00cc:  throw
+    IL_00cd:  ldloc.s    V_6
+    IL_00cf:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00d4:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00d9:  nop
+    IL_00da:  ldarg.0
+    IL_00db:  ldfld      ""int C.<Main>d__0.<>s__3""
+    IL_00e0:  pop
+    IL_00e1:  ldarg.0
+    IL_00e2:  ldnull
+    IL_00e3:  stfld      ""object C.<Main>d__0.<>s__2""
+    // sequence point: }
+    IL_00e8:  nop
+    IL_00e9:  ldarg.0
+    IL_00ea:  ldnull
+    IL_00eb:  stfld      ""C C.<Main>d__0.<x>5__1""
+    // sequence point: System.Console.Write(""return"");
+    IL_00f0:  ldstr      ""return""
+    IL_00f5:  call       ""void System.Console.Write(string)""
+    IL_00fa:  nop
+    // sequence point: return 1;
+    IL_00fb:  ldc.i4.1
+    IL_00fc:  stloc.1
+    IL_00fd:  leave.s    IL_0119
+  }
+  catch System.Exception
+  {
+    // async: catch handler, sequence point: <hidden>
+    IL_00ff:  stloc.s    V_6
+    IL_0101:  ldarg.0
+    IL_0102:  ldc.i4.s   -2
+    IL_0104:  stfld      ""int C.<Main>d__0.<>1__state""
+    IL_0109:  ldarg.0
+    IL_010a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<Main>d__0.<>t__builder""
+    IL_010f:  ldloc.s    V_6
+    IL_0111:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0116:  nop
+    IL_0117:  leave.s    IL_012e
+  }
+  // sequence point: }
+  IL_0119:  ldarg.0
+  IL_011a:  ldc.i4.s   -2
+  IL_011c:  stfld      ""int C.<Main>d__0.<>1__state""
+  // sequence point: <hidden>
+  IL_0121:  ldarg.0
+  IL_0122:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<Main>d__0.<>t__builder""
+  IL_0127:  ldloc.1
+  IL_0128:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_012d:  nop
+  IL_012e:  ret
+}
+", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingDeclarationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
@@ -16,7 +17,7 @@ namespace System
     }
 }";
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void UsingVariableVarEmitTest()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingDeclarationTests.cs
@@ -37,22 +37,27 @@ class C2
   // Code size       19 (0x13)
   .maxstack  1
   .locals init (C1 V_0) //c1
+  // sequence point: using var c1 = new C1();
   IL_0000:  newobj     ""C1..ctor()""
   IL_0005:  stloc.0
   .try
   {
+    // sequence point: }
     IL_0006:  leave.s    IL_0012
   }
   finally
   {
+    // sequence point: <hidden>
     IL_0008:  ldloc.0
     IL_0009:  brfalse.s  IL_0011
     IL_000b:  ldloc.0
     IL_000c:  callvirt   ""void System.IDisposable.Dispose()""
+    // sequence point: <hidden>
     IL_0011:  endfinally
   }
+  // sequence point: }
   IL_0012:  ret
-}");
+}", sequencePoints: "C2.Main", source: source);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -977,7 +977,7 @@ class Test
         #endregion
 
         // The object could be created inside the "using" statement 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         public void ObjectCreateInsideUsing()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenUsingStatementTests.cs
@@ -1004,24 +1004,30 @@ class Program
   // Code size       25 (0x19)
   .maxstack  1
   .locals init (Program.MyManagedClass V_0) //mnObj
+  // sequence point: MyManagedClass mnObj = new MyManagedClass()
   IL_0000:  newobj     ""Program.MyManagedClass..ctor()""
   IL_0005:  stloc.0
   .try
   {
+    // sequence point: mnObj.Use();
     IL_0006:  ldloc.0
     IL_0007:  callvirt   ""void Program.MyManagedClass.Use()""
+    // sequence point: }
     IL_000c:  leave.s    IL_0018
   }
   finally
   {
+    // sequence point: <hidden>
     IL_000e:  ldloc.0
     IL_000f:  brfalse.s  IL_0017
     IL_0011:  ldloc.0
     IL_0012:  callvirt   ""void System.IDisposable.Dispose()""
+    // sequence point: <hidden>
     IL_0017:  endfinally
   }
+  // sequence point: }
   IL_0018:  ret
-}");
+}", sequencePoints: "Program.Main", source: source);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5915,7 +5915,7 @@ class C
                 System.IO.MemoryStream V_1) //n
   // sequence point: {
   IL_0000:  nop
-  // sequence point: MemoryStream m = new MemoryStream()
+  // sequence point: using MemoryStream m = new MemoryStream()
   IL_0001:  newobj     ""System.IO.MemoryStream..ctor()""
   IL_0006:  stloc.0
   .try
@@ -5961,41 +5961,41 @@ class C
 ");
 
             c.VerifyPdb("C.Main", @"
- <symbols>
-   <files>
-     <file id=""1"" name="""" language=""C#"" />
-   </files>
-   <methods>
-     <method containingType=""C"" name=""Main"">
-       <customDebugInfo>
-         <using>
-           <namespace usingCount=""2"" />
-         </using>
-         <encLocalSlotMap>
-           <slot kind=""0"" offset=""30"" />
-           <slot kind=""0"" offset=""54"" />
-         </encLocalSlotMap>
-       </customDebugInfo>
-       <sequencePoints>
-         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-         <entry offset=""0x1"" startLine=""8"" startColumn=""15"" endLine=""8"" endColumn=""50"" document=""1"" />
-         <entry offset=""0x7"" startLine=""8"" startColumn=""52"" endLine=""8"" endColumn=""74"" document=""1"" />
-         <entry offset=""0xd"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""30"" document=""1"" />
-         <entry offset=""0x14"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
-         <entry offset=""0x16"" hidden=""true"" document=""1"" />
-         <entry offset=""0x20"" hidden=""true"" document=""1"" />
-         <entry offset=""0x21"" hidden=""true"" document=""1"" />
-         <entry offset=""0x2b"" hidden=""true"" document=""1"" />
-         <entry offset=""0x2c"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
-       </sequencePoints>
-       <scope startOffset=""0x0"" endOffset=""0x2d"">
-         <namespace name=""System"" />
-         <namespace name=""System.IO"" />
-         <local name=""m"" il_index=""0"" il_start=""0x0"" il_end=""0x2d"" attributes=""0"" />
-         <local name=""n"" il_index=""1"" il_start=""0x0"" il_end=""0x2d"" attributes=""0"" />
-       </scope>
-     </method>
-   </methods>
+<symbols>
+  <files>
+    <file id=""1"" name="""" language=""C#"" />
+  </files>
+  <methods>
+    <method containingType=""C"" name=""Main"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""2"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""0"" offset=""30"" />
+          <slot kind=""0"" offset=""54"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""50"" document=""1"" />
+        <entry offset=""0x7"" startLine=""8"" startColumn=""52"" endLine=""8"" endColumn=""74"" document=""1"" />
+        <entry offset=""0xd"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""30"" document=""1"" />
+        <entry offset=""0x14"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x16"" hidden=""true"" document=""1"" />
+        <entry offset=""0x20"" hidden=""true"" document=""1"" />
+        <entry offset=""0x21"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2b"" hidden=""true"" document=""1"" />
+        <entry offset=""0x2c"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" document=""1"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x2d"">
+        <namespace name=""System"" />
+        <namespace name=""System.IO"" />
+        <local name=""m"" il_index=""0"" il_start=""0x0"" il_end=""0x2d"" attributes=""0"" />
+        <local name=""n"" il_index=""1"" il_start=""0x0"" il_end=""0x2d"" attributes=""0"" />
+      </scope>
+    </method>
+  </methods>
  </symbols>");
         }
 
@@ -6030,7 +6030,7 @@ class C
                 int V_1)
   // sequence point: {
   IL_0000:  nop
-  // sequence point: MemoryStream m = new MemoryStream();
+  // sequence point: using MemoryStream m = new MemoryStream();
   IL_0001:  newobj     ""System.IO.MemoryStream..ctor()""
   IL_0006:  stloc.0
   .try
@@ -6079,7 +6079,7 @@ class C
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x1"" startLine=""8"" startColumn=""15"" endLine=""8"" endColumn=""51"" document=""1"" />
+        <entry offset=""0x1"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""51"" document=""1"" />
         <entry offset=""0x7"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""30"" document=""1"" />
         <entry offset=""0xe"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""18"" document=""1"" />
         <entry offset=""0x12"" hidden=""true"" document=""1"" />
@@ -6141,7 +6141,7 @@ class C
   IL_0008:  brfalse.s  IL_0026
   // sequence point: {
   IL_000a:  nop
-  // sequence point: var m = new MemoryStream();
+  // sequence point: using var m = new MemoryStream();
   IL_000b:  newobj     ""System.IO.MemoryStream..ctor()""
   IL_0010:  stloc.1
   .try
@@ -6175,7 +6175,7 @@ class C
 ");
 
             c.VerifyPdb("C.Main", @"
- <symbols>
+<symbols>
   <files>
     <file id=""1"" name="""" language=""C#"" />
   </files>
@@ -6193,7 +6193,7 @@ class C
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""17"" document=""1"" />
         <entry offset=""0x7"" hidden=""true"" document=""1"" />
         <entry offset=""0xa"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" document=""1"" />
-        <entry offset=""0xb"" startLine=""12"" startColumn=""19"" endLine=""12"" endColumn=""46"" document=""1"" />
+        <entry offset=""0xb"" startLine=""12"" startColumn=""13"" endLine=""12"" endColumn=""46"" document=""1"" />
         <entry offset=""0x11"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""34"" document=""1"" />
         <entry offset=""0x1a"" hidden=""true"" document=""1"" />
         <entry offset=""0x24"" hidden=""true"" document=""1"" />


### PR DESCRIPTION
Highlight the `using` and `await` in `await foreach (...)`, `using var x = ...` and `await using var x = ...`.

Fixes https://github.com/dotnet/roslyn/issues/37402