### PR TITLE
Handle invalid local function parameter with default value in GetDeclaredSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -821,7 +821,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (paramList.Parent.Kind() == SyntaxKind.LocalFunctionStatement)
             {
-                var localFunction = (MethodSymbol)_containingSemanticModelOpt?.GetDeclaredSymbol((LocalFunctionStatementSyntax)paramList.Parent, cancellationToken);
+                var localFunction = (MethodSymbol)GetDeclaredSymbol((LocalFunctionStatementSyntax)paramList.Parent, cancellationToken);
                 if ((object)localFunction != null)
                 {
                     return GetParameterSymbol(localFunction.Parameters, parameter, cancellationToken);

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -821,7 +821,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (paramList.Parent.Kind() == SyntaxKind.LocalFunctionStatement)
             {
-                var localFunction = (MethodSymbol)GetDeclaredSymbol((LocalFunctionStatementSyntax)paramList.Parent, cancellationToken);
+                var localFunction = (MethodSymbol)_containingSemanticModelOpt?.GetDeclaredSymbol((LocalFunctionStatementSyntax)paramList.Parent, cancellationToken);
                 if ((object)localFunction != null)
                 {
                     return GetParameterSymbol(localFunction.Parameters, parameter, cancellationToken);

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -880,7 +880,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return GetOrAddModelForAttribute((AttributeSyntax)memberDecl);
 
                     case SyntaxKind.Parameter:
-                        return GetOrAddModelForParameter((ParameterSyntax)memberDecl, span);
+                        if (node != memberDecl)
+                        {
+                            return GetOrAddModelForParameter((ParameterSyntax)memberDecl, span);
+                        }
+                        else
+                        {
+                            return GetMemberModel(memberDecl.Parent);
+                        }
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -5220,5 +5220,27 @@ class C
 
             Assert.Contains(symbols, s => s.Name == "Local");
         }
+
+        [Fact]
+        [WorkItem(784401, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/784401")]
+        public void LocalFunctionInvalidParameterWithDefaultValue()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        void F(int x, = 3) { }
+    }
+}";
+            var comp = CreateCompilation(source);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var decls = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ParameterSyntax>().ToArray();
+            foreach (var decl in decls)
+            {
+                _ = model.GetDeclaredSymbol(decl);
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -5222,8 +5222,29 @@ class C
         }
 
         [Fact]
+        public void InvalidParameterWithDefaultValue_Method()
+        {
+            var source =
+@"class Program
+{
+    static void F(int x = 2, = 3) { }
+}";
+            var comp = CreateCompilation(source);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var decls = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ParameterSyntax>().ToArray();
+            var symbol1 = model.GetDeclaredSymbol(decls[0]);
+            Assert.Equal("[System.Int32 x = 2]", symbol1.ToTestDisplayString());
+            Assert.Equal(0, ((ParameterSymbol)symbol1).Ordinal);
+            var symbol2 = model.GetDeclaredSymbol(decls[1]);
+            Assert.Equal("[?  = null]", symbol2.ToTestDisplayString());
+            Assert.Equal(1, ((ParameterSymbol)symbol2).Ordinal);
+            Assert.Same(symbol1.ContainingSymbol, symbol2.ContainingSymbol);
+        }
+
+        [Fact]
         [WorkItem(784401, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/784401")]
-        public void LocalFunctionInvalidParameterWithDefaultValue()
+        public void InvalidParameterWithDefaultValue_LocalFunction_01()
         {
             var source =
 @"class Program
@@ -5237,10 +5258,38 @@ class C
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
             var decls = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ParameterSyntax>().ToArray();
-            foreach (var decl in decls)
-            {
-                _ = model.GetDeclaredSymbol(decl);
-            }
+            var symbol1 = model.GetDeclaredSymbol(decls[0]);
+            Assert.Equal("System.Int32 x", symbol1.ToTestDisplayString());
+            Assert.Equal(0, ((ParameterSymbol)symbol1).Ordinal);
+            var symbol2 = model.GetDeclaredSymbol(decls[1]);
+            Assert.Equal("[?  = null]", symbol2.ToTestDisplayString());
+            Assert.Equal(1, ((ParameterSymbol)symbol2).Ordinal);
+            Assert.Same(symbol1.ContainingSymbol, symbol2.ContainingSymbol);
+        }
+
+        [Fact]
+        [WorkItem(784401, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/784401")]
+        public void InvalidParameterWithDefaultValue_LocalFunction_02()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        void F(int x = 2, = 3) { }
+    }
+}";
+            var comp = CreateCompilation(source);
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var decls = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ParameterSyntax>().ToArray();
+            var symbol1 = model.GetDeclaredSymbol(decls[0]);
+            Assert.Equal("[System.Int32 x = 2]", symbol1.ToTestDisplayString());
+            Assert.Equal(0, ((ParameterSymbol)symbol1).Ordinal);
+            var symbol2 = model.GetDeclaredSymbol(decls[1]);
+            Assert.Equal("[?  = null]", symbol2.ToTestDisplayString());
+            Assert.Equal(1, ((ParameterSymbol)symbol2).Ordinal);
+            Assert.Same(symbol1.ContainingSymbol, symbol2.ContainingSymbol);
         }
     }
 }


### PR DESCRIPTION
Avoids `ArgumentOutOfRangeException` in `CheckAndAdjustPosition`.