### PR TITLE
Re-add master-vs-deps to the publish branch list

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -45,6 +45,15 @@
       "vsBranch": "rel/d16.3",
       "vsMajorVersion": 16
     },
+    "master-vs-deps": {
+      "nugetKind": ["Shipping", "NonShipping"],
+      "version": "3.4.*",
+      "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
+      "channels": [ "dev16.4", "dev16.4p1" ],
+      "vsBranch": "master",
+      "vsMajorVersion": 16
+    },
     "features/NullableReferenceTypes": {
       "nugetKind": "PerBuildPreRelease",
       "version": "2.6.*",


### PR DESCRIPTION
master-vs-deps is the backup for all branch publishing, so it
must always be in the list.