### PR TITLE
Adjust inconsistent accessibility checks to properly handle protected types declared within interfaces.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns true if the members of superType are accessible from subType due to inheritance.
         /// </summary>
-        public static bool IsAccessibleViaInheritance(this TypeSymbol superType, TypeSymbol subType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        public static bool IsAccessibleViaInheritance(this NamedTypeSymbol superType, NamedTypeSymbol subType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // NOTE: we don't use strict inheritance.  Instead we ignore constructed generic types
             // and only consider the unconstructed types.  Ecma-334, 4th edition contained the
@@ -54,14 +54,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             //       class type constructed from G or a class type derived from a class type
             //       constructed from G.
             // This text is missing in the current version of the spec, but we believe this is accidental.
-            var originalSuperType = superType.OriginalDefinition;
-            for (TypeSymbol current = subType;
+            NamedTypeSymbol originalSuperType = superType.OriginalDefinition;
+            for (NamedTypeSymbol current = subType;
                 (object)current != null;
-                current = (current.Kind == SymbolKind.TypeParameter) ? ((TypeParameterSymbol)current).EffectiveBaseClass(ref useSiteDiagnostics) : current.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics))
+                current = current.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics))
             {
                 if (ReferenceEquals(current.OriginalDefinition, originalSuperType))
                 {
                     return true;
+                }
+            }
+
+            if (originalSuperType.IsInterface)
+            {
+                foreach (NamedTypeSymbol current in subType.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics))
+                {
+                    if (ReferenceEquals(current.OriginalDefinition, originalSuperType))
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -20694,6 +20694,300 @@ class Test2 : I1, I2, I3
         }
 
         [Fact]
+        [WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")]
+        public void InconsistentAccessibility_01()
+        {
+            var source1 =
+@"
+    interface I1
+    {
+        protected interface I2
+        {
+        }
+    }
+
+    class C1
+    {
+        protected interface I2
+        {
+        }
+    }
+
+    interface I3 : I1
+    {
+        protected I1.I2 M1();
+
+        interface I4
+        {
+            protected I1.I2 M4();
+        }
+
+        protected interface I5
+        {
+            I1.I2 M5();
+        }
+    }
+
+    class CI3 : I3
+    {
+        I1.I2 I3.M1() => null;
+
+        class CI5 : I3.I5
+        {
+            I1.I2 I3.I5.M5() => null;
+        }
+    }
+
+    class CI4 : I3.I4
+    {
+        I1.I2 I3.I4.M4() => null;
+    }
+
+    class C3 : I1
+    {
+        protected virtual void M1(I1.I2 x) { }
+
+        public interface I6
+        {
+            protected I1.I2 M6();
+        }
+
+        protected interface I7
+        {
+            I1.I2 M7();
+        }
+    }
+
+    class CC3 : C3
+    {
+        protected override void M1(I1.I2 x) { }
+
+        class CI7 : C3.I7
+        {
+            I1.I2 C3.I7.M7() => null;
+        }
+    }
+
+    class CI6 : C3.I6
+    {
+        I1.I2 C3.I6.M6() => null;
+    }
+
+    class C33 : C1
+    {
+        protected virtual void M1(C1.I2 x) { }
+
+        public class C44
+        {
+            protected virtual C1.I2 M44() => null;
+        }
+
+        protected class C55
+        {
+            public virtual C1.I2 M55() => null;
+        }
+    }
+
+    class CC33 : C33
+    {
+        protected override void M1(C1.I2 x) { }
+
+        class CC55 : C33.C55
+        {
+            public override C1.I2 M55() => null;
+        }
+    }
+
+    class CC44 : C33.C44
+    {
+        protected override C1.I2 M44() => null;
+    }
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+            compilation1.VerifyDiagnostics(
+                // (22,29): error CS0050: Inconsistent accessibility: return type 'I1.I2' is less accessible than method 'I3.I4.M4()'
+                //             protected I1.I2 M4();
+                Diagnostic(ErrorCode.ERR_BadVisReturnType, "M4").WithArguments("I3.I4.M4()", "I1.I2").WithLocation(22, 29),
+                // (41,17): error CS0535: 'CI4' does not implement interface member 'I3.I4.M4()'
+                //     class CI4 : I3.I4
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I3.I4").WithArguments("CI4", "I3.I4.M4()").WithLocation(41, 17),
+                // (43,12): error CS0122: 'I1.I2' is inaccessible due to its protection level
+                //         I1.I2 I3.I4.M4() => null;
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1.I2").WithLocation(43, 12),
+                // (43,21): error CS0539: 'CI4.M4()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //         I1.I2 I3.I4.M4() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M4").WithArguments("CI4.M4()").WithLocation(43, 21),
+                // (52,29): error CS0050: Inconsistent accessibility: return type 'I1.I2' is less accessible than method 'C3.I6.M6()'
+                //             protected I1.I2 M6();
+                Diagnostic(ErrorCode.ERR_BadVisReturnType, "M6").WithArguments("C3.I6.M6()", "I1.I2").WithLocation(52, 29),
+                // (71,17): error CS0535: 'CI6' does not implement interface member 'C3.I6.M6()'
+                //     class CI6 : C3.I6
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "C3.I6").WithArguments("CI6", "C3.I6.M6()").WithLocation(71, 17),
+                // (73,12): error CS0122: 'I1.I2' is inaccessible due to its protection level
+                //         I1.I2 C3.I6.M6() => null;
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1.I2").WithLocation(73, 12),
+                // (73,21): error CS0539: 'CI6.M6()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //         I1.I2 C3.I6.M6() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M6").WithArguments("CI6.M6()").WithLocation(73, 21),
+                // (82,37): error CS0050: Inconsistent accessibility: return type 'C1.I2' is less accessible than method 'C33.C44.M44()'
+                //             protected virtual C1.I2 M44() => null;
+                Diagnostic(ErrorCode.ERR_BadVisReturnType, "M44").WithArguments("C33.C44.M44()", "C1.I2").WithLocation(82, 37),
+                // (103,31): error CS0122: 'C1.I2' is inaccessible due to its protection level
+                //         protected override C1.I2 M44() => null;
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("C1.I2").WithLocation(103, 31)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")]
+        public void InconsistentAccessibility_02()
+        {
+            var source1 =
+@"
+    interface I1<T>
+    {
+        protected interface I2
+        {
+        }
+    }
+
+    class C1<T>
+    {
+        protected interface I2
+        {
+        }
+    }
+
+    interface I3 : I1<int>
+    {
+        protected I1<string>.I2 M1();
+
+        interface I4
+        {
+            protected I1<string>.I2 M4();
+        }
+
+        protected interface I5
+        {
+            I1<string>.I2 M5();
+        }
+    }
+
+    class CI3 : I3
+    {
+        I1<string>.I2 I3.M1() => null;
+
+        class CI5 : I3.I5
+        {
+            I1<string>.I2 I3.I5.M5() => null;
+        }
+    }
+
+    class CI4 : I3.I4
+    {
+        I1<string>.I2 I3.I4.M4() => null;
+    }
+
+    class C3 : I1<int>
+    {
+        protected virtual void M1(I1<string>.I2 x) { }
+
+        public interface I6
+        {
+            protected I1<string>.I2 M6();
+        }
+
+        protected interface I7
+        {
+            I1<string>.I2 M7();
+        }
+    }
+
+    class CC3 : C3
+    {
+        protected override void M1(I1<string>.I2 x) { }
+
+        class CI7 : C3.I7
+        {
+            I1<string>.I2 C3.I7.M7() => null;
+        }
+    }
+
+    class CI6 : C3.I6
+    {
+        I1<string>.I2 C3.I6.M6() => null;
+    }
+
+    class C33 : C1<int>
+    {
+        protected virtual void M1(C1<string>.I2 x) { }
+
+        public class C44
+        {
+            protected virtual C1<string>.I2 M44() => null;
+        }
+
+        protected class C55
+        {
+            public virtual C1<string>.I2 M55() => null;
+        }
+    }
+
+    class CC33 : C33
+    {
+        protected override void M1(C1<string>.I2 x) { }
+
+        class CC55 : C33.C55
+        {
+            public override C1<string>.I2 M55() => null;
+        }
+    }
+
+    class CC44 : C33.C44
+    {
+        protected override C1<string>.I2 M44() => null;
+    }
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+            compilation1.VerifyDiagnostics(
+                // (22,37): error CS0050: Inconsistent accessibility: return type 'I1<string>.I2' is less accessible than method 'I3.I4.M4()'
+                //             protected I1<string>.I2 M4();
+                Diagnostic(ErrorCode.ERR_BadVisReturnType, "M4").WithArguments("I3.I4.M4()", "I1<string>.I2").WithLocation(22, 37),
+                // (41,17): error CS0535: 'CI4' does not implement interface member 'I3.I4.M4()'
+                //     class CI4 : I3.I4
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I3.I4").WithArguments("CI4", "I3.I4.M4()").WithLocation(41, 17),
+                // (43,20): error CS0122: 'I1<string>.I2' is inaccessible due to its protection level
+                //         I1<string>.I2 I3.I4.M4() => null;
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1<string>.I2").WithLocation(43, 20),
+                // (43,29): error CS0539: 'CI4.M4()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //         I1<string>.I2 I3.I4.M4() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M4").WithArguments("CI4.M4()").WithLocation(43, 29),
+                // (52,37): error CS0050: Inconsistent accessibility: return type 'I1<string>.I2' is less accessible than method 'C3.I6.M6()'
+                //             protected I1<string>.I2 M6();
+                Diagnostic(ErrorCode.ERR_BadVisReturnType, "M6").WithArguments("C3.I6.M6()", "I1<string>.I2").WithLocation(52, 37),
+                // (71,17): error CS0535: 'CI6' does not implement interface member 'C3.I6.M6()'
+                //     class CI6 : C3.I6
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "C3.I6").WithArguments("CI6", "C3.I6.M6()").WithLocation(71, 17),
+                // (73,20): error CS0122: 'I1<string>.I2' is inaccessible due to its protection level
+                //         I1<string>.I2 C3.I6.M6() => null;
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1<string>.I2").WithLocation(73, 20),
+                // (73,29): error CS0539: 'CI6.M6()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //         I1<string>.I2 C3.I6.M6() => null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M6").WithArguments("CI6.M6()").WithLocation(73, 29),
+                // (82,45): error CS0050: Inconsistent accessibility: return type 'C1<string>.I2' is less accessible than method 'C33.C44.M44()'
+                //             protected virtual C1<string>.I2 M44() => null;
+                Diagnostic(ErrorCode.ERR_BadVisReturnType, "M44").WithArguments("C33.C44.M44()", "C1<string>.I2").WithLocation(82, 45),
+                // (103,39): error CS0122: 'C1<string>.I2' is inaccessible due to its protection level
+                //         protected override C1<string>.I2 M44() => null;
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("C1<string>.I2").WithLocation(103, 39)
+                );
+        }
+
+        [Fact]
         public void IndexerModifiers_15()
         {
             var source1 =
@@ -28960,6 +29254,190 @@ class Test1
 
                 compilation5.VerifyDiagnostics(expected);
             }
+        }
+
+        [Fact]
+        [WorkItem(34704, "https://github.com/dotnet/roslyn/issues/34704")]
+        public void NestedTypes_10()
+        {
+            var source1 =
+@"
+interface I1
+{
+    protected interface I2
+    {
+    }
+}
+
+class C1
+{
+    protected interface I2
+    {
+    }
+}
+
+interface I3 : I1, I1.I2
+{
+    private void M1(I1.I2 x) { }
+}
+
+interface I4 : I1, I2
+{
+    I2 MI4();
+}
+
+interface I5 : I1.I2, I1
+{
+    private void M1(I1.I2 x) { }
+}
+
+interface I6 : I2, I1
+{
+    I2 MI6();
+}
+
+class C3 : I1, I1.I2
+{
+    private void M1(I1.I2 x) { }
+}
+
+class C4 : I1, I2
+{
+    void MC4(I2 x) { }
+}
+
+class C5 : I1.I2, I1
+{
+    private void M1(I1.I2 x) { }
+}
+
+class C6 : I2, I1
+{
+    void MC6(I2 x) { }
+}
+
+class C33 : C1, C1.I2
+{
+    protected void M1(C1.I2 x) { }
+}
+
+class C44 : C1, I2
+{
+    void M1(I2 x) { }
+}
+
+interface I7 : I8
+{
+    public interface I8 : I7
+    {
+    }
+}
+
+class C7 : I8
+{
+    public interface I8
+    {
+    }
+}
+
+interface I9 : I9.I10
+{
+    public interface I10 : I9
+    {
+    }
+}
+
+interface I11
+{
+    public interface I12 : I13
+    {
+    }
+
+    public interface I13
+    {
+    }
+
+    public interface I14 : I11.I13
+    {
+    }
+}
+
+class C11
+{
+    public interface I12 : I13
+    {
+    }
+
+    public interface I13
+    {
+    }
+
+    public interface I14 : I11.I13
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (16,23): error CS0122: 'I1.I2' is inaccessible due to its protection level
+                // interface I3 : I1, I1.I2
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1.I2").WithLocation(16, 23),
+                // (21,20): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                // interface I4 : I1, I2
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(21, 20),
+                // (23,5): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                //     I2 MI4();
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(23, 5),
+                // (26,19): error CS0122: 'I1.I2' is inaccessible due to its protection level
+                // interface I5 : I1.I2, I1
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1.I2").WithLocation(26, 19),
+                // (31,16): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                // interface I6 : I2, I1
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(31, 16),
+                // (33,5): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                //     I2 MI6();
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(33, 5),
+                // (36,19): error CS0122: 'I1.I2' is inaccessible due to its protection level
+                // class C3 : I1, I1.I2
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1.I2").WithLocation(36, 19),
+                // (41,16): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                // class C4 : I1, I2
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(41, 16),
+                // (43,14): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                //     void MC4(I2 x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(43, 14),
+                // (46,15): error CS0122: 'I1.I2' is inaccessible due to its protection level
+                // class C5 : I1.I2, I1
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("I1.I2").WithLocation(46, 15),
+                // (51,12): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                // class C6 : I2, I1
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(51, 12),
+                // (53,14): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                //     void MC6(I2 x) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(53, 14),
+                // (56,20): error CS0122: 'C1.I2' is inaccessible due to its protection level
+                // class C33 : C1, C1.I2
+                Diagnostic(ErrorCode.ERR_BadAccess, "I2").WithArguments("C1.I2").WithLocation(56, 20),
+                // (61,17): error CS0246: The type or namespace name 'I2' could not be found (are you missing a using directive or an assembly reference?)
+                // class C44 : C1, I2
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I2").WithArguments("I2").WithLocation(61, 17),
+                // (66,16): error CS0246: The type or namespace name 'I8' could not be found (are you missing a using directive or an assembly reference?)
+                // interface I7 : I8
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I8").WithArguments("I8").WithLocation(66, 16),
+                // (73,12): error CS0246: The type or namespace name 'I8' could not be found (are you missing a using directive or an assembly reference?)
+                // class C7 : I8
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "I8").WithArguments("I8").WithLocation(73, 12),
+                // (80,11): error CS0529: Inherited interface 'I9.I10' causes a cycle in the interface hierarchy of 'I9'
+                // interface I9 : I9.I10
+                Diagnostic(ErrorCode.ERR_CycleInInterfaceInheritance, "I9").WithArguments("I9", "I9.I10").WithLocation(80, 11),
+                // (82,22): error CS0529: Inherited interface 'I9' causes a cycle in the interface hierarchy of 'I9.I10'
+                //     public interface I10 : I9
+                Diagnostic(ErrorCode.ERR_CycleInInterfaceInheritance, "I10").WithArguments("I9.I10", "I9").WithLocation(82, 22)
+                );
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
@@ -947,15 +947,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If container.OriginalDefinition.Equals(containerOfTypeDefinition) Then
                 Return True
-            ElseIf container.IsInterfaceType() Then
-                If containerOfType.IsInterfaceType() Then
-                    For Each iface In container.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                        If iface.OriginalDefinition.Equals(containerOfTypeDefinition) Then
-                            Return True
-                        End If
-                    Next
-                End If
-            ElseIf Not containerOfType.IsInterfaceType() Then
+            End If
+
+            If containerOfType.IsInterfaceType() Then
+                For Each iface In container.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    If iface.OriginalDefinition.Equals(containerOfTypeDefinition) Then
+                        Return True
+                    End If
+                Next
+            Else
                 Dim baseDefinition = container.BaseTypeOriginalDefinition(useSiteDiagnostics)
 
                 While baseDefinition IsNot Nothing

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -3266,12 +3266,6 @@ public class C1
             Dim source1 =
 <compilation>
     <file name="c.vb"><![CDATA[
-interface I3 
-    Inherits I1
-
-    Function M1() As I1.I2
-End Interface
-
 Class C3
     Implements I1
 
@@ -3302,12 +3296,6 @@ class C33
     protected overridable Sub M1(x As C1.I2)
     End Sub
 
-    public class C44
-        protected overridable Function M44() As C1.I2
-            Return Nothing
-        End Function
-    End Class
-
     protected class C55
         public overridable Function M55() As C1.I2
             Return Nothing
@@ -3325,6 +3313,54 @@ class CC33
         Inherits C33.C55
     
         public overrides Function M55() As C1.I2
+            Return Nothing
+        End Function
+    End Class
+End Class
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+
+            CompileAndVerify(comp1, verify:=VerifyOnMonoOrCoreClr).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        <WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")>
+        Public Sub InconsistentAccessibility_02()
+
+            Dim csSource =
+"
+public interface I1
+{
+    protected interface I2
+    {
+    }
+}
+
+public class C1
+{
+    protected interface I2
+    {
+    }
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+interface I3 
+    Inherits I1
+
+    Function M1() As I1.I2
+End Interface
+
+class C33 
+    Inherits C1
+
+    public class C44
+        protected overridable Function M44() As C1.I2
             Return Nothing
         End Function
     End Class
@@ -3361,7 +3397,7 @@ BC30389: 'C1.I2' is not accessible in this context because it is 'Protected'.
 
         <Fact>
         <WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")>
-        Public Sub InconsistentAccessibility_02()
+        Public Sub InconsistentAccessibility_03()
 
             Dim csSource =
 "
@@ -3384,12 +3420,6 @@ public class C1<T>
             Dim source1 =
 <compilation>
     <file name="c.vb"><![CDATA[
-interface I3 
-    Inherits I1(Of Integer)
-
-    Function M1() As I1(Of String).I2
-End Interface
-
 Class C3
     Implements I1(Of Integer)
 
@@ -3420,12 +3450,6 @@ class C33
     protected overridable Sub M1(x As C1(Of String).I2)
     End Sub
 
-    public class C44
-        protected overridable Function M44() As C1(Of String).I2
-            Return Nothing
-        End Function
-    End Class
-
     protected class C55
         public overridable Function M55() As C1(Of String).I2
             Return Nothing
@@ -3443,6 +3467,54 @@ class CC33
         Inherits C33.C55
     
         public overrides Function M55() As C1(Of String).I2
+            Return Nothing
+        End Function
+    End Class
+End Class
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+
+            CompileAndVerify(comp1, verify:=VerifyOnMonoOrCoreClr).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        <WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")>
+        Public Sub InconsistentAccessibility_04()
+
+            Dim csSource =
+"
+public interface I1<T>
+{
+    protected interface I2
+    {
+    }
+}
+
+public class C1<T>
+{
+    protected interface I2
+    {
+    }
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+interface I3 
+    Inherits I1(Of Integer)
+
+    Function M1() As I1(Of String).I2
+End Interface
+
+class C33 
+    Inherits C1(Of Integer)
+
+    public class C44
+        protected overridable Function M44() As C1(Of String).I2
             Return Nothing
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -3242,6 +3242,242 @@ End Class
         End Sub
 
         <Fact>
+        <WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")>
+        Public Sub InconsistentAccessibility_01()
+
+            Dim csSource =
+"
+public interface I1
+{
+    protected interface I2
+    {
+    }
+}
+
+public class C1
+{
+    protected interface I2
+    {
+    }
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+interface I3 
+    Inherits I1
+
+    Function M1() As I1.I2
+End Interface
+
+Class C3
+    Implements I1
+
+    protected overridable Sub M1(x As I1.I2)
+    End Sub
+
+    protected interface I7
+        Function M7() As I1.I2
+    End Interface
+End Class
+
+class CC3 
+    Inherits C3
+
+    protected overrides Sub M1(x As I1.I2)
+    End Sub
+
+    class CI7 
+        Implements C3.I7
+        Private Function M7() As I1.I2 Implements C3.I7.M7
+            Return Nothing
+        End Function
+    End Class
+End Class
+
+class C33 
+    Inherits C1
+    protected overridable Sub M1(x As C1.I2)
+    End Sub
+
+    public class C44
+        protected overridable Function M44() As C1.I2
+            Return Nothing
+        End Function
+    End Class
+
+    protected class C55
+        public overridable Function M55() As C1.I2
+            Return Nothing
+        End Function
+    End Class
+End Class
+
+class CC33
+    Inherits C33
+
+    protected overrides Sub M1(x As C1.I2)
+    End Sub
+
+    private class CC55
+        Inherits C33.C55
+    
+        public overrides Function M55() As C1.I2
+            Return Nothing
+        End Function
+    End Class
+End Class
+
+class CC44 
+    Inherits C33.C44
+
+    protected overrides Function M44() As C1.I2
+        Return Nothing
+    End Function
+End Class
+
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+            comp1.AssertTheseDiagnostics(
+<error><![CDATA[
+BC30508: 'M1' cannot expose type 'I1.I2' in namespace '<Default>' through interface 'I3'.
+    Function M1() As I1.I2
+                     ~~~~~
+BC30508: 'M44' cannot expose type 'C1.I2' in namespace '<Default>' through class 'C44'.
+        protected overridable Function M44() As C1.I2
+                                                ~~~~~
+BC30437: 'Protected Overrides Function M44() As C1.I2' cannot override 'Protected Overridable Function M44() As C1.I2' because they differ by their return types.
+    protected overrides Function M44() As C1.I2
+                                 ~~~
+BC30389: 'C1.I2' is not accessible in this context because it is 'Protected'.
+    protected overrides Function M44() As C1.I2
+                                          ~~~~~
+]]></error>)
+        End Sub
+
+        <Fact>
+        <WorkItem(38398, "https://github.com/dotnet/roslyn/issues/38398")>
+        Public Sub InconsistentAccessibility_02()
+
+            Dim csSource =
+"
+public interface I1<T>
+{
+    protected interface I2
+    {
+    }
+}
+
+public class C1<T>
+{
+    protected interface I2
+    {
+    }
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+interface I3 
+    Inherits I1(Of Integer)
+
+    Function M1() As I1(Of String).I2
+End Interface
+
+Class C3
+    Implements I1(Of Integer)
+
+    protected overridable Sub M1(x As I1(Of String).I2)
+    End Sub
+
+    protected interface I7
+        Function M7() As I1(Of String).I2
+    End Interface
+End Class
+
+class CC3 
+    Inherits C3
+
+    protected overrides Sub M1(x As I1(Of String).I2)
+    End Sub
+
+    class CI7 
+        Implements C3.I7
+        Private Function M7() As I1(Of String).I2 Implements C3.I7.M7
+            Return Nothing
+        End Function
+    End Class
+End Class
+
+class C33 
+    Inherits C1(Of Integer)
+    protected overridable Sub M1(x As C1(Of String).I2)
+    End Sub
+
+    public class C44
+        protected overridable Function M44() As C1(Of String).I2
+            Return Nothing
+        End Function
+    End Class
+
+    protected class C55
+        public overridable Function M55() As C1(Of String).I2
+            Return Nothing
+        End Function
+    End Class
+End Class
+
+class CC33
+    Inherits C33
+
+    protected overrides Sub M1(x As C1(Of String).I2)
+    End Sub
+
+    private class CC55
+        Inherits C33.C55
+    
+        public overrides Function M55() As C1(Of String).I2
+            Return Nothing
+        End Function
+    End Class
+End Class
+
+class CC44 
+    Inherits C33.C44
+
+    protected overrides Function M44() As C1(Of String).I2
+        Return Nothing
+    End Function
+End Class
+
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, options:=TestOptions.DebugDll, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+            comp1.AssertTheseDiagnostics(
+<error><![CDATA[
+BC30508: 'M1' cannot expose type 'I1(Of String).I2' in namespace '<Default>' through interface 'I3'.
+    Function M1() As I1(Of String).I2
+                     ~~~~~~~~~~~~~~~~
+BC30508: 'M44' cannot expose type 'C1(Of String).I2' in namespace '<Default>' through class 'C44'.
+        protected overridable Function M44() As C1(Of String).I2
+                                                ~~~~~~~~~~~~~~~~
+BC30437: 'Protected Overrides Function M44() As C1.I2' cannot override 'Protected Overridable Function M44() As C1(Of String).I2' because they differ by their return types.
+    protected overrides Function M44() As C1(Of String).I2
+                                 ~~~
+BC30389: 'C1(Of String).I2' is not accessible in this context because it is 'Protected'.
+    protected overrides Function M44() As C1(Of String).I2
+                                          ~~~~~~~~~~~~~~~~
+]]></error>)
+        End Sub
+
+        <Fact>
         <WorkItem(35820, "https://github.com/dotnet/roslyn/issues/35820")>
         Public Sub PropertyImplementation_001()
 


### PR DESCRIPTION
Fixes #38398.