### PR TITLE
Support compound operators with pattern Index/Range indexers

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -364,6 +364,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 indexerAccess.Type);
         }
 
+        private BoundExpression TransformPatternIndexerAccess(
+            BoundIndexOrRangePatternIndexerAccess indexerAccess,
+            ArrayBuilder<BoundExpression> stores,
+            ArrayBuilder<LocalSymbol> temps,
+            bool isDynamicAssignment)
+        {
+            // A pattern indexer is fundamentally a sequence which ends in either
+            // a conventional indexer access or a method call. The lowering of a
+            // pattern indexer already lowers everything we need into temps, so
+            // the only thing we need to do is lift the stores and temps out of
+            // the sequence, and use the final expression as the new argument
+
+            var sequence = VisitIndexOrRangePatternIndexerAccess(indexerAccess, isLeftOfAssignment: true);
+            stores.AddRange(sequence.SideEffects);
+            temps.AddRange(sequence.Locals);
+            return TransformCompoundAssignmentLHS(sequence.Value, stores, temps, isDynamicAssignment);
+        }
+
         /// <summary>
         /// Returns true if the <paramref name="receiver"/> was lowered and transformed.
         /// The <paramref name="receiver"/> is not changed if this function returns false. 
@@ -516,6 +534,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (indexerAccess.Indexer.RefKind == RefKind.None)
                         {
                             return TransformIndexerAccess((BoundIndexerAccess)originalLHS, stores, temps);
+                        }
+                    }
+                    break;
+
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    {
+                        var patternIndexerAccess = (BoundIndexOrRangePatternIndexerAccess)originalLHS;
+                        (RefKind refKind, bool isRange) = patternIndexerAccess.PatternSymbol switch
+                        {
+                            PropertySymbol { RefKind: var r } => (r, false),
+                            MethodSymbol { RefKind: var r } => (r, true),
+                            var x => throw ExceptionUtilities.UnexpectedValue(x)
+                        };
+                        if (refKind == RefKind.None)
+                        {
+                            return TransformPatternIndexerAccess(patternIndexerAccess, stores, temps, isDynamicAssignment);
                         }
                     }
                     break;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -541,10 +541,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.IndexOrRangePatternIndexerAccess:
                     {
                         var patternIndexerAccess = (BoundIndexOrRangePatternIndexerAccess)originalLHS;
-                        (RefKind refKind, bool isRange) = patternIndexerAccess.PatternSymbol switch
+                        RefKind refKind = patternIndexerAccess.PatternSymbol switch
                         {
-                            PropertySymbol { RefKind: var r } => (r, false),
-                            MethodSymbol { RefKind: var r } => (r, true),
+                            PropertySymbol p => p.RefKind,
+                            MethodSymbol m => m.RefKind,
                             var x => throw ExceptionUtilities.UnexpectedValue(x)
                         };
                         if (refKind == RefKind.None)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return VisitIndexOrRangePatternIndexerAccess(node, isLeftOfAssignment: false);
         }
 
-        private BoundExpression VisitIndexOrRangePatternIndexerAccess(BoundIndexOrRangePatternIndexerAccess node, bool isLeftOfAssignment)
+        private BoundSequence VisitIndexOrRangePatternIndexerAccess(BoundIndexOrRangePatternIndexerAccess node, bool isLeftOfAssignment)
         {
             if (TypeSymbol.Equals(
                 node.Argument.Type,
@@ -192,7 +192,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression VisitIndexPatternIndexerAccess(
+
+        private BoundSequence VisitIndexPatternIndexerAccess(
             SyntaxNode syntax,
             BoundExpression receiver,
             PropertySymbol lengthOrCountProperty,
@@ -236,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             locals.Add(indexLocal.LocalSymbol);
             sideEffects.Add(indexStore);
 
-            return F.Sequence(
+            return (BoundSequence)F.Sequence(
                 locals.ToImmutable(),
                 sideEffects.ToImmutable(),
                 MakeIndexerAccess(
@@ -290,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression VisitRangePatternIndexerAccess(
+        private BoundSequence VisitRangePatternIndexerAccess(
             BoundExpression receiver,
             PropertySymbol lengthOrCountProperty,
             MethodSymbol sliceMethod,
@@ -419,7 +420,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rangeSizeExpr = rangeSizeLocal;
             }
 
-            return F.Sequence(
+            return (BoundSequence)F.Sequence(
                 localsBuilder.ToImmutableAndFree(),
                 sideEffectsBuilder.ToImmutableAndFree(),
                 F.Call(receiverLocal, sliceMethod, startExpr, rangeSizeExpr));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -319,6 +319,7 @@ class C
         Console.WriteLine(array[1] is null);
         var s = new S(array);
         s[^1] ??= s[^2];
+        s[^1] ??= s[^2];
         Console.WriteLine(array[1]);
     }
 }";
@@ -330,10 +331,12 @@ Get 1
 Length 2
 Get 3
 Set 4
+Length 5
+Get 6
 1");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size      135 (0x87)
+  // Code size      201 (0xc9)
   .maxstack  5
   .locals init (int?[] V_0, //array
                 S V_1, //s
@@ -392,12 +395,41 @@ Set 4
   IL_006d:  dup
   IL_006e:  stloc.s    V_6
   IL_0070:  call       ""void S.this[int].set""
-  IL_0075:  ldloc.0
-  IL_0076:  ldc.i4.1
-  IL_0077:  ldelem     ""int?""
-  IL_007c:  box        ""int?""
-  IL_0081:  call       ""void System.Console.WriteLine(object)""
-  IL_0086:  ret
+  IL_0075:  ldloca.s   V_1
+  IL_0077:  stloc.s    V_4
+  IL_0079:  ldloc.s    V_4
+  IL_007b:  call       ""int S.Length.get""
+  IL_0080:  ldc.i4.1
+  IL_0081:  sub
+  IL_0082:  ldloc.s    V_4
+  IL_0084:  stloc.3
+  IL_0085:  stloc.s    V_5
+  IL_0087:  ldloc.3
+  IL_0088:  ldloc.s    V_5
+  IL_008a:  call       ""int? S.this[int].get""
+  IL_008f:  stloc.2
+  IL_0090:  ldloca.s   V_2
+  IL_0092:  call       ""bool int?.HasValue.get""
+  IL_0097:  brtrue.s   IL_00b7
+  IL_0099:  ldloc.3
+  IL_009a:  ldloc.s    V_5
+  IL_009c:  ldloca.s   V_1
+  IL_009e:  dup
+  IL_009f:  call       ""int S.Length.get""
+  IL_00a4:  ldc.i4.2
+  IL_00a5:  sub
+  IL_00a6:  stloc.s    V_7
+  IL_00a8:  ldloc.s    V_7
+  IL_00aa:  call       ""int? S.this[int].get""
+  IL_00af:  dup
+  IL_00b0:  stloc.s    V_6
+  IL_00b2:  call       ""void S.this[int].set""
+  IL_00b7:  ldloc.0
+  IL_00b8:  ldc.i4.1
+  IL_00b9:  ldelem     ""int?""
+  IL_00be:  box        ""int?""
+  IL_00c3:  call       ""void System.Console.WriteLine(object)""
+  IL_00c8:  ret
 }");
         }
 


### PR DESCRIPTION
When we added a pattern-based range, compound operator lowering was
not updated to deal with the new node, which it does pre-lowering, since
some bound nodes (like indexers) have different code gen in the presence
of compound operators.

This change implements compound operator support for pattern Index/Range.

Fixes #37789