### PR TITLE
Record updated symbols for properties, fields, event access, and event assignments

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -3223,6 +3223,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     break;
 
+                case BoundKind.EventAccess when boundNodeForSyntacticParent is BoundEventAssignmentOperator { ResultKind: LookupResultKind.Viable } parentOperator &&
+                                                boundNode.ExpressionSymbol is Symbol accessSymbol &&
+                                                boundNode != parentOperator.Argument &&
+                                                parentOperator.Event.Equals(accessSymbol, TypeCompareKind.AllNullableIgnoreOptions):
+                    // When we're looking at the left-hand side of an event assignment, we synthesize a BoundEventAccess node. This node does not have
+                    // nullability information, however, so if we're in that case then we need to grab the event symbol from the parent event assignment
+                    // which does have the nullability-reinfered symbol
+                    symbols = ImmutableArray.Create<Symbol>(parentOperator.Event);
+                    resultKind = parentOperator.ResultKind;
+                    break;
+
                 case BoundKind.Conversion:
                     var conversion = (BoundConversion)boundNode;
                     isDynamic = conversion.ConversionKind.IsDynamic();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Net;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
@@ -42,6 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var ((expr, originalSymbol), updatedSymbol) in updatedMethodSymbols)
                 {
+                    Debug.Assert((object)originalSymbol != updatedSymbol, $"Recorded exact same symbol for {expr.Syntax}");
                     Debug.Assert(originalSymbol.Equals(updatedSymbol, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames), @$"Symbol for `{expr.Syntax}` changed:
 Was {originalSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}
 Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
@@ -80,12 +82,6 @@ Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
                     return VisitExpressionWithStackGuard(ref _recursionDepth, expr);
                 }
                 return base.Visit(node);
-            }
-
-            public override BoundNode? VisitCall(BoundCall node)
-            {
-                Debug.Assert(_updatedMethodSymbols.ContainsKey((node, node.Method)), $"Did not find updated method symbol for {node} `{node.Syntax}`.");
-                return base.VisitCall(node);
             }
 
             public override BoundNode? VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -665,9 +665,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void SetUpdatedSymbol(BoundNode node, Symbol originalSymbol, Symbol updatedSymbol)
         {
-            if (_updatedSymbolMapOpt is object && (object)originalSymbol != updatedSymbol)
+            if (_updatedSymbolMapOpt is object)
             {
-                _updatedSymbolMapOpt[(node, originalSymbol)] = updatedSymbol;
+                var key = (node, originalSymbol);
+                if ((object)originalSymbol != updatedSymbol)
+                {
+                    _updatedSymbolMapOpt[key] = updatedSymbol;
+                }
+                else if (_updatedSymbolMapOpt.TryGetValue(key, out var currentSymbol) && (object)currentSymbol != updatedSymbol)
+                {
+                    // If the symbol is reset, remove the updated symbol so we don't needlessly update the
+                    // bound node later on.
+                    _updatedSymbolMapOpt.Remove(key);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6187,7 +6187,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitFieldAccess(BoundFieldAccess node)
         {
             var updatedSymbol = VisitMemberAccess(node, node.ReceiverOpt, node.FieldSymbol);
-            Debug.Assert(updatedSymbol.Kind == SymbolKind.Field);
             SetUpdatedSymbol(node, node.FieldSymbol, updatedSymbol);
             return null;
         }
@@ -6195,7 +6194,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
         {
             var updatedMember = VisitMemberAccess(node, node.ReceiverOpt, node.PropertySymbol);
-            Debug.Assert(updatedMember.Kind == SymbolKind.Property);
             SetUpdatedSymbol(node, node.PropertySymbol, updatedMember);
             return null;
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -2319,10 +2319,10 @@ class C<T>
 
             var symInfo = model.GetSymbolInfo(memberAccess[0]);
             Assert.Equal(PublicNullableAnnotation.Annotated, ((IPropertySymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.Annotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.Annotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
             symInfo = model.GetSymbolInfo(memberAccess[1]);
             Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((IPropertySymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.NotAnnotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
         }
 
         [Fact]
@@ -2361,14 +2361,14 @@ class C<T>
 
             var symInfo = model.GetSymbolInfo(memberAccess[0]);
             Assert.Equal(PublicNullableAnnotation.Annotated, ((IFieldSymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.Annotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.Annotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
             symInfo = model.GetSymbolInfo(memberAccess[1]);
             Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((IFieldSymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.NotAnnotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
         }
 
         [Fact]
-        public void GetSymbolInfo_EventAssignmentSymbols()
+        public void GetSymbolInfo_EventAdditionSymbols()
         {
             var source = @"
 #pragma warning disable CS0067
@@ -2400,10 +2400,10 @@ class C<T>
 
             var symInfo = model.GetSymbolInfo(memberAccess[0]);
             Assert.Equal(PublicNullableAnnotation.Annotated, ((IEventSymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.Annotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.Annotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
             symInfo = model.GetSymbolInfo(memberAccess[1]);
             Assert.Equal(PublicNullableAnnotation.Annotated, ((IEventSymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.NotAnnotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
 
             var event1 = model.GetSymbolInfo(memberAccess[2]).Symbol;
             var event2 = model.GetSymbolInfo(memberAccess[3]).Symbol;
@@ -2414,7 +2414,7 @@ class C<T>
         }
 
         [Fact]
-        public void GetSymbolInfo_EventAccessSymbols()
+        public void GetSymbolInfo_EventAssignmentSymbols()
         {
             var source = @"
 #pragma warning disable CS0067
@@ -2445,10 +2445,10 @@ class C<T>
 
             var symInfo = model.GetSymbolInfo(memberAccess[0]);
             Assert.Equal(PublicNullableAnnotation.Annotated, ((IEventSymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.Annotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.Annotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
             symInfo = model.GetSymbolInfo(memberAccess[1]);
             Assert.Equal(PublicNullableAnnotation.Annotated, ((IEventSymbol)symInfo.Symbol).NullableAnnotation);
-            Assert.Equal(PublicNullableAnnotation.NotAnnotated, (symInfo.Symbol.ContainingType).TypeArgumentNullableAnnotations[0]);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, symInfo.Symbol.ContainingType.TypeArgumentNullableAnnotations[0]);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -2287,7 +2287,7 @@ static class ArrayExtensions
         }
 
         [Fact]
-        public void GetSymbolInfo_ParameterSymbols()
+        public void GetSymbolInfo_PropertySymbols()
         {
             var source = @"
 class C<T>


### PR DESCRIPTION
This expands the range of symbols for which `GetSymbolInfo` will return correct information. @dotnet/roslyn-compiler for a review please. /cc @jasonmalinowski @ryzngard.