### PR TITLE
Formatter throws a exception where HostObjectValue is null

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
     internal sealed partial class CSharpFormatter : Formatter
     {
         public CSharpFormatter()
-            : base(defaultFormat: "{{{0}}}", nullString: "null", thisString: "this", hostValueNotFoundString: Resources.HostValueNotFound)
+            : base(defaultFormat: "{{{0}}}", nullString: "null", thisString: "this")
         {
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/CSharpFormatter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
     internal sealed partial class CSharpFormatter : Formatter
     {
         public CSharpFormatter()
-            : base(defaultFormat: "{{{0}}}", nullString: "null", thisString: "this")
+            : base(defaultFormat: "{{{0}}}", nullString: "null", thisString: "this", hostValueNotFoundString: Resources.HostValueNotFound)
         {
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
@@ -660,7 +660,7 @@ namespace System.Xml.Linq
         }
 
         [Fact]
-        public void HostValueIsNotFound_int()
+        public void HostValueNotFound_int()
         {
             var clrValue = new DkmClrValue(
                 value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(int)),
@@ -670,7 +670,7 @@ namespace System.Xml.Linq
         }
 
         [Fact]
-        public void HostValueIsNotFound_char()
+        public void HostValueNotFound_char()
         {
             var clrValue = new DkmClrValue(
                 value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(char)),
@@ -680,7 +680,27 @@ namespace System.Xml.Linq
         }
 
         [Fact]
-        public void HostValueIsNotFound_enum()
+        public void HostValueNotFound_IntPtr()
+        {
+            var clrValue = new DkmClrValue(
+                value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(IntPtr)),
+                alias: null, evalFlags: DkmEvaluationResultFlags.None, valueFlags: DkmClrValueFlags.None);
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue));
+        }
+
+        [Fact]
+        public void HostValueNotFound_UIntPtr()
+        {
+            var clrValue = new DkmClrValue(
+                value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(UIntPtr)),
+                alias: null, evalFlags: DkmEvaluationResultFlags.None, valueFlags: DkmClrValueFlags.None);
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue));
+        }
+
+        [Fact]
+        public void HostValueNotFound_enum()
         {
             var clrValue = new DkmClrValue(
                 value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(TestEnum)),

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Globalization;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
+using Microsoft.VisualStudio.Debugger.Clr;
 using Microsoft.VisualStudio.Debugger.Evaluation;
+using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
@@ -655,6 +657,41 @@ namespace System.Xml.Linq
 
             Assert.Equal("Test1", GetUnderlyingString(xnType.Instantiate()));
             Assert.Equal("Test2", GetUnderlyingString(xeType.Instantiate()));
+        }
+
+        [Fact]
+        public void HostValueIsNotFound_int()
+        {
+            var clrValue = new DkmClrValue(
+                value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(int)),
+                alias: null, evalFlags: DkmEvaluationResultFlags.None, valueFlags: DkmClrValueFlags.None);
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue));
+        }
+
+        [Fact]
+        public void HostValueIsNotFound_char()
+        {
+            var clrValue = new DkmClrValue(
+                value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(char)),
+                alias: null, evalFlags: DkmEvaluationResultFlags.None, valueFlags: DkmClrValueFlags.None);
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue));
+        }
+
+        [Fact]
+        public void HostValueIsNotFound_enum()
+        {
+            var clrValue = new DkmClrValue(
+                value: null, hostObjectValue: null, new DkmClrType((TypeImpl)typeof(TestEnum)),
+                alias: null, evalFlags: DkmEvaluationResultFlags.None, valueFlags: DkmClrValueFlags.None);
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue));
+        }
+
+        private enum TestEnum
+        {
+            One
         }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -53,6 +53,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
                 else if (lmrType.IsCharacter())
                 {
+                    // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
+                    if (value.HostObjectValue == null)
+                    {
+                        return null;
+                    }
+
                     return IncludeObjectId(
                         value,
                         FormatLiteral((char)value.HostObjectValue, options | ObjectDisplayOptions.IncludeCodePoints),
@@ -102,6 +108,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
             else if (lmrType.IsIntPtr())
             {
+                // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
+                if (value.HostObjectValue == null)
+                {
+                    return null;
+                }
+
                 if (IntPtr.Size == 8)
                 {
                     var intPtr = ((IntPtr)value.HostObjectValue).ToInt64();
@@ -115,6 +127,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             }
             else if (lmrType.IsUIntPtr())
             {
+                // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
+                if (value.HostObjectValue == null)
+                {
+                    return null;
+                }
+
                 if (UIntPtr.Size == 8)
                 {
                     var uIntPtr = ((UIntPtr)value.HostObjectValue).ToUInt64();
@@ -161,6 +179,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             {
                 options |= ObjectDisplayOptions.UseHexadecimalNumbers;
             }
+            // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
+            if (value.HostObjectValue == null)
+            {
+                return null;
+            }
+
             var charTemp = FormatLiteral((char)value.HostObjectValue, options);
             Debug.Assert(charTemp != null);
             return charTemp;
@@ -173,7 +197,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private string GetUnderlyingString(DkmClrValue value, DkmInspectionContext inspectionContext)
         {
-            RawStringDataItem dataItem = value.GetDataItem<RawStringDataItem>();
+            var dataItem = value.GetDataItem<RawStringDataItem>();
             if (dataItem != null)
             {
                 return dataItem.RawString;
@@ -241,11 +265,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Debug.Assert(value != null);
 
             object underlyingValue = value.HostObjectValue;
-            Debug.Assert(underlyingValue != null);
+            // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
+            if (value.HostObjectValue == null)
+            {
+                return null;
+            }
 
             string displayString;
 
-            ArrayBuilder<EnumField> fields = ArrayBuilder<EnumField>.GetInstance();
+            var fields = ArrayBuilder<EnumField>.GetInstance();
             FillEnumFields(fields, lmrType);
             // We will normalize/extend all enum values to ulong to ensure that we are always comparing the full underlying value.
             ulong valueForComparison = ConvertEnumUnderlyingTypeToUInt64(underlyingValue, Type.GetTypeCode(lmrType));
@@ -405,18 +433,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private string FormatPrimitive(DkmClrValue value, ObjectDisplayOptions options, DkmInspectionContext inspectionContext)
         {
             Debug.Assert(value != null);
+            // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
+            if (value.HostObjectValue == null)
+            {
+                return null;
+            }
 
             object obj;
             if (value.Type.GetLmrType().IsDateTime())
             {
-                DkmClrValue dateDataValue = value.GetPropertyValue("Ticks", inspectionContext);
-                Debug.Assert(dateDataValue.HostObjectValue != null);
+                var dateDataValue = value.GetPropertyValue("Ticks", inspectionContext);
 
                 obj = new DateTime((long)dateDataValue.HostObjectValue);
             }
             else
             {
-                Debug.Assert(value.HostObjectValue != null);
                 obj = value.HostObjectValue;
             }
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             object underlyingValue = value.HostObjectValue;
             // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
-            if (value.HostObjectValue == null)
+            if (underlyingValue == null)
             {
                 return _hostValueNotFoundString;
             }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.Values.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
                     if (value.HostObjectValue == null)
                     {
-                        return null;
+                        return _hostValueNotFoundString;
                     }
 
                     return IncludeObjectId(
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
                 if (value.HostObjectValue == null)
                 {
-                    return null;
+                    return _hostValueNotFoundString;
                 }
 
                 if (IntPtr.Size == 8)
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
                 if (value.HostObjectValue == null)
                 {
-                    return null;
+                    return _hostValueNotFoundString;
                 }
 
                 if (UIntPtr.Size == 8)
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
             if (value.HostObjectValue == null)
             {
-                return null;
+                return _hostValueNotFoundString;
             }
 
             var charTemp = FormatLiteral((char)value.HostObjectValue, options);
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
             if (value.HostObjectValue == null)
             {
-                return null;
+                return _hostValueNotFoundString;
             }
 
             string displayString;
@@ -436,14 +436,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             // check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.
             if (value.HostObjectValue == null)
             {
-                return null;
+                return _hostValueNotFoundString;
             }
 
+            // DateTime is primitive in VB but not in C#.
             object obj;
             if (value.Type.GetLmrType().IsDateTime())
             {
                 var dateDataValue = value.GetPropertyValue("Ticks", inspectionContext);
-
                 obj = new DateTime((long)dateDataValue.HostObjectValue);
             }
             else

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -22,14 +22,13 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private readonly string _defaultFormat;
         private readonly string _nullString;
         private readonly string _thisString;
-        private readonly string _hostValueNotFoundString;
+        private string _hostValueNotFoundString => Resources.HostValueNotFound;
 
-        internal Formatter(string defaultFormat, string nullString, string thisString, string hostValueNotFoundString)
+        internal Formatter(string defaultFormat, string nullString, string thisString)
         {
             _defaultFormat = defaultFormat;
             _nullString = nullString;
             _thisString = thisString;
-            _hostValueNotFoundString = hostValueNotFoundString;
         }
 
         string IDkmClrFormatter.GetValueString(DkmClrValue value, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Formatter.cs
@@ -22,12 +22,14 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private readonly string _defaultFormat;
         private readonly string _nullString;
         private readonly string _thisString;
+        private readonly string _hostValueNotFoundString;
 
-        internal Formatter(string defaultFormat, string nullString, string thisString)
+        internal Formatter(string defaultFormat, string nullString, string thisString, string hostValueNotFoundString)
         {
             _defaultFormat = defaultFormat;
             _nullString = nullString;
             _thisString = thisString;
+            _hostValueNotFoundString = hostValueNotFoundString;
         }
 
         string IDkmClrFormatter.GetValueString(DkmClrValue value, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers)

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Resources.Designer.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Resources.Designer.cs
@@ -213,5 +213,16 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator {
                 return ResourceManager.GetString("TypeVariablesName", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Host Value Not Found.
+        /// </summary>
+        internal static string HostValueNotFound
+        {
+            get
+            {
+                return ResourceManager.GetString("HostValueNotFound", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Resources.resx
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Resources.resx
@@ -138,7 +138,7 @@
     <comment>Threw an exception while evaluating a value.</comment>
   </data>
   <data name="HostValueNotFound" xml:space="preserve">
-    <value>Cannot provide the value: Host Value Not Found</value>
+    <value>Cannot provide the value: host value not found</value>
   </data>
   <data name="InvalidPointerDereference" xml:space="preserve">
     <value>Cannot dereference '{0}'. The pointer is not valid.</value>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Resources.resx
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Resources.resx
@@ -137,6 +137,9 @@
     <value>'{0}' threw an exception of type '{1}'</value>
     <comment>Threw an exception while evaluating a value.</comment>
   </data>
+  <data name="HostValueNotFound" xml:space="preserve">
+    <value>Cannot provide the value: Host Value Not Found</value>
+  </data>
   <data name="InvalidPointerDereference" xml:space="preserve">
     <value>Cannot dereference '{0}'. The pointer is not valid.</value>
     <comment>Invalid pointer dereference</comment>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.cs.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.cs.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.cs.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0} – došlo k výjimce typu {1}.</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Nejde přistoupit přes ukazatel na: {0}. Ukazatel není platný.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.de.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' löste eine Ausnahme des Typs '{1}' aus</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Dereferenzieren von '{0}' ist nicht möglich. Der Pointer ist ungültig.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.de.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.de.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.es.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.es.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.es.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' inició una excepción de tipo '{1}'</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">No se puede desreferenciar '{0}'. El puntero no es válido.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.fr.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' a levé une exception de type '{1}'</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Impossible de déréférencer '{0}'. Le pointeur n'est pas valide.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.fr.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.fr.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.it.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' ha generato un'eccezione di tipo '{1}'</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Non è possibile dereferenziare '{0}'. Il puntatore non è valido.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.it.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.it.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ja.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' は型 '{1}' の例外をスローしました</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">{0}' を逆参照できません。ポインターが無効です。</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ja.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ja.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ko.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}'이(가) '{1}' 형식의 예외를 throw했습니다.</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">{0}'을(를) 역참조할 수 없습니다. 포인터가 잘못되었습니다.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ko.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ko.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pl.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'„{0}”: zwrócono wyjątek typu „{1}”</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Nie można usunąć odwołania do elementu „{0}”. Wskaźnik jest nieprawidłowy.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pl.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pl.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pt-BR.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' gerou uma exceção do tipo '{1}'</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Não é possível cancelar a referência '{0}'. O ponteiro não é válido.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pt-BR.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ru.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'"{0}" выдал исключение типа "{1}"</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">Не удается разыменовать "{0}". Недопустимый указатель.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ru.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.ru.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.tr.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}', '{1}' türünde bir özel durum oluşturdu</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">{0}' başvurusu çözülemiyor. İşaretçi geçerli değil.</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.tr.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.tr.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hans.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hans.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'“{0}”引发了类型“{1}”的异常</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">无法取消引用“{0}”。指针无效。</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hant.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">'{0}' 擲回 '{1}' 類型的例外狀況</target>
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
+      <trans-unit id="HostValueNotFound">
+        <source>Cannot provide the value: Host Value Not Found</source>
+        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPointerDereference">
         <source>Cannot dereference '{0}'. The pointer is not valid.</source>
         <target state="translated">無法取值 '{0}'。指標無效。</target>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hant.xlf
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/xlf/Resources.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note>Threw an exception while evaluating a value.</note>
       </trans-unit>
       <trans-unit id="HostValueNotFound">
-        <source>Cannot provide the value: Host Value Not Found</source>
-        <target state="new">Cannot provide the value: Host Value Not Found</target>
+        <source>Cannot provide the value: host value not found</source>
+        <target state="new">Cannot provide the value: host value not found</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPointerDereference">

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -118,6 +118,11 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal string FormatValue(object value, Type type, bool useHexadecimal = false)
         {
             var clrValue = CreateDkmClrValue(value, type);
+            return FormatValue(clrValue, useHexadecimal);
+        }
+
+        internal string FormatValue(DkmClrValue clrValue, bool useHexadecimal = false)
+        {
             var inspectionContext = CreateDkmInspectionContext(_inspectionSession, DkmEvaluationFlags.None, radix: useHexadecimal ? 16u : 10u);
             return clrValue.GetValueString(inspectionContext, Formatter.NoFormatSpecifiers);
         }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Shared ReadOnly Instance As VisualBasicFormatter = New VisualBasicFormatter()
 
         Public Sub New()
-            MyBase.New(defaultFormat:="{{{0}}}", nullString:="Nothing", thisString:="Me", hostValueNotFoundString:=Resources.HostValueNotFound)
+            MyBase.New(defaultFormat:="{{{0}}}", nullString:="Nothing", thisString:="Me")
         End Sub
 
         Friend Overrides Function IsValidIdentifier(name As String) As Boolean

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/VisualBasicFormatter.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Shared ReadOnly Instance As VisualBasicFormatter = New VisualBasicFormatter()
 
         Public Sub New()
-            MyBase.New(defaultFormat:="{{{0}}}", nullString:="Nothing", thisString:="Me")
+            MyBase.New(defaultFormat:="{{{0}}}", nullString:="Nothing", thisString:="Me", hostValueNotFoundString:=Resources.HostValueNotFound)
         End Sub
 
         Friend Overrides Function IsValidIdentifier(name As String) As Boolean

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ValueFormatterTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ValueFormatterTests.vb
@@ -2,6 +2,7 @@
 
 Imports System
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.VisualStudio.Debugger.Clr
 Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Xunit
@@ -575,6 +576,43 @@ End Namespace
             Assert.Equal("#1/1/1970 12:00:00 AM#", FormatValue(New Date(&H89F7FF5F7B58000, DateTimeKind.Local)))
             Assert.Equal("#1/1/1970 12:00:00 AM#", FormatValue(New Date(&H89F7FF5F7B58000, DateTimeKind.Utc)))
         End Sub
+
+        <Fact>
+        Public Sub HostValueIsNotFound_Integer()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(Integer), TypeImpl)),
+                alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
+        End Sub
+
+        <Fact>
+        Public Sub HostValueIsNotFound_char()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(char), TypeImpl)),
+                                           alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
+        End Sub
+
+        <Fact>
+        Public Sub HostValueIsNotFound_Enum()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(TestEnum), TypeImpl)),
+                                           alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
+        End Sub
+
+        ' DateTime is a primitive type in VB but not in C#.
+        <Fact>
+        Public Sub HostValueIsNotFound_DateTime()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(DateTime), TypeImpl)),
+                                           alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
+        End Sub
+
+        Private Enum TestEnum
+            One
+        End Enum
 
     End Class
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ValueFormatterTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/ValueFormatterTests.vb
@@ -578,7 +578,7 @@ End Namespace
         End Sub
 
         <Fact>
-        Public Sub HostValueIsNotFound_Integer()
+        Public Sub HostValueNotFound_Integer()
             Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(Integer), TypeImpl)),
                 alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
 
@@ -586,15 +586,31 @@ End Namespace
         End Sub
 
         <Fact>
-        Public Sub HostValueIsNotFound_char()
-            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(char), TypeImpl)),
+        Public Sub HostValueNotFound_char()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(Char), TypeImpl)),
                                            alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
 
             Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
         End Sub
 
         <Fact>
-        Public Sub HostValueIsNotFound_Enum()
+        Public Sub HostValueNotFound_IntPtr()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(IntPtr), TypeImpl)),
+                                           alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
+        End Sub
+
+        <Fact>
+        Public Sub HostValueNotFound_UIntPtr()
+            Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(UIntPtr), TypeImpl)),
+                                           alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
+
+            Assert.Equal(Resources.HostValueNotFound, FormatValue(clrValue))
+        End Sub
+
+        <Fact>
+        Public Sub HostValueNotFound_Enum()
             Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(TestEnum), TypeImpl)),
                                            alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
 
@@ -603,7 +619,7 @@ End Namespace
 
         ' DateTime is a primitive type in VB but not in C#.
         <Fact>
-        Public Sub HostValueIsNotFound_DateTime()
+        Public Sub HostValueNotFound_DateTime()
             Dim clrValue = New DkmClrValue(value:=Nothing, hostObjectValue:=Nothing, New DkmClrType(CType(GetType(DateTime), TypeImpl)),
                                            alias:=Nothing, evalFlags:=DkmEvaluationResultFlags.None, valueFlags:=DkmClrValueFlags.None)
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/971364

Always check if HostObjectValue is null, since any of these types might actually be a synthetic value as well.