### PR TITLE
Allow is operators to update null state of value types

### DIFF
--- a/docs/features/nullable-reference-types.md
+++ b/docs/features/nullable-reference-types.md
@@ -61,7 +61,7 @@ Some expressions which may not return `bool` are also considered pure null tests
 
 Example of how a pure null test can affect flow analysis:
 ```cs
-string? s = "hello";
+string s = "hello";
 if (s != null)
 {
     _ = s.ToString(); // ok
@@ -74,7 +74,7 @@ else
 
 Versus a "not pure" null test:
 ```cs
-string? s = "hello";
+string s = "hello";
 if (s is string)
 {
     _ = s.ToString(); // ok

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6865,17 +6865,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = base.VisitIsOperator(node);
             Debug.Assert(node.Type.SpecialType == SpecialType.System_Boolean);
 
-            if (operand.Type?.IsValueType == false)
+            var slotBuilder = ArrayBuilder<int>.GetInstance();
+            GetSlotsToMarkAsNotNullable(operand, slotBuilder);
+            if (slotBuilder.Count > 0)
             {
-                var slotBuilder = ArrayBuilder<int>.GetInstance();
-                GetSlotsToMarkAsNotNullable(operand, slotBuilder);
-                if (slotBuilder.Count > 0)
-                {
-                    Split();
-                    MarkSlotsAsNotNull(slotBuilder, ref StateWhenTrue);
-                }
-                slotBuilder.Free();
+                Split();
+                MarkSlotsAsNotNull(slotBuilder, ref StateWhenTrue);
             }
+            slotBuilder.Free();
 
             VisitTypeExpression(node.TargetType);
             SetNotNullResult(node);


### PR DESCRIPTION
Closes #38213 

I saw that VisitIsOperator requires the operand type to not be value type in order to update the flow-state to not-null. I don't see a reason why it should require this, so I just removed the check and added a few tests for @sharwell's scenario.