### PR TITLE
Preserve "unsafe" when refactoring between properties and methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -2153,6 +2153,58 @@ class C
 }");
         }
 
+        [WorkItem(38379, "https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestUnsafeGetter()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public unsafe int [||]GetP()
+    {
+        return 0;
+    }
+
+    public void SetP(int value)
+    { }
+}",
+@"class C
+{
+    public unsafe int P
+    {
+        get => 0;
+        set
+        { }
+    }
+}", index: 1);
+        }
+
+        [WorkItem(38379, "https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestUnsafeSetter()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public int [||]GetP()
+    {
+        return 0;
+    }
+
+    public unsafe void SetP(int value)
+    { }
+}",
+@"class C
+{
+    public unsafe int P
+    {
+        get => 0;
+        set
+        { }
+    }
+}", index: 1);
+        }
+
         private async Task TestWithAllCodeStyleOff(
             string initialMarkup, string expectedMarkup,
             ParseOptions parseOptions = null, int index = 0)

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -1682,6 +1682,74 @@ class C : IGoo
 }");
         }
 
+        [WorkItem(38379, "https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestUnsafeExpressionBody()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public unsafe void* [||]Pointer => default;
+}",
+@"class C
+{
+    public unsafe void* GetPointer()
+    {
+        return default;
+    }
+}");
+        }
+
+        [WorkItem(38379, "https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestUnsafeAutoProperty()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public unsafe void* [||]Pointer { get; set; }
+}",
+@"class C
+{
+    private unsafe void* pointer;
+
+    public unsafe void* GetPointer()
+    {
+        return pointer;
+    }
+
+    public unsafe void SetPointer(void* value)
+    {
+        pointer = value;
+    }
+}");
+        }
+
+        [WorkItem(38379, "https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestUnsafeSafeType()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    public unsafe int [||]P
+    {
+        get => 0;
+        set {}
+    }
+}",
+@"class C
+{
+    public unsafe int GetP()
+    {
+        return 0;
+    }
+
+    public unsafe void SetP(int value)
+    { }
+}");
+        }
+
         private IDictionary<OptionKey, object> PreferExpressionBodiedMethods =>
             OptionsSet(SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CSharpCodeStyleOptions.WhenPossibleWithSuggestionEnforcement));
     }

--- a/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
+++ b/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
@@ -129,6 +129,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             var setAccessorDeclaration = (AccessorDeclarationSyntax)setMethod.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
             var methodDeclaration = (MethodDeclarationSyntax)generator.MethodDeclaration(setMethod, desiredSetMethodName);
 
+            // property has unsafe, but generator didn't add it to the method, so we have to add it here
+            if (propertyDeclaration.Modifiers.Any(SyntaxKind.UnsafeKeyword)
+                && !methodDeclaration.Modifiers.Any(SyntaxKind.UnsafeKeyword))
+            {
+                methodDeclaration = methodDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.UnsafeKeyword));
+            }
+
             if (setAccessorDeclaration.Body != null)
             {
                 return methodDeclaration.WithBody(setAccessorDeclaration.Body)
@@ -241,6 +248,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
             CancellationToken cancellationToken)
         {
             var methodDeclaration = (MethodDeclarationSyntax)generator.MethodDeclaration(getMethod, desiredGetMethodName);
+
+            // property has unsafe, but generator didn't add it to the method, so we have to add it here
+            if (propertyDeclaration.Modifiers.Any(SyntaxKind.UnsafeKeyword)
+                && !methodDeclaration.Modifiers.Any(SyntaxKind.UnsafeKeyword))
+            {
+                methodDeclaration = methodDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.UnsafeKeyword));
+            }
 
             if (propertyDeclaration.ExpressionBody != null)
             {

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -1785,6 +1785,19 @@ public class C { } // end").Members[0];
     event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 }");
         }
+
+        [WorkItem(38379, "https://github.com/dotnet/roslyn/issues/38379")]
+        [Fact]
+        public void TestUnsafeFieldDeclarationFromSymbol()
+        {
+            VerifySyntax<MethodDeclarationSyntax>(
+                Generator.Declaration(
+                    _emptyCompilation.GetTypeByMetadataName("System.IntPtr").GetMembers("ToPointer").Single()),
+@"public unsafe void *ToPointer()
+{
+}");
+        }
+
         #endregion
 
         #region Add/Insert/Remove/Get declarations & members/elements

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Editing
 {
@@ -59,7 +60,8 @@ namespace Microsoft.CodeAnalysis.Editing
                 isVirtual: symbol.IsVirtual,
                 isOverride: symbol.IsOverride,
                 isSealed: symbol.IsSealed,
-                isConst: field != null && field.IsConst);
+                isConst: field != null && field.IsConst,
+                isUnsafe: symbol.IsUnsafe());
         }
 
         public bool IsStatic => (_modifiers & Modifiers.Static) != 0;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38379.

The problem is that `ISymbol` does not expose the `unsafe` modifier, which is why `DeclarationModifiers.From(ISymbol)` did not preserve it.

This PR changes `DeclarationModifiers.From(ISymbol)` so that it adds `unsafe` when it's clear from the `ISymbol` that it's necessary and also adds code to the refactoring to make sure `unsafe` is preserved even in cases where it's not clear from the `ISymbol`.

A similar change is also made to the reverse refactoring.