### PR TITLE
LSP Server Handle DisplayTextPrefix and DisplayTextSuffix on Completion Items

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -60,15 +60,27 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             static TCompletionItem CreateCompletionItem<TCompletionItem>(LSP.CompletionParams request, CompletionItem item) where TCompletionItem : LSP.CompletionItem, new()
-                => new TCompletionItem
+            {
+                var label = "";
+                if (item.DisplayTextPrefix != null)
                 {
-                    Label = item.DisplayText,
+                    label += item.DisplayTextPrefix;
+                }
+                label += item.DisplayText;
+                if (item.DisplayTextSuffix != null)
+                {
+                    label += item.DisplayTextSuffix;
+                }
+                return new TCompletionItem
+                {
+                    Label = label,
                     InsertText = item.Properties.ContainsKey("InsertionText") ? item.Properties["InsertionText"] : item.DisplayText,
                     SortText = item.SortText,
                     FilterText = item.FilterText,
                     Kind = GetCompletionKind(item.Tags),
                     Data = new CompletionResolveData { CompletionParams = request, DisplayText = item.DisplayText }
                 };
+            }
         }
 
         private static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -60,30 +60,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             static TCompletionItem CreateCompletionItem<TCompletionItem>(LSP.CompletionParams request, CompletionItem item) where TCompletionItem : LSP.CompletionItem, new()
+            => new TCompletionItem
             {
-                var label = "";
-                if (item.DisplayTextPrefix != null)
-                {
-                    label += item.DisplayTextPrefix;
-                }
-                label += item.DisplayText;
-                if (item.DisplayTextSuffix != null)
-                {
-                    label += item.DisplayTextSuffix;
-                }
-                return new TCompletionItem
-                {
-                    Label = label,
-                    InsertText = item.Properties.ContainsKey("InsertionText") ? item.Properties["InsertionText"] : item.DisplayText,
-                    SortText = item.SortText,
-                    FilterText = item.FilterText,
-                    Kind = GetCompletionKind(item.Tags),
-                    Data = new CompletionResolveData { CompletionParams = request, DisplayText = item.DisplayText }
-                };
-            }
-        }
+                Label = item.DisplayTextPrefix + item.DisplayText + item.DisplayTextSuffix,
+                InsertText = item.Properties.ContainsKey("InsertionText") ? item.Properties["InsertionText"] : item.DisplayText,
+                SortText = item.SortText,
+                FilterText = item.FilterText,
+                Kind = GetCompletionKind(item.Tags),
+                Data = new CompletionResolveData { CompletionParams = request, DisplayText = item.DisplayText }
+            };
 
-        private static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)
+            private static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)
         {
             foreach (var tag in tags)
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                     Kind = GetCompletionKind(item.Tags),
                     Data = new CompletionResolveData { CompletionParams = request, DisplayText = item.DisplayText }
                 };
+        }
 
         private static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)
         {

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -60,17 +60,17 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             static TCompletionItem CreateCompletionItem<TCompletionItem>(LSP.CompletionParams request, CompletionItem item) where TCompletionItem : LSP.CompletionItem, new()
-            => new TCompletionItem
-            {
-                Label = item.DisplayTextPrefix + item.DisplayText + item.DisplayTextSuffix,
-                InsertText = item.Properties.ContainsKey("InsertionText") ? item.Properties["InsertionText"] : item.DisplayText,
-                SortText = item.SortText,
-                FilterText = item.FilterText,
-                Kind = GetCompletionKind(item.Tags),
-                Data = new CompletionResolveData { CompletionParams = request, DisplayText = item.DisplayText }
-            };
+                => new TCompletionItem
+                {
+                    Label = item.DisplayTextPrefix + item.DisplayText + item.DisplayTextSuffix,
+                    InsertText = item.Properties.ContainsKey("InsertionText") ? item.Properties["InsertionText"] : item.DisplayText,
+                    SortText = item.SortText,
+                    FilterText = item.FilterText,
+                    Kind = GetCompletionKind(item.Tags),
+                    Data = new CompletionResolveData { CompletionParams = request, DisplayText = item.DisplayText }
+                };
 
-            private static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)
+        private static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)
         {
             foreach (var tag in tags)
             {


### PR DESCRIPTION
Currently the  LSP completion item label is being set equal to the Roslyn completion item's display text. This PR also includes the item's `DisplayTextPrefix` and `DisplayTextSuffix` on the label.