### PR TITLE
Change unused parameters analyzer configuration to analyze generated …

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1335,6 +1335,46 @@ public sealed class C : IDisposable
 }", options);
         }
 
+        [WorkItem(37483, "https://github.com/dotnet/roslyn/issues/37483")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task MethodUsedAsDelegateInGeneratedCode_NoDiagnostic()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System;
+
+public partial class C
+{
+    private void M(int [|x|])
+    {
+    }
+}
+
+public partial class C
+{
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("""", """")]
+    public void M2(out Action<int> a)
+    {
+        a = M;
+    }
+}  
+");
+        }
+
+        [WorkItem(37483, "https://github.com/dotnet/roslyn/issues/37483")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
+        public async Task UnusedParameterInGeneratedCode_NoDiagnostic()
+        {
+            await TestDiagnosticMissingAsync(
+@"public partial class C
+{
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("""", """")]
+    private void M(int [|x|])
+    {
+    }
+}
+");
+        }
+
         [WorkItem(36817, "https://github.com/dotnet/roslyn/issues/36817")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedParameters)]
         public async Task ParameterWithoutName_NoDiagnostic()

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -181,8 +181,12 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         protected sealed override void InitializeWorker(AnalysisContext context)
-            => context.RegisterCompilationStartAction(
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            context.RegisterCompilationStartAction(
                 compilationContext => SymbolStartAnalyzer.CreateAndRegisterActions(compilationContext, this));
+        }
 
         private bool TryGetOptions(
             SyntaxTree syntaxTree,


### PR DESCRIPTION
…code

This fixes false reports for unused parameters of event handlers that are referenced/invoked from xaml generated code files. Fixes #37483