### PR TITLE
Cache diagnostic ID strings in the AnalyzerConfigSet

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1429,6 +1429,32 @@ dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
             }, options.Select(o => o.TreeOptions).ToArray());
         }
 
+        [Fact]
+        public void DiagnosticIdInstancesAreSharedBetweenMultipleTrees()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/a.cs", "/b.cs", "/c.cs" },
+                configs);
+            configs.Free();
+
+            Assert.Equal("cs000", options[0].TreeOptions.Keys.Single());
+
+            Assert.True(
+                object.ReferenceEquals(
+                    options[0].TreeOptions.Keys.First(),
+                    options[1].TreeOptions.Keys.First()));
+
+            Assert.True(
+                object.ReferenceEquals(
+                    options[1].TreeOptions.Keys.First(),
+                    options[2].TreeOptions.Keys.First()));
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.SectionNameMatching.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
 {
     public sealed partial class AnalyzerConfig
     {
-        public readonly struct SectionNameMatcher
+        internal readonly struct SectionNameMatcher
         {
             private readonly ImmutableArray<(int minValue, int maxValue)> _numberRangePairs;
             // internal for testing
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis
         /// matches the the given language. Returns null if the section name is
         /// invalid.
         /// </summary>
-        public static SectionNameMatcher? TryCreateSectionNameMatcher(string sectionName)
+        internal static SectionNameMatcher? TryCreateSectionNameMatcher(string sectionName)
         {
             // An editorconfig section name is a language for recognizing file paths
             // defined by the following grammar:

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfig.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis
         /// at 2018-04-21 19:37:05Z. New keys may be added to this list in newer versions, but old ones will
         /// not be removed.
         /// </remarks>
-        public static ImmutableHashSet<string> ReservedKeys { get; }
+        internal static ImmutableHashSet<string> ReservedKeys { get; }
             = ImmutableHashSet.CreateRange(Section.PropertiesKeyComparer, new[] {
                 "root",
                 "indent_style",
@@ -50,21 +50,21 @@ namespace Microsoft.CodeAnalysis
         /// A set of values that are reserved for special use for the editorconfig specification
         /// and will always be lower-cased by the parser.
         /// </summary>
-        public static ImmutableHashSet<string> ReservedValues { get; }
+        internal static ImmutableHashSet<string> ReservedValues { get; }
             = ImmutableHashSet.CreateRange(CaseInsensitiveComparison.Comparer, new[] { "unset" });
 
-        public Section GlobalSection { get; }
+        internal Section GlobalSection { get; }
 
         /// <summary>
         /// The directory the editorconfig was contained in, with all directory separators
         /// replaced with '/'.
         /// </summary>
-        public string NormalizedDirectory { get; }
+        internal string NormalizedDirectory { get; }
 
         /// <summary>
         /// The path passed to <see cref="Parse(string, string)"/> during construction.
         /// </summary>
-        public string PathToFile { get; }
+        internal string PathToFile { get; }
 
         /// <summary>
         /// Comparer for sorting <see cref="AnalyzerConfig"/> files by <see cref="NormalizedDirectory"/> path length.
@@ -72,12 +72,12 @@ namespace Microsoft.CodeAnalysis
         internal static Comparer<AnalyzerConfig> DirectoryLengthComparer { get; } = Comparer<AnalyzerConfig>.Create(
             (e1, e2) => e1.NormalizedDirectory.Length.CompareTo(e2.NormalizedDirectory.Length));
 
-        public ImmutableArray<Section> NamedSections { get; }
+        internal ImmutableArray<Section> NamedSections { get; }
 
         /// <summary>
         /// Gets whether this editorconfig is a topmost editorconfig.
         /// </summary>
-        public bool IsRoot => GlobalSection.Properties.TryGetValue("root", out string val) && val == "true";
+        internal bool IsRoot => GlobalSection.Properties.TryGetValue("root", out string val) && val == "true";
 
         private AnalyzerConfig(
             Section globalSection,
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis
         /// Represents a named section of the editorconfig file, which consists of a name followed by a set
         /// of key-value pairs.
         /// </summary>
-        public sealed class Section
+        internal sealed class Section
         {
             /// <summary>
             /// Used to compare <see cref="Name"/>s of sections. Specified by editorconfig to

--- a/src/Compilers/Core/Portable/InternalUtilities/CharMemoryEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CharMemoryEqualityComparer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// Provide structural equality for ReadOnlyMemory{char} instances.
+    /// </summary>
+    internal sealed class CharMemoryEqualityComparer : IEqualityComparer<ReadOnlyMemory<char>>
+    {
+        public static readonly CharMemoryEqualityComparer Instance = new CharMemoryEqualityComparer();
+
+        private CharMemoryEqualityComparer() { }
+
+        public bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
+        {
+            if (x.Length != y.Length)
+            {
+                return false;
+            }
+
+            var xSpan = x.Span;
+            var ySpan = y.Span;
+
+            for (int i = 0; i < xSpan.Length; i++)
+            {
+                if (xSpan[i] != ySpan[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(ReadOnlyMemory<char> mem) => Hash.GetFNVHashCode(mem.Span);
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/CharMemoryEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CharMemoryEqualityComparer.cs
@@ -14,26 +14,7 @@ namespace Roslyn.Utilities
 
         private CharMemoryEqualityComparer() { }
 
-        public bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
-        {
-            if (x.Length != y.Length)
-            {
-                return false;
-            }
-
-            var xSpan = x.Span;
-            var ySpan = y.Span;
-
-            for (int i = 0; i < xSpan.Length; i++)
-            {
-                if (xSpan[i] != ySpan[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        public bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y) => x.Span.SequenceEqual(y.Span);
 
         public int GetHashCode(ReadOnlyMemory<char> mem) => Hash.GetFNVHashCode(mem.Span);
     }

--- a/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
@@ -223,22 +223,32 @@ namespace Roslyn.Utilities
         /// fit into 8-bits and, therefore, the algorithm will retain its desirable traits
         /// for generating hash codes.
         /// </summary>
+        internal static int GetFNVHashCode(ReadOnlySpan<char> data)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                hashCode = unchecked((hashCode ^ data[i]) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a sub-string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: FNV-1a was developed and tuned for 8-bit sequences. We're using it here
+        /// for 16-bit Unicode chars on the understanding that the majority of chars will
+        /// fit into 8-bits and, therefore, the algorithm will retain its desirable traits
+        /// for generating hash codes.
+        /// </summary>
         /// <param name="text">The input string</param>
         /// <param name="start">The start index of the first character to hash</param>
         /// <param name="length">The number of characters, beginning with <paramref name="start"/> to hash</param>
         /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending after <paramref name="length"/> characters.</returns>
         internal static int GetFNVHashCode(string text, int start, int length)
-        {
-            int hashCode = Hash.FnvOffsetBias;
-            int end = start + length;
-
-            for (int i = start; i < end; i++)
-            {
-                hashCode = unchecked((hashCode ^ text[i]) * Hash.FnvPrime);
-            }
-
-            return hashCode;
-        }
+            => GetFNVHashCode(text.AsSpan(start, length));
 
         internal static int GetCaseInsensitiveFNVHashCode(string text)
         {

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -129,17 +129,6 @@ const Microsoft.CodeAnalysis.WellKnownMemberNames.GetAsyncEnumeratorMethodName =
 const Microsoft.CodeAnalysis.WellKnownMemberNames.LengthPropertyName = "Length" -> string
 const Microsoft.CodeAnalysis.WellKnownMemberNames.MoveNextAsyncMethodName = "MoveNextAsync" -> string
 Microsoft.CodeAnalysis.AnalyzerConfig
-Microsoft.CodeAnalysis.AnalyzerConfig.GlobalSection.get -> Microsoft.CodeAnalysis.AnalyzerConfig.Section
-Microsoft.CodeAnalysis.AnalyzerConfig.IsRoot.get -> bool
-Microsoft.CodeAnalysis.AnalyzerConfig.NamedSections.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AnalyzerConfig.Section>
-Microsoft.CodeAnalysis.AnalyzerConfig.NormalizedDirectory.get -> string
-Microsoft.CodeAnalysis.AnalyzerConfig.PathToFile.get -> string
-Microsoft.CodeAnalysis.AnalyzerConfig.Section
-Microsoft.CodeAnalysis.AnalyzerConfig.Section.Name.get -> string
-Microsoft.CodeAnalysis.AnalyzerConfig.Section.Properties.get -> System.Collections.Immutable.ImmutableDictionary<string, string>
-Microsoft.CodeAnalysis.AnalyzerConfig.Section.Section(string name, System.Collections.Immutable.ImmutableDictionary<string, string> properties) -> void
-Microsoft.CodeAnalysis.AnalyzerConfig.SectionNameMatcher
-Microsoft.CodeAnalysis.AnalyzerConfig.SectionNameMatcher.IsMatch(string s) -> bool
 Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult
 Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult.AnalyzerOptions.get -> System.Collections.Immutable.ImmutableDictionary<string, string>
 Microsoft.CodeAnalysis.AnalyzerConfigOptionsResult.Diagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
@@ -337,11 +326,6 @@ override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.Initiali
 override sealed Microsoft.CodeAnalysis.Diagnostics.DiagnosticSuppressor.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor>
 static Microsoft.CodeAnalysis.AnalyzerConfig.Parse(Microsoft.CodeAnalysis.Text.SourceText text, string pathToFile) -> Microsoft.CodeAnalysis.AnalyzerConfig
 static Microsoft.CodeAnalysis.AnalyzerConfig.Parse(string text, string pathToFile) -> Microsoft.CodeAnalysis.AnalyzerConfig
-static Microsoft.CodeAnalysis.AnalyzerConfig.ReservedKeys.get -> System.Collections.Immutable.ImmutableHashSet<string>
-static Microsoft.CodeAnalysis.AnalyzerConfig.ReservedValues.get -> System.Collections.Immutable.ImmutableHashSet<string>
-static Microsoft.CodeAnalysis.AnalyzerConfig.Section.NameComparer.get -> System.StringComparison
-static Microsoft.CodeAnalysis.AnalyzerConfig.Section.PropertiesKeyComparer.get -> System.StringComparer
-static Microsoft.CodeAnalysis.AnalyzerConfig.TryCreateSectionNameMatcher(string sectionName) -> Microsoft.CodeAnalysis.AnalyzerConfig.SectionNameMatcher?
 static Microsoft.CodeAnalysis.AnalyzerConfigSet.Create<TList>(TList analyzerConfigs) -> Microsoft.CodeAnalysis.AnalyzerConfigSet
 static Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions.KeyComparer.get -> System.StringComparer
 override Microsoft.CodeAnalysis.NullabilityInfo.Equals(object other) -> bool


### PR DESCRIPTION
I'm not sure if this is exactly where we want to do the caching, so I've
taken the opportunity to make all the non-core AnalyzerConfig APIs internal.
There are no existing consumers depending on them, so this is not a breaking
change.

Fixes #38426