### PR TITLE
Skip uninitialized field warning for generic constrained to nullable reference type

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -162,10 +162,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     continue;
                 }
+
                 if (fieldType.Type.IsValueType || fieldType.Type.IsErrorType())
                 {
                     continue;
                 }
+
+                if (fieldType.IsDefinitelyNullableReferenceType())
+                {
+                    continue;
+                }
+
                 if (!fieldType.NullableAnnotation.IsNotAnnotated() && !fieldType.Type.IsTypeParameterDisallowingAnnotation())
                 {
                     continue;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -123,6 +123,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                  Type?.IsNullableTypeOrTypeParameter() == true);
         }
 
+        internal bool IsDefinitelyNullableReferenceType()
+        {
+            if (NullableAnnotation.IsAnnotated())
+            {
+                return true;
+            }
+            else if (Type is TypeParameterSymbol typeParameter)
+            {
+                if (typeParameter.ReferenceTypeConstraintIsNullable == true)
+                {
+                    return true;
+                }
+                else
+                {
+                    foreach (var constraint in typeParameter.ConstraintTypesNoUseSiteDiagnostics)
+                    {
+                        if (constraint.IsDefinitelyNullableReferenceType())
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
         internal NullableAnnotation GetValueNullableAnnotation()
         {
             if (IsPossiblyNullableTypeTypeParameter())

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UninitializedNonNullableFieldTests.cs
@@ -884,6 +884,99 @@ class C<T>
         }
 
         [Fact]
+        public void GenericType_NullableClassConstraint_01()
+        {
+            var source =
+@"class C<T> where T : class?
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private T P1 { get; }
+    internal T P2 { get; set; }
+    private C()
+    {
+    }
+}";
+            var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void GenericType_NullableClassConstraint_02()
+        {
+            var source =
+@"class A
+{
+    public string field = """";
+}
+
+class C<T> where T : A?
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private T P1 { get; }
+    internal T P2 { get; set; }
+    private C()
+    {
+    }
+}";
+            var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void GenericType_NullableClassConstraint_03()
+        {
+            var source =
+@"class A
+{
+    public string field = """";
+}
+
+class C<T, U> where U : T where T : A?
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private readonly U F2;
+    private T P1 { get; }
+    internal T P2 { get; set; }
+    private U P3 { get; }
+    internal U P4 { get; set; }
+    private C()
+    {
+    }
+}";
+            var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void GenericType_NullableClassConstraint_04()
+        {
+            var source =
+@"class A
+{
+    public string field = """";
+}
+
+class C<T, U> where U : T where T : class?
+{
+#pragma warning disable 0169
+    private readonly T F1;
+    private readonly U F2;
+    private T P1 { get; }
+    internal T P2 { get; set; }
+    private U P3 { get; }
+    internal U P4 { get; set; }
+    private C()
+    {
+    }
+}";
+            var comp = CreateCompilation(new[] { source }, options: WithNonNullTypesTrue(), parseOptions: TestOptions.Regular8);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void GenericType_StructConstraint()
         {
             var source =


### PR DESCRIPTION
Closes #37987

I wasn't able to find an API that did quite what I want, so I ended up adding it to TypeWithAnnotations. I would like to know if there's a better or already existing way to answer the question it is answering.