### PR TITLE
Do not report an NFW for analyzer exception diagnostic in IDE

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -152,11 +152,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 hostDiagnosticUpdateSource?.ReportAnalyzerDiagnostic(analyzer, diagnostic, hostDiagnosticUpdateSource?.Workspace, projectIdOpt);
             }
-
-            if (IsBuiltInAnalyzer(analyzer))
-            {
-                FatalError.ReportWithoutCrashUnlessCanceled(ex);
-            }
         }
 
         internal static void OnAnalyzerExceptionForSupportedDiagnostics(DiagnosticAnalyzer analyzer, Exception exception, AbstractHostDiagnosticUpdateSource hostDiagnosticUpdateSource)


### PR DESCRIPTION
This seems to cause a noticable UI delay while the NFW gets reported. We already report the AD0001 diagnostic with exception callstack and the analysis context on which exception occurred, so user has enough information to file an actionable bug.
Fixes #38180