### PR TITLE
Generalize the map used for storing BoundCall/MethodSymbols

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1456,7 +1456,7 @@
     <Field Name="Properties" Type="ImmutableArray&lt;PropertySymbol&gt;" />
   </Node>
 
-  <Node Name="BoundCall" Base="BoundExpression" SkipInNullabilityRewriter="true">
+  <Node Name="BoundCall" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -74,23 +74,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return currentBinary!;
         }
 
-        public override BoundNode? VisitCall(BoundCall node)
+        private T GetUpdatedSymbol<T>(BoundNode expr, T sym) where T : Symbol?
         {
-            BoundExpression? receiverOpt = (BoundExpression)this.Visit(node.ReceiverOpt);
-            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
-            BoundCall updatedNode;
+            if (sym is null) return sym;
 
-            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType) &&
-                _updatedMethodSymbols.TryGetValue(node, out MethodSymbol updatedMethodSymbol))
+            if (_updatedSymbols.TryGetValue((expr, sym), out var updatedSymbol))
             {
-                updatedNode = node.Update(receiverOpt, updatedMethodSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, infoAndType.Type);
-                updatedNode.TopLevelNullability = infoAndType.Info;
+                Debug.Assert(updatedSymbol is object);
+                return (T)updatedSymbol;
             }
-            else
-            {
-                updatedNode = node.Update(receiverOpt, node.Method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, node.Type);
-            }
-            return updatedNode;
+
+            return sym;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                        delegateInvokeMethod: delegateType?.DelegateInvokeMethod,
                                        initialState: nullableState,
                                        analyzedNullabilityMapOpt: null,
-                                       updatedMethodSymbolMapOpt: null,
+                                       updatedSymbolMapOpt: null,
                                        snapshotBuilderOpt: null,
                                        returnTypes);
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundNode nodeToAnalyze,
                 Binder binder,
                 ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMap,
-                ImmutableDictionary<BoundCall, MethodSymbol>.Builder updatedMethodSymbolMap,
+                ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMap,
                 SnapshotManager.Builder newManagerOpt)
             {
                 Snapshot incrementalSnapshot = GetSnapshotForPosition(position);
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                            variableState,
                                            returnTypesOpt: null,
                                            analyzedNullabilityMap,
-                                           updatedMethodSymbolMap,
+                                           updatedSymbolMap,
                                            snapshotBuilderOpt: newManagerOpt,
                                            isSpeculative: true),
                         variableState,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -158,9 +158,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)>.Builder _analyzedNullabilityMapOpt;
 
         /// <summary>
-        /// Contains the map of calls to reinferred method symbols, used by the optional rewriter phase of the compiler.
+        /// Contains the map of expression and original symbol to reinferred symbols, used by the optional
+        /// rewriter phase of the compiler.
         /// </summary>
-        private readonly ImmutableDictionary<BoundCall, MethodSymbol>.Builder _updatedMethodSymbolMapOpt;
+        private readonly ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder _updatedSymbolMapOpt;
 
         /// <summary>
         /// Manages creating snapshots of the walker as appropriate. Null if we're not taking snapshots of
@@ -345,7 +346,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VariableState initialState,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)> returnTypesOpt,
             ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMapOpt,
-            ImmutableDictionary<BoundCall, MethodSymbol>.Builder updatedMethodSymbolMapOpt,
+            ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMapOpt,
             SnapshotManager.Builder snapshotBuilderOpt,
             bool isSpeculative = false)
             // Members of variables are tracked up to a fixed depth, to avoid cycles. The
@@ -357,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _useMethodSignatureParameterTypes = (object)methodSignatureOpt != null && useMethodSignatureParameterTypes;
             _methodSignatureOpt = methodSignatureOpt;
             _analyzedNullabilityMapOpt = analyzedNullabilityMapOpt;
-            _updatedMethodSymbolMapOpt = updatedMethodSymbolMapOpt;
+            _updatedSymbolMapOpt = updatedSymbolMapOpt;
             _returnTypesOpt = returnTypesOpt;
             _snapshotBuilderOpt = snapshotBuilderOpt;
             _isSpeculative = isSpeculative;
@@ -447,7 +448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodSignatureOpt: method,
                 initialState: null,
                 analyzedNullabilityMapOpt: null,
-                updatedMethodSymbolMapOpt: null,
+                updatedSymbolMapOpt: null,
                 snapshotBuilderOpt: null,
                 returnTypesOpt: null);
         }
@@ -462,7 +463,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out SnapshotManager snapshotManager)
         {
             var analyzedNullabilities = ImmutableDictionary.CreateBuilder<BoundExpression, (NullabilityInfo, TypeSymbol)>(EqualityComparer<BoundExpression>.Default, NullabilityInfoTypeComparer.Instance);
-            var updatedMethodSymbols = ImmutableDictionary.CreateBuilder<BoundCall, MethodSymbol>(EqualityComparer<BoundCall>.Default, SymbolEqualityComparer.ConsiderEverything);
+            var updatedSymbols = ImmutableDictionary.CreateBuilder<(BoundNode, Symbol), Symbol>(ExpressionAndSymbolEqualityComparer.Instance, SymbolEqualityComparer.ConsiderEverything);
             var methodSymbol = symbol as MethodSymbol;
             // Attributes don't have a symbol, which is what SnapshotBuilder uses as an index for maintaining global state.
             // Until we have a workaround for this, disable snapshots for null symbols.
@@ -479,22 +480,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodSignatureOpt: methodSymbol,
                 initialState: null,
                 analyzedNullabilities,
-                updatedMethodSymbols,
+                updatedSymbols,
                 snapshotBuilder,
                 returnTypesOpt: null);
 
             var analyzedNullabilitiesMap = analyzedNullabilities.ToImmutable();
-            var updatedMethodSymbolsMap = updatedMethodSymbols.ToImmutable();
+            var updatedSymbolsMap = updatedSymbols.ToImmutable();
             snapshotManager = snapshotBuilder?.ToManagerAndFree();
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
             if (compilation.NullableSemanticAnalysisEnabled)
             {
-                DebugVerifier.Verify(analyzedNullabilitiesMap, updatedMethodSymbolsMap, snapshotManager, node);
+                DebugVerifier.Verify(analyzedNullabilitiesMap, updatedSymbolsMap, snapshotManager, node);
             }
 #endif
-            return new NullabilityRewriter(analyzedNullabilitiesMap, updatedMethodSymbolsMap).Visit(node);
+            return new NullabilityRewriter(analyzedNullabilitiesMap, updatedSymbolsMap).Visit(node);
         }
 
         internal static BoundNode AnalyzeAndRewriteSpeculation(
@@ -506,9 +507,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             out SnapshotManager newSnapshots)
         {
             var analyzedNullabilities = ImmutableDictionary.CreateBuilder<BoundExpression, (NullabilityInfo, TypeSymbol)>(EqualityComparer<BoundExpression>.Default, NullabilityInfoTypeComparer.Instance);
-            var updatedMethodSymbols = ImmutableDictionary.CreateBuilder<BoundCall, MethodSymbol>();
+            var updatedSymbols = ImmutableDictionary.CreateBuilder<(BoundNode, Symbol), Symbol>(ExpressionAndSymbolEqualityComparer.Instance, SymbolEqualityComparer.ConsiderEverything);
             var newSnapshotBuilder = takeNewSnapshots ? new SnapshotManager.Builder() : null;
-            var (walker, initialState, symbol) = originalSnapshots.RestoreWalkerToAnalyzeNewNode(position, node, binder, analyzedNullabilities, updatedMethodSymbols, newSnapshotBuilder);
+            var (walker, initialState, symbol) = originalSnapshots.RestoreWalkerToAnalyzeNewNode(position, node, binder, analyzedNullabilities, updatedSymbols, newSnapshotBuilder);
             try
             {
                 Analyze(walker, symbol, diagnostics: null, initialState, snapshotBuilderOpt: newSnapshotBuilder);
@@ -519,17 +520,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var analyzedNullabilitiesMap = analyzedNullabilities.ToImmutable();
-            var updatedMethodSymbolsMap = updatedMethodSymbols.ToImmutable();
+            var updatedSymbolsMap = updatedSymbols.ToImmutable();
             newSnapshots = newSnapshotBuilder?.ToManagerAndFree();
 
 #if DEBUG
             if (binder.Compilation.NullableSemanticAnalysisEnabled)
             {
-                DebugVerifier.Verify(analyzedNullabilitiesMap, updatedMethodSymbolsMap, newSnapshots, node);
+                DebugVerifier.Verify(analyzedNullabilitiesMap, updatedSymbolsMap, newSnapshots, node);
             }
 #endif
 
-            return new NullabilityRewriter(analyzedNullabilitiesMap, updatedMethodSymbolsMap).Visit(node);
+            return new NullabilityRewriter(analyzedNullabilitiesMap, updatedSymbolsMap).Visit(node);
         }
 
         internal static void AnalyzeIfNeeded(
@@ -554,7 +555,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodSignatureOpt: null,
                 initialState: null,
                 analyzedNullabilityMapOpt: null,
-                updatedMethodSymbolMapOpt: null,
+                updatedSymbolMapOpt: null,
                 snapshotBuilderOpt: null,
                 returnTypesOpt: null);
         }
@@ -567,7 +568,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol delegateInvokeMethod,
             VariableState initialState,
             ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMapOpt,
-            ImmutableDictionary<BoundCall, MethodSymbol>.Builder updatedMethodSymbolMapOpt,
+            ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMapOpt,
             SnapshotManager.Builder snapshotBuilderOpt,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)> returnTypesOpt)
         {
@@ -582,7 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 methodSignatureOpt: delegateInvokeMethod,
                 initialState,
                 analyzedNullabilityMapOpt,
-                updatedMethodSymbolMapOpt,
+                updatedSymbolMapOpt,
                 snapshotBuilderOpt,
                 returnTypesOpt);
         }
@@ -598,7 +599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol methodSignatureOpt,
             VariableState initialState,
             ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMapOpt,
-            ImmutableDictionary<BoundCall, MethodSymbol>.Builder updatedMethodSymbolMapOpt,
+            ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMapOpt,
             SnapshotManager.Builder snapshotBuilderOpt,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)> returnTypesOpt)
         {
@@ -613,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                     initialState,
                                                     returnTypesOpt,
                                                     analyzedNullabilityMapOpt,
-                                                    updatedMethodSymbolMapOpt,
+                                                    updatedSymbolMapOpt,
                                                     snapshotBuilderOpt);
 
             try
@@ -2026,7 +2027,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                             initialState: null,
                                             returnTypesOpt: null,
                                             analyzedNullabilityMapOpt: null,
-                                            updatedMethodSymbolMapOpt: null,
+                                            updatedSymbolMapOpt: null,
                                             snapshotBuilderOpt: null);
 
             int n = returns.Count;
@@ -2874,9 +2875,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             SetResult(node, returnState, method.ReturnTypeWithAnnotations);
-            if (_updatedMethodSymbolMapOpt is object)
+            if (_updatedSymbolMapOpt is object)
             {
-                _updatedMethodSymbolMapOpt[node] = method;
+                _updatedSymbolMapOpt[(node, node.Method)] = method;
             }
         }
 
@@ -5369,12 +5370,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(delegateTypeOpt?.IsDelegateType() != false);
             var analyzedNullabilityMap = _analyzedNullabilityMapOpt;
-            var updatedMethodSymbolMap = _updatedMethodSymbolMapOpt;
+            var updatedSymbolMap = _updatedSymbolMapOpt;
             var snapshotBuilder = _snapshotBuilderOpt;
             if (_disableNullabilityAnalysis)
             {
                 analyzedNullabilityMap = null;
-                updatedMethodSymbolMap = null;
+                updatedSymbolMap = null;
                 snapshotBuilder = null;
             }
 
@@ -5386,7 +5387,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 delegateTypeOpt?.DelegateInvokeMethod,
                 initialState: initialState ?? GetVariableState(State.Clone()),
                 analyzedNullabilityMap,
-                updatedMethodSymbolMap,
+                updatedSymbolMap,
                 snapshotBuilder,
                 returnTypesOpt: null);
         }
@@ -5407,12 +5408,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (body != null)
             {
                 var analyzedNullabilityMap = _analyzedNullabilityMapOpt;
-                var updatedMethodSymbolMap = _updatedMethodSymbolMapOpt;
+                var updatedSymbolMap = _updatedSymbolMapOpt;
                 var snapshotBuilder = _snapshotBuilderOpt;
                 if (_disableNullabilityAnalysis)
                 {
                     analyzedNullabilityMap = null;
-                    updatedMethodSymbolMap = null;
+                    updatedSymbolMap = null;
                     snapshotBuilder = null;
                 }
 
@@ -5426,7 +5427,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         methodSignatureOpt: null,
                         initialState: GetVariableState(this.TopState()),
                         analyzedNullabilityMap,
-                        updatedMethodSymbolMap,
+                        updatedSymbolMap,
                         snapshotBuilder,
                         returnTypesOpt: null);
             }
@@ -7401,6 +7402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#nullable enable
         private sealed class NullabilityInfoTypeComparer : IEqualityComparer<(NullabilityInfo info, TypeSymbol type)>
         {
             public static readonly NullabilityInfoTypeComparer Instance = new NullabilityInfoTypeComparer();
@@ -7414,6 +7416,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             public int GetHashCode((NullabilityInfo info, TypeSymbol type) obj)
             {
                 return obj.GetHashCode();
+            }
+        }
+
+        private sealed class ExpressionAndSymbolEqualityComparer : IEqualityComparer<(BoundNode expr, Symbol sym)>
+        {
+            internal static ExpressionAndSymbolEqualityComparer Instance = new ExpressionAndSymbolEqualityComparer();
+
+            public bool Equals((BoundNode expr, Symbol sym) x, (BoundNode expr, Symbol sym) y)
+            {
+                Debug.Assert(x is ({ }, { }) && y is ({ }, { }));
+
+                // We specifically use reference equality for the symbols here because the BoundNode should be immutable.
+                // We should be storing and retreiving the exact same instance of the symbol, not just an "equivalent"
+                // symbol.
+                return x.expr == y.expr && (object)x.sym == y.sym;
+            }
+
+            public int GetHashCode((BoundNode expr, Symbol sym) obj)
+            {
+                Debug.Assert(obj is ({ }, { }));
+                return Hash.Combine(obj.expr, obj.sym.GetHashCode());
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -9961,12 +9961,30 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed partial class NullabilityRewriter : BoundTreeRewriter
     {
         private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> _updatedNullabilities;
-        private readonly ImmutableDictionary<BoundCall, MethodSymbol> _updatedMethodSymbols;
+        private readonly ImmutableDictionary<(BoundNode, Symbol), Symbol> _updatedSymbols;
 
-        public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities, ImmutableDictionary<BoundCall, MethodSymbol> updatedMethodSymbols)
+        public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities, ImmutableDictionary<(BoundNode, Symbol), Symbol> updatedSymbols)
         {
             _updatedNullabilities = updatedNullabilities;
-            _updatedMethodSymbols = updatedMethodSymbols;
+            _updatedSymbols = updatedSymbols;
+        }
+
+        public override BoundNode? VisitFieldEqualsValue(BoundFieldEqualsValue node)
+        {
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
+            return node.Update(GetUpdatedSymbol(node, node.Field), node.Locals, value);
+        }
+
+        public override BoundNode? VisitPropertyEqualsValue(BoundPropertyEqualsValue node)
+        {
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
+            return node.Update(GetUpdatedSymbol(node, node.Property), node.Locals, value);
+        }
+
+        public override BoundNode? VisitParameterEqualsValue(BoundParameterEqualsValue node)
+        {
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
+            return node.Update(GetUpdatedSymbol(node, node.Parameter), node.Locals, value);
         }
 
         public override BoundNode? VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
@@ -10112,12 +10130,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, GetUpdatedSymbol(node, node.MethodOpt), node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, GetUpdatedSymbol(node, node.MethodOpt), node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
             }
             return updatedNode;
         }
@@ -10129,12 +10147,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, GetUpdatedSymbol(node, node.MethodOpt), node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.MethodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, GetUpdatedSymbol(node, node.MethodOpt), node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
             }
             return updatedNode;
         }
@@ -10198,12 +10216,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, node.GetTypeFromHandle, infoAndType.Type);
+                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.GetTypeFromHandle), infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, node.GetTypeFromHandle, node.Type);
+                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.GetTypeFromHandle), node.Type);
             }
             return updatedNode;
         }
@@ -10249,12 +10267,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, node.MethodOpt, infoAndType.Type);
+                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.MethodOpt), infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, node.MethodOpt, node.Type);
+                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.MethodOpt), node.Type);
             }
             return updatedNode;
         }
@@ -10267,12 +10285,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, node.MethodOpt, infoAndType.Type);
+                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, GetUpdatedSymbol(node, node.MethodOpt), infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, node.MethodOpt, node.Type);
+                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, GetUpdatedSymbol(node, node.MethodOpt), node.Type);
             }
             return updatedNode;
         }
@@ -10463,12 +10481,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(sourceType, node.GetTypeFromHandle, infoAndType.Type);
+                updatedNode = node.Update(sourceType, GetUpdatedSymbol(node, node.GetTypeFromHandle), infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(sourceType, node.GetTypeFromHandle, node.Type);
+                updatedNode = node.Update(sourceType, GetUpdatedSymbol(node, node.GetTypeFromHandle), node.Type);
             }
             return updatedNode;
         }
@@ -10480,7 +10498,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundMethodDefIndex updatedNode = node.Update(node.Method, infoAndType.Type);
+            BoundMethodDefIndex updatedNode = node.Update(GetUpdatedSymbol(node, node.Method), infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -10552,7 +10570,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundMethodInfo updatedNode = node.Update(node.Method, node.GetMethodFromHandle, infoAndType.Type);
+            BoundMethodInfo updatedNode = node.Update(GetUpdatedSymbol(node, node.Method), GetUpdatedSymbol(node, node.GetMethodFromHandle), infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -10564,7 +10582,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundFieldInfo updatedNode = node.Update(node.Field, node.GetFieldFromHandle, infoAndType.Type);
+            BoundFieldInfo updatedNode = node.Update(GetUpdatedSymbol(node, node.Field), GetUpdatedSymbol(node, node.GetFieldFromHandle), infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -10663,12 +10681,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, node.ConversionMethod, infoAndType.Type);
+                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.ConversionMethod), infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, node.ConversionMethod, node.Type);
+                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.ConversionMethod), node.Type);
             }
             return updatedNode;
         }
@@ -10709,14 +10727,41 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, infoAndType.Type);
+                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, GetUpdatedSymbol(node, node.GetPinnableOpt), infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, node.GetPinnableOpt, node.Type);
+                updatedNode = node.Update(node.ElementPointerType, node.ElementPointerTypeConversion, expression, GetUpdatedSymbol(node, node.GetPinnableOpt), node.Type);
             }
             return updatedNode;
+        }
+
+        public override BoundNode? VisitUsingLocalDeclarations(BoundUsingLocalDeclarations node)
+        {
+            ImmutableArray<BoundLocalDeclaration> localDeclarations = this.VisitList(node.LocalDeclarations);
+            return node.Update(GetUpdatedSymbol(node, node.DisposeMethodOpt), node.IDisposableConversion, node.AwaitOpt, localDeclarations);
+        }
+
+        public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
+            BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
+            return node.Update(GetUpdatedSymbol(node, node.Symbol), blockBody, expressionBody);
+        }
+
+        public override BoundNode? VisitSwitchDispatch(BoundSwitchDispatch node)
+        {
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
+            return node.Update(expression, node.Cases, node.DefaultLabel, GetUpdatedSymbol(node, node.EqualityMethod));
+        }
+
+        public override BoundNode? VisitUsingStatement(BoundUsingStatement node)
+        {
+            BoundMultipleLocalDeclarations? declarationsOpt = (BoundMultipleLocalDeclarations?)this.Visit(node.DeclarationsOpt);
+            BoundExpression? expressionOpt = (BoundExpression?)this.Visit(node.ExpressionOpt);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(node.Locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body, node.AwaitOpt, GetUpdatedSymbol(node, node.DisposeMethodOpt));
         }
 
         public override BoundNode? VisitLiteral(BoundLiteral node)
@@ -10810,12 +10855,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.RangeVariableSymbol, value, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.RangeVariableSymbol), value, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.RangeVariableSymbol, value, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.RangeVariableSymbol), value, node.Type);
             }
             return updatedNode;
         }
@@ -10827,7 +10872,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundParameter updatedNode = node.Update(node.ParameterSymbol, infoAndType.Type);
+            BoundParameter updatedNode = node.Update(GetUpdatedSymbol(node, node.ParameterSymbol), infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -10880,6 +10925,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                 updatedNode = node.Update(node.NaturalTypeOpt, expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.Type);
             }
             return updatedNode;
+        }
+
+        public override BoundNode? VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(GetUpdatedSymbol(node, node.DeconstructMethod), input);
+        }
+
+        public override BoundNode? VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(GetUpdatedSymbol(node, node.Field), input);
+        }
+
+        public override BoundNode? VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(GetUpdatedSymbol(node, node.Property), input);
+        }
+
+        public override BoundNode? VisitDagIndexEvaluation(BoundDagIndexEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(GetUpdatedSymbol(node, node.Property), node.Index, input);
         }
 
         public override BoundNode? VisitSequencePointExpression(BoundSequencePointExpression node)
@@ -10997,12 +11066,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, infoAndType.Type);
+                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiver, node.HasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, node.Type);
+                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, node.Type);
             }
             return updatedNode;
         }
@@ -11044,12 +11113,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
+                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, GetUpdatedSymbol(node, node.LookupSymbolOpt), node.LookupError, node.Flags, receiverOpt, node.ResultKind);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, node.LookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
+                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, node.Methods, GetUpdatedSymbol(node, node.LookupSymbolOpt), node.LookupError, node.Flags, receiverOpt, node.ResultKind);
             }
             return updatedNode;
         }
@@ -11071,6 +11140,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             return updatedNode;
         }
 
+        public override BoundNode? VisitCall(BoundCall node)
+        {
+            BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
+            ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
+            BoundCall updatedNode;
+
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Method), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Method), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, node.Type);
+            }
+            return updatedNode;
+        }
+
         public override BoundNode? VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
@@ -11079,12 +11166,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Event), node.IsAddition, node.IsDynamic, receiverOpt, argument, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Event, node.IsAddition, node.IsDynamic, receiverOpt, argument, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Event), node.IsAddition, node.IsDynamic, receiverOpt, argument, node.Type);
             }
             return updatedNode;
         }
@@ -11097,12 +11184,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, node.Type);
             }
             return updatedNode;
         }
@@ -11115,12 +11202,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Constructor, node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), node.ConstructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
@@ -11219,12 +11306,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.MemberSymbol), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.MemberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.MemberSymbol), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, node.ReceiverType, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
@@ -11266,12 +11353,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.AddMethod), arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.AddMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.AddMethod), arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
@@ -11314,12 +11401,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Constructor, arguments, declarations, infoAndType.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), arguments, declarations, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Constructor, arguments, declarations, node.Type);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), arguments, declarations, node.Type);
             }
             return updatedNode;
         }
@@ -11331,7 +11418,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundAnonymousPropertyDeclaration updatedNode = node.Update(node.Property, infoAndType.Type);
+            BoundAnonymousPropertyDeclaration updatedNode = node.Update(GetUpdatedSymbol(node, node.Property), infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -11360,12 +11447,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, infoAndType.Type);
+                updatedNode = node.Update(argument, GetUpdatedSymbol(node, node.MethodOpt), node.IsExtensionMethod, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(argument, node.MethodOpt, node.IsExtensionMethod, node.Type);
+                updatedNode = node.Update(argument, GetUpdatedSymbol(node, node.MethodOpt), node.IsExtensionMethod, node.Type);
             }
             return updatedNode;
         }
@@ -11448,12 +11535,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.FieldSymbol), node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, node.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.FieldSymbol), node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, node.Type);
             }
             return updatedNode;
         }
@@ -11465,7 +11552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            BoundHoistedFieldAccess updatedNode = node.Update(node.FieldSymbol, infoAndType.Type);
+            BoundHoistedFieldAccess updatedNode = node.Update(GetUpdatedSymbol(node, node.FieldSymbol), infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -11477,12 +11564,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.PropertySymbol), node.ResultKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, node.PropertySymbol, node.ResultKind, node.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.PropertySymbol), node.ResultKind, node.Type);
             }
             return updatedNode;
         }
@@ -11494,12 +11581,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.EventSymbol), node.IsUsableAsField, node.ResultKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, node.EventSymbol, node.IsUsableAsField, node.ResultKind, node.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.EventSymbol), node.IsUsableAsField, node.ResultKind, node.Type);
             }
             return updatedNode;
         }
@@ -11512,12 +11599,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Indexer), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, node.Indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, node.Type);
+                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Indexer), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, node.Type);
             }
             return updatedNode;
         }
@@ -11530,12 +11617,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiver, node.LengthOrCountProperty, node.PatternSymbol, argument, infoAndType.Type);
+                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.LengthOrCountProperty), GetUpdatedSymbol(node, node.PatternSymbol), argument, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiver, node.LengthOrCountProperty, node.PatternSymbol, argument, node.Type);
+                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.LengthOrCountProperty), GetUpdatedSymbol(node, node.PatternSymbol), argument, node.Type);
             }
             return updatedNode;
         }
@@ -11566,12 +11653,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, infoAndType.Type);
+                updatedNode = node.Update(unboundLambda, GetUpdatedSymbol(node, node.Symbol), body, node.Diagnostics, node.Binder, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(unboundLambda, node.Symbol, body, node.Diagnostics, node.Binder, node.Type);
+                updatedNode = node.Update(unboundLambda, GetUpdatedSymbol(node, node.Symbol), body, node.Diagnostics, node.Binder, node.Type);
             }
             return updatedNode;
         }
@@ -11598,12 +11685,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(value, node.DefinedSymbol, operation, cast, node.Binder, unoptimizedForm, infoAndType.Type);
+                updatedNode = node.Update(value, GetUpdatedSymbol(node, node.DefinedSymbol), operation, cast, node.Binder, unoptimizedForm, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(value, node.DefinedSymbol, operation, cast, node.Binder, unoptimizedForm, node.Type);
+                updatedNode = node.Update(value, GetUpdatedSymbol(node, node.DefinedSymbol), operation, cast, node.Binder, unoptimizedForm, node.Type);
             }
             return updatedNode;
         }
@@ -11680,6 +11767,34 @@ namespace Microsoft.CodeAnalysis.CSharp
             return updatedNode;
         }
 
+        public override BoundNode? VisitDeclarationPattern(BoundDeclarationPattern node)
+        {
+            BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
+            BoundTypeExpression? declaredType = (BoundTypeExpression?)this.Visit(node.DeclaredType);
+            return node.Update(GetUpdatedSymbol(node, node.Variable), variableAccess, declaredType, node.IsVar, node.InputType);
+        }
+
+        public override BoundNode? VisitRecursivePattern(BoundRecursivePattern node)
+        {
+            BoundTypeExpression? declaredType = (BoundTypeExpression?)this.Visit(node.DeclaredType);
+            ImmutableArray<BoundSubpattern> deconstruction = this.VisitList(node.Deconstruction);
+            ImmutableArray<BoundSubpattern> properties = this.VisitList(node.Properties);
+            BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
+            return node.Update(declaredType, GetUpdatedSymbol(node, node.DeconstructMethod), deconstruction, properties, GetUpdatedSymbol(node, node.Variable), variableAccess, node.InputType);
+        }
+
+        public override BoundNode? VisitITuplePattern(BoundITuplePattern node)
+        {
+            ImmutableArray<BoundSubpattern> subpatterns = this.VisitList(node.Subpatterns);
+            return node.Update(GetUpdatedSymbol(node, node.GetLengthMethod), GetUpdatedSymbol(node, node.GetItemMethod), subpatterns, node.InputType);
+        }
+
+        public override BoundNode? VisitSubpattern(BoundSubpattern node)
+        {
+            BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
+            return node.Update(GetUpdatedSymbol(node, node.Symbol), pattern);
+        }
+
         public override BoundNode? VisitDiscardExpression(BoundDiscardExpression node)
         {
             if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
@@ -11716,12 +11831,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.VariableSymbol, receiverOpt);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.VariableSymbol, receiverOpt);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
             }
             return updatedNode;
         }
@@ -11733,12 +11848,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.VariableSymbol, receiverOpt);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.VariableSymbol, receiverOpt);
+                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
             }
             return updatedNode;
         }


### PR DESCRIPTION
Generalize the map used for storing BoundCall/MethodSymbols to allow for any boundnode and original symbol -> updated symbol pair, and update the rewriter generator to consume the map. Followup changes will capture more reinferred symbols, this change just sets up the infrastructure without breaking existing functionality. @dotnet/roslyn-compiler for review.