### PR TITLE
Add missing properties to the build pipeline for stages-based publishing

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,6 +11,12 @@ resources:
 #  IbcSourceBranchName: 'default'
 #  IbcDropId: 'default'
 
+variables:
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+  - name: _DotNetValidationArtifactsCategory
+    value: .NETCoreValidation
+
 stages:
 - stage: build
   displayName: Build and Test
@@ -81,6 +87,8 @@ stages:
                 /p:PublishToSymbolServer=true
                 /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                 /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                /p:DotnetPublishUsingPipelines=true
       displayName: Build
       condition: succeeded()
 
@@ -228,6 +236,7 @@ stages:
   # Publish to Build Asset Registry
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
+      publishUsingPipelines: true
       dependsOn:
         - OfficialBuild
       queue:


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/7561

Sets up a few properties that were previously not documented as part of the onboarding process, and are causing issues in the publishing process.

Test build for this: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2972442&view=results

You will notice a few differences in that build:

* The build stage doesn't publish anything to the dotnet-core feed, and instead publishes all artifacts to the build's containers.
* I set up a default channel for my testing branch to the ".NET Tools -latest" channel for testing purposes: `https://github.com/dotnet/roslyn @ refs/heads/dev/riarenas/add-stages-properties -> .NET Tools - Latest`. Which causes publishing to happen as part of the channel's publishing stage:
![image](https://user-images.githubusercontent.com/23242101/63628210-092f5380-c5c0-11e9-866c-bcb9e8b62cac.png)


**Followup**:

The `Publish Ngen Logs` step failed in my test builds, I'm not sure if it's expected due to the configuration I used to queue the test build, or if it's a legitimate failure.