### PR TITLE
Remove withinTypeSyntax restriction for UseExplicit/ImplicitType refactoring.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseImplicitTypeRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeRefactorings/UseExplicitOrImplicitType/UseImplicitTypeRefactoringTests.cs
@@ -92,17 +92,28 @@ class C
 
         [Fact]
         [WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
-        public async Task TestMissingSelectionNotType()
+        [WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")]
+        public async Task TestSelectionNotType()
         {
             var code = @"
 class C
 {
     static void Main()
     {
-       int [|i|] = 0;
+        int [|i|] = 0;
     }
 }";
-            await TestMissingInRegularAndScriptAsync(code);
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        var i = 0;
+    }
+}";
+
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
         }
 
         [Fact]
@@ -241,6 +252,81 @@ class C
     static void Main()
     {
         foreach (var i in new[] { 0 }) { }
+    }
+}";
+
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
+        }
+
+        [Fact]
+        [WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")]
+        public async Task TestIntForeachLoop2()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        foreach ([|int|] i in new[] { 0 }) { }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var i in new[] { 0 }) { }
+    }
+}";
+
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
+        }
+
+        [Fact]
+        [WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")]
+        public async Task TestIntForeachLoop3()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        foreach (int [|i|] in new[] { 0 }) { }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var i in new[] { 0 }) { }
+    }
+}";
+
+            await TestInRegularAndScriptWhenDiagnosticNotAppliedAsync(code, expected);
+        }
+
+        [Fact]
+        [WorkItem(35525, "https://github.com/dotnet/roslyn/issues/35525")]
+        public async Task TestIntForeachLoop4()
+        {
+            var code = @"
+class C
+{
+    static void Main()
+    {
+        foreach ([|object|] i in new[] { new object() }) { }
+    }
+}";
+
+            var expected = @"
+class C
+{
+    static void Main()
+    {
+        foreach (var i in new[] { new object() }) { }
     }
 }";
 

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1520,6 +1520,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public SyntaxNode GetExpressionOfAwaitExpression(SyntaxNode node)
             => ((AwaitExpressionSyntax)node).Expression;
 
+        public bool IsExpressionOfForeach(SyntaxNode node)
+            => node?.Parent is ForEachStatementSyntax foreachStatement && foreachStatement.Expression == node;
+
         public bool IsPossibleTupleContext(SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
         {
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -139,6 +139,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsAwaitExpression(SyntaxNode node);
         bool IsExpressionOfAwaitExpression(SyntaxNode node);
         SyntaxNode GetExpressionOfAwaitExpression(SyntaxNode node);
+        bool IsExpressionOfForeach(SyntaxNode node);
 
         bool IsLogicalAndExpression(SyntaxNode node);
         bool IsLogicalOrExpression(SyntaxNode node);

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1588,6 +1588,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return DirectCast(node, AwaitExpressionSyntax).Expression
         End Function
 
+        Public Function IsExpressionOfForeach(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsExpressionOfForeach
+            Return node IsNot Nothing AndAlso TryCast(node.Parent, ForEachStatementSyntax)?.Expression Is node
+        End Function
+
         Public Function IsPossibleTupleContext(
             syntaxTree As SyntaxTree,
             position As Integer,


### PR DESCRIPTION
Lifts a restriction that selection/caret must intersect the typeSyntax for Use[Explicit/Implicit]Type refactoring. 

While it potentially introduces noise (addition refactorings) it shouldn't be much of an issue do to the way ordering works. Since the applicableToSpan is still the type, the distance to it should be sufficiently larger than to any other refactoring. 

If it proves to be problematic the ordering via applicableToSpan should be updated to create distance for refactorings that whose applicableToSpan doesn't intersect current selection/caret location.

Work for #35525