### PR TITLE
Make only typescript handlers and run code actions switch to main thr…

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/Shims/FindImplementationsHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FindImplementationsHandlerShim.cs
@@ -3,9 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -13,27 +10,27 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
+    /// <summary>
+    /// Typescript format expects to be called from the main thread.
+    /// </summary>
+    internal class FindImplementationsHandlerOnMainThreadShim : AbstractLiveShareHandlerOnMainThreadShim<TextDocumentPositionParams, object>
+    {
+        public FindImplementationsHandlerOnMainThreadShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+            : base(requestHandlers, Methods.TextDocumentImplementationName, threadingContext)
+        {
+        }
+    }
+
     internal class FindImplementationsHandlerShim : AbstractLiveShareHandlerShim<TextDocumentPositionParams, object>
     {
-        private readonly IThreadingContext _threadingContext;
-
-        public FindImplementationsHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
-            : base(requestHandlers, Methods.TextDocumentImplementationName)
+        public FindImplementationsHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers, Methods.TextDocumentImplementationName)
         {
-            _threadingContext = threadingContext;
-        }
-
-        public override async Task<object> HandleAsync(TextDocumentPositionParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-        {
-            // TypeScript requires this call to be on the UI thread.
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            return await base.HandleAsyncPreserveThreadContext(param, requestContext, cancellationToken).ConfigureAwait(false);
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentImplementationName)]
     [Obsolete("Used for backwards compatibility with old liveshare clients.")]
-    internal class RoslynFindImplementationsHandlerShim : FindImplementationsHandlerShim
+    internal class RoslynFindImplementationsHandlerShim : FindImplementationsHandlerOnMainThreadShim
     {
         [ImportingConstructor]
         public RoslynFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
@@ -45,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class CSharpFindImplementationsHandlerShim : FindImplementationsHandlerShim
     {
         [ImportingConstructor]
-        public CSharpFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public CSharpFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
@@ -54,13 +51,13 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class VisualBasicFindImplementationsHandlerShim : FindImplementationsHandlerShim
     {
         [ImportingConstructor]
-        public VisualBasicFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public VisualBasicFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentImplementationName)]
-    internal class TypeScriptFindImplementationsHandlerShim : FindImplementationsHandlerShim
+    internal class TypeScriptFindImplementationsHandlerShim : FindImplementationsHandlerOnMainThreadShim
     {
         [ImportingConstructor]
         public TypeScriptFindImplementationsHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)

--- a/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentHandlerShim.cs
@@ -3,9 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -13,30 +10,34 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
-    internal class FormatDocumentHandlerShim : AbstractLiveShareHandlerShim<DocumentFormattingParams, TextEdit[]>
+    /// <summary>
+    /// Typescript format expects to be called from the main thread.
+    /// </summary>
+    internal class FormatDocumentHandlerOnMainThreadShim : AbstractLiveShareHandlerOnMainThreadShim<DocumentFormattingParams, TextEdit[]>
     {
-        private readonly IThreadingContext _threadingContext;
-
-        public FormatDocumentHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
-            : base(requestHandlers, Methods.TextDocumentFormattingName)
+        public FormatDocumentHandlerOnMainThreadShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+            : base(requestHandlers, Methods.TextDocumentFormattingName, threadingContext)
         {
-            _threadingContext = threadingContext;
-        }
-
-        public override async Task<TextEdit[]> HandleAsync(DocumentFormattingParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-        {
-            // To get the formatting options, TypeScript expects to be called on the UI thread.
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            return await base.HandleAsyncPreserveThreadContext(param, requestContext, cancellationToken).ConfigureAwait(false);
         }
     }
 
+    internal class FormatDocumentHandlerShim : AbstractLiveShareHandlerShim<DocumentFormattingParams, TextEdit[]>
+    {
+
+        public FormatDocumentHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers)
+            : base(requestHandlers, Methods.TextDocumentFormattingName)
+        {
+        }
+    }
+
+
     [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentFormattingName)]
     [Obsolete("Used for backwards compatibility with old liveshare clients.")]
-    internal class RoslynFormatDocumentHandlerShim : FormatDocumentHandlerShim
+    internal class RoslynFormatDocumentHandlerShim : FormatDocumentHandlerOnMainThreadShim
     {
         [ImportingConstructor]
-        public RoslynFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public RoslynFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+            : base(requestHandlers, threadingContext)
         {
         }
     }
@@ -45,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class CSharpFormatDocumentHandlerShim : FormatDocumentHandlerShim
     {
         [ImportingConstructor]
-        public CSharpFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public CSharpFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
@@ -54,16 +55,17 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class VisualBasicFormatDocumentHandlerShim : FormatDocumentHandlerShim
     {
         [ImportingConstructor]
-        public VisualBasicFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public VisualBasicFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentFormattingName)]
-    internal class TypeScriptFormatDocumentHandlerShim : FormatDocumentHandlerShim
+    internal class TypeScriptFormatDocumentHandlerShim : FormatDocumentHandlerOnMainThreadShim
     {
         [ImportingConstructor]
-        public TypeScriptFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public TypeScriptFormatDocumentHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+            : base(requestHandlers, threadingContext)
         {
         }
     }

--- a/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentOnTypeHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentOnTypeHandlerShim.cs
@@ -3,9 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -13,27 +10,27 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
+    /// <summary>
+    /// Typescript format expects to be called from the main thread.
+    /// </summary>
+    internal class FormatDocumentOnTypeHandlerOnMainThreadShim : AbstractLiveShareHandlerOnMainThreadShim<DocumentOnTypeFormattingParams, TextEdit[]>
+    {
+        public FormatDocumentOnTypeHandlerOnMainThreadShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+            : base(requestHandlers, Methods.TextDocumentOnTypeFormattingName, threadingContext)
+        {
+        }
+    }
+
     internal class FormatDocumentOnTypeHandlerShim : AbstractLiveShareHandlerShim<DocumentOnTypeFormattingParams, TextEdit[]>
     {
-        private readonly IThreadingContext _threadingContext;
-
-        public FormatDocumentOnTypeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
-            : base(requestHandlers, Methods.TextDocumentOnTypeFormattingName)
+        public FormatDocumentOnTypeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers, Methods.TextDocumentOnTypeFormattingName)
         {
-            _threadingContext = threadingContext;
-        }
-
-        public override async Task<TextEdit[]> HandleAsync(DocumentOnTypeFormattingParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-        {
-            // To get the formatting options, TypeScript expects to be called on the UI thread.
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            return await base.HandleAsyncPreserveThreadContext(param, requestContext, cancellationToken).ConfigureAwait(false);
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentOnTypeFormattingName)]
     [Obsolete("Used for backwards compatibility with old liveshare clients.")]
-    internal class RoslynFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
+    internal class RoslynFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerOnMainThreadShim
     {
         [ImportingConstructor]
         public RoslynFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
@@ -45,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class CSharpFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
     {
         [ImportingConstructor]
-        public CSharpFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public CSharpFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
@@ -54,13 +51,13 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class VisualBasicFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
     {
         [ImportingConstructor]
-        public VisualBasicFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public VisualBasicFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentOnTypeFormattingName)]
-    internal class TypeScriptFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerShim
+    internal class TypeScriptFormatDocumentOnTypeHandlerShim : FormatDocumentOnTypeHandlerOnMainThreadShim
     {
         [ImportingConstructor]
         public TypeScriptFormatDocumentOnTypeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)

--- a/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentRangeHandlerShim.cs
+++ b/src/VisualStudio/LiveShare/Impl/Shims/FormatDocumentRangeHandlerShim.cs
@@ -3,9 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -13,27 +10,27 @@ using Microsoft.VisualStudio.LiveShare.LanguageServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare
 {
+    /// <summary>
+    /// Typescript format expects to be called from the main thread.
+    /// </summary>
+    internal class FormatDocumentRangeHandlerOnMainThreadShim : AbstractLiveShareHandlerOnMainThreadShim<DocumentRangeFormattingParams, TextEdit[]>
+    {
+        public FormatDocumentRangeHandlerOnMainThreadShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
+            : base(requestHandlers, Methods.TextDocumentRangeFormattingName, threadingContext)
+        {
+        }
+    }
+
     internal class FormatDocumentRangeHandlerShim : AbstractLiveShareHandlerShim<DocumentRangeFormattingParams, TextEdit[]>
     {
-        private readonly IThreadingContext _threadingContext;
-
-        public FormatDocumentRangeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext)
-            : base(requestHandlers, Methods.TextDocumentRangeFormattingName)
+        public FormatDocumentRangeHandlerShim(IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers, Methods.TextDocumentRangeFormattingName)
         {
-            _threadingContext = threadingContext;
-        }
-
-        public override async Task<TextEdit[]> HandleAsync(DocumentRangeFormattingParams param, RequestContext<Solution> requestContext, CancellationToken cancellationToken)
-        {
-            // To get the formatting options, TypeScript expects to be called on the UI thread.
-            await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            return await base.HandleAsyncPreserveThreadContext(param, requestContext, cancellationToken).ConfigureAwait(false);
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.RoslynContractName, Methods.TextDocumentRangeFormattingName)]
     [Obsolete("Used for backwards compatibility with old liveshare clients.")]
-    internal class RoslynFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
+    internal class RoslynFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerOnMainThreadShim
     {
         [ImportingConstructor]
         public RoslynFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
@@ -45,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class CSharpFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
     {
         [ImportingConstructor]
-        public CSharpFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public CSharpFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
@@ -54,13 +51,13 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     internal class VisualBasicFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
     {
         [ImportingConstructor]
-        public VisualBasicFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)
+        public VisualBasicFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers) : base(requestHandlers)
         {
         }
     }
 
     [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, Methods.TextDocumentRangeFormattingName)]
-    internal class TypeScriptFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerShim
+    internal class TypeScriptFormatDocumentRangeHandlerShim : FormatDocumentRangeHandlerOnMainThreadShim
     {
         [ImportingConstructor]
         public TypeScriptFormatDocumentRangeHandlerShim([ImportMany] IEnumerable<Lazy<IRequestHandler, IRequestHandlerMetadata>> requestHandlers, IThreadingContext threadingContext) : base(requestHandlers, threadingContext)


### PR DESCRIPTION
…ead.

Make the c#/vb handlers not require main thread execution.  

Left typescript and obsolete roslyn handler to request main thread (as it serves typescript as well).