### PR TITLE
When a synthetic ref local is captured, variables referenced in its initializer must be captured too

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundParameter { ParameterSymbol: var symbol }:
                     CaptureVariable(symbol, syntax);
                     break;
-                case BoundFieldAccess { FieldSymbol: { IsStatic: false, ContainingType: var containingType }, ReceiverOpt: { } receiver } when containingType.IsValueType:
+                case BoundFieldAccess { FieldSymbol: { IsStatic: false, ContainingType: { IsValueType: true } }, ReceiverOpt: BoundExpression receiver }:
                     CaptureRefInitializer(receiver, syntax);
                     break;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/IteratorAndAsyncCaptureWalker.cs
@@ -24,13 +24,17 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         // In Release builds we hoist only variables (locals and parameters) that are captured. 
         // This set will contain such variables after the bound tree is visited.
-        private readonly OrderedSet<Symbol> _variablesToHoist;
+        private readonly OrderedSet<Symbol> _variablesToHoist = new OrderedSet<Symbol>();
 
         // Contains variables that are captured but can't be hoisted since their type can't be allocated on heap.
         // The value is a list of all uses of each such variable.
         private MultiDictionary<Symbol, SyntaxNode> _lazyDisallowedCaptures;
 
         private bool _seenYieldInCurrentTry;
+
+        // The initializing expressions for compiler-generated ref local temps.  If the temp needs to be hoisted, then any
+        // variables in its initializing expression will need to be hoisted too.
+        private readonly Dictionary<LocalSymbol, BoundExpression> _boundRefLocalInitializers = new Dictionary<LocalSymbol, BoundExpression>();
 
         private IteratorAndAsyncCaptureWalker(CSharpCompilation compilation, MethodSymbol method, BoundNode node, HashSet<Symbol> initiallyAssignedVariables)
             : base(compilation,
@@ -40,7 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                   trackUnassignments: true,
                   initiallyAssignedVariables: initiallyAssignedVariables)
         {
-            _variablesToHoist = new OrderedSet<Symbol>();
         }
 
         // Returns deterministically ordered list of variables that ought to be hoisted.
@@ -192,7 +195,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                _variablesToHoist.Add(variable);
+                if (_variablesToHoist.Add(variable) && variable is LocalSymbol local && _boundRefLocalInitializers.TryGetValue(local, out var variableInitializer))
+                    CaptureRefInitializer(variableInitializer, syntax);
+            }
+        }
+
+        private void CaptureRefInitializer(BoundExpression variableInitializer, SyntaxNode syntax)
+        {
+            switch (variableInitializer)
+            {
+                case BoundLocal { LocalSymbol: var symbol }:
+                    CaptureVariable(symbol, syntax);
+                    break;
+                case BoundParameter { ParameterSymbol: var symbol }:
+                    CaptureVariable(symbol, syntax);
+                    break;
+                case BoundFieldAccess { FieldSymbol: { IsStatic: false, ContainingType: var containingType }, ReceiverOpt: { } receiver } when containingType.IsValueType:
+                    CaptureRefInitializer(receiver, syntax);
+                    break;
             }
         }
 
@@ -283,6 +303,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             base.VisitFinallyBlock(finallyBlock, ref unsetInFinally);
+        }
+
+        public override BoundNode VisitAssignmentOperator(BoundAssignmentOperator node)
+        {
+            base.VisitAssignmentOperator(node);
+            // for compiler-generated ref local temp, save the initializer.
+            if (node is { IsRef: true, Left: BoundLocal { LocalSymbol: LocalSymbol { IsCompilerGenerated: true } local } })
+                _boundRefLocalInitializers[local] = node.Right;
+            return null;
         }
 
         private sealed class OutsideVariablesUsedInside : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3087,6 +3087,33 @@ class C
             CompileAndVerify(source, expectedOutput: "43", options: TestOptions.DebugExe);
         }
 
+        [Fact, WorkItem(36443, "https://github.com/dotnet/roslyn/issues/36443")]
+        public void SpillCompoundAssignmentToNullableMemberOfLocal_04()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+struct S
+{
+    int? i;
+
+    static async Task M(S s = default)
+    {
+        s = default;
+        Console.WriteLine(s.i += await GetInt());
+    }
+
+    static async Task Main()
+    {
+        M();
+    }
+
+    static Task<int?> GetInt() => Task.FromResult((int?)1);
+}";
+            CompileAndVerify(source, expectedOutput: "", options: TestOptions.ReleaseExe);
+            CompileAndVerify(source, expectedOutput: "", options: TestOptions.DebugExe);
+        }
+
         [Fact]
         public void SpillSacrificialRead()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3020,20 +3020,13 @@ struct S
     static async Task Main()
     {
         S s = default;
-        await M(s);
-        s.i = 0;
-        await M(s);
-    }
-
-    static async Task M(S s)
-    {
         Console.WriteLine(s.i += await GetInt());
     }
 
     static Task<int?> GetInt() => Task.FromResult((int?)1);
 }";
-            CompileAndVerify(source, expectedOutput: "1", options: TestOptions.DebugExe);
-            CompileAndVerify(source, expectedOutput: "1", options: TestOptions.ReleaseExe);
+            CompileAndVerify(source, expectedOutput: "", options: TestOptions.ReleaseExe);
+            CompileAndVerify(source, expectedOutput: "", options: TestOptions.DebugExe);
         }
 
         [Fact, WorkItem(36443, "https://github.com/dotnet/roslyn/issues/36443")]
@@ -3090,8 +3083,8 @@ class C
     }
 }
 ";
-            CompileAndVerify(source, expectedOutput: "43", options: TestOptions.DebugExe);
             CompileAndVerify(source, expectedOutput: "43", options: TestOptions.ReleaseExe);
+            CompileAndVerify(source, expectedOutput: "43", options: TestOptions.DebugExe);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #36443