### PR TITLE
Intellisense ignores case sensitivity in case of enums and prefers wrong items

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5509,6 +5509,33 @@ class C
 
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
         <MemberData(NameOf(AllCompletionImplementations))>
+        <WorkItem(38297, "https://github.com/dotnet/roslyn/issues/38297")>
+        Public Async Function SelectionMustBeCaseSensitiveWithEnums(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                <Document><![CDATA[
+class C
+{
+    void M(SampleEnum sampleEnum)
+    {
+        N($$
+    }
+
+    void N(SampleEnum sampleEnum) { }
+    enum SampleEnum
+    {
+        One,
+        Two
+    }
+}]]>
+                </Document>)
+
+                state.SendTypeChars("sam")
+                Await state.AssertSelectedCompletionItem("sampleEnum")
+            End Using
+        End Function
+
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        <MemberData(NameOf(AllCompletionImplementations))>
         Public Async Function CompletionBeforeVarWithEnableNullableReferenceAnalysisIDEFeatures(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateTestStateFromWorkspace(completionImplementation,
                  <Workspace>

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -182,14 +182,10 @@ namespace Microsoft.CodeAnalysis.Completion
 
         private int CompareMatches(PatternMatch match1, PatternMatch match2, CompletionItem item1, CompletionItem item2)
         {
-            // First see how the two items compare in a case insensitive fashion.  Matches that 
-            // are strictly better (ignoring case) should prioritize the item.  i.e. if we have
-            // a prefix match, that should always be better than a substring match.
-            //
-            // The reason we ignore case is that it's very common for people to type expecting
-            // completion to fix up their casing.  i.e. 'false' will be written with the 
-            // expectation that it will get fixed by the completion list to 'False'.  
-            var diff = match1.CompareTo(match2, ignoreCase: true);
+            // Use the case sensitivity preferred by the helper, i.e. by language.
+            // For VB, we expect 'false' corrected to 'False'.
+            // For C#, we should prefer 'class' rather than 'Class' if typed 'cl'.
+            var diff = match1.CompareTo(match2, ignoreCase: !_isCaseSensitive);
             if (diff != 0)
             {
                 return diff;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38297

When comparing completion items, we ignore case sensitivity in the following scenario:

  ```
      void M(SampleEnumsampleEnum)
        {
            N($$
        }

        void N(SampleEnumsampleEnum) { }
        enum SampleEnum
        {
            One,
            Two
        }
```
Type `s`.

**Expected**
The selected item is `sampleEnum`.

**Actual**
The selected item is `SampleEnum`.


