### PR TITLE
Report error for async-iterator with expression-body

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3069,6 +3069,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CheckForUnobservedAwaitable(expression, diagnostics);
                     statement = expressionStatement;
                 }
+                else if (IsIAsyncEnumerableOrIAsyncEnumeratorReturningAsyncMethod())
+                {
+                    Error(diagnostics, ErrorCode.ERR_ReturnInIterator, syntax);
+                    statement = new BoundReturnStatement(syntax, returnRefKind, expression) { WasCompilerGenerated = true };
+                }
                 else
                 {
                     expression = CreateReturnConversion(syntax, diagnostics, expression, refKind, returnType);

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -169,14 +169,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var info = new IteratorInfo(elementType, elementTypeDiagnostics.ToReadOnlyAndFree());
 
-                Interlocked.CompareExchange(ref _iteratorInfo, info, IteratorInfo.Empty);
-            }
-
-            if (node == null)
-            {
-                // node==null indicates this we are being called from the top-level of processing of a method. We report
-                // the diagnostic, if any, at that time to ensure it is reported exactly once.
-                diagnostics.AddRange(_iteratorInfo.ElementTypeDiagnostics);
+                var oldInfo = Interlocked.CompareExchange(ref _iteratorInfo, info, IteratorInfo.Empty);
+                if (oldInfo == IteratorInfo.Empty)
+                {
+                    diagnostics.AddRange(_iteratorInfo.ElementTypeDiagnostics);
+                }
             }
 
             return _iteratorInfo.ElementType;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -2413,6 +2413,41 @@ class TestClass
                 Diagnostic(ErrorCode.ERR_BadIteratorReturnRef, "TestFunction").WithArguments("TestClass.TestFunction()").WithLocation(5, 13));
         }
 
+        [Fact]
+        public void CannotUseYieldReturnInAReturnByRefFunction_InIfBlock()
+        {
+            var code = @"
+class TestClass
+{
+    int x = 0;
+    ref int TestFunction()
+    {
+        if (true)
+        {
+            yield return x;
+        }
+
+        ref int localFunction()
+        {
+            if (true)
+            {
+                yield return x;
+            }
+        }
+
+        yield return localFunction();
+    }
+}";
+
+            CreateCompilation(code).VerifyDiagnostics(
+                // (12,17): error CS8154: The body of 'localFunction()' cannot be an iterator block because 'localFunction()' returns by reference
+                //         ref int localFunction()
+                Diagnostic(ErrorCode.ERR_BadIteratorReturnRef, "localFunction").WithArguments("localFunction()").WithLocation(12, 17),
+                // (5,13): error CS8154: The body of 'TestClass.TestFunction()' cannot be an iterator block because 'TestClass.TestFunction()' returns by reference
+                //     ref int TestFunction()
+                Diagnostic(ErrorCode.ERR_BadIteratorReturnRef, "TestFunction").WithArguments("TestClass.TestFunction()").WithLocation(5, 13));
+        }
+
         [Fact, WorkItem(13073, "https://github.com/dotnet/roslyn/issues/13073")]
         public void CannotUseRefReturnInExpressionTree_ParenthesizedLambdaExpression()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38201

Also adjusts the diagnostic reporting to avoid duplicates reported by `GetIteratorElementType`.