### PR TITLE
Avoid posibility of a race around SynthesizedMethodBaseSymbol._iteratorElementType field in the future.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly string _name;
         private ImmutableArray<TypeParameterSymbol> _typeParameters;
         private ImmutableArray<ParameterSymbol> _parameters;
-        private TypeWithAnnotations _iteratorElementType;
+        private TypeWithAnnotations.Boxed _iteratorElementType;
 
         protected SynthesizedMethodBaseSymbol(NamedTypeSymbol containingType,
                                               MethodSymbol baseMethod,
@@ -169,16 +170,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if (_iteratorElementType.IsDefault)
+                if (_iteratorElementType is null)
                 {
-                    _iteratorElementType = TypeMap.SubstituteType(BaseMethod.IteratorElementTypeWithAnnotations.Type);
+                    Interlocked.CompareExchange(ref _iteratorElementType,
+                                                new TypeWithAnnotations.Boxed(TypeMap.SubstituteType(BaseMethod.IteratorElementTypeWithAnnotations.Type)),
+                                                null);
                 }
-                return _iteratorElementType;
+
+                return _iteratorElementType.Value;
             }
             set
             {
                 Debug.Assert(!value.IsDefault);
-                _iteratorElementType = value;
+                Interlocked.Exchange(ref _iteratorElementType, new TypeWithAnnotations.Boxed(value));
             }
         }
     }


### PR DESCRIPTION
Fixes #38285.