### PR TITLE
Remove System.Runtime.Loader hack

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -173,7 +173,6 @@
     <RoslynToolsVSIXExpInstallerVersion>1.0.0-beta2-63222-01</RoslynToolsVSIXExpInstallerVersion>
     <RoslynToolsOptProfVersion>1.0.0-beta3.19057.1</RoslynToolsOptProfVersion>
     <RoslynOptProfRunSettingsGeneratorVersion>1.0.0-beta3.19057.1</RoslynOptProfRunSettingsGeneratorVersion>
-    <RoslynToolsLightUpSystemRuntimeLoaderFixedVersion>4.3.0</RoslynToolsLightUpSystemRuntimeLoaderFixedVersion>
     <RoslynMicrosoftVisualStudioExtensionManagerVersion>0.0.4</RoslynMicrosoftVisualStudioExtensionManagerVersion>
     <SourceBrowserVersion>1.0.21</SourceBrowserVersion>
     <StreamJsonRpcVersion>2.0.167</StreamJsonRpcVersion>
@@ -188,6 +187,7 @@
     <SystemMemoryVersion>4.5.3</SystemMemoryVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.5.2</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>
     <SystemTextEncodingCodePagesVersion>4.5.1</SystemTextEncodingCodePagesVersion>
     <SystemTextEncodingExtensionsVersion>4.3.0</SystemTextEncodingExtensionsVersion>
     <SystemThreadingTasksDataflowVersion>4.9.0</SystemThreadingTasksDataflowVersion>

--- a/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
+++ b/src/Scripting/Core/Microsoft.CodeAnalysis.Scripting.csproj
@@ -20,14 +20,7 @@
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <!-- 
-      Workaround for https://github.com/NuGet/Home/issues/1471.
-
-      RoslynTools.LightUp.System.Runtime.Loader distributes System.Runtime.Loader in ref/netstandard1.3 directory,
-      so that it can be referenced in libraries targeting netstandard1.3 once they check that the executing runtime 
-      is .NET Core.
-    -->
-    <PackageReference Include="RoslynTools.LightUp.System.Runtime.Loader" Version="$(RoslynToolsLightUpSystemRuntimeLoaderFixedVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Compilers\Shared\CoreClrShim.cs" />


### PR DESCRIPTION
Microsoft.CodeAnalysis.Scripting now targets NS2.0, so the custom package is no longer needed.
Should fix a composition error in VSMac, due to the fact that we don't ship the dll from this nuget