### PR TITLE
VB: Adjust merging of lookup result for inaccessible members of different kind, prefer more accessible candidate.

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -44,6 +44,18 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
+        public static bool All<T, A>(this ArrayBuilder<T> builder, Func<T, A, bool> predicate, A arg)
+        {
+            foreach (var item in builder)
+            {
+                if (!predicate(item, arg))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         /// <summary>
         /// Maps an array builder to immutable array.
         /// </summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/LookupResult.vb
@@ -631,9 +631,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 MergeOverloadedOrAmbiguousInTheSameType(other, imported)
             ElseIf other.Kind > Me.Kind Then
                 SetFrom(other)
-            ElseIf Me.Kind <> LookupResultKind.Inaccessible OrElse Me.Kind > other.Kind OrElse
-                Not CanOverload(Me.Symbols(0), other.Symbol) Then
+            ElseIf Me.Kind <> LookupResultKind.Inaccessible OrElse Me.Kind > other.Kind Then
                 Return
+            ElseIf Not CanOverload(Me.Symbols(0), other.Symbol) Then
+                Debug.Assert(Me.Kind = LookupResultKind.Inaccessible)
+                Debug.Assert(Me.Kind = other.Kind)
+                If Me.Symbols.All(Function(candidate, otherSymbol) candidate.DeclaredAccessibility < otherSymbol.DeclaredAccessibility, other.Symbol) Then
+                    SetFrom(other)
+                End If
             Else
                 _symList.Add(other.Symbol)
             End If

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -9699,10 +9699,10 @@ BC30456: 'P1' is not a member of 'I1'.
             Dim comp2 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation}, options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
             comp2.AssertTheseDiagnostics(
 <error>
-BC30389: 'I1.P1' is not accessible in this context because it is 'Private'.
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
         AddHandler I1.P1, Nothing
                    ~~~~~
-BC30389: 'I1.P1' is not accessible in this context because it is 'Private'.
+BC30389: 'I1.P1' is not accessible in this context because it is 'Friend'.
         RemoveHandler I1.P1, Nothing
                       ~~~~~
 </error>)
@@ -9834,10 +9834,10 @@ BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protec
             Dim comp2 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation}, options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
             comp2.AssertTheseDiagnostics(
 <error>
-BC30389: 'I1.P1' is not accessible in this context because it is 'Private'.
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
         AddHandler I1.P1, Nothing
                    ~~~~~
-BC30389: 'I1.P1' is not accessible in this context because it is 'Private'.
+BC30389: 'I1.P1' is not accessible in this context because it is 'Private Protected'.
         RemoveHandler I1.P1, Nothing
                       ~~~~~
 </error>)


### PR DESCRIPTION
Fixes #35948.