### PR TITLE
Move to a newer FlowAnalysis utilities package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,7 +59,7 @@
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.18</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>$(MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisVisualBasicCodeFixTestingXUnitVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>$(CodeStyleAnalyzerVersion)</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>
-    <MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>2.9.4</MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>
+    <MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>2.9.5</MicrosoftCodeAnalysisFlowAnalysisUtilitiesVersion>
     <MicrosoftCodeQualityAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftCodeQualityAnalyzersVersion>
     <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                         disposeAnalysisResult: out var disposeAnalysisResult,
                         pointsToAnalysisResult: out var pointsToAnalysisResult))
                     {
-                        var exitBlock = disposeAnalysisResult.ControlFlowGraph.GetExit();
+                        var exitBlock = disposeAnalysisResult.ControlFlowGraph.ExitBlock();
                         foreach (var fieldWithPointsToValue in disposeAnalysisResult.TrackedInstanceFieldPointsToMap)
                         {
                             var field = fieldWithPointsToValue.Key;

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                 try
                 {
                     // Compute diagnostics for undisposed objects at exit block.
-                    var exitBlock = disposeAnalysisResult.ControlFlowGraph.GetExit();
+                    var exitBlock = disposeAnalysisResult.ControlFlowGraph.ExitBlock();
                     var disposeDataAtExit = disposeAnalysisResult.ExitBlockOutput.Data;
                     ComputeDiagnostics(disposeDataAtExit, notDisposedDiagnostics, mayBeNotDisposedDiagnostics,
                         disposeAnalysisResult, pointsToAnalysisResult);


### PR DESCRIPTION
This addresses the memory leak in #38330. The underlying memory leak was fixed in the FlowAnalysis utilities assembly with https://github.com/dotnet/roslyn-analyzers/pull/2795. This PR just moves Roslyn to newer Flow analysis utilities package reference with the fix.

Fixes #38330