### PR TITLE
Show error every time CallHierarchyView doesn't a find suitable node.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CallHierarchy/CallHierarchyCommandHandler.cs
@@ -66,18 +66,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
                         if (node != null)
                         {
                             _presenter.PresentRoot((CallHierarchyItem)node);
+                            return true;
                         }
                     }
                 }
-                else
-                {
-                    // We are about to show a modal UI dialog so we should take over the command execution
-                    // wait context. That means the command system won't attempt to show its own wait dialog 
-                    // and also will take it into consideration when measuring command handling duration.
-                    waitScope.Context.TakeOwnership();
-                    var notificationService = document.Project.Solution.Workspace.Services.GetService<INotificationService>();
-                    notificationService.SendNotification(EditorFeaturesResources.Cursor_must_be_on_a_member_name, severity: NotificationSeverity.Information);
-                }
+
+                // Haven't found suitable hierarchy -> caret wasn't on symbol that can have call hierarchy.
+                //
+                // We are about to show a modal UI dialog so we should take over the command execution
+                // wait context. That means the command system won't attempt to show its own wait dialog 
+                // and also will take it into consideration when measuring command handling duration.
+                waitScope.Context.TakeOwnership();
+                var notificationService = document.Project.Solution.Workspace.Services.GetService<INotificationService>();
+                notificationService.SendNotification(EditorFeaturesResources.Cursor_must_be_on_a_member_name, severity: NotificationSeverity.Information);
             }
 
             return true;

--- a/src/VisualStudio/Core/Test/CallHierarchy/CallHierarchyTests.vb
+++ b/src/VisualStudio/Core/Test/CallHierarchy/CallHierarchyTests.vb
@@ -374,6 +374,52 @@ cla$$ss C
             Assert.NotNull(testState.NotificationMessage)
         End Sub
 
+        <WorkItem(38303, "https://github.com/dotnet/roslyn/issues/38303")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CallHierarchy)>
+        Public Sub TestDisplayErrorWhenNotOnMemberCS2()
+            Dim input =
+    <Workspace>
+        <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+            <Document>
+class CC
+{
+    C$$C Goo()
+    {
+        return null;
+    }
+}
+        </Document>
+        </Project>
+    </Workspace>
+            Dim testState = CallHierarchyTestState.Create(input)
+            Dim root = testState.GetRoot()
+            Assert.Null(root)
+            Assert.NotNull(testState.NotificationMessage)
+        End Sub
+
+        <WorkItem(38303, "https://github.com/dotnet/roslyn/issues/38303")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CallHierarchy)>
+        Public Sub TestDisplayErrorWhenNotOnMemberCS3()
+            Dim input =
+    <Workspace>
+        <Project Language="C#" AssemblyName="Assembly1" CommonReferences="true">
+            <Document>
+class CC
+{
+    CC Goo(C$$C c)
+    {
+        return null;
+    }
+}
+        </Document>
+        </Project>
+    </Workspace>
+            Dim testState = CallHierarchyTestState.Create(input)
+            Dim root = testState.GetRoot()
+            Assert.Null(root)
+            Assert.NotNull(testState.NotificationMessage)
+        End Sub
+
         <WorkItem(1098507, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1098507")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.CallHierarchy)>
         Public Sub TestDisplayErrorWhenNotOnMemberVB()


### PR DESCRIPTION
The simplest & quickest hot-fix for #38303

Should be expended with allowing way more locations instead.