### PR TITLE
Include SyntaxTree in Exception thrown from CheckAndAdjustPosition

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1202,7 +1202,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return fullStart;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(position), position,
+            throw new ArgumentOutOfRangeException(nameof(position), new SyntaxTreeAndPosition(this.SyntaxTree, position),
                 string.Format(CSharpResources.PositionIsNotWithinSyntax, Root.FullSpan));
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeAndPosition.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeAndPosition.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed class SyntaxTreeAndPosition
+    {
+        internal readonly SyntaxTree SyntaxTree;
+        internal readonly int Position;
+
+        internal SyntaxTreeAndPosition(SyntaxTree syntaxTree, int position)
+        {
+            SyntaxTree = syntaxTree;
+            Position = position;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AccessibilityTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AccessibilityTests.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -42,11 +39,16 @@ class C1
         [Fact]
         public void IsAccessibleLocationNotInSource()
         {
-            Assert.Throws(typeof(ArgumentOutOfRangeException), () =>
-                s_testModel.IsAccessible(-1, s_testSymbol));
+            checkException(-1);
+            checkException(s_testModel.SyntaxTree.GetCompilationUnitRoot().FullSpan.End + 1);
 
-            Assert.Throws(typeof(ArgumentOutOfRangeException), () =>
-                s_testModel.IsAccessible(s_testModel.SyntaxTree.GetCompilationUnitRoot().FullSpan.End + 1, s_testSymbol));
+            static void checkException(int position)
+            {
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(() => s_testModel.IsAccessible(position, s_testSymbol));
+                var value = (SyntaxTreeAndPosition)ex.ActualValue;
+                Assert.Same(s_testModel.SyntaxTree, value.SyntaxTree);
+                Assert.Equal(position, value.Position);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Include `SyntaxTree` in `ArgumentOutOfRangeException` thrown from `CSharpSemanticModel.CheckAndAdjustPosition()` to improve debuggability in cases where an exception is re-thrown from `Task` completion.