### PR TITLE
A switch expression only has a common type if all arms can be converted to that type.

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -8,3 +8,6 @@ Each entry should include a short description of the break, followed by either a
     bool M<T>(T t) => t is null;
     ```
 However, in *Visual Studio 2019* we improperly permitted this to compile in language versions `7.0`, `7.1`, `7.2`, and `7.3`.  In *Visual Studio 2019 Update 1* we will make it an error (as it was in *Visual Studio 2017*), and suggest updating to `preview` or `8.0`.
+
+2. https://github.com/dotnet/roslyn/issues/38226 When there exists a common type among those arms of a switch expression that have a type, but there are some arms that have an expression without a type (e.g. `null`) that cannot convert to that common type, the compiler improperly inferred that common type as the natural type of the switch expression. That would cause an error.  In VS 2019 Update 4, we fixed the compiler to no longer consider such a switch expression to have a common type.  This may permit some programs to compile without error that would produce an error in the previous version.
+

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -1204,5 +1204,141 @@ Target->Ultimate
                 );
             var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
+
+        [Fact, WorkItem(38226, "https://github.com/dotnet/roslyn/issues/38226")]
+        public void TargetTypedSwitch_NaturalTypeWithUntypedArm_01()
+        {
+            var source = @"
+class Program
+{
+    public static bool? GetBool(string name)
+    {
+        return name switch
+        {
+            ""a"" => true,
+            ""b"" => false,
+            _ => null,
+        };
+    }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics(
+                );
+        }
+
+        [Fact, WorkItem(38226, "https://github.com/dotnet/roslyn/issues/38226")]
+        public void TargetTypedSwitch_NaturalTypeWithUntypedArm_02()
+        {
+            var source = @"
+class Program
+{
+    public static bool? GetBool(string name) => name switch
+        {
+            ""a"" => true,
+            ""b"" => false,
+            _ => null,
+        };
+}
+";
+            CreateCompilation(source).VerifyDiagnostics(
+                );
+        }
+
+        [Fact, WorkItem(38226, "https://github.com/dotnet/roslyn/issues/38226")]
+        public void TargetTypedSwitch_NaturalTypeWithUntypedArm_03()
+        {
+            var source = @"
+class Program
+{
+    public static bool? GetBool(string name)
+    {
+        return name switch
+        {
+            ""a"" => true,
+            _ => name switch
+                {
+                    ""b"" => false,
+                    _ => null,
+                },
+        };
+    }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics(
+                );
+        }
+
+        [Fact, WorkItem(38226, "https://github.com/dotnet/roslyn/issues/38226")]
+        public void TargetTypedSwitch_NaturalTypeWithUntypedArm_04()
+        {
+            var source = @"
+class Program
+{
+    public static bool? GetBool(string name)
+    {
+        var result = name switch
+        {
+            ""a"" => true,
+            ""b"" => false,
+            _ => null,
+        };
+        return result;
+    }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics(
+                // (6,27): error CS8506: No best type was found for the switch expression.
+                //         var result = name switch
+                Diagnostic(ErrorCode.ERR_SwitchExpressionNoBestType, "switch").WithLocation(6, 27)
+                );
+        }
+
+        [Fact, WorkItem(38226, "https://github.com/dotnet/roslyn/issues/38226")]
+        public void TargetTypedSwitch_NaturalTypeWithUntypedArm_05()
+        {
+            var source = @"
+class Program
+{
+    public static void Main(string[] args)
+    {
+        System.Console.WriteLine(Get(""a"").Item1?.ToString() ?? ""null"");
+    }
+    public static (int?, int) Get(string name)
+    {
+        return name switch
+        {
+            ""a"" => (default, 1), // this is convertible to (int, int)
+            ""b"" => (1, 2),
+            _ => (3, 4),
+        };
+    }
+}
+";
+            CompileAndVerify(CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(), expectedOutput: "0");
+        }
+
+        [Fact, WorkItem(38226, "https://github.com/dotnet/roslyn/issues/38226")]
+        public void TargetTypedSwitch_NaturalTypeWithUntypedArm_06()
+        {
+            var source = @"
+class Program
+{
+    public static void Main(string[] args)
+    {
+        System.Console.WriteLine(Get(""a"").Item1?.ToString() ?? ""null"");
+    }
+    public static (int?, int) Get(string name)
+    {
+        return name switch
+        {
+            ""a"" => (default, 1), // this is convertible to (int?, int)
+            ""b"" => (1, 2),
+            _ => (null, 4),
+        };
+    }
+}
+";
+            CompileAndVerify(CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(), expectedOutput: "null");
+        }
     }
 }


### PR DESCRIPTION
Fixes #38226