### PR TITLE
Treat AddImport replacement text changes as insertions.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProviderTests.cs
@@ -386,5 +386,45 @@ namespace B
 
             await TestInRegularAndScriptAsync(code, expected, placeSystemNamespaceFirst: false, separateImportDirectiveGroups: false);
         }
+
+        [WpfFact]
+        [WorkItem(35982, "https://github.com/dotnet/roslyn/issues/35982")]
+        public async Task AddMissingImports_RetainsAdditionalNewLinesFollowingUsingDirectives()
+        {
+            var code = @"
+using System;
+
+
+
+class C
+{
+    [|public D Foo { get; }|]
+}
+
+namespace A
+{
+    public class D { }
+}
+";
+
+            var expected = @"
+using System;
+using A;
+
+
+
+class C
+{
+    public D Foo { get; }
+}
+
+namespace A
+{
+    public class D { }
+}
+";
+
+            await TestInRegularAndScriptAsync(code, expected, placeSystemNamespaceFirst: true, separateImportDirectiveGroups: false);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProviderTests.vb
@@ -362,5 +362,42 @@ End Namespace
 
             Await TestInRegularAndScriptAsync(code, expected, placeSystemNamespaceFirst:=False, separateImportDirectiveGroups:=False)
         End Function
+
+        <WpfFact>
+        <WorkItem(35982, "https://github.com/dotnet/roslyn/issues/35982")>
+        Public Async Function AddMissingImports_RetainsAdditionalNewLinesFollowingUsingDirectives() As Task
+            Dim code = "
+Imports System
+
+
+
+Class C
+    [|Dim foo As D|]
+End Class
+
+Namespace A
+    Public Class D
+    End Class
+End Namespace
+"
+
+            Dim expected = "
+Imports System
+Imports A
+
+
+
+Class C
+    Dim foo As D
+End Class
+
+Namespace A
+    Public Class D
+    End Class
+End Namespace
+"
+
+            Await TestInRegularAndScriptAsync(code, expected, placeSystemNamespaceFirst:=True, separateImportDirectiveGroups:=False)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             newProject = newProject.AddProjectReferences(allAddedProjectReferences);
 
 
-            // The text changes produced by the AddImport code fixes with be inserts except in
+            // The text changes produced by the AddImport code fixes will be inserts except in
             // the case where there were multiple trailing newlines.
 
             // Insertion case (zero or one trailing newline following the using directives):


### PR DESCRIPTION
In AddMissingImports refactoring, AddImport fix text changes can come back
as a replacement instead of an insertion when there are multiple trailing
newlines following the using directives. Convert these to insertions so
that we retain the newlines and the text changes don't step on each other.

Fixes #35982