### PR TITLE
Call GetTextSynchronously when fetching in a synchronous way

### DIFF
--- a/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigateTo/NavigateToItemDisplay.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Wpf;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Navigation;
@@ -51,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 return new List<DescriptionItem>().AsReadOnly();
             }
 
-            var sourceText = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+            var sourceText = document.GetTextSynchronously(CancellationToken.None);
 
             var items = new List<DescriptionItem>
                     {


### PR DESCRIPTION
This code is trying to fetch the text of a single line, but since it's responding to an API that's synchronous it must be synchronous. We were doing it with GetTextAsync + WaitAndGetResult which can be slow if the thread pool is busy.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/974884