### PR TITLE
Update null state of argument to delegate creation

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5341,6 +5341,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             ReportNullabilityMismatchWithTargetDelegate(arg.Syntax.Location, delegateType, argType.DelegateInvokeMethod(), invokedAsExtensionMethod: false);
                         }
+
+                        LearnFromNonNullTest(arg, ref State);
                     }
                     break;
                 default:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5342,6 +5342,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ReportNullabilityMismatchWithTargetDelegate(arg.Syntax.Location, delegateType, argType.DelegateInvokeMethod(), invokedAsExtensionMethod: false);
                         }
 
+                        // Delegate creation will throw an exception if the argument is null
                         LearnFromNonNullTest(arg, ref State);
                     }
                     break;


### PR DESCRIPTION
Closes #38171

Just a small oversight in delegate creation analysis. Passing a null argument to a delegate creation will always throw, so we should always update the null-state of the argument to not-null after the creation. This is similar to what is done in `CheckPossibleNullReceiver`.

Thanks @TessenR.