### PR TITLE
Fix deadlock due to VS Experiement service jumping to UI thread in certain cases.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageClient/CSharpLanguageServerClient.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageClient/CSharpLanguageServerClient.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Composition;
@@ -25,10 +29,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageClient
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpLanguageServerClient(
+            IThreadingContext threadingContext,
             VisualStudioWorkspace workspace,
+            IEnumerable<Lazy<IOptionPersister>> lazyOptions,
             LanguageServerClientEventListener eventListener,
             IAsynchronousOperationListenerProvider listenerProvider)
-            : base(workspace,
+            : base(
+                threadingContext,
+                workspace,
+                lazyOptions,
                 eventListener,
                 listenerProvider,
                 languageServerName: WellKnownServiceHubServices.CSharpLanguageServer,

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -55,16 +55,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             public void Enable()
             {
-                // experimentation service unfortunately uses JTF to jump to UI thread in certain cases
-                // which can cause deadlock if 2 parties try to enable OOP from BG and then FG before 
-                // experimentation service tries to jump to UI thread.
-                // 
-                // this doesn't attempt to solve our JTF and some services being not free-thread issue here, but
-                // try to fix this particular deadlock issue only. we already have long discussion on
-                // how we need to deal with JTF, Roslyn service requirements and VS services reality conflicting
-                // each others. architectural fix should come from the result of that discussion.
-                var experimentationService = _workspace.Services.GetService<IExperimentationService>();
-
                 lock (_gate)
                 {
                     if (_remoteClientTask != null)
@@ -92,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     }
 
                     // set bitness
-                    SetRemoteHostBitness(experimentationService);
+                    SetRemoteHostBitness();
 
                     // make sure we run it on background thread
                     _shutdownCancellationTokenSource = new CancellationTokenSource();
@@ -186,12 +176,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return remoteClientTask;
             }
 
-            private void SetRemoteHostBitness(IExperimentationService experimentationService)
+            private void SetRemoteHostBitness()
             {
                 var x64 = _workspace.Options.GetOption(RemoteHostOptions.OOP64Bit);
                 if (!x64)
                 {
-                    x64 = experimentationService.IsExperimentEnabled(WellKnownExperimentNames.RoslynOOP64bit);
+                    x64 = _workspace.Services.GetService<IExperimentationService>().IsExperimentEnabled(WellKnownExperimentNames.RoslynOOP64bit);
                 }
 
                 // log OOP bitness

--- a/src/VisualStudio/VisualBasic/Impl/LanguageClient/VisualBasicLanguageServerClient.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageClient/VisualBasicLanguageServerClient.vb
@@ -2,7 +2,9 @@
 
 Imports System.ComponentModel.Composition
 Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Remote
 Imports Microsoft.CodeAnalysis.Shared.TestHooks
 Imports Microsoft.VisualStudio.LanguageServer.Client
@@ -23,10 +25,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.LanguageClient
 
         <ImportingConstructor>
         <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
-        Public Sub New(workspace As VisualStudioWorkspace,
+        Public Sub New(threadingContext As IThreadingContext,
+                       workspace As VisualStudioWorkspace,
+                       lazyOptions As IEnumerable(Of Lazy(Of IOptionPersister)),
                        eventListener As LanguageServerClientEventListener,
                        listenerProvider As IAsynchronousOperationListenerProvider)
-            MyBase.New(workspace,
+            MyBase.New(threadingContext,
+                       workspace,
+                       lazyOptions,
                        eventListener,
                        listenerProvider,
                        languageServerName:=WellKnownServiceHubServices.VisualBasicLanguageServer,


### PR DESCRIPTION
make sure to acquire IExperiementationService outside of a lock so that we don't get into deadlock in certain cases.