### PR TITLE
Enable xUnit2002: Assert.NotNull validation

### DIFF
--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -147,7 +147,6 @@
     <Rule Id="xUnit1004" Action="None" /> <!-- allow skipped tests -->
     <Rule Id="xUnit1024" Action="None" /> <!-- seems broken: https://github.com/xunit/xunit/issues/1361 -->
     <Rule Id="xUnit2000" Action="None" /> <!-- "literal or constant value should be first in Assert.Equal" is a valid assert, but very noisy. Will do the refactoring later -->
-    <Rule Id="xUnit2002" Action="None" /> <!-- "do not use Assert.NonNull on struct" is a valid assert, but will require a codebase audit to turn on -->
     <Rule Id="xUnit2003" Action="None" /> <!-- "do not use Assert.Equal for null value" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2004" Action="None" /> <!-- "do not use Assert.Equal for boolean conditions" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2006" Action="None" /> <!-- "do not use generic Assert.Equal to test string equality" is a valid assert, but very noisy right now -->

--- a/src/Compilers/CSharp/Test/Emit/Emit/ResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/ResourceTests.cs
@@ -155,15 +155,15 @@ class C
 
                 uint stringTableSize;
                 IntPtr stringTable = Win32Res.GetResource(lib, "#1", "#6", out stringTableSize);
-                Assert.NotNull(stringTable);
+                Assert.NotEqual(default, stringTable);
 
                 uint elevenSize;
                 IntPtr elevenRsrc = Win32Res.GetResource(lib, "#1", "#11", out elevenSize);
-                Assert.NotNull(elevenRsrc);
+                Assert.NotEqual(default, elevenRsrc);
 
                 uint wevtSize;
                 IntPtr wevtRsrc = Win32Res.GetResource(lib, "#1", "WEVT_TEMPLATE", out wevtSize);
-                Assert.NotNull(wevtRsrc);
+                Assert.NotEqual(default, wevtRsrc);
             }
             finally
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -1068,7 +1068,8 @@ class F
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotEqual(default, parentInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.None, parentInfo.CandidateReason);
             Assert.Equal(0, parentInfo.CandidateSymbols.Length);
@@ -1113,7 +1114,8 @@ class F
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotEqual(default, parentInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.None, parentInfo.CandidateReason);
             Assert.Equal(0, parentInfo.CandidateSymbols.Length);
@@ -1281,7 +1283,8 @@ enum Color
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotEqual(default, parentInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.None, parentInfo.CandidateReason);
             Assert.Equal(0, parentInfo.CandidateSymbols.Length);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ColorColorTests.cs
@@ -592,7 +592,7 @@ class F
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Equal(SymbolKind.Method, parentInfo.Symbol.Kind);
             Assert.Equal("void E.M(params System.Int32[] a)", parentInfo.Symbol.ToTestDisplayString());
         }
@@ -632,14 +632,14 @@ class C
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(SymbolKind.Local, info.Symbol.Kind);
             Assert.Equal("Color Color", info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol); // the lexically first matching method
             Assert.Equal(2, parentInfo.CandidateSymbols.Length);
             Assert.Equal("void Color.M()", parentInfo.CandidateSymbols[0].ToTestDisplayString());
@@ -721,7 +721,7 @@ class Program
             var model = comp.GetSemanticModel(tree);
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
         }
 
         [WorkItem(542642, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542642")]
@@ -1061,14 +1061,14 @@ class F
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(SymbolKind.Property, info.Symbol.Kind);
             Assert.Equal("E F.E { get; set; }", info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.None, parentInfo.CandidateReason);
             Assert.Equal(0, parentInfo.CandidateSymbols.Length);
@@ -1106,14 +1106,14 @@ class F
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(SymbolKind.Property, info.Symbol.Kind);
             Assert.Equal("E F.E { get; set; }", info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.None, parentInfo.CandidateReason);
             Assert.Equal(0, parentInfo.CandidateSymbols.Length);
@@ -1151,14 +1151,14 @@ class F
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(SymbolKind.Property, info.Symbol.Kind);
             Assert.Equal("E F.E { get; set; }", info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.OverloadResolutionFailure, parentInfo.CandidateReason);
             Assert.Equal(2, parentInfo.CandidateSymbols.Length);
@@ -1196,14 +1196,14 @@ class F
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(SymbolKind.Property, info.Symbol.Kind);
             Assert.Equal("E F.E { get; set; }", info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.OverloadResolutionFailure, parentInfo.CandidateReason);
             Assert.Equal(2, parentInfo.CandidateSymbols.Length);
@@ -1237,7 +1237,7 @@ class F
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Null(info.Symbol);
             Assert.Equal(CandidateReason.NotAValue, info.CandidateReason);
             var candidate = info.CandidateSymbols.Single();
@@ -1247,7 +1247,7 @@ class F
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Equal(WellKnownMemberNames.DelegateInvokeName, parentInfo.Symbol.Name); // Succeeded even though the receiver has an error.
         }
 
@@ -1274,14 +1274,14 @@ enum Color
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(SymbolKind.Field, info.Symbol.Kind);
             Assert.Equal("Color.Color", info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Null(parentInfo.Symbol);
             Assert.Equal(CandidateReason.None, parentInfo.CandidateReason);
             Assert.Equal(0, parentInfo.CandidateSymbols.Length);
@@ -1837,14 +1837,14 @@ public class Example
             var expr = GetExprSyntaxForBinding(GetExprSyntaxList(tree));
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind());
             var info = model.GetSymbolInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(exprSymbolKind, info.Symbol.Kind);
             Assert.Equal(exprDisplayString, info.Symbol.ToTestDisplayString());
 
             var parentExpr = (ExpressionSyntax)expr.Parent;
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, parentExpr.Kind());
             var parentInfo = model.GetSymbolInfo(parentExpr);
-            Assert.NotNull(parentInfo);
+            Assert.NotEqual(default, parentInfo);
             Assert.Equal(parentSymbolKind, parentInfo.Symbol.Kind);
             Assert.Equal(parentDisplayString, parentInfo.Symbol.ToTestDisplayString());
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LockTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LockTests.cs
@@ -45,12 +45,12 @@ class C
 
             var lockStatement = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LockStatementSyntax>().Single();
             var lockExprInfo = model.GetSymbolInfo(lockStatement.Expression);
-            Assert.NotNull(lockExprInfo);
+            Assert.NotEqual(default, lockExprInfo);
             Assert.Equal(localSymbol, lockExprInfo.Symbol);
 
             var memberAccessExpression = tree.GetCompilationUnitRoot().DescendantNodes().OfType<MemberAccessExpressionSyntax>().Single();
             var memberAccessInfo = model.GetSymbolInfo(memberAccessExpression.Expression);
-            Assert.NotNull(memberAccessInfo);
+            Assert.NotEqual(default, memberAccessInfo);
             Assert.Equal(localSymbol, memberAccessInfo.Symbol);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -681,7 +681,7 @@ class B : A
             Assert.NotEqual(0, baseExprLocation);
 
             var baseExprInfo = model.GetTypeInfo((ExpressionSyntax)baseExprNode);
-            Assert.NotNull(baseExprInfo);
+            Assert.NotEqual(default, baseExprInfo);
 
             var baseExprType = (NamedTypeSymbol)baseExprInfo.Type;
             Assert.NotNull(baseExprType);
@@ -1924,7 +1924,7 @@ class Program
             var call = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First();
 
             var symbolInfo = model.GetSymbolInfo(call.Expression);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             Assert.Equal(symbolInfo.Symbol, m);
         }
 
@@ -1954,7 +1954,7 @@ class Program
             var node = tree.GetRoot().DescendantNodes().OfType<ConditionalAccessExpressionSyntax>().Single().Expression;
 
             var symbolInfo = model.GetSymbolInfo(node);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             Assert.Equal(symbolInfo.Symbol, m);
         }
 
@@ -1984,7 +1984,7 @@ class Program
             var node = tree.GetRoot().DescendantNodes().OfType<ConditionalAccessExpressionSyntax>().Single().Expression;
 
             var symbolInfo = model.GetSymbolInfo(node);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             Assert.Equal(symbolInfo.Symbol, m);
         }
 
@@ -2010,7 +2010,7 @@ class Program
             var node = tree.GetRoot().DescendantNodes().OfType<GenericNameSyntax>().Single();
 
             var symbolInfo = model.GetSymbolInfo(node);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             Assert.NotNull(symbolInfo.Symbol);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullCoalsceAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullCoalsceAssignmentTests.cs
@@ -39,7 +39,7 @@ class C
             void assertTypeInfo(SyntaxNode syntax)
             {
                 var typeInfo = semanticModel.GetTypeInfo(syntax);
-                Assert.NotNull(typeInfo);
+                Assert.NotEqual(default, typeInfo);
                 Assert.NotNull(typeInfo.Type);
                 Assert.Equal(cType, typeInfo.Type);
                 Assert.Equal(cType, typeInfo.ConvertedType);
@@ -74,14 +74,14 @@ class D : C {}";
             assertTypeInfo(coalesceAssignment.Left);
 
             var whenNullTypeInfo = semanticModel.GetTypeInfo(coalesceAssignment.Right);
-            Assert.NotNull(whenNullTypeInfo);
+            Assert.NotEqual(default, whenNullTypeInfo);
             Assert.Equal(dType, whenNullTypeInfo.Type);
             Assert.Equal(cType, whenNullTypeInfo.ConvertedType);
 
             void assertTypeInfo(SyntaxNode syntax)
             {
                 var typeInfo = semanticModel.GetTypeInfo(syntax);
-                Assert.NotNull(typeInfo);
+                Assert.NotEqual(default, typeInfo);
                 Assert.NotNull(typeInfo.Type);
                 Assert.Equal(cType, typeInfo.Type);
                 Assert.Equal(cType, typeInfo.ConvertedType);
@@ -114,7 +114,7 @@ class D : C {}";
             var coalesceAssignment = syntaxRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
 
             var whenNullTypeInfo = semanticModel.GetTypeInfo(coalesceAssignment);
-            Assert.NotNull(whenNullTypeInfo);
+            Assert.NotEqual(default, whenNullTypeInfo);
             Assert.Equal(dType, whenNullTypeInfo.Type);
             Assert.Equal(cType, whenNullTypeInfo.ConvertedType);
 
@@ -124,7 +124,7 @@ class D : C {}";
             void assertTypeInfo(SyntaxNode syntax)
             {
                 var typeInfo = semanticModel.GetTypeInfo(syntax);
-                Assert.NotNull(typeInfo);
+                Assert.NotEqual(default, typeInfo);
                 Assert.NotNull(typeInfo.Type);
                 Assert.Equal(dType, typeInfo.Type);
                 Assert.Equal(dType, typeInfo.ConvertedType);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         private static void AssertEmpty(SymbolInfo info)
         {
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Null(info.Symbol);
             Assert.Equal(CandidateReason.None, info.CandidateReason);
         }
@@ -64,7 +64,7 @@ class Point
             AssertEmpty(model.GetSymbolInfo(subpatterns[1].NameColon));
             var y = subpatterns[1].NameColon.Name;
             var ySymbol = model.GetSymbolInfo(y);
-            Assert.NotNull(ySymbol);
+            Assert.NotEqual(default, ySymbol);
             Assert.Equal(CandidateReason.None, ySymbol.CandidateReason);
             Assert.Equal("System.Int32 Point.Y { get; }", ySymbol.Symbol.ToTestDisplayString());
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         private static void AssertEmpty(SymbolInfo info)
         {
-            Assert.NotEqual(default, info);
+            Assert.Equal(default, info);
             Assert.Null(info.Symbol);
             Assert.Equal(CandidateReason.None, info.CandidateReason);
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         private static void AssertEmpty(SymbolInfo info)
         {
-            Assert.Equal(default, info);
+            Assert.NotEqual(default, info);
             Assert.Null(info.Symbol);
             Assert.Equal(CandidateReason.None, info.CandidateReason);
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -3106,7 +3106,8 @@ class Test
             var selectNode = tree.GetCompilationUnitRoot().FindToken(index).Parent as SelectClauseSyntax;
             var model = compilation.GetSemanticModel(tree);
             var symbolInfo = model.GetSymbolInfo(selectNode);
-            Assert.NotEqual(default, symbolInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, symbolInfo);
             Assert.Null(symbolInfo.Symbol); // there is no select method to call because the receiver is bad
             var typeInfo = model.GetTypeInfo(selectNode);
             Assert.Equal(SymbolKind.ErrorType, typeInfo.Type.Kind);
@@ -3134,7 +3135,8 @@ class Test
             var model = compilation.GetSemanticModel(tree);
             var queryInfo = model.GetQueryClauseInfo(joinNode);
 
-            Assert.NotEqual(default, queryInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, queryInfo);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -3106,7 +3106,7 @@ class Test
             var selectNode = tree.GetCompilationUnitRoot().FindToken(index).Parent as SelectClauseSyntax;
             var model = compilation.GetSemanticModel(tree);
             var symbolInfo = model.GetSymbolInfo(selectNode);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             Assert.Null(symbolInfo.Symbol); // there is no select method to call because the receiver is bad
             var typeInfo = model.GetTypeInfo(selectNode);
             Assert.Equal(SymbolKind.ErrorType, typeInfo.Type.Kind);
@@ -3134,7 +3134,7 @@ class Test
             var model = compilation.GetSemanticModel(tree);
             var queryInfo = model.GetQueryClauseInfo(joinNode);
 
-            Assert.NotNull(queryInfo);
+            Assert.NotEqual(default, queryInfo);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -1152,7 +1152,7 @@ class Program
             // Ensure the model can still bind without throwing when multiple labels values 
             // have duplicate constants (ConstantValue.Bad).  
             var symbolInfo = semanticModel.GetSymbolInfo(node);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -72,7 +72,7 @@ class C
             var memberAccessExpression = tree.GetCompilationUnitRoot().DescendantNodes().OfType<MemberAccessExpressionSyntax>().Single();
 
             var info = model.GetSymbolInfo(memberAccessExpression.Expression);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(declaredLocal, info.Symbol);
 
             var lookupSymbol = model.LookupSymbols(memberAccessExpression.SpanStart, name: declaredLocal.Name).Single();

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -313,7 +313,7 @@ namespace A.B {
             // Create Compilation with Option is not null
             var comp = CSharpCompilation.Create("Compilation", listSyntaxTree, listRef, ops);
             Assert.Equal(ops, comp.Options);
-            Assert.NotNull(comp.SyntaxTrees);
+            Assert.NotEqual(default, comp.SyntaxTrees);
             Assert.NotNull(comp.References);
             Assert.Equal(1, comp.SyntaxTrees.Length);
             Assert.Equal(1, comp.ExternalReferences.Length);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoBrokenCodeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoBrokenCodeTests.cs
@@ -357,7 +357,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             foreach (var expr in GetAllExpressions(tree.GetCompilationUnitRoot()))
             {
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.NotEqual(default, symbolInfo);
+                // https://github.com/dotnet/roslyn/issues/38509
+                // Assert.NotEqual(default, symbolInfo);
                 model.AnalyzeDataFlow(expr);
             }
         }
@@ -367,7 +368,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             foreach (var expr in GetAllExpressions(node))
             {
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.NotEqual(default, symbolInfo);
+
+                // https://github.com/dotnet/roslyn/issues/38509
+                // Assert.NotEqual(default, symbolInfo);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoBrokenCodeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoBrokenCodeTests.cs
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             foreach (var expr in GetAllExpressions(tree.GetCompilationUnitRoot()))
             {
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.NotNull(symbolInfo);
+                Assert.NotEqual(default, symbolInfo);
                 model.AnalyzeDataFlow(expr);
             }
         }
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             foreach (var expr in GetAllExpressions(node))
             {
                 var symbolInfo = model.GetSymbolInfo(expr);
-                Assert.NotNull(symbolInfo);
+                Assert.NotEqual(default, symbolInfo);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -593,7 +593,7 @@ class MyClass
             var expr2 = exprs.Last();
 
             var info = model.GetTypeInfo(expr1);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.NotNull(info.ConvertedType);
             // It was ImplicitUserDef -> Design Meeting resolution: not expose op_True|False as conversion through API
             var impconv = model.GetConversion(expr1);
@@ -624,7 +624,7 @@ class C {
             var exprs = GetBindingNodes<ExpressionSyntax>(comp);
             var expr1 = exprs.First();
             var info = model.GetTypeInfo(expr1);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.NotNull(info.ConvertedType);
             var impconv = model.GetConversion(expr1);
             Assert.True(impconv.IsImplicit);
@@ -837,7 +837,7 @@ class C {
         private void ConversionTestHelper(SemanticModel semanticModel, ExpressionSyntax expr, ConversionKind ept1, ConversionKind ept2)
         {
             var info = semanticModel.GetTypeInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.NotNull(info.ConvertedType);
             var conv = semanticModel.GetConversion(expr);
 
@@ -864,7 +864,7 @@ class C {
         private void ConversionTestHelper(SemanticModel semanticModel, ExpressionSyntax expr, ITypeSymbol expsym, ConversionKind expkind)
         {
             var info = semanticModel.GetTypeInfo(expr);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.NotNull(info.ConvertedType);
 
             // NOT expect NoConversion
@@ -1062,7 +1062,7 @@ class C
 }
 ";
             var bindInfo = BindFirstConstructorInitializer(text);
-            Assert.NotNull(bindInfo);
+            Assert.NotEqual(default, bindInfo);
 
             var baseConstructor = bindInfo.Symbol;
             Assert.Equal(SymbolKind.Method, baseConstructor.Kind);
@@ -1081,7 +1081,7 @@ class C
 }
 ";
             var bindInfo = BindFirstConstructorInitializer(text);
-            Assert.NotNull(bindInfo);
+            Assert.NotEqual(default, bindInfo);
 
             var baseConstructor = bindInfo.Symbol;
             Assert.Equal(SymbolKind.Method, baseConstructor.Kind);
@@ -1106,7 +1106,7 @@ class MyClass
 }
 ";
             var bindInfo = BindFirstConstructorInitializer(text);
-            Assert.NotNull(bindInfo);
+            Assert.NotEqual(default, bindInfo);
             var invokedConstructor = (MethodSymbol)bindInfo.Symbol;
             Assert.Equal(MethodKind.Constructor, invokedConstructor.MethodKind);
             Assert.Equal("MyClass..ctor()", invokedConstructor.ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
@@ -140,13 +140,13 @@ class B
             Assert.Equal(name, sym.Symbol.Name);
 
             var typeInfo = model.GetTypeInfo(expr);
-            Assert.NotNull(typeInfo);
+            Assert.NotEqual(default, typeInfo);
 
             var methodGroup = model.GetMemberGroup(expr);
-            Assert.NotNull(methodGroup);
+            Assert.NotEqual(default, methodGroup);
 
             var indexerGroup = model.GetIndexerGroup(expr);
-            Assert.NotNull(indexerGroup);
+            Assert.NotEqual(default, indexerGroup);
 
             var position = GetPositionForBinding(tree);
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/IndexedProperties_BindingTests.cs
@@ -140,7 +140,8 @@ class B
             Assert.Equal(name, sym.Symbol.Name);
 
             var typeInfo = model.GetTypeInfo(expr);
-            Assert.NotEqual(default, typeInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, typeInfo);
 
             var methodGroup = model.GetMemberGroup(expr);
             Assert.NotEqual(default, methodGroup);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -1956,7 +1956,7 @@ foreach(short ele in a)
             Assert.NotNull(speculativeModel);
 
             ForEachStatementInfo info = speculativeModel.GetForEachStatementInfo(statement);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal("System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()", info.GetEnumeratorMethod.ToTestDisplayString());
             Assert.Equal("System.Object System.Collections.IEnumerator.Current.get", info.CurrentProperty.GetMethod.ToTestDisplayString());
             Assert.Equal("System.Boolean System.Collections.IEnumerator.MoveNext()", info.MoveNextMethod.ToTestDisplayString());
@@ -1999,14 +1999,14 @@ foreach(short ele in a)
             Assert.Equal(position, speculativeModel.OriginalPositionForSpeculation);
 
             var typeInfo = speculativeModel.GetTypeInfo(expr);
-            Assert.NotNull(typeInfo);
+            Assert.NotEqual(default, typeInfo);
             Assert.Equal("Int32", typeInfo.Type.Name);
 
             var thisSyntax = expr.DescendantNodes().OfType<ThisExpressionSyntax>().Single();
             var symbolInfo = speculativeModel.GetSpeculativeSymbolInfo(
                 thisSyntax.SpanStart,
                 thisSyntax, SpeculativeBindingOption.BindAsExpression);
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             var candidates = symbolInfo.CandidateSymbols;
             Assert.Equal(1, candidates.Length);
             Assert.IsType<ThisParameterSymbol>(candidates[0]);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -8215,7 +8215,7 @@ class Program
 
             var symbolInfo = semanticModel.GetSymbolInfo(selectClauseNode);
 
-            Assert.NotNull(symbolInfo);
+            Assert.NotEqual(default, symbolInfo);
             Assert.Null(symbolInfo.Symbol);
         }
 
@@ -14399,7 +14399,7 @@ class A
             var model = compilation.GetSemanticModel(tree);
             var typeInfo = model.GetTypeInfo(node); // Ensure that this doesn't throw.
 
-            Assert.NotNull(typeInfo);
+            Assert.NotEqual(default, typeInfo);
         }
 
         [WorkItem(11451, "DevDiv_Projects/Roslyn")]
@@ -14653,7 +14653,7 @@ class C2
 
                 var info1 = model.GetTypeInfo(syntaxToBind);
 
-                Assert.NotNull(info1);
+                Assert.NotEqual(default, info1);
                 Assert.Equal("System.Int32", info1.Type.ToTestDisplayString());
             }
         }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -8215,7 +8215,8 @@ class Program
 
             var symbolInfo = semanticModel.GetSymbolInfo(selectClauseNode);
 
-            Assert.NotEqual(default, symbolInfo);
+            // https://github.com/dotnet/roslyn/issues/38509
+            // Assert.NotEqual(default, symbolInfo);
             Assert.Null(symbolInfo.Symbol);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DestructorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DestructorTests.cs
@@ -405,7 +405,7 @@ class C
             Assert.Equal(WellKnownMemberNames.DestructorName, finalizeSyntax.ToString());
 
             var info = model.GetSymbolInfo(finalizeSyntax);
-            Assert.NotNull(info);
+            Assert.NotEqual(default, info);
             Assert.Equal(destructor, info.Symbol);
 
             var lookupSymbols = model.LookupSymbols(finalizeSyntax.SpanStart, name: WellKnownMemberNames.DestructorName);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -82,7 +82,7 @@ event System.Action e;
             c.VerifyDiagnostics();
 
             var evnt = c.ScriptClass.GetMember<EventSymbol>("e");
-            Assert.NotNull(evnt.TypeWithAnnotations);
+            Assert.NotEqual(default, evnt.TypeWithAnnotations);
         }
 
         [WorkItem(598860, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/598860")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -81,8 +81,8 @@ event System.Action e;
 
             c.VerifyDiagnostics();
 
-            var evnt = c.ScriptClass.GetMember<EventSymbol>("e");
-            Assert.NotEqual(default, evnt.TypeWithAnnotations);
+            var @event = c.ScriptClass.GetMember<EventSymbol>("e");
+            Assert.False(@event.TypeWithAnnotations.IsDefault);
         }
 
         [WorkItem(598860, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/598860")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
@@ -1344,7 +1344,7 @@ class P
 
             var type = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
             var method = type.GetMember<MethodSymbol>("M");
-            Assert.NotEqual(default, method.ReturnTypeWithAnnotations);
+            Assert.False(method.ReturnTypeWithAnnotations.IsDefault);
         }
 
         [Fact, WorkItem(217681, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217681")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingMethods.cs
@@ -1344,7 +1344,7 @@ class P
 
             var type = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
             var method = type.GetMember<MethodSymbol>("M");
-            Assert.NotNull(method.ReturnTypeWithAnnotations);
+            Assert.NotEqual(default, method.ReturnTypeWithAnnotations);
         }
 
         [Fact, WorkItem(217681, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217681")]

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -697,7 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeArgumentList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -731,7 +731,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayType();
             
             Assert.NotNull(node.ElementType);
-            Assert.NotNull(node.RankSpecifiers);
+            Assert.NotEqual(default, node.RankSpecifiers);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -742,7 +742,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayRankSpecifier();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotNull(node.Sizes);
+            Assert.NotEqual(default, node.Sizes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -776,7 +776,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleType();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Elements);
+            Assert.NotEqual(default, node.Elements);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -833,7 +833,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleExpression();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1128,7 +1128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1140,7 +1140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedArgumentList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1252,7 +1252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInitializerExpression();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Expressions);
+            Assert.NotEqual(default, node.Expressions);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1289,7 +1289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Initializers);
+            Assert.NotEqual(default, node.Initializers);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1314,7 +1314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotNull(node.Commas);
+            Assert.NotEqual(default, node.Commas);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             Assert.NotNull(node.Initializer);
             
@@ -1362,7 +1362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateQueryBody();
             
-            Assert.NotNull(node.Clauses);
+            Assert.NotEqual(default, node.Clauses);
             Assert.NotNull(node.SelectOrGroup);
             Assert.Null(node.Continuation);
             
@@ -1443,7 +1443,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateOrderByClause();
             
             Assert.Equal(SyntaxKind.OrderByKeyword, node.OrderByKeyword.Kind);
-            Assert.NotNull(node.Orderings);
+            Assert.NotEqual(default, node.Orderings);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -1511,7 +1511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInterpolatedStringExpression();
             
             Assert.Equal(SyntaxKind.InterpolatedStringStartToken, node.StringStartToken.Kind);
-            Assert.NotNull(node.Contents);
+            Assert.NotEqual(default, node.Contents);
             Assert.Equal(SyntaxKind.InterpolatedStringEndToken, node.StringEndToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1602,7 +1602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePositionalPatternClause();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Subpatterns);
+            Assert.NotEqual(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1614,7 +1614,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePropertyPatternClause();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Subpatterns);
+            Assert.NotEqual(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1692,8 +1692,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateGlobalStatement();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Statement);
             
             AttachAndCheckDiagnostics(node);
@@ -1705,7 +1705,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBlock();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Statements);
+            Assert.NotEqual(default, node.Statements);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1716,12 +1716,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateLocalFunctionStatement();
             
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Null(node.SemicolonToken);
@@ -1736,7 +1736,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Null(node.AwaitKeyword);
             Assert.Null(node.UsingKeyword);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
             
@@ -1749,7 +1749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateVariableDeclaration();
             
             Assert.NotNull(node.Type);
-            Assert.NotNull(node.Variables);
+            Assert.NotEqual(default, node.Variables);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -1803,7 +1803,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParenthesizedVariableDesignation();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Variables);
+            Assert.NotEqual(default, node.Variables);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1952,11 +1952,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ForKeyword, node.ForKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
             Assert.Null(node.Declaration);
-            Assert.NotNull(node.Initializers);
+            Assert.NotEqual(default, node.Initializers);
             Assert.Equal(SyntaxKind.SemicolonToken, node.FirstSemicolonToken.Kind);
             Assert.Null(node.Condition);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SecondSemicolonToken.Kind);
-            Assert.NotNull(node.Incrementors);
+            Assert.NotEqual(default, node.Incrementors);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             Assert.NotNull(node.Statement);
             
@@ -2100,7 +2100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Expression);
             Assert.Null(node.CloseParenToken);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Sections);
+            Assert.NotEqual(default, node.Sections);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2111,8 +2111,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSwitchSection();
             
-            Assert.NotNull(node.Labels);
-            Assert.NotNull(node.Statements);
+            Assert.NotEqual(default, node.Labels);
+            Assert.NotEqual(default, node.Statements);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2161,7 +2161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.GoverningExpression);
             Assert.Equal(SyntaxKind.SwitchKeyword, node.SwitchKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Arms);
+            Assert.NotEqual(default, node.Arms);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2187,7 +2187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.TryKeyword, node.TryKeyword.Kind);
             Assert.NotNull(node.Block);
-            Assert.NotNull(node.Catches);
+            Assert.NotEqual(default, node.Catches);
             Assert.Null(node.Finally);
             
             AttachAndCheckDiagnostics(node);
@@ -2248,10 +2248,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCompilationUnit();
             
-            Assert.NotNull(node.Externs);
-            Assert.NotNull(node.Usings);
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Externs);
+            Assert.NotEqual(default, node.Usings);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.EndOfFileToken, node.EndOfFileToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2289,14 +2289,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateNamespaceDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.NamespaceKeyword, node.NamespaceKeyword.Kind);
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Externs);
-            Assert.NotNull(node.Usings);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Externs);
+            Assert.NotEqual(default, node.Usings);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2310,7 +2310,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
             Assert.Null(node.Target);
-            Assert.NotNull(node.Attributes);
+            Assert.NotEqual(default, node.Attributes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2344,7 +2344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAttributeArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2379,7 +2379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeParameterList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2390,7 +2390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateTypeParameter();
             
-            Assert.NotNull(node.AttributeLists);
+            Assert.NotEqual(default, node.AttributeLists);
             Assert.Null(node.VarianceKeyword);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             
@@ -2402,15 +2402,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateClassDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ClassKeyword, node.Keyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2422,15 +2422,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateStructDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.StructKeyword, node.Keyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2442,15 +2442,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateInterfaceDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.InterfaceKeyword, node.Keyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2462,13 +2462,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EnumKeyword, node.EnumKeyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.BaseList);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2480,14 +2480,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDelegateDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.DelegateKeyword, node.DelegateKeyword.Kind);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2498,8 +2498,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumMemberDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.EqualsValue);
             
@@ -2512,7 +2512,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBaseList();
             
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
-            Assert.NotNull(node.Types);
+            Assert.NotEqual(default, node.Types);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2535,7 +2535,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.WhereKeyword, node.WhereKeyword.Kind);
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
-            Assert.NotNull(node.Constraints);
+            Assert.NotEqual(default, node.Constraints);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2578,8 +2578,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateFieldDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
             
@@ -2591,8 +2591,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventFieldDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
@@ -2616,14 +2616,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateMethodDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Null(node.SemicolonToken);
@@ -2636,8 +2636,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateOperatorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind);
             Assert.Equal(SyntaxKind.PlusToken, node.OperatorToken.Kind);
@@ -2654,8 +2654,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConversionOperatorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ImplicitKeyword, node.ImplicitOrExplicitKeyword.Kind);
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind);
             Assert.NotNull(node.Type);
@@ -2672,8 +2672,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConstructorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.NotNull(node.ParameterList);
             Assert.Null(node.Initializer);
@@ -2701,8 +2701,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDestructorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.TildeToken, node.TildeToken.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.NotNull(node.ParameterList);
@@ -2718,8 +2718,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GeneratePropertyDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
@@ -2747,8 +2747,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
@@ -2764,8 +2764,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIndexerDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.ThisKeyword, node.ThisKeyword.Kind);
@@ -2783,7 +2783,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAccessorList();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotNull(node.Accessors);
+            Assert.NotEqual(default, node.Accessors);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2794,8 +2794,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateAccessorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.GetKeyword, node.Keyword.Kind);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
@@ -2810,7 +2810,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2822,7 +2822,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2833,8 +2833,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateParameter();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Null(node.Type);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.Default);
@@ -2847,8 +2847,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIncompleteMember();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Null(node.Type);
             
             AttachAndCheckDiagnostics(node);
@@ -2859,7 +2859,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSkippedTokensTrivia();
             
-            Assert.NotNull(node.Tokens);
+            Assert.NotEqual(default, node.Tokens);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2869,7 +2869,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDocumentationCommentTrivia();
             
-            Assert.NotNull(node.Content);
+            Assert.NotEqual(default, node.Content);
             Assert.Equal(SyntaxKind.EndOfDocumentationCommentToken, node.EndOfComment.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2950,7 +2950,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2962,7 +2962,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2985,7 +2985,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlElement();
             
             Assert.NotNull(node.StartTag);
-            Assert.NotNull(node.Content);
+            Assert.NotEqual(default, node.Content);
             Assert.NotNull(node.EndTag);
             
             AttachAndCheckDiagnostics(node);
@@ -2998,7 +2998,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
             Assert.NotNull(node.Name);
-            Assert.NotNull(node.Attributes);
+            Assert.NotEqual(default, node.Attributes);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3023,7 +3023,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
             Assert.NotNull(node.Name);
-            Assert.NotNull(node.Attributes);
+            Assert.NotEqual(default, node.Attributes);
             Assert.Equal(SyntaxKind.SlashGreaterThanToken, node.SlashGreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3059,7 +3059,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.EqualsToken, node.EqualsToken.Kind);
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.StartQuoteToken.Kind);
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.EndQuoteToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3098,7 +3098,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateXmlText();
             
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -3109,7 +3109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlCDataSection();
             
             Assert.Equal(SyntaxKind.XmlCDataStartToken, node.StartCDataToken.Kind);
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCDataEndToken, node.EndCDataToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3122,7 +3122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.XmlProcessingInstructionStartToken, node.StartProcessingInstructionToken.Kind);
             Assert.NotNull(node.Name);
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlProcessingInstructionEndToken, node.EndProcessingInstructionToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3134,7 +3134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlComment();
             
             Assert.Equal(SyntaxKind.XmlCommentStartToken, node.LessThanExclamationMinusMinusToken.Kind);
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCommentEndToken, node.MinusMinusGreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3316,7 +3316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.PragmaKeyword, node.PragmaKeyword.Kind);
             Assert.Equal(SyntaxKind.WarningKeyword, node.WarningKeyword.Kind);
             Assert.Equal(SyntaxKind.DisableKeyword, node.DisableOrRestoreKeyword.Kind);
-            Assert.NotNull(node.ErrorCodes);
+            Assert.NotEqual(default, node.ErrorCodes);
             Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind);
             Assert.Equal(new bool(), node.IsActive);
             
@@ -9679,7 +9679,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeArgumentList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithArguments(node.Arguments).WithGreaterThanToken(node.GreaterThanToken);
             Assert.Equal(node, newNode);
@@ -9713,7 +9713,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayType();
             
             Assert.NotNull(node.ElementType);
-            Assert.NotNull(node.RankSpecifiers);
+            Assert.NotEqual(default, node.RankSpecifiers);
             var newNode = node.WithElementType(node.ElementType).WithRankSpecifiers(node.RankSpecifiers);
             Assert.Equal(node, newNode);
         }
@@ -9724,7 +9724,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayRankSpecifier();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotNull(node.Sizes);
+            Assert.NotEqual(default, node.Sizes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithSizes(node.Sizes).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -9758,7 +9758,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleType();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Elements);
+            Assert.NotEqual(default, node.Elements);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithElements(node.Elements).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -9815,7 +9815,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleExpression();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10110,7 +10110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10122,7 +10122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedArgumentList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithArguments(node.Arguments).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -10234,7 +10234,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInitializerExpression();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Expressions);
+            Assert.NotEqual(default, node.Expressions);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithExpressions(node.Expressions).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10271,7 +10271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Initializers);
+            Assert.NotEqual(default, node.Initializers);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithNewKeyword(node.NewKeyword).WithOpenBraceToken(node.OpenBraceToken).WithInitializers(node.Initializers).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10296,7 +10296,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotNull(node.Commas);
+            Assert.NotEqual(default, node.Commas);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             Assert.NotNull(node.Initializer);
             var newNode = node.WithNewKeyword(node.NewKeyword).WithOpenBracketToken(node.OpenBracketToken).WithCommas(node.Commas).WithCloseBracketToken(node.CloseBracketToken).WithInitializer(node.Initializer);
@@ -10344,7 +10344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateQueryBody();
             
-            Assert.NotNull(node.Clauses);
+            Assert.NotEqual(default, node.Clauses);
             Assert.NotNull(node.SelectOrGroup);
             Assert.Null(node.Continuation);
             var newNode = node.WithClauses(node.Clauses).WithSelectOrGroup(node.SelectOrGroup).WithContinuation(node.Continuation);
@@ -10425,7 +10425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateOrderByClause();
             
             Assert.Equal(SyntaxKind.OrderByKeyword, node.OrderByKeyword.Kind());
-            Assert.NotNull(node.Orderings);
+            Assert.NotEqual(default, node.Orderings);
             var newNode = node.WithOrderByKeyword(node.OrderByKeyword).WithOrderings(node.Orderings);
             Assert.Equal(node, newNode);
         }
@@ -10493,7 +10493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInterpolatedStringExpression();
             
             Assert.Equal(SyntaxKind.InterpolatedStringStartToken, node.StringStartToken.Kind());
-            Assert.NotNull(node.Contents);
+            Assert.NotEqual(default, node.Contents);
             Assert.Equal(SyntaxKind.InterpolatedStringEndToken, node.StringEndToken.Kind());
             var newNode = node.WithStringStartToken(node.StringStartToken).WithContents(node.Contents).WithStringEndToken(node.StringEndToken);
             Assert.Equal(node, newNode);
@@ -10584,7 +10584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePositionalPatternClause();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Subpatterns);
+            Assert.NotEqual(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithSubpatterns(node.Subpatterns).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10596,7 +10596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePropertyPatternClause();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Subpatterns);
+            Assert.NotEqual(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithSubpatterns(node.Subpatterns).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10674,8 +10674,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateGlobalStatement();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Statement);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithStatement(node.Statement);
             Assert.Equal(node, newNode);
@@ -10687,7 +10687,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBlock();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Statements);
+            Assert.NotEqual(default, node.Statements);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithStatements(node.Statements).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10698,12 +10698,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateLocalFunctionStatement();
             
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
@@ -10718,7 +10718,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.None, node.AwaitKeyword.Kind());
             Assert.Equal(SyntaxKind.None, node.UsingKeyword.Kind());
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
             var newNode = node.WithAwaitKeyword(node.AwaitKeyword).WithUsingKeyword(node.UsingKeyword).WithModifiers(node.Modifiers).WithDeclaration(node.Declaration).WithSemicolonToken(node.SemicolonToken);
@@ -10731,7 +10731,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateVariableDeclaration();
             
             Assert.NotNull(node.Type);
-            Assert.NotNull(node.Variables);
+            Assert.NotEqual(default, node.Variables);
             var newNode = node.WithType(node.Type).WithVariables(node.Variables);
             Assert.Equal(node, newNode);
         }
@@ -10785,7 +10785,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParenthesizedVariableDesignation();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Variables);
+            Assert.NotEqual(default, node.Variables);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithVariables(node.Variables).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10934,11 +10934,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ForKeyword, node.ForKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
             Assert.Null(node.Declaration);
-            Assert.NotNull(node.Initializers);
+            Assert.NotEqual(default, node.Initializers);
             Assert.Equal(SyntaxKind.SemicolonToken, node.FirstSemicolonToken.Kind());
             Assert.Null(node.Condition);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SecondSemicolonToken.Kind());
-            Assert.NotNull(node.Incrementors);
+            Assert.NotEqual(default, node.Incrementors);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             Assert.NotNull(node.Statement);
             var newNode = node.WithForKeyword(node.ForKeyword).WithOpenParenToken(node.OpenParenToken).WithDeclaration(node.Declaration).WithInitializers(node.Initializers).WithFirstSemicolonToken(node.FirstSemicolonToken).WithCondition(node.Condition).WithSecondSemicolonToken(node.SecondSemicolonToken).WithIncrementors(node.Incrementors).WithCloseParenToken(node.CloseParenToken).WithStatement(node.Statement);
@@ -11082,7 +11082,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Expression);
             Assert.Equal(SyntaxKind.None, node.CloseParenToken.Kind());
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Sections);
+            Assert.NotEqual(default, node.Sections);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithSwitchKeyword(node.SwitchKeyword).WithOpenParenToken(node.OpenParenToken).WithExpression(node.Expression).WithCloseParenToken(node.CloseParenToken).WithOpenBraceToken(node.OpenBraceToken).WithSections(node.Sections).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -11093,8 +11093,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSwitchSection();
             
-            Assert.NotNull(node.Labels);
-            Assert.NotNull(node.Statements);
+            Assert.NotEqual(default, node.Labels);
+            Assert.NotEqual(default, node.Statements);
             var newNode = node.WithLabels(node.Labels).WithStatements(node.Statements);
             Assert.Equal(node, newNode);
         }
@@ -11143,7 +11143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.GoverningExpression);
             Assert.Equal(SyntaxKind.SwitchKeyword, node.SwitchKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Arms);
+            Assert.NotEqual(default, node.Arms);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithGoverningExpression(node.GoverningExpression).WithSwitchKeyword(node.SwitchKeyword).WithOpenBraceToken(node.OpenBraceToken).WithArms(node.Arms).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -11169,7 +11169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.TryKeyword, node.TryKeyword.Kind());
             Assert.NotNull(node.Block);
-            Assert.NotNull(node.Catches);
+            Assert.NotEqual(default, node.Catches);
             Assert.Null(node.Finally);
             var newNode = node.WithTryKeyword(node.TryKeyword).WithBlock(node.Block).WithCatches(node.Catches).WithFinally(node.Finally);
             Assert.Equal(node, newNode);
@@ -11230,10 +11230,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCompilationUnit();
             
-            Assert.NotNull(node.Externs);
-            Assert.NotNull(node.Usings);
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Externs);
+            Assert.NotEqual(default, node.Usings);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.EndOfFileToken, node.EndOfFileToken.Kind());
             var newNode = node.WithExterns(node.Externs).WithUsings(node.Usings).WithAttributeLists(node.AttributeLists).WithMembers(node.Members).WithEndOfFileToken(node.EndOfFileToken);
             Assert.Equal(node, newNode);
@@ -11271,14 +11271,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateNamespaceDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.NamespaceKeyword, node.NamespaceKeyword.Kind());
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Externs);
-            Assert.NotNull(node.Usings);
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Externs);
+            Assert.NotEqual(default, node.Usings);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithNamespaceKeyword(node.NamespaceKeyword).WithName(node.Name).WithOpenBraceToken(node.OpenBraceToken).WithExterns(node.Externs).WithUsings(node.Usings).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11292,7 +11292,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
             Assert.Null(node.Target);
-            Assert.NotNull(node.Attributes);
+            Assert.NotEqual(default, node.Attributes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithTarget(node.Target).WithAttributes(node.Attributes).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -11326,7 +11326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAttributeArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Arguments);
+            Assert.NotEqual(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -11361,7 +11361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeParameterList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithParameters(node.Parameters).WithGreaterThanToken(node.GreaterThanToken);
             Assert.Equal(node, newNode);
@@ -11372,7 +11372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateTypeParameter();
             
-            Assert.NotNull(node.AttributeLists);
+            Assert.NotEqual(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.None, node.VarianceKeyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithVarianceKeyword(node.VarianceKeyword).WithIdentifier(node.Identifier);
@@ -11384,15 +11384,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateClassDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ClassKeyword, node.Keyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithKeyword(node.Keyword).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithBaseList(node.BaseList).WithConstraintClauses(node.ConstraintClauses).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11404,15 +11404,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateStructDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.StructKeyword, node.Keyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithKeyword(node.Keyword).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithBaseList(node.BaseList).WithConstraintClauses(node.ConstraintClauses).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11424,15 +11424,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateInterfaceDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.InterfaceKeyword, node.Keyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithKeyword(node.Keyword).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithBaseList(node.BaseList).WithConstraintClauses(node.ConstraintClauses).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11444,13 +11444,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EnumKeyword, node.EnumKeyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.BaseList);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Members);
+            Assert.NotEqual(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithEnumKeyword(node.EnumKeyword).WithIdentifier(node.Identifier).WithBaseList(node.BaseList).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11462,14 +11462,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDelegateDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.DelegateKeyword, node.DelegateKeyword.Kind());
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithDelegateKeyword(node.DelegateKeyword).WithReturnType(node.ReturnType).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithParameterList(node.ParameterList).WithConstraintClauses(node.ConstraintClauses).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
@@ -11480,8 +11480,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumMemberDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.EqualsValue);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithIdentifier(node.Identifier).WithEqualsValue(node.EqualsValue);
@@ -11494,7 +11494,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBaseList();
             
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
-            Assert.NotNull(node.Types);
+            Assert.NotEqual(default, node.Types);
             var newNode = node.WithColonToken(node.ColonToken).WithTypes(node.Types);
             Assert.Equal(node, newNode);
         }
@@ -11517,7 +11517,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.WhereKeyword, node.WhereKeyword.Kind());
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
-            Assert.NotNull(node.Constraints);
+            Assert.NotEqual(default, node.Constraints);
             var newNode = node.WithWhereKeyword(node.WhereKeyword).WithName(node.Name).WithColonToken(node.ColonToken).WithConstraints(node.Constraints);
             Assert.Equal(node, newNode);
         }
@@ -11560,8 +11560,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateFieldDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithDeclaration(node.Declaration).WithSemicolonToken(node.SemicolonToken);
@@ -11573,8 +11573,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventFieldDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind());
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
@@ -11598,14 +11598,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateMethodDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotNull(node.ConstraintClauses);
+            Assert.NotEqual(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
@@ -11618,8 +11618,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateOperatorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind());
             Assert.Equal(SyntaxKind.PlusToken, node.OperatorToken.Kind());
@@ -11636,8 +11636,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConversionOperatorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ImplicitKeyword, node.ImplicitOrExplicitKeyword.Kind());
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind());
             Assert.NotNull(node.Type);
@@ -11654,8 +11654,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConstructorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.NotNull(node.ParameterList);
             Assert.Null(node.Initializer);
@@ -11683,8 +11683,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDestructorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.TildeToken, node.TildeToken.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.NotNull(node.ParameterList);
@@ -11700,8 +11700,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GeneratePropertyDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
@@ -11729,8 +11729,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind());
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
@@ -11746,8 +11746,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIndexerDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.ThisKeyword, node.ThisKeyword.Kind());
@@ -11765,7 +11765,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAccessorList();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotNull(node.Accessors);
+            Assert.NotEqual(default, node.Accessors);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithAccessors(node.Accessors).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -11776,8 +11776,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateAccessorDeclaration();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Equal(SyntaxKind.GetKeyword, node.Keyword.Kind());
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
@@ -11792,7 +11792,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -11804,7 +11804,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithParameters(node.Parameters).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -11815,8 +11815,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateParameter();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Null(node.Type);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.Default);
@@ -11829,8 +11829,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIncompleteMember();
             
-            Assert.NotNull(node.AttributeLists);
-            Assert.NotNull(node.Modifiers);
+            Assert.NotEqual(default, node.AttributeLists);
+            Assert.NotEqual(default, node.Modifiers);
             Assert.Null(node.Type);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithType(node.Type);
             Assert.Equal(node, newNode);
@@ -11841,7 +11841,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSkippedTokensTrivia();
             
-            Assert.NotNull(node.Tokens);
+            Assert.NotEqual(default, node.Tokens);
             var newNode = node.WithTokens(node.Tokens);
             Assert.Equal(node, newNode);
         }
@@ -11851,7 +11851,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDocumentationCommentTrivia();
             
-            Assert.NotNull(node.Content);
+            Assert.NotEqual(default, node.Content);
             Assert.Equal(SyntaxKind.EndOfDocumentationCommentToken, node.EndOfComment.Kind());
             var newNode = node.WithContent(node.Content).WithEndOfComment(node.EndOfComment);
             Assert.Equal(node, newNode);
@@ -11932,7 +11932,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -11944,7 +11944,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotNull(node.Parameters);
+            Assert.NotEqual(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithParameters(node.Parameters).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -11967,7 +11967,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlElement();
             
             Assert.NotNull(node.StartTag);
-            Assert.NotNull(node.Content);
+            Assert.NotEqual(default, node.Content);
             Assert.NotNull(node.EndTag);
             var newNode = node.WithStartTag(node.StartTag).WithContent(node.Content).WithEndTag(node.EndTag);
             Assert.Equal(node, newNode);
@@ -11980,7 +11980,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
             Assert.NotNull(node.Name);
-            Assert.NotNull(node.Attributes);
+            Assert.NotEqual(default, node.Attributes);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithName(node.Name).WithAttributes(node.Attributes).WithGreaterThanToken(node.GreaterThanToken);
             Assert.Equal(node, newNode);
@@ -12005,7 +12005,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
             Assert.NotNull(node.Name);
-            Assert.NotNull(node.Attributes);
+            Assert.NotEqual(default, node.Attributes);
             Assert.Equal(SyntaxKind.SlashGreaterThanToken, node.SlashGreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithName(node.Name).WithAttributes(node.Attributes).WithSlashGreaterThanToken(node.SlashGreaterThanToken);
             Assert.Equal(node, newNode);
@@ -12041,7 +12041,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.EqualsToken, node.EqualsToken.Kind());
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.StartQuoteToken.Kind());
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.EndQuoteToken.Kind());
             var newNode = node.WithName(node.Name).WithEqualsToken(node.EqualsToken).WithStartQuoteToken(node.StartQuoteToken).WithTextTokens(node.TextTokens).WithEndQuoteToken(node.EndQuoteToken);
             Assert.Equal(node, newNode);
@@ -12080,7 +12080,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateXmlText();
             
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             var newNode = node.WithTextTokens(node.TextTokens);
             Assert.Equal(node, newNode);
         }
@@ -12091,7 +12091,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlCDataSection();
             
             Assert.Equal(SyntaxKind.XmlCDataStartToken, node.StartCDataToken.Kind());
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCDataEndToken, node.EndCDataToken.Kind());
             var newNode = node.WithStartCDataToken(node.StartCDataToken).WithTextTokens(node.TextTokens).WithEndCDataToken(node.EndCDataToken);
             Assert.Equal(node, newNode);
@@ -12104,7 +12104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.XmlProcessingInstructionStartToken, node.StartProcessingInstructionToken.Kind());
             Assert.NotNull(node.Name);
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlProcessingInstructionEndToken, node.EndProcessingInstructionToken.Kind());
             var newNode = node.WithStartProcessingInstructionToken(node.StartProcessingInstructionToken).WithName(node.Name).WithTextTokens(node.TextTokens).WithEndProcessingInstructionToken(node.EndProcessingInstructionToken);
             Assert.Equal(node, newNode);
@@ -12116,7 +12116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlComment();
             
             Assert.Equal(SyntaxKind.XmlCommentStartToken, node.LessThanExclamationMinusMinusToken.Kind());
-            Assert.NotNull(node.TextTokens);
+            Assert.NotEqual(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCommentEndToken, node.MinusMinusGreaterThanToken.Kind());
             var newNode = node.WithLessThanExclamationMinusMinusToken(node.LessThanExclamationMinusMinusToken).WithTextTokens(node.TextTokens).WithMinusMinusGreaterThanToken(node.MinusMinusGreaterThanToken);
             Assert.Equal(node, newNode);
@@ -12298,7 +12298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.PragmaKeyword, node.PragmaKeyword.Kind());
             Assert.Equal(SyntaxKind.WarningKeyword, node.WarningKeyword.Kind());
             Assert.Equal(SyntaxKind.DisableKeyword, node.DisableOrRestoreKeyword.Kind());
-            Assert.NotNull(node.ErrorCodes);
+            Assert.NotEqual(default, node.ErrorCodes);
             Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind());
             Assert.Equal(new bool(), node.IsActive);
             var newNode = node.WithHashToken(node.HashToken).WithPragmaKeyword(node.PragmaKeyword).WithWarningKeyword(node.WarningKeyword).WithDisableOrRestoreKeyword(node.DisableOrRestoreKeyword).WithErrorCodes(node.ErrorCodes).WithEndOfDirectiveToken(node.EndOfDirectiveToken).WithIsActive(node.IsActive);

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -697,7 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeArgumentList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -731,7 +731,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayType();
             
             Assert.NotNull(node.ElementType);
-            Assert.NotEqual(default, node.RankSpecifiers);
+            Assert.Equal(default, node.RankSpecifiers);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -742,7 +742,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayRankSpecifier();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotEqual(default, node.Sizes);
+            Assert.Equal(default, node.Sizes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -776,7 +776,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleType();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Elements);
+            Assert.Equal(default, node.Elements);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -833,7 +833,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleExpression();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1128,7 +1128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1140,7 +1140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedArgumentList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1252,7 +1252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInitializerExpression();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Expressions);
+            Assert.Equal(default, node.Expressions);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1289,7 +1289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Initializers);
+            Assert.Equal(default, node.Initializers);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1314,7 +1314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotEqual(default, node.Commas);
+            Assert.Equal(default, node.Commas);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             Assert.NotNull(node.Initializer);
             
@@ -1362,7 +1362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateQueryBody();
             
-            Assert.NotEqual(default, node.Clauses);
+            Assert.Equal(default, node.Clauses);
             Assert.NotNull(node.SelectOrGroup);
             Assert.Null(node.Continuation);
             
@@ -1443,7 +1443,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateOrderByClause();
             
             Assert.Equal(SyntaxKind.OrderByKeyword, node.OrderByKeyword.Kind);
-            Assert.NotEqual(default, node.Orderings);
+            Assert.Equal(default, node.Orderings);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -1511,7 +1511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInterpolatedStringExpression();
             
             Assert.Equal(SyntaxKind.InterpolatedStringStartToken, node.StringStartToken.Kind);
-            Assert.NotEqual(default, node.Contents);
+            Assert.Equal(default, node.Contents);
             Assert.Equal(SyntaxKind.InterpolatedStringEndToken, node.StringEndToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1602,7 +1602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePositionalPatternClause();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Subpatterns);
+            Assert.Equal(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1614,7 +1614,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePropertyPatternClause();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Subpatterns);
+            Assert.Equal(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1692,8 +1692,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateGlobalStatement();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Statement);
             
             AttachAndCheckDiagnostics(node);
@@ -1705,7 +1705,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBlock();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Statements);
+            Assert.Equal(default, node.Statements);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1716,12 +1716,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateLocalFunctionStatement();
             
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Null(node.SemicolonToken);
@@ -1736,7 +1736,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Null(node.AwaitKeyword);
             Assert.Null(node.UsingKeyword);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
             
@@ -1749,7 +1749,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateVariableDeclaration();
             
             Assert.NotNull(node.Type);
-            Assert.NotEqual(default, node.Variables);
+            Assert.Equal(default, node.Variables);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -1803,7 +1803,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParenthesizedVariableDesignation();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Variables);
+            Assert.Equal(default, node.Variables);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -1952,11 +1952,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ForKeyword, node.ForKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
             Assert.Null(node.Declaration);
-            Assert.NotEqual(default, node.Initializers);
+            Assert.Equal(default, node.Initializers);
             Assert.Equal(SyntaxKind.SemicolonToken, node.FirstSemicolonToken.Kind);
             Assert.Null(node.Condition);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SecondSemicolonToken.Kind);
-            Assert.NotEqual(default, node.Incrementors);
+            Assert.Equal(default, node.Incrementors);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             Assert.NotNull(node.Statement);
             
@@ -2100,7 +2100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Expression);
             Assert.Null(node.CloseParenToken);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Sections);
+            Assert.Equal(default, node.Sections);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2111,8 +2111,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSwitchSection();
             
-            Assert.NotEqual(default, node.Labels);
-            Assert.NotEqual(default, node.Statements);
+            Assert.Equal(default, node.Labels);
+            Assert.Equal(default, node.Statements);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2161,7 +2161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.GoverningExpression);
             Assert.Equal(SyntaxKind.SwitchKeyword, node.SwitchKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Arms);
+            Assert.Equal(default, node.Arms);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2187,7 +2187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.TryKeyword, node.TryKeyword.Kind);
             Assert.NotNull(node.Block);
-            Assert.NotEqual(default, node.Catches);
+            Assert.Equal(default, node.Catches);
             Assert.Null(node.Finally);
             
             AttachAndCheckDiagnostics(node);
@@ -2248,10 +2248,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCompilationUnit();
             
-            Assert.NotEqual(default, node.Externs);
-            Assert.NotEqual(default, node.Usings);
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Externs);
+            Assert.Equal(default, node.Usings);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.EndOfFileToken, node.EndOfFileToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2289,14 +2289,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateNamespaceDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.NamespaceKeyword, node.NamespaceKeyword.Kind);
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Externs);
-            Assert.NotEqual(default, node.Usings);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Externs);
+            Assert.Equal(default, node.Usings);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2310,7 +2310,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
             Assert.Null(node.Target);
-            Assert.NotEqual(default, node.Attributes);
+            Assert.Equal(default, node.Attributes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2344,7 +2344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAttributeArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2379,7 +2379,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeParameterList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2390,7 +2390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateTypeParameter();
             
-            Assert.NotEqual(default, node.AttributeLists);
+            Assert.Equal(default, node.AttributeLists);
             Assert.Null(node.VarianceKeyword);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             
@@ -2402,15 +2402,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateClassDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ClassKeyword, node.Keyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2422,15 +2422,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateStructDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.StructKeyword, node.Keyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2442,15 +2442,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateInterfaceDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.InterfaceKeyword, node.Keyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2462,13 +2462,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EnumKeyword, node.EnumKeyword.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.BaseList);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             Assert.Null(node.SemicolonToken);
             
@@ -2480,14 +2480,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDelegateDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.DelegateKeyword, node.DelegateKeyword.Kind);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2498,8 +2498,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumMemberDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.EqualsValue);
             
@@ -2512,7 +2512,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBaseList();
             
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
-            Assert.NotEqual(default, node.Types);
+            Assert.Equal(default, node.Types);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2535,7 +2535,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.WhereKeyword, node.WhereKeyword.Kind);
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind);
-            Assert.NotEqual(default, node.Constraints);
+            Assert.Equal(default, node.Constraints);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2578,8 +2578,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateFieldDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
             
@@ -2591,8 +2591,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventFieldDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
@@ -2616,14 +2616,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateMethodDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Null(node.SemicolonToken);
@@ -2636,8 +2636,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateOperatorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind);
             Assert.Equal(SyntaxKind.PlusToken, node.OperatorToken.Kind);
@@ -2654,8 +2654,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConversionOperatorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ImplicitKeyword, node.ImplicitOrExplicitKeyword.Kind);
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind);
             Assert.NotNull(node.Type);
@@ -2672,8 +2672,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConstructorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.NotNull(node.ParameterList);
             Assert.Null(node.Initializer);
@@ -2701,8 +2701,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDestructorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.TildeToken, node.TildeToken.Kind);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.NotNull(node.ParameterList);
@@ -2718,8 +2718,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GeneratePropertyDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
@@ -2747,8 +2747,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
@@ -2764,8 +2764,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIndexerDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.ThisKeyword, node.ThisKeyword.Kind);
@@ -2783,7 +2783,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAccessorList();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind);
-            Assert.NotEqual(default, node.Accessors);
+            Assert.Equal(default, node.Accessors);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2794,8 +2794,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateAccessorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.GetKeyword, node.Keyword.Kind);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
@@ -2810,7 +2810,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2822,7 +2822,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2833,8 +2833,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateParameter();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Null(node.Type);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
             Assert.Null(node.Default);
@@ -2847,8 +2847,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIncompleteMember();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Null(node.Type);
             
             AttachAndCheckDiagnostics(node);
@@ -2859,7 +2859,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSkippedTokensTrivia();
             
-            Assert.NotEqual(default, node.Tokens);
+            Assert.Equal(default, node.Tokens);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -2869,7 +2869,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDocumentationCommentTrivia();
             
-            Assert.NotEqual(default, node.Content);
+            Assert.Equal(default, node.Content);
             Assert.Equal(SyntaxKind.EndOfDocumentationCommentToken, node.EndOfComment.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2950,7 +2950,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2962,7 +2962,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind);
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -2985,7 +2985,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlElement();
             
             Assert.NotNull(node.StartTag);
-            Assert.NotEqual(default, node.Content);
+            Assert.Equal(default, node.Content);
             Assert.NotNull(node.EndTag);
             
             AttachAndCheckDiagnostics(node);
@@ -2998,7 +2998,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
             Assert.NotNull(node.Name);
-            Assert.NotEqual(default, node.Attributes);
+            Assert.Equal(default, node.Attributes);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3023,7 +3023,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind);
             Assert.NotNull(node.Name);
-            Assert.NotEqual(default, node.Attributes);
+            Assert.Equal(default, node.Attributes);
             Assert.Equal(SyntaxKind.SlashGreaterThanToken, node.SlashGreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3059,7 +3059,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.EqualsToken, node.EqualsToken.Kind);
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.StartQuoteToken.Kind);
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.EndQuoteToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3098,7 +3098,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateXmlText();
             
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             
             AttachAndCheckDiagnostics(node);
         }
@@ -3109,7 +3109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlCDataSection();
             
             Assert.Equal(SyntaxKind.XmlCDataStartToken, node.StartCDataToken.Kind);
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCDataEndToken, node.EndCDataToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3122,7 +3122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.XmlProcessingInstructionStartToken, node.StartProcessingInstructionToken.Kind);
             Assert.NotNull(node.Name);
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlProcessingInstructionEndToken, node.EndProcessingInstructionToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3134,7 +3134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlComment();
             
             Assert.Equal(SyntaxKind.XmlCommentStartToken, node.LessThanExclamationMinusMinusToken.Kind);
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCommentEndToken, node.MinusMinusGreaterThanToken.Kind);
             
             AttachAndCheckDiagnostics(node);
@@ -3316,7 +3316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.PragmaKeyword, node.PragmaKeyword.Kind);
             Assert.Equal(SyntaxKind.WarningKeyword, node.WarningKeyword.Kind);
             Assert.Equal(SyntaxKind.DisableKeyword, node.DisableOrRestoreKeyword.Kind);
-            Assert.NotEqual(default, node.ErrorCodes);
+            Assert.Equal(default, node.ErrorCodes);
             Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind);
             Assert.Equal(new bool(), node.IsActive);
             
@@ -9679,7 +9679,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeArgumentList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithArguments(node.Arguments).WithGreaterThanToken(node.GreaterThanToken);
             Assert.Equal(node, newNode);
@@ -9713,7 +9713,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayType();
             
             Assert.NotNull(node.ElementType);
-            Assert.NotEqual(default, node.RankSpecifiers);
+            Assert.Equal(default, node.RankSpecifiers);
             var newNode = node.WithElementType(node.ElementType).WithRankSpecifiers(node.RankSpecifiers);
             Assert.Equal(node, newNode);
         }
@@ -9724,7 +9724,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArrayRankSpecifier();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotEqual(default, node.Sizes);
+            Assert.Equal(default, node.Sizes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithSizes(node.Sizes).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -9758,7 +9758,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleType();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Elements);
+            Assert.Equal(default, node.Elements);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithElements(node.Elements).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -9815,7 +9815,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTupleExpression();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10110,7 +10110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10122,7 +10122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedArgumentList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithArguments(node.Arguments).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -10234,7 +10234,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInitializerExpression();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Expressions);
+            Assert.Equal(default, node.Expressions);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithExpressions(node.Expressions).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10271,7 +10271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Initializers);
+            Assert.Equal(default, node.Initializers);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithNewKeyword(node.NewKeyword).WithOpenBraceToken(node.OpenBraceToken).WithInitializers(node.Initializers).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10296,7 +10296,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.NewKeyword, node.NewKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotEqual(default, node.Commas);
+            Assert.Equal(default, node.Commas);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             Assert.NotNull(node.Initializer);
             var newNode = node.WithNewKeyword(node.NewKeyword).WithOpenBracketToken(node.OpenBracketToken).WithCommas(node.Commas).WithCloseBracketToken(node.CloseBracketToken).WithInitializer(node.Initializer);
@@ -10344,7 +10344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateQueryBody();
             
-            Assert.NotEqual(default, node.Clauses);
+            Assert.Equal(default, node.Clauses);
             Assert.NotNull(node.SelectOrGroup);
             Assert.Null(node.Continuation);
             var newNode = node.WithClauses(node.Clauses).WithSelectOrGroup(node.SelectOrGroup).WithContinuation(node.Continuation);
@@ -10425,7 +10425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateOrderByClause();
             
             Assert.Equal(SyntaxKind.OrderByKeyword, node.OrderByKeyword.Kind());
-            Assert.NotEqual(default, node.Orderings);
+            Assert.Equal(default, node.Orderings);
             var newNode = node.WithOrderByKeyword(node.OrderByKeyword).WithOrderings(node.Orderings);
             Assert.Equal(node, newNode);
         }
@@ -10493,7 +10493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateInterpolatedStringExpression();
             
             Assert.Equal(SyntaxKind.InterpolatedStringStartToken, node.StringStartToken.Kind());
-            Assert.NotEqual(default, node.Contents);
+            Assert.Equal(default, node.Contents);
             Assert.Equal(SyntaxKind.InterpolatedStringEndToken, node.StringEndToken.Kind());
             var newNode = node.WithStringStartToken(node.StringStartToken).WithContents(node.Contents).WithStringEndToken(node.StringEndToken);
             Assert.Equal(node, newNode);
@@ -10584,7 +10584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePositionalPatternClause();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Subpatterns);
+            Assert.Equal(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithSubpatterns(node.Subpatterns).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10596,7 +10596,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GeneratePropertyPatternClause();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Subpatterns);
+            Assert.Equal(default, node.Subpatterns);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithSubpatterns(node.Subpatterns).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10674,8 +10674,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateGlobalStatement();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Statement);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithStatement(node.Statement);
             Assert.Equal(node, newNode);
@@ -10687,7 +10687,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBlock();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Statements);
+            Assert.Equal(default, node.Statements);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithStatements(node.Statements).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -10698,12 +10698,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateLocalFunctionStatement();
             
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
@@ -10718,7 +10718,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.None, node.AwaitKeyword.Kind());
             Assert.Equal(SyntaxKind.None, node.UsingKeyword.Kind());
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
             var newNode = node.WithAwaitKeyword(node.AwaitKeyword).WithUsingKeyword(node.UsingKeyword).WithModifiers(node.Modifiers).WithDeclaration(node.Declaration).WithSemicolonToken(node.SemicolonToken);
@@ -10731,7 +10731,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateVariableDeclaration();
             
             Assert.NotNull(node.Type);
-            Assert.NotEqual(default, node.Variables);
+            Assert.Equal(default, node.Variables);
             var newNode = node.WithType(node.Type).WithVariables(node.Variables);
             Assert.Equal(node, newNode);
         }
@@ -10785,7 +10785,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParenthesizedVariableDesignation();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Variables);
+            Assert.Equal(default, node.Variables);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithVariables(node.Variables).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -10934,11 +10934,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ForKeyword, node.ForKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
             Assert.Null(node.Declaration);
-            Assert.NotEqual(default, node.Initializers);
+            Assert.Equal(default, node.Initializers);
             Assert.Equal(SyntaxKind.SemicolonToken, node.FirstSemicolonToken.Kind());
             Assert.Null(node.Condition);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SecondSemicolonToken.Kind());
-            Assert.NotEqual(default, node.Incrementors);
+            Assert.Equal(default, node.Incrementors);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             Assert.NotNull(node.Statement);
             var newNode = node.WithForKeyword(node.ForKeyword).WithOpenParenToken(node.OpenParenToken).WithDeclaration(node.Declaration).WithInitializers(node.Initializers).WithFirstSemicolonToken(node.FirstSemicolonToken).WithCondition(node.Condition).WithSecondSemicolonToken(node.SecondSemicolonToken).WithIncrementors(node.Incrementors).WithCloseParenToken(node.CloseParenToken).WithStatement(node.Statement);
@@ -11082,7 +11082,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Expression);
             Assert.Equal(SyntaxKind.None, node.CloseParenToken.Kind());
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Sections);
+            Assert.Equal(default, node.Sections);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithSwitchKeyword(node.SwitchKeyword).WithOpenParenToken(node.OpenParenToken).WithExpression(node.Expression).WithCloseParenToken(node.CloseParenToken).WithOpenBraceToken(node.OpenBraceToken).WithSections(node.Sections).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -11093,8 +11093,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSwitchSection();
             
-            Assert.NotEqual(default, node.Labels);
-            Assert.NotEqual(default, node.Statements);
+            Assert.Equal(default, node.Labels);
+            Assert.Equal(default, node.Statements);
             var newNode = node.WithLabels(node.Labels).WithStatements(node.Statements);
             Assert.Equal(node, newNode);
         }
@@ -11143,7 +11143,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.GoverningExpression);
             Assert.Equal(SyntaxKind.SwitchKeyword, node.SwitchKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Arms);
+            Assert.Equal(default, node.Arms);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithGoverningExpression(node.GoverningExpression).WithSwitchKeyword(node.SwitchKeyword).WithOpenBraceToken(node.OpenBraceToken).WithArms(node.Arms).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -11169,7 +11169,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.TryKeyword, node.TryKeyword.Kind());
             Assert.NotNull(node.Block);
-            Assert.NotEqual(default, node.Catches);
+            Assert.Equal(default, node.Catches);
             Assert.Null(node.Finally);
             var newNode = node.WithTryKeyword(node.TryKeyword).WithBlock(node.Block).WithCatches(node.Catches).WithFinally(node.Finally);
             Assert.Equal(node, newNode);
@@ -11230,10 +11230,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCompilationUnit();
             
-            Assert.NotEqual(default, node.Externs);
-            Assert.NotEqual(default, node.Usings);
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Externs);
+            Assert.Equal(default, node.Usings);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.EndOfFileToken, node.EndOfFileToken.Kind());
             var newNode = node.WithExterns(node.Externs).WithUsings(node.Usings).WithAttributeLists(node.AttributeLists).WithMembers(node.Members).WithEndOfFileToken(node.EndOfFileToken);
             Assert.Equal(node, newNode);
@@ -11271,14 +11271,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateNamespaceDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.NamespaceKeyword, node.NamespaceKeyword.Kind());
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Externs);
-            Assert.NotEqual(default, node.Usings);
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Externs);
+            Assert.Equal(default, node.Usings);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithNamespaceKeyword(node.NamespaceKeyword).WithName(node.Name).WithOpenBraceToken(node.OpenBraceToken).WithExterns(node.Externs).WithUsings(node.Usings).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11292,7 +11292,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
             Assert.Null(node.Target);
-            Assert.NotEqual(default, node.Attributes);
+            Assert.Equal(default, node.Attributes);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithTarget(node.Target).WithAttributes(node.Attributes).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -11326,7 +11326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAttributeArgumentList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Arguments);
+            Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -11361,7 +11361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateTypeParameterList();
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithParameters(node.Parameters).WithGreaterThanToken(node.GreaterThanToken);
             Assert.Equal(node, newNode);
@@ -11372,7 +11372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateTypeParameter();
             
-            Assert.NotEqual(default, node.AttributeLists);
+            Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.None, node.VarianceKeyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithVarianceKeyword(node.VarianceKeyword).WithIdentifier(node.Identifier);
@@ -11384,15 +11384,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateClassDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ClassKeyword, node.Keyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithKeyword(node.Keyword).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithBaseList(node.BaseList).WithConstraintClauses(node.ConstraintClauses).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11404,15 +11404,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateStructDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.StructKeyword, node.Keyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithKeyword(node.Keyword).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithBaseList(node.BaseList).WithConstraintClauses(node.ConstraintClauses).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11424,15 +11424,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateInterfaceDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.InterfaceKeyword, node.Keyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.Null(node.BaseList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithKeyword(node.Keyword).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithBaseList(node.BaseList).WithConstraintClauses(node.ConstraintClauses).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11444,13 +11444,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EnumKeyword, node.EnumKeyword.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.BaseList);
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Members);
+            Assert.Equal(default, node.Members);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithEnumKeyword(node.EnumKeyword).WithIdentifier(node.Identifier).WithBaseList(node.BaseList).WithOpenBraceToken(node.OpenBraceToken).WithMembers(node.Members).WithCloseBraceToken(node.CloseBraceToken).WithSemicolonToken(node.SemicolonToken);
@@ -11462,14 +11462,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDelegateDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.DelegateKeyword, node.DelegateKeyword.Kind());
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithDelegateKeyword(node.DelegateKeyword).WithReturnType(node.ReturnType).WithIdentifier(node.Identifier).WithTypeParameterList(node.TypeParameterList).WithParameterList(node.ParameterList).WithConstraintClauses(node.ConstraintClauses).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
@@ -11480,8 +11480,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEnumMemberDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.EqualsValue);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithIdentifier(node.Identifier).WithEqualsValue(node.EqualsValue);
@@ -11494,7 +11494,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBaseList();
             
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
-            Assert.NotEqual(default, node.Types);
+            Assert.Equal(default, node.Types);
             var newNode = node.WithColonToken(node.ColonToken).WithTypes(node.Types);
             Assert.Equal(node, newNode);
         }
@@ -11517,7 +11517,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.WhereKeyword, node.WhereKeyword.Kind());
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.ColonToken, node.ColonToken.Kind());
-            Assert.NotEqual(default, node.Constraints);
+            Assert.Equal(default, node.Constraints);
             var newNode = node.WithWhereKeyword(node.WhereKeyword).WithName(node.Name).WithColonToken(node.ColonToken).WithConstraints(node.Constraints);
             Assert.Equal(node, newNode);
         }
@@ -11560,8 +11560,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateFieldDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithDeclaration(node.Declaration).WithSemicolonToken(node.SemicolonToken);
@@ -11573,8 +11573,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventFieldDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind());
             Assert.NotNull(node.Declaration);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
@@ -11598,14 +11598,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateMethodDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.TypeParameterList);
             Assert.NotNull(node.ParameterList);
-            Assert.NotEqual(default, node.ConstraintClauses);
+            Assert.Equal(default, node.ConstraintClauses);
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
             Assert.Equal(SyntaxKind.None, node.SemicolonToken.Kind());
@@ -11618,8 +11618,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateOperatorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.ReturnType);
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind());
             Assert.Equal(SyntaxKind.PlusToken, node.OperatorToken.Kind());
@@ -11636,8 +11636,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConversionOperatorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.ImplicitKeyword, node.ImplicitOrExplicitKeyword.Kind());
             Assert.Equal(SyntaxKind.OperatorKeyword, node.OperatorKeyword.Kind());
             Assert.NotNull(node.Type);
@@ -11654,8 +11654,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateConstructorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.NotNull(node.ParameterList);
             Assert.Null(node.Initializer);
@@ -11683,8 +11683,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDestructorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.TildeToken, node.TildeToken.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.NotNull(node.ParameterList);
@@ -11700,8 +11700,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GeneratePropertyDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
@@ -11729,8 +11729,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateEventDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.EventKeyword, node.EventKeyword.Kind());
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
@@ -11746,8 +11746,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIndexerDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.NotNull(node.Type);
             Assert.Null(node.ExplicitInterfaceSpecifier);
             Assert.Equal(SyntaxKind.ThisKeyword, node.ThisKeyword.Kind());
@@ -11765,7 +11765,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateAccessorList();
             
             Assert.Equal(SyntaxKind.OpenBraceToken, node.OpenBraceToken.Kind());
-            Assert.NotEqual(default, node.Accessors);
+            Assert.Equal(default, node.Accessors);
             Assert.Equal(SyntaxKind.CloseBraceToken, node.CloseBraceToken.Kind());
             var newNode = node.WithOpenBraceToken(node.OpenBraceToken).WithAccessors(node.Accessors).WithCloseBraceToken(node.CloseBraceToken);
             Assert.Equal(node, newNode);
@@ -11776,8 +11776,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateAccessorDeclaration();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.GetKeyword, node.Keyword.Kind());
             Assert.Null(node.Body);
             Assert.Null(node.ExpressionBody);
@@ -11792,7 +11792,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -11804,7 +11804,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithParameters(node.Parameters).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -11815,8 +11815,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateParameter();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Null(node.Type);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
             Assert.Null(node.Default);
@@ -11829,8 +11829,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateIncompleteMember();
             
-            Assert.NotEqual(default, node.AttributeLists);
-            Assert.NotEqual(default, node.Modifiers);
+            Assert.Equal(default, node.AttributeLists);
+            Assert.Equal(default, node.Modifiers);
             Assert.Null(node.Type);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithType(node.Type);
             Assert.Equal(node, newNode);
@@ -11841,7 +11841,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateSkippedTokensTrivia();
             
-            Assert.NotEqual(default, node.Tokens);
+            Assert.Equal(default, node.Tokens);
             var newNode = node.WithTokens(node.Tokens);
             Assert.Equal(node, newNode);
         }
@@ -11851,7 +11851,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateDocumentationCommentTrivia();
             
-            Assert.NotEqual(default, node.Content);
+            Assert.Equal(default, node.Content);
             Assert.Equal(SyntaxKind.EndOfDocumentationCommentToken, node.EndOfComment.Kind());
             var newNode = node.WithContent(node.Content).WithEndOfComment(node.EndOfComment);
             Assert.Equal(node, newNode);
@@ -11932,7 +11932,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefParameterList();
             
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             var newNode = node.WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
@@ -11944,7 +11944,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCrefBracketedParameterList();
             
             Assert.Equal(SyntaxKind.OpenBracketToken, node.OpenBracketToken.Kind());
-            Assert.NotEqual(default, node.Parameters);
+            Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseBracketToken, node.CloseBracketToken.Kind());
             var newNode = node.WithOpenBracketToken(node.OpenBracketToken).WithParameters(node.Parameters).WithCloseBracketToken(node.CloseBracketToken);
             Assert.Equal(node, newNode);
@@ -11967,7 +11967,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlElement();
             
             Assert.NotNull(node.StartTag);
-            Assert.NotEqual(default, node.Content);
+            Assert.Equal(default, node.Content);
             Assert.NotNull(node.EndTag);
             var newNode = node.WithStartTag(node.StartTag).WithContent(node.Content).WithEndTag(node.EndTag);
             Assert.Equal(node, newNode);
@@ -11980,7 +11980,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
             Assert.NotNull(node.Name);
-            Assert.NotEqual(default, node.Attributes);
+            Assert.Equal(default, node.Attributes);
             Assert.Equal(SyntaxKind.GreaterThanToken, node.GreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithName(node.Name).WithAttributes(node.Attributes).WithGreaterThanToken(node.GreaterThanToken);
             Assert.Equal(node, newNode);
@@ -12005,7 +12005,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.LessThanToken, node.LessThanToken.Kind());
             Assert.NotNull(node.Name);
-            Assert.NotEqual(default, node.Attributes);
+            Assert.Equal(default, node.Attributes);
             Assert.Equal(SyntaxKind.SlashGreaterThanToken, node.SlashGreaterThanToken.Kind());
             var newNode = node.WithLessThanToken(node.LessThanToken).WithName(node.Name).WithAttributes(node.Attributes).WithSlashGreaterThanToken(node.SlashGreaterThanToken);
             Assert.Equal(node, newNode);
@@ -12041,7 +12041,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.EqualsToken, node.EqualsToken.Kind());
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.StartQuoteToken.Kind());
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.SingleQuoteToken, node.EndQuoteToken.Kind());
             var newNode = node.WithName(node.Name).WithEqualsToken(node.EqualsToken).WithStartQuoteToken(node.StartQuoteToken).WithTextTokens(node.TextTokens).WithEndQuoteToken(node.EndQuoteToken);
             Assert.Equal(node, newNode);
@@ -12080,7 +12080,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateXmlText();
             
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             var newNode = node.WithTextTokens(node.TextTokens);
             Assert.Equal(node, newNode);
         }
@@ -12091,7 +12091,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlCDataSection();
             
             Assert.Equal(SyntaxKind.XmlCDataStartToken, node.StartCDataToken.Kind());
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCDataEndToken, node.EndCDataToken.Kind());
             var newNode = node.WithStartCDataToken(node.StartCDataToken).WithTextTokens(node.TextTokens).WithEndCDataToken(node.EndCDataToken);
             Assert.Equal(node, newNode);
@@ -12104,7 +12104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             
             Assert.Equal(SyntaxKind.XmlProcessingInstructionStartToken, node.StartProcessingInstructionToken.Kind());
             Assert.NotNull(node.Name);
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlProcessingInstructionEndToken, node.EndProcessingInstructionToken.Kind());
             var newNode = node.WithStartProcessingInstructionToken(node.StartProcessingInstructionToken).WithName(node.Name).WithTextTokens(node.TextTokens).WithEndProcessingInstructionToken(node.EndProcessingInstructionToken);
             Assert.Equal(node, newNode);
@@ -12116,7 +12116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateXmlComment();
             
             Assert.Equal(SyntaxKind.XmlCommentStartToken, node.LessThanExclamationMinusMinusToken.Kind());
-            Assert.NotEqual(default, node.TextTokens);
+            Assert.Equal(default, node.TextTokens);
             Assert.Equal(SyntaxKind.XmlCommentEndToken, node.MinusMinusGreaterThanToken.Kind());
             var newNode = node.WithLessThanExclamationMinusMinusToken(node.LessThanExclamationMinusMinusToken).WithTextTokens(node.TextTokens).WithMinusMinusGreaterThanToken(node.MinusMinusGreaterThanToken);
             Assert.Equal(node, newNode);
@@ -12298,7 +12298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.PragmaKeyword, node.PragmaKeyword.Kind());
             Assert.Equal(SyntaxKind.WarningKeyword, node.WarningKeyword.Kind());
             Assert.Equal(SyntaxKind.DisableKeyword, node.DisableOrRestoreKeyword.Kind());
-            Assert.NotEqual(default, node.ErrorCodes);
+            Assert.Equal(default, node.ErrorCodes);
             Assert.Equal(SyntaxKind.EndOfDirectiveToken, node.EndOfDirectiveToken.Kind());
             Assert.Equal(new bool(), node.IsActive);
             var newNode = node.WithHashToken(node.HashToken).WithPragmaKeyword(node.PragmaKeyword).WithWarningKeyword(node.WarningKeyword).WithDisableOrRestoreKeyword(node.DisableOrRestoreKeyword).WithErrorCodes(node.ErrorCodes).WithEndOfDirectiveToken(node.EndOfDirectiveToken).WithIsActive(node.IsActive);

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "// comment";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             Assert.Equal(text.Length, token.FullWidth);
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, errors.Length);
             var trivia = token.LeadingTrivia.ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[0].Kind());
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "// ҉ ҉̵̞̟̠̖̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̐̑̒̓̔̊̋̌̍̎̏̐̑̒̓̔̿̿̿… ͡҉҉ ̵̡̢̛̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̿̿̿̚ ҉ ҉҉̡̢̡̢̛̛̖̗̘̙̜̝̞̟̠̖̗̘̙̜̝̞̟̠̊̋̌̍̎̏̐̑̒̓̔̊̋̌… ̒̓̔̕̚ ̍̎̏̐̑̒̓̔̕̚̕̚ ̡̢̛̗̘̙̜̝̞̟̠̊̋̌̍̎̏̚ ̡̢̡̢̛̛̖̗̘̙̜̝̞̟̠̖̗̘̙̜̝̞̟̠̊̋̌̍̎̏̐̑̒̓̔̊̋̌̍̎… ̕̚̕̚ ̔̕̚̕̚҉ ҉̵̞̟̠̖̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̐̑̒̓̔̊̋̌̍̎̏̐̑̒̓̔̿̿̿… ͡҉҉ ̵̡̢̛̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̿̿̿̚ ҉ ";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             Assert.Equal(text.Length, token.FullWidth);
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, errors.Length);
             var trivia = token.LeadingTrivia.ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[0].Kind());
         }
 
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string text = "/// xml comment";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             Assert.Equal(text.Length, token.FullWidth);
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, errors.Length);
             var trivia = token.LeadingTrivia.ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.SingleLineDocumentationCommentTrivia, trivia[0].Kind());
         }
 
@@ -178,14 +178,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "/* comment */";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             var trivia = token.GetLeadingTrivia().ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
         }
 
@@ -200,14 +200,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 */";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             var trivia = token.GetLeadingTrivia().ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
         }
 
@@ -222,14 +222,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 **/";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             var trivia = token.GetLeadingTrivia().ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.MultiLineDocumentationCommentTrivia, trivia[0].Kind());
         }
 
@@ -240,14 +240,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "/* comment";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
             var trivia = token.GetLeadingTrivia().ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.MultiLineCommentTrivia, trivia[0].Kind());
             errors = trivia[0].Errors();
             Assert.Equal(1, errors.Length);
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "// com\uFFFFment";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             Assert.Equal(text.Length, token.FullWidth);
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, errors.Length);
             var trivia = token.LeadingTrivia.ToArray();
             Assert.Equal(1, trivia.Length);
-            Assert.NotNull(trivia[0]);
+            Assert.NotEqual(default, trivia[0]);
             Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[0].Kind());
         }
 
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "a";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "abc";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "a0b1c2";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "Fō̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄̄o";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "my͏very͏long͏identifier"; // These are COMBINING GRAPHEME JOINERs, not actual spaces
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@x";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@if";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -385,12 +385,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\\u1234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
@@ -402,12 +402,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@\\u1234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
@@ -419,12 +419,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\\U00001234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
@@ -436,12 +436,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@\\U00001234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
@@ -453,12 +453,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "a\\u1234b";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(3, ((string)token.ValueText).Length);
         }
@@ -470,12 +470,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "a\\u1234\\u5678b";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(4, ((string)token.ValueText).Length);
         }
@@ -487,12 +487,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\\u123";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.ToFullString());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
-            Assert.NotNull(token.ValueText);
+            Assert.NotEqual(default, token.ValueText);
             Assert.IsType(typeof(string), token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
@@ -509,7 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     var text = "@" + value;
                     var token = LexToken(text);
 
-                    Assert.NotNull(token);
+                    Assert.NotEqual(default, token);
                     Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
                     Assert.Equal(text, token.Text);
                     var errors = token.Errors();
@@ -529,7 +529,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotEqual('\\', text[0]);
             Assert.Equal(System.Globalization.UnicodeCategory.UppercaseLetter, CharUnicodeInfo.GetUnicodeCategory(text[0]));
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     var text = SyntaxFacts.GetText(keyword);
                     var token = LexToken(text);
 
-                    Assert.NotNull(token);
+                    Assert.NotEqual(default, token);
                     Assert.True(SyntaxFacts.IsReservedKeyword(token.Kind()));
                     Assert.Equal(text, token.Text);
                     var errors = token.Errors();
@@ -629,7 +629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var text = SyntaxFacts.GetText(kind);
             var token = LexToken(text);
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(kind, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -644,7 +644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\"literal\"";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -659,7 +659,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\"҉ ҉̵̞̟̠̖̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̐̑̒̓̔̊̋̌̍̎̏̐̑̒̓̔̿̿̿… ͡҉҉ ̵̡̢̛̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̿̿̿̚ ҉ ҉҉̡̢̡̢̛̛̖̗̘̙̜̝̞̟̠̖̗̘̙̜̝̞̟̠̊̋̌̍̎̏̐̑̒̓̔̊̋̌… ̒̓̔̕̚ ̍̎̏̐̑̒̓̔̕̚̕̚ ̡̢̛̗̘̙̜̝̞̟̠̊̋̌̍̎̏̚ ̡̢̡̢̛̛̖̗̘̙̜̝̞̟̠̖̗̘̙̜̝̞̟̠̊̋̌̍̎̏̐̑̒̓̔̊̋̌̍̎… ̕̚̕̚ ̔̕̚̕̚҉ ҉̵̞̟̠̖̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̐̑̒̓̔̊̋̌̍̎̏̐̑̒̓̔̿̿̿… ͡҉҉ ̵̡̢̛̗̘̙̜̝̞̟̠͇̊̋̌̍̎̏̿̿̿̚ ҉\"";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -674,7 +674,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@\"literal\"";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -689,7 +689,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@\"multi line\r\nliteral\"";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -704,7 +704,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\"literal\r\nwith new line\"";
             var token = Lex(text).First();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.NotEqual(text, token.Text);
             var errors = token.Errors();
@@ -720,7 +720,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\"literal";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -736,7 +736,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@\"literal";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var value = "\u1234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -769,7 +769,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var value = "\U00001234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -785,7 +785,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var value = "\u1234\u1234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -801,7 +801,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\"\\u12\"";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.StringLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'" + value + "'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\r'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -850,7 +850,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\n'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -866,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\0'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -882,7 +882,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\t'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -898,7 +898,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\a'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -914,7 +914,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\b'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -930,7 +930,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\v'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -946,7 +946,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\f'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -962,7 +962,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\q'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -978,7 +978,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\\\'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -994,7 +994,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\''";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1010,7 +1010,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\\"'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1026,7 +1026,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\u1234'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1042,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\U00001234'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1058,7 +1058,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\\u12'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1074,7 +1074,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "''";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1091,7 +1091,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'ab'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal(text, token.Text);
             var errors = token.Errors();
@@ -1108,7 +1108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'a\r'";
             var token = Lex(text).First();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal("'a", token.Text);
             var errors = token.Errors();
@@ -1124,7 +1124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\r'";
             var token = Lex(text).First();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal("'", token.Text);
             var errors = token.Errors();
@@ -1142,7 +1142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'ab\r'";
             var token = Lex(text).First();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal("'ab", token.Text);
             var errors = token.Errors();
@@ -1162,7 +1162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "'\uFFFF'";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, token.Kind());
             Assert.Equal("'\uFFFF'", token.Text);
             var errors = token.Errors();
@@ -1177,7 +1177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\\";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.BadToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1192,7 +1192,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.BadToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1207,7 +1207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "@  ";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.BadToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1224,7 +1224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1240,7 +1240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1256,7 +1256,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.45632434234234234234234234324234234234";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1272,7 +1272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "12332434234234234234234234324234234234.456";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1288,7 +1288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "12332434234234234234234234324234234234.45623423423423423423423423423423423423";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1303,7 +1303,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e10";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1317,7 +1317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e999";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1332,7 +1332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e999f";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1347,7 +1347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e999d";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1362,7 +1362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e999m";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1377,7 +1377,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "10234230492340923423423423423423423434234.23402349234098230498234m";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1392,7 +1392,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0.0E1000M";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             decimal d;
@@ -1415,7 +1415,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "1.0E29M";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1430,7 +1430,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0.1E29M";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1445,7 +1445,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0.1EM";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -1460,7 +1460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456E10";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1475,7 +1475,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = ".456";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1491,7 +1491,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = ".456e10";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1507,7 +1507,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123f";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1523,7 +1523,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123F";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1539,7 +1539,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456f";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1555,7 +1555,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e10f";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1571,7 +1571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123d";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1587,7 +1587,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123D";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1603,7 +1603,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456d";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1619,7 +1619,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e10D";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1635,7 +1635,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123m";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1651,7 +1651,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456m";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1667,7 +1667,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123.456e2m";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1683,7 +1683,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123u";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1699,7 +1699,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123U";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1715,7 +1715,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123l";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.ErrorsAndWarnings();
             Assert.Equal(1, errors.Length);
@@ -1732,7 +1732,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123L";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1748,7 +1748,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123ul";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1758,7 +1758,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "123lu";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1774,7 +1774,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123Ul";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1784,7 +1784,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "123lU";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1800,7 +1800,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123uL";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1810,7 +1810,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "123Lu";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1826,7 +1826,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "123UL";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1836,7 +1836,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "123LU";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1852,7 +1852,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123ul";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1862,7 +1862,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0x123lu";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1878,7 +1878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123Ul";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1888,7 +1888,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0x123lU";
             token = LexToken(text);
             errors = token.Errors();
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -1903,7 +1903,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123uL";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1914,7 +1914,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = LexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -1929,7 +1929,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123UL";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1940,7 +1940,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = LexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -1969,7 +1969,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011ul";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1979,7 +1979,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0b100100011lu";
             token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -1995,7 +1995,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011Ul";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2005,7 +2005,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0b100100011lU";
             token = LexToken(text, _binaryOptions);
             errors = token.Errors();
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -2020,7 +2020,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011uL";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2031,7 +2031,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = LexToken(text, _binaryOptions);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -2046,7 +2046,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011UL";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2057,7 +2057,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = LexToken(text, _binaryOptions);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -2071,7 +2071,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = Int32.MaxValue.ToString();
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2086,7 +2086,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = UInt32.MaxValue.ToString() + "U";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2102,7 +2102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = value.ToString();
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2118,7 +2118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = value.ToString();
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2134,7 +2134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = value.ToString();
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2149,7 +2149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = UInt64.MaxValue.ToString() + "0U";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2164,7 +2164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = Int64.MaxValue.ToString() + "L";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2179,7 +2179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = (((ulong)Int64.MaxValue) + 1).ToString() + "L";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2194,7 +2194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = UInt64.MaxValue.ToString() + "UL";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2209,7 +2209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = UInt64.MaxValue.ToString() + "0UL";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2225,7 +2225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2241,7 +2241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123u";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2257,7 +2257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x123L";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2273,7 +2273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x12345678";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2289,7 +2289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x7FFFFFFF";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2305,7 +2305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0xFFFFFFFF";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2321,7 +2321,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0xFFFFFFFFu";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2337,7 +2337,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x7FFFFFFFFFFFFFFF";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2353,7 +2353,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0xFFFFFFFFFFFFFFFF";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2369,7 +2369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2385,7 +2385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011u";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2401,7 +2401,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b100100011L";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2417,7 +2417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b10101010";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2433,7 +2433,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b1111111111111111111111111111111";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2449,7 +2449,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b11111111111111111111111111111111";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2465,7 +2465,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b11111111111111111111111111111111u";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2481,7 +2481,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b111111111111111111111111111111111111111111111111111111111111111";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2497,7 +2497,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b1111111111111111111111111111111111111111111111111111111111111111";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2512,7 +2512,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b10000000000000000000000000000000000000000000000000000000000000000";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2528,7 +2528,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0b";
             var token = LexToken(text, _binaryOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2544,7 +2544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "1_000";
             var token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(1000, token.Value);
@@ -2553,7 +2553,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1___0_0___0";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(1000, token.Value);
@@ -2562,7 +2562,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1_000.000_1";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(1000.0001, token.Value);
@@ -2571,7 +2571,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1_01__0.0__10_1f";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(1010.0101f, token.Value);
@@ -2580,7 +2580,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1_01__0.0__10_1e0_1";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(1010.0101e01, token.Value);
@@ -2589,7 +2589,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0xA_A";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(0xAA, token.Value);
@@ -2598,7 +2598,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0b1_1";
             token = LexToken(text, _binaryUnderscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(3, token.Value);
@@ -2626,7 +2626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "0x_A";
             var token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(0xA, token.Value);
@@ -2635,7 +2635,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0b_1";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(1, token.Value);
@@ -2644,7 +2644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0x__A_1L";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(0xA1L, token.Value);
@@ -2653,7 +2653,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0b__1_1L";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
             Assert.Equal(0b11L, token.Value);
@@ -2709,14 +2709,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "_1000";
             var token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(0, token.Errors().Length);
 
             text = "1000_";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2727,7 +2727,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1000_.0";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2742,7 +2742,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1000.0_";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2753,7 +2753,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1000.0_e1";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2764,7 +2764,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1000.0e_1";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2775,7 +2775,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1000.0e1_";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2786,7 +2786,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0xA_";
             token = LexToken(text, _underscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2797,7 +2797,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0b1_";
             token = LexToken(text, _binaryUnderscoreOptions);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2808,7 +2808,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0x_";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2819,7 +2819,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "0x_2_";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2830,7 +2830,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1E+_2";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2841,7 +2841,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1E-_2";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -2852,7 +2852,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "1E_";
             token = LexToken(text, _options72);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             errors = token.Errors();
             Assert.Equal(2, errors.Length);
@@ -2870,7 +2870,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "3.";
             var token = Lex(text).First();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2886,7 +2886,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = ".3";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2902,7 +2902,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "3e1";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2918,7 +2918,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "3e-1";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2939,7 +2939,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string text = "$";
             var token = DebuggerLexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
@@ -2950,7 +2950,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = DebuggerLexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -2960,7 +2960,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = DebuggerLexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text.Substring(0, text.Length - 1), token.Text);
@@ -3041,7 +3041,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string text = "123#";
             var token = DebuggerLexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
@@ -3054,7 +3054,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = DebuggerLexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(1, errors.Length);
             Assert.Equal(text, token.Text);
@@ -3064,7 +3064,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = DebuggerLexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(1, errors.Length);
             Assert.Equal(text.Substring(0, text.Length - 1), token.Text);
@@ -3074,7 +3074,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = DebuggerLexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             Assert.Equal(1, errors.Length);
             Assert.Equal(text.Substring(0, text.Length - 1), token.Text);
@@ -3085,7 +3085,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             token = DebuggerLexToken(text);
             errors = token.Errors();
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal(0, errors.Length);
             Assert.Equal(text, token.Text);
@@ -3098,7 +3098,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string text = " \t\v\f\u00A0token\u00A0\f\v\t ";
             var token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal("token", token.Text);
             Assert.True(token.HasLeadingTrivia);
@@ -3116,7 +3116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "\u001Atoken\u001A";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal("token", token.Text);
             Assert.True(token.HasLeadingTrivia);
@@ -3136,7 +3136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             text = "\uFEFFto\uFEFFken\uFEFF \uFEFF";
             token = LexToken(text);
 
-            Assert.NotNull(token);
+            Assert.NotEqual(default, token);
             Assert.Equal(SyntaxKind.IdentifierToken, token.Kind());
             Assert.Equal("to\uFEFFken\uFEFF", token.Text);
             Assert.Equal("token", token.Value);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -3014,7 +3014,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("b", ms.ReturnType.ToString());
             Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotEqual(default, default, ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(2, ms.ParameterList.Parameters.Count);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -34,14 +34,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ea = file.Externs[0];
 
-            Assert.NotNull(ea.ExternKeyword);
+            Assert.NotEqual(default, ea.ExternKeyword);
             Assert.Equal(SyntaxKind.ExternKeyword, ea.ExternKeyword.Kind());
-            Assert.NotNull(ea.AliasKeyword);
+            Assert.NotEqual(default, ea.AliasKeyword);
             Assert.Equal(SyntaxKind.AliasKeyword, ea.AliasKeyword.Kind());
             Assert.False(ea.AliasKeyword.IsMissing);
-            Assert.NotNull(ea.Identifier);
+            Assert.NotEqual(default, ea.Identifier);
             Assert.Equal("a", ea.Identifier.ToString());
-            Assert.NotNull(ea.SemicolonToken);
+            Assert.NotEqual(default, ea.SemicolonToken);
         }
 
         [Fact]
@@ -59,14 +59,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ea = file.Externs[0];
 
-            Assert.NotNull(ea.ExternKeyword);
+            Assert.NotEqual(default, ea.ExternKeyword);
             Assert.Equal(SyntaxKind.ExternKeyword, ea.ExternKeyword.Kind());
-            Assert.NotNull(ea.AliasKeyword);
+            Assert.NotEqual(default, ea.AliasKeyword);
             Assert.Equal(SyntaxKind.AliasKeyword, ea.AliasKeyword.Kind());
             Assert.True(ea.AliasKeyword.IsMissing);
-            Assert.NotNull(ea.Identifier);
+            Assert.NotEqual(default, ea.Identifier);
             Assert.Equal("a", ea.Identifier.ToString());
-            Assert.NotNull(ea.SemicolonToken);
+            Assert.NotEqual(default, ea.SemicolonToken);
         }
 
         [Fact]
@@ -82,13 +82,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.True(ud.StaticKeyword == default(SyntaxToken));
             Assert.NotNull(ud.Name);
             Assert.Equal("a", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -104,13 +104,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.Equal(SyntaxKind.StaticKeyword, ud.StaticKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
             Assert.Equal("a", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -171,13 +171,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.True(ud.StaticKeyword == default(SyntaxToken));
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
             Assert.Equal("a.b", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -193,13 +193,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.Equal(SyntaxKind.StaticKeyword, ud.StaticKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
             Assert.Equal("a.b", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -215,13 +215,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.Equal(SyntaxKind.StaticKeyword, ud.StaticKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
             Assert.Equal("a<int?>", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -237,15 +237,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.NotNull(ud.Alias);
             Assert.NotNull(ud.Alias.Name);
             Assert.Equal("a", ud.Alias.Name.ToString());
-            Assert.NotNull(ud.Alias.EqualsToken);
+            Assert.NotEqual(default, ud.Alias.EqualsToken);
             Assert.NotNull(ud.Name);
             Assert.Equal("b", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -261,15 +261,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotNull(ud.UsingKeyword);
+            Assert.NotEqual(default, ud.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
             Assert.NotNull(ud.Alias);
             Assert.NotNull(ud.Alias.Name);
             Assert.Equal("a", ud.Alias.Name.ToString());
-            Assert.NotNull(ud.Alias.EqualsToken);
+            Assert.NotEqual(default, ud.Alias.EqualsToken);
             Assert.NotNull(ud.Name);
             Assert.Equal("b<c>", ud.Name.ToString());
-            Assert.NotNull(ud.SemicolonToken);
+            Assert.NotEqual(default, ud.SemicolonToken);
         }
 
         [Fact]
@@ -286,16 +286,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -312,19 +312,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("@assembly", ad.Target.Identifier.ToString());
             Assert.Equal("assembly", ad.Target.Identifier.ValueText);
             Assert.Equal(SyntaxKind.IdentifierToken, ad.Target.Identifier.Kind());
             Assert.Equal(AttributeLocation.Assembly, ad.Target.Identifier.ToAttributeLocation());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -341,19 +341,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
-            Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.Target);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal(@"as\u0073embly", ad.Target.Identifier.ToString());
             Assert.Equal("assembly", ad.Target.Identifier.ValueText);
             Assert.Equal(SyntaxKind.IdentifierToken, ad.Target.Identifier.Kind());
             Assert.Equal(AttributeLocation.Assembly, ad.Target.Identifier.ToAttributeLocation());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -370,17 +370,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("module", ad.Target.Identifier.ToString());
             Assert.Equal(SyntaxKind.ModuleKeyword, ad.Target.Identifier.Kind());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -397,18 +397,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("@module", ad.Target.Identifier.ToString());
             Assert.Equal(SyntaxKind.IdentifierToken, ad.Target.Identifier.Kind());
             Assert.Equal(AttributeLocation.Module, ad.Target.Identifier.ToAttributeLocation());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -425,20 +425,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
             Assert.Equal(SyntaxKind.AssemblyKeyword, ad.Target.Identifier.Kind());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.NotNull(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.Attributes[0].ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.OpenParenToken);
             Assert.Equal(0, ad.Attributes[0].ArgumentList.Arguments.Count);
-            Assert.NotNull(ad.Attributes[0].ArgumentList.CloseParenToken);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -455,21 +455,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.NotNull(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.Attributes[0].ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.OpenParenToken);
             Assert.Equal(2, ad.Attributes[0].ArgumentList.Arguments.Count);
             Assert.Equal("b", ad.Attributes[0].ArgumentList.Arguments[0].ToString());
             Assert.Equal("c", ad.Attributes[0].ArgumentList.Arguments[1].ToString());
-            Assert.NotNull(ad.Attributes[0].ArgumentList.CloseParenToken);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -486,26 +486,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.NotNull(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.Attributes[0].ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.OpenParenToken);
             Assert.Equal(1, ad.Attributes[0].ArgumentList.Arguments.Count);
             Assert.Equal("b = c", ad.Attributes[0].ArgumentList.Arguments[0].ToString());
             Assert.NotNull(ad.Attributes[0].ArgumentList.Arguments[0].NameEquals);
             Assert.NotNull(ad.Attributes[0].ArgumentList.Arguments[0].NameEquals.Name);
             Assert.Equal("b", ad.Attributes[0].ArgumentList.Arguments[0].NameEquals.Name.ToString());
-            Assert.NotNull(ad.Attributes[0].ArgumentList.Arguments[0].NameEquals.EqualsToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.Arguments[0].NameEquals.EqualsToken);
             Assert.NotNull(ad.Attributes[0].ArgumentList.Arguments[0].Expression);
             Assert.Equal("c", ad.Attributes[0].ArgumentList.Arguments[0].Expression.ToString());
-            Assert.NotNull(ad.Attributes[0].ArgumentList.CloseParenToken);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.Attributes[0].ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -522,11 +522,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
 
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(2, ad.Attributes.Count);
 
             Assert.NotNull(ad.Attributes[0].Name);
@@ -537,7 +537,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("b", ad.Attributes[1].Name.ToString());
             Assert.Null(ad.Attributes[1].ArgumentList);
 
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -553,28 +553,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.AttributeList, file.AttributeLists[0].Kind());
             var ad = (AttributeListSyntax)file.AttributeLists[0];
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("a", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
 
             ad = (AttributeListSyntax)file.AttributeLists[1];
-            Assert.NotNull(ad.OpenBracketToken);
+            Assert.NotEqual(default, ad.OpenBracketToken);
             Assert.NotNull(ad.Target);
-            Assert.NotNull(ad.Target.Identifier);
+            Assert.NotEqual(default, ad.Target.Identifier);
             Assert.Equal("assembly", ad.Target.Identifier.ToString());
-            Assert.NotNull(ad.Target.ColonToken);
+            Assert.NotEqual(default, ad.Target.ColonToken);
             Assert.Equal(1, ad.Attributes.Count);
             Assert.NotNull(ad.Attributes[0].Name);
             Assert.Equal("b", ad.Attributes[0].Name.ToString());
             Assert.Null(ad.Attributes[0].ArgumentList);
-            Assert.NotNull(ad.CloseBracketToken);
+            Assert.NotEqual(default, ad.CloseBracketToken);
         }
 
         [Fact]
@@ -590,13 +590,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.NamespaceDeclaration, file.Members[0].Kind());
             var ns = (NamespaceDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ns.NamespaceKeyword);
+            Assert.NotEqual(default, ns.NamespaceKeyword);
             Assert.NotNull(ns.Name);
             Assert.Equal("a", ns.Name.ToString());
-            Assert.NotNull(ns.OpenBraceToken);
+            Assert.NotEqual(default, ns.OpenBraceToken);
             Assert.Equal(0, ns.Usings.Count);
             Assert.Equal(0, ns.Members.Count);
-            Assert.NotNull(ns.CloseBraceToken);
+            Assert.NotEqual(default, ns.CloseBraceToken);
         }
 
         [Fact]
@@ -612,13 +612,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.NamespaceDeclaration, file.Members[0].Kind());
             var ns = (NamespaceDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ns.NamespaceKeyword);
+            Assert.NotEqual(default, ns.NamespaceKeyword);
             Assert.NotNull(ns.Name);
             Assert.Equal("a.b.c", ns.Name.ToString());
-            Assert.NotNull(ns.OpenBraceToken);
+            Assert.NotEqual(default, ns.OpenBraceToken);
             Assert.Equal(0, ns.Usings.Count);
             Assert.Equal(0, ns.Members.Count);
-            Assert.NotNull(ns.CloseBraceToken);
+            Assert.NotEqual(default, ns.CloseBraceToken);
         }
 
         [Fact]
@@ -634,14 +634,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.NamespaceDeclaration, file.Members[0].Kind());
             var ns = (NamespaceDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ns.NamespaceKeyword);
+            Assert.NotEqual(default, ns.NamespaceKeyword);
             Assert.NotNull(ns.Name);
             Assert.Equal("a", ns.Name.ToString());
-            Assert.NotNull(ns.OpenBraceToken);
+            Assert.NotEqual(default, ns.OpenBraceToken);
             Assert.Equal(1, ns.Usings.Count);
             Assert.Equal("using b.c;", ns.Usings[0].ToString());
             Assert.Equal(0, ns.Members.Count);
-            Assert.NotNull(ns.CloseBraceToken);
+            Assert.NotEqual(default, ns.CloseBraceToken);
         }
 
         [Fact]
@@ -657,14 +657,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.NamespaceDeclaration, file.Members[0].Kind());
             var ns = (NamespaceDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ns.NamespaceKeyword);
+            Assert.NotEqual(default, ns.NamespaceKeyword);
             Assert.NotNull(ns.Name);
             Assert.Equal("a", ns.Name.ToString());
-            Assert.NotNull(ns.OpenBraceToken);
+            Assert.NotEqual(default, ns.OpenBraceToken);
             Assert.Equal(1, ns.Externs.Count);
             Assert.Equal("extern alias b;", ns.Externs[0].ToString());
             Assert.Equal(0, ns.Members.Count);
-            Assert.NotNull(ns.CloseBraceToken);
+            Assert.NotEqual(default, ns.CloseBraceToken);
         }
 
         [Fact]
@@ -680,15 +680,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.NamespaceDeclaration, file.Members[0].Kind());
             var ns = (NamespaceDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ns.NamespaceKeyword);
+            Assert.NotEqual(default, ns.NamespaceKeyword);
             Assert.NotNull(ns.Name);
             Assert.Equal("a", ns.Name.ToString());
-            Assert.NotNull(ns.OpenBraceToken);
+            Assert.NotEqual(default, ns.OpenBraceToken);
             Assert.Equal(1, ns.Usings.Count);
             Assert.Equal("using b;", ns.Usings[0].ToString());
             Assert.Equal(0, ns.Externs.Count);
             Assert.Equal(0, ns.Members.Count);
-            Assert.NotNull(ns.CloseBraceToken);
+            Assert.NotEqual(default, ns.CloseBraceToken);
         }
 
         [Fact]
@@ -704,22 +704,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.NamespaceDeclaration, file.Members[0].Kind());
             var ns = (NamespaceDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ns.NamespaceKeyword);
+            Assert.NotEqual(default, ns.NamespaceKeyword);
             Assert.NotNull(ns.Name);
             Assert.Equal("a", ns.Name.ToString());
-            Assert.NotNull(ns.OpenBraceToken);
+            Assert.NotEqual(default, ns.OpenBraceToken);
             Assert.Equal(0, ns.Usings.Count);
             Assert.Equal(1, ns.Members.Count);
             Assert.Equal(SyntaxKind.NamespaceDeclaration, ns.Members[0].Kind());
             var ns2 = (NamespaceDeclarationSyntax)ns.Members[0];
-            Assert.NotNull(ns2.NamespaceKeyword);
+            Assert.NotEqual(default, ns2.NamespaceKeyword);
             Assert.NotNull(ns2.Name);
             Assert.Equal("b", ns2.Name.ToString());
-            Assert.NotNull(ns2.OpenBraceToken);
+            Assert.NotEqual(default, ns2.OpenBraceToken);
             Assert.Equal(0, ns2.Usings.Count);
             Assert.Equal(0, ns2.Members.Count);
 
-            Assert.NotNull(ns.CloseBraceToken);
+            Assert.NotEqual(default, ns.CloseBraceToken);
         }
 
         [Fact]
@@ -737,15 +737,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -764,15 +764,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.PublicKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -791,15 +791,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.InternalKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -818,15 +818,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.StaticKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -845,15 +845,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.SealedKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -872,15 +872,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.AbstractKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -899,15 +899,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.PartialKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -926,15 +926,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(1, cs.AttributeLists.Count);
             Assert.Equal("[attr]", cs.AttributeLists[0].ToString());
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -954,15 +954,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("[attr1]", cs.AttributeLists[0].ToString());
             Assert.Equal("[attr2]", cs.AttributeLists[1].ToString());
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -981,15 +981,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(1, cs.AttributeLists.Count);
             Assert.Equal("[attr1, attr2]", cs.AttributeLists[0].ToString());
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1007,20 +1007,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
 
             Assert.NotNull(cs.BaseList);
-            Assert.NotNull(cs.BaseList.ColonToken);
+            Assert.NotEqual(default, cs.BaseList.ColonToken);
             Assert.Equal(1, cs.BaseList.Types.Count);
             Assert.Equal("b", cs.BaseList.Types[0].Type.ToString());
 
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1038,21 +1038,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
 
             Assert.NotNull(cs.BaseList);
-            Assert.NotNull(cs.BaseList.ColonToken);
+            Assert.NotEqual(default, cs.BaseList.ColonToken);
             Assert.Equal(2, cs.BaseList.Types.Count);
             Assert.Equal("b", cs.BaseList.Types[0].Type.ToString());
             Assert.Equal("c", cs.BaseList.Types[1].Type.ToString());
 
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1070,19 +1070,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
@@ -1090,9 +1090,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(bound.Type);
             Assert.Equal("c", bound.Type.ToString());
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1112,18 +1112,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
@@ -1131,9 +1131,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(bound.Type);
             Assert.Equal("c", bound.Type.ToString());
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             CreateCompilation(text).GetDeclarationDiagnostics().Verify(
                 // (1,9): error CS0080: Constraints are not allowed on non-generic declarations
@@ -1167,33 +1167,33 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.ConstructorConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
             var bound = (ConstructorConstraintSyntax)cs.ConstraintClauses[0].Constraints[0];
-            Assert.NotNull(bound.NewKeyword);
+            Assert.NotEqual(default, bound.NewKeyword);
             Assert.False(bound.NewKeyword.IsMissing);
-            Assert.NotNull(bound.OpenParenToken);
+            Assert.NotEqual(default, bound.OpenParenToken);
             Assert.False(bound.OpenParenToken.IsMissing);
-            Assert.NotNull(bound.CloseParenToken);
+            Assert.NotEqual(default, bound.CloseParenToken);
             Assert.False(bound.CloseParenToken.IsMissing);
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1211,30 +1211,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.ClassConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
             var bound = (ClassOrStructConstraintSyntax)cs.ConstraintClauses[0].Constraints[0];
-            Assert.NotNull(bound.ClassOrStructKeyword);
+            Assert.NotEqual(default, bound.ClassOrStructKeyword);
             Assert.False(bound.ClassOrStructKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ClassKeyword, bound.ClassOrStructKeyword.Kind());
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1252,30 +1252,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.StructConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
             var bound = (ClassOrStructConstraintSyntax)cs.ConstraintClauses[0].Constraints[0];
-            Assert.NotNull(bound.ClassOrStructKeyword);
+            Assert.NotEqual(default, bound.ClassOrStructKeyword);
             Assert.False(bound.ClassOrStructKeyword.IsMissing);
             Assert.Equal(SyntaxKind.StructKeyword, bound.ClassOrStructKeyword.Kind());
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1293,25 +1293,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(3, cs.ConstraintClauses[0].Constraints.Count);
 
             Assert.Equal(SyntaxKind.ClassConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
             var classBound = (ClassOrStructConstraintSyntax)cs.ConstraintClauses[0].Constraints[0];
-            Assert.NotNull(classBound.ClassOrStructKeyword);
+            Assert.NotEqual(default, classBound.ClassOrStructKeyword);
             Assert.False(classBound.ClassOrStructKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ClassKeyword, classBound.ClassOrStructKeyword.Kind());
 
@@ -1322,16 +1322,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.ConstructorConstraint, cs.ConstraintClauses[0].Constraints[2].Kind());
             var bound = (ConstructorConstraintSyntax)cs.ConstraintClauses[0].Constraints[2];
-            Assert.NotNull(bound.NewKeyword);
+            Assert.NotEqual(default, bound.NewKeyword);
             Assert.False(bound.NewKeyword.IsMissing);
-            Assert.NotNull(bound.OpenParenToken);
+            Assert.NotEqual(default, bound.OpenParenToken);
             Assert.False(bound.OpenParenToken.IsMissing);
-            Assert.NotNull(bound.CloseParenToken);
+            Assert.NotEqual(default, bound.CloseParenToken);
             Assert.False(bound.CloseParenToken.IsMissing);
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1349,19 +1349,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(2, cs.ConstraintClauses.Count);
 
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
@@ -1369,24 +1369,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(typeBound.Type);
             Assert.Equal("c", typeBound.Type.ToString());
 
-            Assert.NotNull(cs.ConstraintClauses[1].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[1].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[1].Name);
             Assert.Equal("b", cs.ConstraintClauses[1].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[1].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[1].ColonToken);
             Assert.False(cs.ConstraintClauses[1].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[1].Constraints.Count);
             Assert.Equal(SyntaxKind.ConstructorConstraint, cs.ConstraintClauses[1].Constraints[0].Kind());
             var bound = (ConstructorConstraintSyntax)cs.ConstraintClauses[1].Constraints[0];
-            Assert.NotNull(bound.NewKeyword);
+            Assert.NotEqual(default, bound.NewKeyword);
             Assert.False(bound.NewKeyword.IsMissing);
-            Assert.NotNull(bound.OpenParenToken);
+            Assert.NotEqual(default, bound.OpenParenToken);
             Assert.False(bound.OpenParenToken.IsMissing);
-            Assert.NotNull(bound.CloseParenToken);
+            Assert.NotEqual(default, bound.CloseParenToken);
             Assert.False(bound.CloseParenToken.IsMissing);
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1404,19 +1404,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(2, cs.ConstraintClauses.Count);
 
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
@@ -1424,10 +1424,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(typeBound.Type);
             Assert.Equal("c", typeBound.Type.ToString());
 
-            Assert.NotNull(cs.ConstraintClauses[1].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[1].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[1].Name);
             Assert.Equal("b", cs.ConstraintClauses[1].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[1].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[1].ColonToken);
             Assert.True(cs.ConstraintClauses[1].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[1].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, cs.ConstraintClauses[1].Constraints[0].Kind());
@@ -1450,19 +1450,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.Null(cs.BaseList);
 
             Assert.Equal(2, cs.ConstraintClauses.Count);
 
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
@@ -1470,7 +1470,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(typeBound.Type);
             Assert.Equal("c", typeBound.Type.ToString());
 
-            Assert.NotNull(cs.ConstraintClauses[1].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[1].WhereKeyword);
             Assert.True(cs.ConstraintClauses[1].Name.IsMissing);
             Assert.True(cs.ConstraintClauses[1].ColonToken.IsMissing);
             Assert.Equal(1, cs.ConstraintClauses[1].Constraints.Count);
@@ -1494,29 +1494,29 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Equal("<b>", cs.TypeParameterList.ToString());
 
             Assert.NotNull(cs.BaseList);
-            Assert.NotNull(cs.BaseList.ColonToken);
+            Assert.NotEqual(default, cs.BaseList.ColonToken);
             Assert.Equal(2, cs.BaseList.Types.Count);
             Assert.Equal("c", cs.BaseList.Types[0].Type.ToString());
             Assert.Equal("d", cs.BaseList.Types[1].Type.ToString());
 
             Assert.Equal(1, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(cs.ConstraintClauses[0].Name);
             Assert.Equal("b", cs.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(cs.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, cs.ConstraintClauses[0].ColonToken);
             Assert.False(cs.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(3, cs.ConstraintClauses[0].Constraints.Count);
 
             Assert.Equal(SyntaxKind.ClassConstraint, cs.ConstraintClauses[0].Constraints[0].Kind());
             var classBound = (ClassOrStructConstraintSyntax)cs.ConstraintClauses[0].Constraints[0];
-            Assert.NotNull(classBound.ClassOrStructKeyword);
+            Assert.NotEqual(default, classBound.ClassOrStructKeyword);
             Assert.False(classBound.ClassOrStructKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ClassKeyword, classBound.ClassOrStructKeyword.Kind());
 
@@ -1527,16 +1527,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.ConstructorConstraint, cs.ConstraintClauses[0].Constraints[2].Kind());
             var bound = (ConstructorConstraintSyntax)cs.ConstraintClauses[0].Constraints[2];
-            Assert.NotNull(bound.NewKeyword);
+            Assert.NotEqual(default, bound.NewKeyword);
             Assert.False(bound.NewKeyword.IsMissing);
-            Assert.NotNull(bound.OpenParenToken);
+            Assert.NotEqual(default, bound.OpenParenToken);
             Assert.False(bound.OpenParenToken.IsMissing);
-            Assert.NotNull(bound.CloseParenToken);
+            Assert.NotEqual(default, bound.CloseParenToken);
             Assert.False(bound.CloseParenToken.IsMissing);
 
-            Assert.NotNull(cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
             Assert.Equal(0, cs.Members.Count);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1554,14 +1554,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.InterfaceKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1579,9 +1579,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.InterfaceKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             var gn = cs.TypeParameterList;
             Assert.Equal("<B>", gn.ToString());
             Assert.Equal("A", cs.Identifier.ToString());
@@ -1590,8 +1590,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("B", gn.Parameters[0].Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1609,21 +1609,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.InterfaceKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
 
             var gn = cs.TypeParameterList;
             Assert.Equal("<[B] out C>", gn.ToString());
             Assert.Equal("A", cs.Identifier.ToString());
             Assert.Equal(1, gn.Parameters[0].AttributeLists.Count);
             Assert.Equal("B", gn.Parameters[0].AttributeLists[0].Attributes[0].Name.ToString());
-            Assert.NotNull(gn.Parameters[0].VarianceKeyword);
+            Assert.NotEqual(default, gn.Parameters[0].VarianceKeyword);
             Assert.Equal(SyntaxKind.OutKeyword, gn.Parameters[0].VarianceKeyword.Kind());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1641,14 +1641,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.StructKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1666,14 +1666,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1681,14 +1681,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             cs = (TypeDeclarationSyntax)cs.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1706,14 +1706,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1722,14 +1722,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.PrivateKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1747,14 +1747,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1763,14 +1763,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.ProtectedKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1788,14 +1788,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1805,14 +1805,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(2, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.ProtectedKeyword, cs.Modifiers[0].Kind());
             Assert.Equal(SyntaxKind.InternalKeyword, cs.Modifiers[1].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1830,14 +1830,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1847,14 +1847,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(2, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.InternalKeyword, cs.Modifiers[0].Kind());
             Assert.Equal(SyntaxKind.ProtectedKeyword, cs.Modifiers[1].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1872,14 +1872,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1888,14 +1888,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.PublicKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1913,14 +1913,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -1929,14 +1929,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(1, cs.Modifiers.Count);
             Assert.Equal(SyntaxKind.InternalKeyword, cs.Modifiers[0].Kind());
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("b", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
         }
 
         [Fact]
@@ -1952,17 +1952,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ds.ParameterList.Parameters.Count);
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -1979,17 +1979,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("ref a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ds.ParameterList.Parameters.Count);
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2007,17 +2007,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("ref readonly a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ds.ParameterList.Parameters.Count);
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2054,17 +2054,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal(typeText, ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ds.ParameterList.Parameters.Count);
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2100,12 +2100,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
@@ -2113,12 +2113,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ds.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal(typeText, ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2135,12 +2135,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
@@ -2148,12 +2148,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ds.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ds.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2170,12 +2170,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(2, ds.ParameterList.Parameters.Count);
@@ -2183,19 +2183,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ds.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ds.ParameterList.Parameters[0].Identifier.ToString());
 
             Assert.Equal(0, ds.ParameterList.Parameters[1].AttributeLists.Count);
             Assert.Equal(0, ds.ParameterList.Parameters[1].Modifiers.Count);
             Assert.NotNull(ds.ParameterList.Parameters[1].Type);
             Assert.Equal("e", ds.ParameterList.Parameters[1].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[1].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[1].Identifier);
             Assert.Equal("f", ds.ParameterList.Parameters[1].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2212,12 +2212,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
@@ -2226,12 +2226,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.RefKeyword, ds.ParameterList.Parameters[0].Modifiers[0].Kind());
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ds.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2248,12 +2248,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
@@ -2262,12 +2262,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.OutKeyword, ds.ParameterList.Parameters[0].Modifiers[0].Kind());
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ds.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2284,12 +2284,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
@@ -2298,12 +2298,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ParamsKeyword, ds.ParameterList.Parameters[0].Modifiers[0].Kind());
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ds.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2321,23 +2321,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
             Assert.Equal(0, ds.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ds.ParameterList.Parameters[0].Modifiers.Count);
             Assert.Null(ds.ParameterList.Parameters[0].Type);
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2354,12 +2354,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, file.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)file.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("a", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("b", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ds.ParameterList.Parameters.Count);
@@ -2368,12 +2368,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ds.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ds.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ds.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ds.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ds.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ds.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2392,30 +2392,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
             Assert.Equal(SyntaxKind.DelegateDeclaration, cs.Members[0].Kind());
             var ds = (DelegateDeclarationSyntax)cs.Members[0];
-            Assert.NotNull(ds.DelegateKeyword);
+            Assert.NotEqual(default, ds.DelegateKeyword);
             Assert.NotNull(ds.ReturnType);
             Assert.Equal("b", ds.ReturnType.ToString());
-            Assert.NotNull(ds.Identifier);
+            Assert.NotEqual(default, ds.Identifier);
             Assert.Equal("c", ds.Identifier.ToString());
-            Assert.NotNull(ds.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ds.ParameterList.OpenParenToken);
             Assert.False(ds.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ds.ParameterList.Parameters.Count);
-            Assert.NotNull(ds.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ds.ParameterList.CloseParenToken);
             Assert.False(ds.ParameterList.CloseParenToken.IsMissing);
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -2434,14 +2434,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2451,12 +2451,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2480,14 +2480,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2496,12 +2496,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.AttributeLists.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("ref b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2526,14 +2526,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2542,12 +2542,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.AttributeLists.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("ref readonly b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2571,14 +2571,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2601,14 +2601,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2629,14 +2629,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2650,12 +2650,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2697,14 +2697,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2715,12 +2715,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.PartialKeyword, ms.Modifiers[0].Kind());
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("void", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("M", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2744,14 +2744,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var structDecl = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, structDecl.AttributeLists.Count);
             Assert.Equal(0, structDecl.Modifiers.Count);
-            Assert.NotNull(structDecl.Keyword);
+            Assert.NotEqual(default, structDecl.Keyword);
             Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
-            Assert.NotNull(structDecl.Identifier);
+            Assert.NotEqual(default, structDecl.Identifier);
             Assert.Equal("a", structDecl.Identifier.ToString());
             Assert.Null(structDecl.BaseList);
             Assert.Equal(0, structDecl.ConstraintClauses.Count);
-            Assert.NotNull(structDecl.OpenBraceToken);
-            Assert.NotNull(structDecl.CloseBraceToken);
+            Assert.NotEqual(default, structDecl.OpenBraceToken);
+            Assert.NotEqual(default, structDecl.CloseBraceToken);
 
             Assert.Equal(1, structDecl.Members.Count);
 
@@ -2762,12 +2762,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ReadOnlyKeyword, ms.Modifiers[0].Kind());
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("void", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("M", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2791,14 +2791,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var structDecl = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, structDecl.AttributeLists.Count);
             Assert.Equal(0, structDecl.Modifiers.Count);
-            Assert.NotNull(structDecl.Keyword);
+            Assert.NotEqual(default, structDecl.Keyword);
             Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
-            Assert.NotNull(structDecl.Identifier);
+            Assert.NotEqual(default, structDecl.Identifier);
             Assert.Equal("a", structDecl.Identifier.ToString());
             Assert.Null(structDecl.BaseList);
             Assert.Equal(0, structDecl.ConstraintClauses.Count);
-            Assert.NotNull(structDecl.OpenBraceToken);
-            Assert.NotNull(structDecl.CloseBraceToken);
+            Assert.NotEqual(default, structDecl.OpenBraceToken);
+            Assert.NotEqual(default, structDecl.CloseBraceToken);
 
             Assert.Equal(1, structDecl.Members.Count);
 
@@ -2812,12 +2812,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.RefKeyword, rt.RefKeyword.Kind());
             Assert.Equal(SyntaxKind.ReadOnlyKeyword, rt.ReadOnlyKeyword.Kind());
             Assert.Equal("int", rt.Type.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("M", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2841,14 +2841,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var structDecl = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, structDecl.AttributeLists.Count);
             Assert.Equal(0, structDecl.Modifiers.Count);
-            Assert.NotNull(structDecl.Keyword);
+            Assert.NotEqual(default, structDecl.Keyword);
             Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
-            Assert.NotNull(structDecl.Identifier);
+            Assert.NotEqual(default, structDecl.Identifier);
             Assert.Equal("a", structDecl.Identifier.ToString());
             Assert.Null(structDecl.BaseList);
             Assert.Equal(0, structDecl.ConstraintClauses.Count);
-            Assert.NotNull(structDecl.OpenBraceToken);
-            Assert.NotNull(structDecl.CloseBraceToken);
+            Assert.NotEqual(default, structDecl.OpenBraceToken);
+            Assert.NotEqual(default, structDecl.CloseBraceToken);
 
             Assert.Equal(1, structDecl.Members.Count);
 
@@ -2859,7 +2859,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.ReadOnlyKeyword, propertySyntax.Modifiers[0].Kind());
             Assert.NotNull(propertySyntax.Type);
             Assert.Equal("int", propertySyntax.Type.ToString());
-            Assert.NotNull(propertySyntax.Identifier);
+            Assert.NotEqual(default, propertySyntax.Identifier);
             Assert.Equal("M", propertySyntax.Identifier.ToString());
             Assert.NotNull(propertySyntax.ExpressionBody);
             Assert.NotEqual(SyntaxKind.None, propertySyntax.ExpressionBody.ArrowToken.Kind());
@@ -2882,14 +2882,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var structDecl = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, structDecl.AttributeLists.Count);
             Assert.Equal(0, structDecl.Modifiers.Count);
-            Assert.NotNull(structDecl.Keyword);
+            Assert.NotEqual(default, structDecl.Keyword);
             Assert.Equal(SyntaxKind.StructKeyword, structDecl.Keyword.Kind());
-            Assert.NotNull(structDecl.Identifier);
+            Assert.NotEqual(default, structDecl.Identifier);
             Assert.Equal("a", structDecl.Identifier.ToString());
             Assert.Null(structDecl.BaseList);
             Assert.Equal(0, structDecl.ConstraintClauses.Count);
-            Assert.NotNull(structDecl.OpenBraceToken);
-            Assert.NotNull(structDecl.CloseBraceToken);
+            Assert.NotEqual(default, structDecl.OpenBraceToken);
+            Assert.NotEqual(default, structDecl.CloseBraceToken);
 
             Assert.Equal(1, structDecl.Members.Count);
 
@@ -2899,7 +2899,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, propertySyntax.Modifiers.Count);
             Assert.NotNull(propertySyntax.Type);
             Assert.Equal("int", propertySyntax.Type.ToString());
-            Assert.NotNull(propertySyntax.Identifier);
+            Assert.NotEqual(default, propertySyntax.Identifier);
             Assert.Equal("P", propertySyntax.Identifier.ToString());
             var accessors = propertySyntax.AccessorList.Accessors;
             Assert.Equal(1, accessors.Count);
@@ -2943,14 +2943,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -2960,18 +2960,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(1, ms.ParameterList.Parameters.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ms.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ms.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ms.ParameterList.Parameters[0].Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -2995,14 +2995,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3012,7 +3012,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
             Assert.NotNull(ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
@@ -3021,22 +3021,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(0, ms.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].Modifiers.Count);
-            Assert.NotNull(ms.ParameterList.Parameters[0].Type);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ms.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ms.ParameterList.Parameters[0].Identifier.ToString());
 
             Assert.Equal(0, ms.ParameterList.Parameters[1].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[1].Modifiers.Count);
-            Assert.NotNull(ms.ParameterList.Parameters[1].Type);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[1].Type);
             Assert.Equal("e", ms.ParameterList.Parameters[1].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[1].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[1].Identifier);
             Assert.Equal("f", ms.ParameterList.Parameters[1].Identifier.ToString());
 
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
-            Assert.NotNull(ms.Body);
+            Assert.NotEqual(default, ms.Body);
             Assert.NotEqual(SyntaxKind.None, ms.Body.OpenBraceToken.Kind());
             Assert.NotEqual(SyntaxKind.None, ms.Body.CloseBraceToken.Kind());
             Assert.Equal(SyntaxKind.None, ms.SemicolonToken.Kind());
@@ -3047,7 +3047,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "class a { b X(" + SyntaxFacts.GetText(mod) + " c d) { } }";
             var file = this.ParseFile(text);
 
-            Assert.NotNull(file);
+            Assert.NotEqual(default, file);
             Assert.Equal(1, file.Members.Count);
             Assert.Equal(text, file.ToString());
             Assert.Equal(0, file.Errors().Length);
@@ -3056,14 +3056,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3073,9 +3073,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ms.ParameterList.Parameters.Count);
@@ -3085,10 +3085,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(mod, ms.ParameterList.Parameters[0].Modifiers[0].Kind());
             Assert.NotNull(ms.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ms.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ms.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -3121,14 +3121,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3138,9 +3138,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(1, ms.ParameterList.Parameters.Count);
@@ -3148,10 +3148,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].Modifiers.Count);
             Assert.Null(ms.ParameterList.Parameters[0].Type);
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal(SyntaxKind.ArgListKeyword, ms.ParameterList.Parameters[0].Identifier.Kind());
 
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -3195,14 +3195,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3212,12 +3212,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal(typeText, ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("M", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -3260,14 +3260,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3277,18 +3277,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(1, ms.ParameterList.Parameters.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ms.ParameterList.Parameters[0].Type);
             Assert.Equal(typeText, ms.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal("c", ms.ParameterList.Parameters[0].Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -3312,14 +3312,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3329,12 +3329,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b<c>", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("M", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, ms.ConstraintClauses.Count);
             Assert.NotNull(ms.Body);
@@ -3358,14 +3358,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3375,21 +3375,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, ms.Modifiers.Count);
             Assert.NotNull(ms.ReturnType);
             Assert.Equal("b", ms.ReturnType.ToString());
-            Assert.NotNull(ms.Identifier);
+            Assert.NotEqual(default, ms.Identifier);
             Assert.NotNull(ms.TypeParameterList);
             Assert.Equal("X", ms.Identifier.ToString());
             Assert.Equal("<c>", ms.TypeParameterList.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
             Assert.Equal(0, ms.ParameterList.Parameters.Count);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
             Assert.False(ms.ParameterList.CloseParenToken.IsMissing);
 
             Assert.Equal(1, ms.ConstraintClauses.Count);
-            Assert.NotNull(ms.ConstraintClauses[0].WhereKeyword);
+            Assert.NotEqual(default, ms.ConstraintClauses[0].WhereKeyword);
             Assert.NotNull(ms.ConstraintClauses[0].Name);
             Assert.Equal("b", ms.ConstraintClauses[0].Name.ToString());
-            Assert.NotNull(ms.ConstraintClauses[0].ColonToken);
+            Assert.NotEqual(default, ms.ConstraintClauses[0].ColonToken);
             Assert.False(ms.ConstraintClauses[0].ColonToken.IsMissing);
             Assert.Equal(1, ms.ConstraintClauses[0].Constraints.Count);
             Assert.Equal(SyntaxKind.TypeConstraint, ms.ConstraintClauses[0].Constraints[0].Kind());
@@ -3439,9 +3439,9 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
@@ -3456,8 +3456,8 @@ class Class1<T>{
             Assert.Equal(0, cn.AttributeLists.Count);
             Assert.Equal(0, cn.Modifiers.Count);
             Assert.NotNull(cn.Body);
-            Assert.NotNull(cn.Body.OpenBraceToken);
-            Assert.NotNull(cn.Body.CloseBraceToken);
+            Assert.NotEqual(default, cn.Body.OpenBraceToken);
+            Assert.NotEqual(default, cn.Body.CloseBraceToken);
         }
 
         private void TestClassConstructorWithModifier(SyntaxKind mod)
@@ -3474,9 +3474,9 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
@@ -3492,8 +3492,8 @@ class Class1<T>{
             Assert.Equal(1, cn.Modifiers.Count);
             Assert.Equal(mod, cn.Modifiers[0].Kind());
             Assert.NotNull(cn.Body);
-            Assert.NotNull(cn.Body.OpenBraceToken);
-            Assert.NotNull(cn.Body.CloseBraceToken);
+            Assert.NotEqual(default, cn.Body.OpenBraceToken);
+            Assert.NotEqual(default, cn.Body.CloseBraceToken);
         }
 
         [Fact]
@@ -3521,9 +3521,9 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
@@ -3535,12 +3535,12 @@ class Class1<T>{
 
             Assert.Equal(SyntaxKind.DestructorDeclaration, cs.Members[0].Kind());
             var cn = (DestructorDeclarationSyntax)cs.Members[0];
-            Assert.NotNull(cn.TildeToken);
+            Assert.NotEqual(default, cn.TildeToken);
             Assert.Equal(0, cn.AttributeLists.Count);
             Assert.Equal(0, cn.Modifiers.Count);
             Assert.NotNull(cn.Body);
-            Assert.NotNull(cn.Body.OpenBraceToken);
-            Assert.NotNull(cn.Body.CloseBraceToken);
+            Assert.NotEqual(default, cn.Body.OpenBraceToken);
+            Assert.NotEqual(default, cn.Body.CloseBraceToken);
         }
 
         [Fact]
@@ -3558,14 +3558,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3576,11 +3576,11 @@ class Class1<T>{
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.Null(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3618,14 +3618,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3636,11 +3636,11 @@ class Class1<T>{
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal(typeText, fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.Null(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3658,14 +3658,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3677,11 +3677,11 @@ class Class1<T>{
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.Null(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3712,14 +3712,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3728,15 +3728,15 @@ class Class1<T>{
             Assert.Equal(0, fs.AttributeLists.Count);
             Assert.Equal(1, fs.Modifiers.Count);
             Assert.Equal(mod, fs.Modifiers[0].Kind());
-            Assert.NotNull(fs.EventKeyword);
+            Assert.NotEqual(default, fs.EventKeyword);
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.Null(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3768,14 +3768,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3787,14 +3787,14 @@ class Class1<T>{
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("d", fs.Declaration.Variables[0].Initializer.Value.ToString());
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3813,14 +3813,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3831,14 +3831,14 @@ class Class1<T>{
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("e", fs.Declaration.Variables[0].Initializer.Value.ToString());
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3848,7 +3848,7 @@ class Class1<T>{
             var text = "class a { b c = { }; }";
             var file = this.ParseFile(text);
 
-            Assert.NotNull(file);
+            Assert.NotEqual(default, file);
             Assert.Equal(1, file.Members.Count);
             Assert.Equal(text, file.ToString());
             Assert.Equal(0, file.Errors().Length);
@@ -3857,14 +3857,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3872,18 +3872,18 @@ class Class1<T>{
             var fs = (FieldDeclarationSyntax)cs.Members[0];
             Assert.Equal(0, fs.AttributeLists.Count);
             Assert.Equal(0, fs.Modifiers.Count);
-            Assert.NotNull(fs.Declaration.Type);
+            Assert.NotEqual(default, fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal(SyntaxKind.ArrayInitializerExpression, fs.Declaration.Variables[0].Initializer.Value.Kind());
             Assert.Equal("{ }", fs.Declaration.Variables[0].Initializer.Value.ToString());
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3893,7 +3893,7 @@ class Class1<T>{
             var text = "class a { b c, d, e; }";
             var file = this.ParseFile(text);
 
-            Assert.NotNull(file);
+            Assert.NotEqual(default, file);
             Assert.Equal(1, file.Members.Count);
             Assert.Equal(text, file.ToString());
             Assert.Equal(0, file.Errors().Length);
@@ -3902,14 +3902,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3922,22 +3922,22 @@ class Class1<T>{
 
             Assert.Equal(3, fs.Declaration.Variables.Count);
 
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.Null(fs.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(fs.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[1].Identifier);
             Assert.Equal("d", fs.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[1].ArgumentList);
             Assert.Null(fs.Declaration.Variables[1].Initializer);
 
-            Assert.NotNull(fs.Declaration.Variables[2].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[2].Identifier);
             Assert.Equal("e", fs.Declaration.Variables[2].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[2].ArgumentList);
             Assert.Null(fs.Declaration.Variables[2].Initializer);
 
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -3956,14 +3956,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -3976,31 +3976,31 @@ class Class1<T>{
 
             Assert.Equal(3, fs.Declaration.Variables.Count);
 
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("x", fs.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(fs.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[1].Identifier);
             Assert.Equal("d", fs.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[1].ArgumentList);
             Assert.NotNull(fs.Declaration.Variables[1].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[1].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[1].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[1].Initializer.Value);
             Assert.Equal("y", fs.Declaration.Variables[1].Initializer.Value.ToString());
 
-            Assert.NotNull(fs.Declaration.Variables[2].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[2].Identifier);
             Assert.Equal("e", fs.Declaration.Variables[2].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[2].ArgumentList);
             Assert.NotNull(fs.Declaration.Variables[2].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[2].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[2].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[2].Initializer.Value);
             Assert.Equal("z", fs.Declaration.Variables[2].Initializer.Value.ToString());
 
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -4019,14 +4019,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4038,15 +4038,15 @@ class Class1<T>{
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("b", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].ArgumentList);
-            Assert.NotNull(fs.Declaration.Variables[0].ArgumentList.OpenBracketToken);
-            Assert.NotNull(fs.Declaration.Variables[0].ArgumentList.CloseBracketToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].ArgumentList.OpenBracketToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].ArgumentList.CloseBracketToken);
             Assert.Equal(1, fs.Declaration.Variables[0].ArgumentList.Arguments.Count);
             Assert.Equal("10", fs.Declaration.Variables[0].ArgumentList.Arguments[0].ToString());
             Assert.Null(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.SemicolonToken);
+            Assert.NotEqual(default, fs.SemicolonToken);
             Assert.False(fs.SemicolonToken.IsMissing);
         }
 
@@ -4065,14 +4065,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4082,26 +4082,26 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -4119,14 +4119,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4136,26 +4136,26 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("ref b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
@@ -4174,14 +4174,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4191,26 +4191,26 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("ref readonly b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -4247,14 +4247,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4264,26 +4264,26 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal(typeText, ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -4301,14 +4301,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4318,23 +4318,23 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.NotNull(ps.AccessorList.Accessors[0].Body);
             Assert.Equal(SyntaxKind.None, ps.AccessorList.Accessors[0].SemicolonToken.Kind());
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.NotNull(ps.AccessorList.Accessors[1].Body);
             Assert.Equal(SyntaxKind.None, ps.AccessorList.Accessors[1].SemicolonToken.Kind());
@@ -4355,14 +4355,14 @@ class Class1<T>{
             var cs = (ClassDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4372,22 +4372,22 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
 
@@ -4439,14 +4439,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4456,17 +4456,17 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(1, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
             Assert.Equal(accessorKind, ps.AccessorList.Accessors[0].Kind());
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(accessorKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Equal(SyntaxKind.None, ps.AccessorList.Accessors[0].SemicolonToken.Kind());
             var body = ps.AccessorList.Accessors[0].Body;
@@ -4495,14 +4495,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4512,17 +4512,17 @@ class Class1<T>{
             Assert.Equal(0, es.Modifiers.Count);
             Assert.NotNull(es.Type);
             Assert.Equal("b", es.Type.ToString());
-            Assert.NotNull(es.Identifier);
+            Assert.NotEqual(default, es.Identifier);
             Assert.Equal("c", es.Identifier.ToString());
 
-            Assert.NotNull(es.AccessorList.OpenBraceToken);
-            Assert.NotNull(es.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, es.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, es.AccessorList.CloseBraceToken);
             Assert.Equal(1, es.AccessorList.Accessors.Count);
 
             Assert.Equal(0, es.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[0].Modifiers.Count);
             Assert.Equal(accessorKind, es.AccessorList.Accessors[0].Kind());
-            Assert.NotNull(es.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[0].Keyword);
             Assert.Equal(accessorKeyword, es.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[0].SemicolonToken.Kind());
             var body = es.AccessorList.Accessors[0].Body;
@@ -4551,14 +4551,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4569,26 +4569,26 @@ class Class1<T>{
             Assert.Equal(mod, ps.Modifiers[0].Kind());
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -4620,14 +4620,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4637,18 +4637,18 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
 
             Assert.Equal(1, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(1, ps.AccessorList.Accessors[0].Modifiers.Count);
             Assert.Equal(mod, ps.AccessorList.Accessors[0].Modifiers[0].Kind());
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.NotNull(ps.AccessorList.Accessors[0].Body);
             Assert.Equal(SyntaxKind.None, ps.AccessorList.Accessors[0].SemicolonToken.Kind());
@@ -4683,14 +4683,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4700,28 +4700,28 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.NotNull(ps.ExplicitInterfaceSpecifier);
             Assert.Equal("I", ps.ExplicitInterfaceSpecifier.Name.ToString());
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -4739,14 +4739,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4754,26 +4754,26 @@ class Class1<T>{
             var es = (EventDeclarationSyntax)cs.Members[0];
             Assert.Equal(0, es.AttributeLists.Count);
             Assert.Equal(0, es.Modifiers.Count);
-            Assert.NotNull(es.EventKeyword);
+            Assert.NotEqual(default, es.EventKeyword);
             Assert.NotNull(es.Type);
             Assert.Equal("b", es.Type.ToString());
-            Assert.NotNull(es.Identifier);
+            Assert.NotEqual(default, es.Identifier);
             Assert.Equal("c", es.Identifier.ToString());
 
-            Assert.NotNull(es.AccessorList.OpenBraceToken);
-            Assert.NotNull(es.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, es.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, es.AccessorList.CloseBraceToken);
             Assert.Equal(2, es.AccessorList.Accessors.Count);
 
             Assert.Equal(0, es.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(es.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.AddKeyword, es.AccessorList.Accessors[0].Keyword.Kind());
             Assert.NotNull(es.AccessorList.Accessors[0].Body);
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[0].SemicolonToken.Kind());
 
             Assert.Equal(0, es.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(es.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.RemoveKeyword, es.AccessorList.Accessors[1].Keyword.Kind());
             Assert.NotNull(es.AccessorList.Accessors[1].Body);
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[1].SemicolonToken.Kind());
@@ -4793,14 +4793,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4809,26 +4809,26 @@ class Class1<T>{
             Assert.Equal(0, es.AttributeLists.Count);
             Assert.Equal(1, es.Modifiers.Count);
             Assert.Equal(mod, es.Modifiers[0].Kind());
-            Assert.NotNull(es.EventKeyword);
+            Assert.NotEqual(default, es.EventKeyword);
             Assert.NotNull(es.Type);
             Assert.Equal("b", es.Type.ToString());
-            Assert.NotNull(es.Identifier);
+            Assert.NotEqual(default, es.Identifier);
             Assert.Equal("c", es.Identifier.ToString());
 
-            Assert.NotNull(es.AccessorList.OpenBraceToken);
-            Assert.NotNull(es.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, es.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, es.AccessorList.CloseBraceToken);
             Assert.Equal(2, es.AccessorList.Accessors.Count);
 
             Assert.Equal(0, es.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(es.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.AddKeyword, es.AccessorList.Accessors[0].Keyword.Kind());
             Assert.NotNull(es.AccessorList.Accessors[0].Body);
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[0].SemicolonToken.Kind());
 
             Assert.Equal(0, es.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(es.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.RemoveKeyword, es.AccessorList.Accessors[1].Keyword.Kind());
             Assert.NotNull(es.AccessorList.Accessors[1].Body);
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[1].SemicolonToken.Kind());
@@ -4861,14 +4861,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4879,18 +4879,18 @@ class Class1<T>{
             Assert.Equal(SyntaxKind.EventKeyword, ps.Modifiers[0].Kind());
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.Identifier);
+            Assert.NotEqual(default, ps.Identifier);
             Assert.Equal("c", ps.Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
 
             Assert.Equal(1, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(1, ps.AccessorList.Accessors[0].Modifiers.Count);
             Assert.Equal(mod, ps.AccessorList.Accessors[0].Modifiers[0].Kind());
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.AddKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.NotNull(ps.AccessorList.Accessors[0].Body);
             Assert.Equal(SyntaxKind.None, ps.AccessorList.Accessors[0].SemicolonToken.Kind());
@@ -4925,14 +4925,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4940,28 +4940,28 @@ class Class1<T>{
             var es = (EventDeclarationSyntax)cs.Members[0];
             Assert.Equal(0, es.AttributeLists.Count);
             Assert.Equal(0, es.Modifiers.Count);
-            Assert.NotNull(es.EventKeyword);
+            Assert.NotEqual(default, es.EventKeyword);
             Assert.NotNull(es.Type);
             Assert.Equal("b", es.Type.ToString());
-            Assert.NotNull(es.Identifier);
+            Assert.NotEqual(default, es.Identifier);
             Assert.NotNull(es.ExplicitInterfaceSpecifier);
             Assert.Equal("I", es.ExplicitInterfaceSpecifier.Name.ToString());
             Assert.Equal("c", es.Identifier.ToString());
 
-            Assert.NotNull(es.AccessorList.OpenBraceToken);
-            Assert.NotNull(es.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, es.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, es.AccessorList.CloseBraceToken);
             Assert.Equal(2, es.AccessorList.Accessors.Count);
 
             Assert.Equal(0, es.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(es.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.AddKeyword, es.AccessorList.Accessors[0].Keyword.Kind());
             Assert.NotNull(es.AccessorList.Accessors[0].Body);
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[0].SemicolonToken.Kind());
 
             Assert.Equal(0, es.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, es.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(es.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, es.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.RemoveKeyword, es.AccessorList.Accessors[1].Keyword.Kind());
             Assert.NotNull(es.AccessorList.Accessors[1].Body);
             Assert.Equal(SyntaxKind.None, es.AccessorList.Accessors[1].SemicolonToken.Kind());
@@ -4982,14 +4982,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -4999,39 +4999,39 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.ThisKeyword);
+            Assert.NotEqual(default, ps.ThisKeyword);
             Assert.Equal("this", ps.ThisKeyword.ToString());
 
             Assert.NotNull(ps.ParameterList); // used with indexer property
-            Assert.NotNull(ps.ParameterList.OpenBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenBracketToken);
             Assert.Equal(SyntaxKind.OpenBracketToken, ps.ParameterList.OpenBracketToken.Kind());
-            Assert.NotNull(ps.ParameterList.CloseBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseBracketToken);
             Assert.Equal(SyntaxKind.CloseBracketToken, ps.ParameterList.CloseBracketToken.Kind());
             Assert.Equal(1, ps.ParameterList.Parameters.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -5049,14 +5049,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5066,39 +5066,39 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("ref b", ps.Type.ToString());
-            Assert.NotNull(ps.ThisKeyword);
+            Assert.NotEqual(default, ps.ThisKeyword);
             Assert.Equal("this", ps.ThisKeyword.ToString());
 
             Assert.NotNull(ps.ParameterList); // used with indexer property
-            Assert.NotNull(ps.ParameterList.OpenBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenBracketToken);
             Assert.Equal(SyntaxKind.OpenBracketToken, ps.ParameterList.OpenBracketToken.Kind());
-            Assert.NotNull(ps.ParameterList.CloseBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseBracketToken);
             Assert.Equal(SyntaxKind.CloseBracketToken, ps.ParameterList.CloseBracketToken.Kind());
             Assert.Equal(1, ps.ParameterList.Parameters.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
@@ -5117,14 +5117,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5134,39 +5134,39 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("ref readonly b", ps.Type.ToString());
-            Assert.NotNull(ps.ThisKeyword);
+            Assert.NotEqual(default, ps.ThisKeyword);
             Assert.Equal("this", ps.ThisKeyword.ToString());
 
             Assert.NotNull(ps.ParameterList); // used with indexer property
-            Assert.NotNull(ps.ParameterList.OpenBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenBracketToken);
             Assert.Equal(SyntaxKind.OpenBracketToken, ps.ParameterList.OpenBracketToken.Kind());
-            Assert.NotNull(ps.ParameterList.CloseBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseBracketToken);
             Assert.Equal(SyntaxKind.CloseBracketToken, ps.ParameterList.CloseBracketToken.Kind());
             Assert.Equal(1, ps.ParameterList.Parameters.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -5184,14 +5184,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5201,13 +5201,13 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.Type);
             Assert.Equal("b", ps.Type.ToString());
-            Assert.NotNull(ps.ThisKeyword);
+            Assert.NotEqual(default, ps.ThisKeyword);
             Assert.Equal("this", ps.ThisKeyword.ToString());
 
             Assert.NotNull(ps.ParameterList); // used with indexer property
-            Assert.NotNull(ps.ParameterList.OpenBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenBracketToken);
             Assert.Equal(SyntaxKind.OpenBracketToken, ps.ParameterList.OpenBracketToken.Kind());
-            Assert.NotNull(ps.ParameterList.CloseBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseBracketToken);
             Assert.Equal(SyntaxKind.CloseBracketToken, ps.ParameterList.CloseBracketToken.Kind());
 
             Assert.Equal(2, ps.ParameterList.Parameters.Count);
@@ -5216,33 +5216,33 @@ class Class1<T>{
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
             Assert.Equal(0, ps.ParameterList.Parameters[1].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[1].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[1].Type);
             Assert.Equal("e", ps.ParameterList.Parameters[1].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[1].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[1].Identifier);
             Assert.Equal("f", ps.ParameterList.Parameters[1].Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         [Fact]
@@ -5260,14 +5260,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5283,35 +5283,35 @@ class Class1<T>{
             Assert.Equal("this", ps.ThisKeyword.ToString());
 
             Assert.NotNull(ps.ParameterList); // used with indexer property
-            Assert.NotNull(ps.ParameterList.OpenBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenBracketToken);
             Assert.Equal(SyntaxKind.OpenBracketToken, ps.ParameterList.OpenBracketToken.Kind());
-            Assert.NotNull(ps.ParameterList.CloseBracketToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseBracketToken);
             Assert.Equal(SyntaxKind.CloseBracketToken, ps.ParameterList.CloseBracketToken.Kind());
             Assert.Equal(1, ps.ParameterList.Parameters.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
-            Assert.NotNull(ps.AccessorList.OpenBraceToken);
-            Assert.NotNull(ps.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, ps.AccessorList.CloseBraceToken);
             Assert.Equal(2, ps.AccessorList.Accessors.Count);
 
             Assert.Equal(0, ps.AccessorList.Accessors[0].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[0].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[0].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].Keyword);
             Assert.Equal(SyntaxKind.GetKeyword, ps.AccessorList.Accessors[0].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[0].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[0].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[0].SemicolonToken);
 
             Assert.Equal(0, ps.AccessorList.Accessors[1].AttributeLists.Count);
             Assert.Equal(0, ps.AccessorList.Accessors[1].Modifiers.Count);
-            Assert.NotNull(ps.AccessorList.Accessors[1].Keyword);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].Keyword);
             Assert.Equal(SyntaxKind.SetKeyword, ps.AccessorList.Accessors[1].Keyword.Kind());
             Assert.Null(ps.AccessorList.Accessors[1].Body);
-            Assert.NotNull(ps.AccessorList.Accessors[1].SemicolonToken);
+            Assert.NotEqual(default, ps.AccessorList.Accessors[1].SemicolonToken);
         }
 
         private void TestClassBinaryOperatorMethod(SyntaxKind op1)
@@ -5328,14 +5328,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5345,12 +5345,12 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.ReturnType);
             Assert.Equal("b", ps.ReturnType.ToString());
-            Assert.NotNull(ps.OperatorKeyword);
+            Assert.NotEqual(default, ps.OperatorKeyword);
             Assert.Equal(SyntaxKind.OperatorKeyword, ps.OperatorKeyword.Kind());
-            Assert.NotNull(ps.OperatorToken);
+            Assert.NotEqual(default, ps.OperatorToken);
             Assert.Equal(op1, ps.OperatorToken.Kind());
-            Assert.NotNull(ps.ParameterList.OpenParenToken);
-            Assert.NotNull(ps.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseParenToken);
             Assert.NotNull(ps.Body);
 
             Assert.Equal(2, ps.ParameterList.Parameters.Count);
@@ -5359,14 +5359,14 @@ class Class1<T>{
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
             Assert.Equal(0, ps.ParameterList.Parameters[1].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[1].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[1].Type);
             Assert.Equal("e", ps.ParameterList.Parameters[1].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[1].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[1].Identifier);
             Assert.Equal("f", ps.ParameterList.Parameters[1].Identifier.ToString());
         }
 
@@ -5408,14 +5408,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5425,12 +5425,12 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.ReturnType);
             Assert.Equal("b", ps.ReturnType.ToString());
-            Assert.NotNull(ps.OperatorKeyword);
+            Assert.NotEqual(default, ps.OperatorKeyword);
             Assert.Equal(SyntaxKind.OperatorKeyword, ps.OperatorKeyword.Kind());
-            Assert.NotNull(ps.OperatorToken);
+            Assert.NotEqual(default, ps.OperatorToken);
             Assert.Equal(SyntaxKind.GreaterThanGreaterThanToken, ps.OperatorToken.Kind());
-            Assert.NotNull(ps.ParameterList.OpenParenToken);
-            Assert.NotNull(ps.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseParenToken);
             Assert.NotNull(ps.Body);
 
             Assert.Equal(2, ps.ParameterList.Parameters.Count);
@@ -5439,14 +5439,14 @@ class Class1<T>{
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
 
             Assert.Equal(0, ps.ParameterList.Parameters[1].AttributeLists.Count);
             Assert.Equal(0, ps.ParameterList.Parameters[1].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[1].Type);
             Assert.Equal("e", ps.ParameterList.Parameters[1].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[1].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[1].Identifier);
             Assert.Equal("f", ps.ParameterList.Parameters[1].Identifier.ToString());
         }
 
@@ -5464,14 +5464,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5481,12 +5481,12 @@ class Class1<T>{
             Assert.Equal(0, ps.Modifiers.Count);
             Assert.NotNull(ps.ReturnType);
             Assert.Equal("b", ps.ReturnType.ToString());
-            Assert.NotNull(ps.OperatorKeyword);
+            Assert.NotEqual(default, ps.OperatorKeyword);
             Assert.Equal(SyntaxKind.OperatorKeyword, ps.OperatorKeyword.Kind());
-            Assert.NotNull(ps.OperatorToken);
+            Assert.NotEqual(default, ps.OperatorToken);
             Assert.Equal(op1, ps.OperatorToken.Kind());
-            Assert.NotNull(ps.ParameterList.OpenParenToken);
-            Assert.NotNull(ps.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ps.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ps.ParameterList.CloseParenToken);
             Assert.NotNull(ps.Body);
 
             Assert.Equal(1, ps.ParameterList.Parameters.Count);
@@ -5495,7 +5495,7 @@ class Class1<T>{
             Assert.Equal(0, ps.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ps.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ps.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ps.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ps.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ps.ParameterList.Parameters[0].Identifier.ToString());
         }
 
@@ -5527,14 +5527,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5542,21 +5542,21 @@ class Class1<T>{
             var ms = (ConversionOperatorDeclarationSyntax)cs.Members[0];
             Assert.Equal(0, ms.AttributeLists.Count);
             Assert.Equal(0, ms.Modifiers.Count);
-            Assert.NotNull(ms.ImplicitOrExplicitKeyword);
+            Assert.NotEqual(default, ms.ImplicitOrExplicitKeyword);
             Assert.Equal(SyntaxKind.ImplicitKeyword, ms.ImplicitOrExplicitKeyword.Kind());
-            Assert.NotNull(ms.OperatorKeyword);
+            Assert.NotEqual(default, ms.OperatorKeyword);
             Assert.Equal(SyntaxKind.OperatorKeyword, ms.OperatorKeyword.Kind());
             Assert.NotNull(ms.Type);
             Assert.Equal("b", ms.Type.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
 
             Assert.Equal(1, ms.ParameterList.Parameters.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ms.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ms.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ms.ParameterList.Parameters[0].Identifier.ToString());
         }
 
@@ -5575,14 +5575,14 @@ class Class1<T>{
             var cs = (TypeDeclarationSyntax)file.Members[0];
             Assert.Equal(0, cs.AttributeLists.Count);
             Assert.Equal(0, cs.Modifiers.Count);
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.ClassKeyword, cs.Keyword.Kind());
-            Assert.NotNull(cs.Identifier);
+            Assert.NotEqual(default, cs.Identifier);
             Assert.Equal("a", cs.Identifier.ToString());
             Assert.Null(cs.BaseList);
             Assert.Equal(0, cs.ConstraintClauses.Count);
-            Assert.NotNull(cs.OpenBraceToken);
-            Assert.NotNull(cs.CloseBraceToken);
+            Assert.NotEqual(default, cs.OpenBraceToken);
+            Assert.NotEqual(default, cs.CloseBraceToken);
 
             Assert.Equal(1, cs.Members.Count);
 
@@ -5590,21 +5590,21 @@ class Class1<T>{
             var ms = (ConversionOperatorDeclarationSyntax)cs.Members[0];
             Assert.Equal(0, ms.AttributeLists.Count);
             Assert.Equal(0, ms.Modifiers.Count);
-            Assert.NotNull(ms.ImplicitOrExplicitKeyword);
+            Assert.NotEqual(default, ms.ImplicitOrExplicitKeyword);
             Assert.Equal(SyntaxKind.ExplicitKeyword, ms.ImplicitOrExplicitKeyword.Kind());
-            Assert.NotNull(ms.OperatorKeyword);
+            Assert.NotEqual(default, ms.OperatorKeyword);
             Assert.Equal(SyntaxKind.OperatorKeyword, ms.OperatorKeyword.Kind());
             Assert.NotNull(ms.Type);
             Assert.Equal("b", ms.Type.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
-            Assert.NotNull(ms.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, ms.ParameterList.CloseParenToken);
 
             Assert.Equal(1, ms.ParameterList.Parameters.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].AttributeLists.Count);
             Assert.Equal(0, ms.ParameterList.Parameters[0].Modifiers.Count);
             Assert.NotNull(ms.ParameterList.Parameters[0].Type);
             Assert.Equal("c", ms.ParameterList.Parameters[0].Type.ToString());
-            Assert.NotNull(ms.ParameterList.Parameters[0].Identifier);
+            Assert.NotEqual(default, ms.ParameterList.Parameters[0].Identifier);
             Assert.Equal("d", ms.ParameterList.Parameters[0].Identifier.ToString());
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -3014,7 +3014,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("b", ms.ReturnType.ToString());
             Assert.NotEqual(default, ms.Identifier);
             Assert.Equal("X", ms.Identifier.ToString());
-            Assert.NotNull(ms.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, default, ms.ParameterList.OpenParenToken);
             Assert.False(ms.ParameterList.OpenParenToken.IsMissing);
 
             Assert.Equal(2, ms.ParameterList.Parameters.Count);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(opKind, expr.Kind());
             Assert.Equal(0, expr.Errors().Length);
             var us = (LiteralExpressionSyntax)expr;
-            Assert.NotNull(us.Token);
+            Assert.NotEqual(default, us.Token);
             Assert.Equal(kind, us.Token.Kind());
         }
 
@@ -152,12 +152,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 case SyntaxKind.ThisExpression:
                     token = ((ThisExpressionSyntax)expr).Token;
-                    Assert.NotNull(token);
+                    Assert.NotEqual(default, token);
                     Assert.Equal(kind, token.Kind());
                     break;
                 case SyntaxKind.BaseExpression:
                     token = ((BaseExpressionSyntax)expr).Token;
-                    Assert.NotNull(token);
+                    Assert.NotEqual(default, token);
                     Assert.Equal(kind, token.Kind());
                     break;
             }
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.StringLiteralExpression, expr.Kind());
             Assert.Equal(0, expr.Errors().Length);
             var us = (LiteralExpressionSyntax)expr;
-            Assert.NotNull(us.Token);
+            Assert.NotEqual(default, us.Token);
             Assert.Equal(SyntaxKind.StringLiteralToken, us.Token.Kind());
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.StringLiteralExpression, expr.Kind());
             Assert.Equal(0, expr.Errors().Length);
             var us = (LiteralExpressionSyntax)expr;
-            Assert.NotNull(us.Token);
+            Assert.NotEqual(default, us.Token);
             Assert.Equal(SyntaxKind.StringLiteralToken, us.Token.Kind());
             Assert.Equal("\"stuff\"", us.Token.ValueText);
         }
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.CharacterLiteralExpression, expr.Kind());
             Assert.Equal(0, expr.Errors().Length);
             var us = (LiteralExpressionSyntax)expr;
-            Assert.NotNull(us.Token);
+            Assert.NotEqual(default, us.Token);
             Assert.Equal(SyntaxKind.CharacterLiteralToken, us.Token.Kind());
         }
 
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.NumericLiteralExpression, expr.Kind());
             Assert.Equal(0, expr.Errors().Length);
             var us = (LiteralExpressionSyntax)expr;
-            Assert.NotNull(us.Token);
+            Assert.NotEqual(default, us.Token);
             Assert.Equal(SyntaxKind.NumericLiteralToken, us.Token.Kind());
         }
 
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var us = (PrefixUnaryExpressionSyntax)expr;
-            Assert.NotNull(us.OperatorToken);
+            Assert.NotEqual(default, us.OperatorToken);
             Assert.Equal(kind, us.OperatorToken.Kind());
             Assert.NotNull(us.Operand);
             Assert.Equal(SyntaxKind.IdentifierName, us.Operand.Kind());
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var us = (PostfixUnaryExpressionSyntax)expr;
-            Assert.NotNull(us.OperatorToken);
+            Assert.NotEqual(default, us.OperatorToken);
             Assert.Equal(kind, us.OperatorToken.Kind());
             Assert.NotNull(us.Operand);
             Assert.Equal(SyntaxKind.IdentifierName, us.Operand.Kind());
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var b = (BinaryExpressionSyntax)expr;
-            Assert.NotNull(b.OperatorToken);
+            Assert.NotEqual(default, b.OperatorToken);
             Assert.Equal(kind, b.OperatorToken.Kind());
             Assert.NotNull(b.Left);
             Assert.NotNull(b.Right);
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var a = (AssignmentExpressionSyntax)expr;
-            Assert.NotNull(a.OperatorToken);
+            Assert.NotEqual(default, a.OperatorToken);
             Assert.Equal(kind, a.OperatorToken.Kind());
             Assert.NotNull(a.Left);
             Assert.NotNull(a.Right);
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var e = (MemberAccessExpressionSyntax)expr;
-            Assert.NotNull(e.OperatorToken);
+            Assert.NotEqual(default, e.OperatorToken);
             Assert.Equal(kind, e.OperatorToken.Kind());
             Assert.NotNull(e.Expression);
             Assert.NotNull(e.Name);
@@ -442,15 +442,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private void TestFunctionKeyword(SyntaxKind kind, SyntaxToken keyword)
         {
-            Assert.NotNull(keyword);
+            Assert.NotEqual(default, keyword);
             Assert.Equal(kind, keyword.Kind());
         }
 
         private void TestParenthesizedArgument(SyntaxToken openParen, CSharpSyntaxNode arg, SyntaxToken closeParen)
         {
-            Assert.NotNull(openParen);
+            Assert.NotEqual(default, openParen);
             Assert.False(openParen.IsMissing);
-            Assert.NotNull(closeParen);
+            Assert.NotEqual(default, closeParen);
             Assert.False(closeParen.IsMissing);
             Assert.Equal("a", arg.ToString());
         }
@@ -529,11 +529,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var fs = (RefValueExpressionSyntax)expr;
-            Assert.NotNull(fs.Keyword);
+            Assert.NotEqual(default, fs.Keyword);
             Assert.Equal(SyntaxKind.RefValueKeyword, fs.Keyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.False(fs.OpenParenToken.IsMissing);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.False(fs.CloseParenToken.IsMissing);
             Assert.Equal("a", fs.Expression.ToString());
             Assert.Equal("b", fs.Type.ToString());
@@ -550,8 +550,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var ts = (ConditionalExpressionSyntax)expr;
-            Assert.NotNull(ts.QuestionToken);
-            Assert.NotNull(ts.ColonToken);
+            Assert.NotEqual(default, ts.QuestionToken);
+            Assert.NotEqual(default, ts.ColonToken);
             Assert.Equal(SyntaxKind.QuestionToken, ts.QuestionToken.Kind());
             Assert.Equal(SyntaxKind.ColonToken, ts.ColonToken.Kind());
             Assert.Equal("a", ts.Condition.ToString());
@@ -580,8 +580,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var cs = (CastExpressionSyntax)expr;
-            Assert.NotNull(cs.OpenParenToken);
-            Assert.NotNull(cs.CloseParenToken);
+            Assert.NotEqual(default, cs.OpenParenToken);
+            Assert.NotEqual(default, cs.CloseParenToken);
             Assert.False(cs.OpenParenToken.IsMissing);
             Assert.False(cs.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Type);
@@ -601,8 +601,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var cs = (InvocationExpressionSyntax)expr;
-            Assert.NotNull(cs.ArgumentList.OpenParenToken);
-            Assert.NotNull(cs.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Expression);
@@ -622,15 +622,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var cs = (InvocationExpressionSyntax)expr;
-            Assert.NotNull(cs.ArgumentList.OpenParenToken);
-            Assert.NotNull(cs.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Expression);
             Assert.Equal(1, cs.ArgumentList.Arguments.Count);
             Assert.Equal("a", cs.Expression.ToString());
             Assert.Equal("ref b", cs.ArgumentList.Arguments[0].ToString());
-            Assert.NotNull(cs.ArgumentList.Arguments[0].RefOrOutKeyword);
+            Assert.NotEqual(default, cs.ArgumentList.Arguments[0].RefOrOutKeyword);
             Assert.Equal(SyntaxKind.RefKeyword, cs.ArgumentList.Arguments[0].RefOrOutKeyword.Kind());
             Assert.NotNull(cs.ArgumentList.Arguments[0].Expression);
             Assert.Equal("b", cs.ArgumentList.Arguments[0].Expression.ToString());
@@ -647,15 +647,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var cs = (InvocationExpressionSyntax)expr;
-            Assert.NotNull(cs.ArgumentList.OpenParenToken);
-            Assert.NotNull(cs.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Expression);
             Assert.Equal(1, cs.ArgumentList.Arguments.Count);
             Assert.Equal("a", cs.Expression.ToString());
             Assert.Equal("out b", cs.ArgumentList.Arguments[0].ToString());
-            Assert.NotNull(cs.ArgumentList.Arguments[0].RefOrOutKeyword);
+            Assert.NotEqual(default, cs.ArgumentList.Arguments[0].RefOrOutKeyword);
             Assert.Equal(SyntaxKind.OutKeyword, cs.ArgumentList.Arguments[0].RefOrOutKeyword.Kind());
             Assert.NotNull(cs.ArgumentList.Arguments[0].Expression);
             Assert.Equal("b", cs.ArgumentList.Arguments[0].Expression.ToString());
@@ -672,8 +672,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var cs = (InvocationExpressionSyntax)expr;
-            Assert.NotNull(cs.ArgumentList.OpenParenToken);
-            Assert.NotNull(cs.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Expression);
@@ -682,7 +682,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("B: b", cs.ArgumentList.Arguments[0].ToString());
             Assert.NotNull(cs.ArgumentList.Arguments[0].NameColon);
             Assert.Equal("B", cs.ArgumentList.Arguments[0].NameColon.Name.ToString());
-            Assert.NotNull(cs.ArgumentList.Arguments[0].NameColon.ColonToken);
+            Assert.NotEqual(default, cs.ArgumentList.Arguments[0].NameColon.ColonToken);
             Assert.Equal("b", cs.ArgumentList.Arguments[0].Expression.ToString());
         }
 
@@ -697,8 +697,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var ea = (ElementAccessExpressionSyntax)expr;
-            Assert.NotNull(ea.ArgumentList.OpenBracketToken);
-            Assert.NotNull(ea.ArgumentList.CloseBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.OpenBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.CloseBracketToken);
             Assert.False(ea.ArgumentList.OpenBracketToken.IsMissing);
             Assert.False(ea.ArgumentList.CloseBracketToken.IsMissing);
             Assert.NotNull(ea.Expression);
@@ -718,15 +718,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var ea = (ElementAccessExpressionSyntax)expr;
-            Assert.NotNull(ea.ArgumentList.OpenBracketToken);
-            Assert.NotNull(ea.ArgumentList.CloseBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.OpenBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.CloseBracketToken);
             Assert.False(ea.ArgumentList.OpenBracketToken.IsMissing);
             Assert.False(ea.ArgumentList.CloseBracketToken.IsMissing);
             Assert.NotNull(ea.Expression);
             Assert.Equal(1, ea.ArgumentList.Arguments.Count);
             Assert.Equal("a", ea.Expression.ToString());
             Assert.Equal("ref b", ea.ArgumentList.Arguments[0].ToString());
-            Assert.NotNull(ea.ArgumentList.Arguments[0].RefOrOutKeyword);
+            Assert.NotEqual(default, ea.ArgumentList.Arguments[0].RefOrOutKeyword);
             Assert.Equal(SyntaxKind.RefKeyword, ea.ArgumentList.Arguments[0].RefOrOutKeyword.Kind());
             Assert.NotNull(ea.ArgumentList.Arguments[0].Expression);
             Assert.Equal("b", ea.ArgumentList.Arguments[0].Expression.ToString());
@@ -743,15 +743,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var ea = (ElementAccessExpressionSyntax)expr;
-            Assert.NotNull(ea.ArgumentList.OpenBracketToken);
-            Assert.NotNull(ea.ArgumentList.CloseBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.OpenBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.CloseBracketToken);
             Assert.False(ea.ArgumentList.OpenBracketToken.IsMissing);
             Assert.False(ea.ArgumentList.CloseBracketToken.IsMissing);
             Assert.NotNull(ea.Expression);
             Assert.Equal(1, ea.ArgumentList.Arguments.Count);
             Assert.Equal("a", ea.Expression.ToString());
             Assert.Equal("out b", ea.ArgumentList.Arguments[0].ToString());
-            Assert.NotNull(ea.ArgumentList.Arguments[0].RefOrOutKeyword);
+            Assert.NotEqual(default, ea.ArgumentList.Arguments[0].RefOrOutKeyword);
             Assert.Equal(SyntaxKind.OutKeyword, ea.ArgumentList.Arguments[0].RefOrOutKeyword.Kind());
             Assert.NotNull(ea.ArgumentList.Arguments[0].Expression);
             Assert.Equal("b", ea.ArgumentList.Arguments[0].Expression.ToString());
@@ -768,8 +768,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var ea = (ElementAccessExpressionSyntax)expr;
-            Assert.NotNull(ea.ArgumentList.OpenBracketToken);
-            Assert.NotNull(ea.ArgumentList.CloseBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.OpenBracketToken);
+            Assert.NotEqual(default, ea.ArgumentList.CloseBracketToken);
             Assert.False(ea.ArgumentList.OpenBracketToken.IsMissing);
             Assert.False(ea.ArgumentList.CloseBracketToken.IsMissing);
             Assert.NotNull(ea.Expression);
@@ -790,8 +790,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var oc = (ObjectCreationExpressionSyntax)expr;
             Assert.NotNull(oc.ArgumentList);
-            Assert.NotNull(oc.ArgumentList.OpenParenToken);
-            Assert.NotNull(oc.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.CloseParenToken);
             Assert.False(oc.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(oc.ArgumentList.CloseParenToken.IsMissing);
             Assert.Equal(0, oc.ArgumentList.Arguments.Count);
@@ -812,8 +812,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var oc = (ObjectCreationExpressionSyntax)expr;
             Assert.NotNull(oc.ArgumentList);
-            Assert.NotNull(oc.ArgumentList.OpenParenToken);
-            Assert.NotNull(oc.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.CloseParenToken);
             Assert.False(oc.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(oc.ArgumentList.CloseParenToken.IsMissing);
             Assert.Equal(1, oc.ArgumentList.Arguments.Count);
@@ -835,8 +835,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var oc = (ObjectCreationExpressionSyntax)expr;
             Assert.NotNull(oc.ArgumentList);
-            Assert.NotNull(oc.ArgumentList.OpenParenToken);
-            Assert.NotNull(oc.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.CloseParenToken);
             Assert.False(oc.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(oc.ArgumentList.CloseParenToken.IsMissing);
             Assert.Equal(1, oc.ArgumentList.Arguments.Count);
@@ -858,8 +858,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var oc = (ObjectCreationExpressionSyntax)expr;
             Assert.NotNull(oc.ArgumentList);
-            Assert.NotNull(oc.ArgumentList.OpenParenToken);
-            Assert.NotNull(oc.ArgumentList.CloseParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.OpenParenToken);
+            Assert.NotEqual(default, oc.ArgumentList.CloseParenToken);
             Assert.False(oc.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(oc.ArgumentList.CloseParenToken.IsMissing);
             Assert.Equal(0, oc.ArgumentList.Arguments.Count);
@@ -867,8 +867,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a", oc.Type.ToString());
 
             Assert.NotNull(oc.Initializer);
-            Assert.NotNull(oc.Initializer.OpenBraceToken);
-            Assert.NotNull(oc.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, oc.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, oc.Initializer.CloseBraceToken);
             Assert.False(oc.Initializer.OpenBraceToken.IsMissing);
             Assert.False(oc.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(0, oc.Initializer.Expressions.Count);
@@ -890,8 +890,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a", oc.Type.ToString());
 
             Assert.NotNull(oc.Initializer);
-            Assert.NotNull(oc.Initializer.OpenBraceToken);
-            Assert.NotNull(oc.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, oc.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, oc.Initializer.CloseBraceToken);
             Assert.False(oc.Initializer.OpenBraceToken.IsMissing);
             Assert.False(oc.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(0, oc.Initializer.Expressions.Count);
@@ -913,8 +913,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a", oc.Type.ToString());
 
             Assert.NotNull(oc.Initializer);
-            Assert.NotNull(oc.Initializer.OpenBraceToken);
-            Assert.NotNull(oc.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, oc.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, oc.Initializer.CloseBraceToken);
             Assert.False(oc.Initializer.OpenBraceToken.IsMissing);
             Assert.False(oc.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(1, oc.Initializer.Expressions.Count);
@@ -937,8 +937,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a", oc.Type.ToString());
 
             Assert.NotNull(oc.Initializer);
-            Assert.NotNull(oc.Initializer.OpenBraceToken);
-            Assert.NotNull(oc.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, oc.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, oc.Initializer.CloseBraceToken);
             Assert.False(oc.Initializer.OpenBraceToken.IsMissing);
             Assert.False(oc.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(3, oc.Initializer.Expressions.Count);
@@ -963,8 +963,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a", oc.Type.ToString());
 
             Assert.NotNull(oc.Initializer);
-            Assert.NotNull(oc.Initializer.OpenBraceToken);
-            Assert.NotNull(oc.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, oc.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, oc.Initializer.CloseBraceToken);
             Assert.False(oc.Initializer.OpenBraceToken.IsMissing);
             Assert.False(oc.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(1, oc.Initializer.Expressions.Count);
@@ -987,8 +987,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a", oc.Type.ToString());
 
             Assert.NotNull(oc.Initializer);
-            Assert.NotNull(oc.Initializer.OpenBraceToken);
-            Assert.NotNull(oc.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, oc.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, oc.Initializer.CloseBraceToken);
             Assert.False(oc.Initializer.OpenBraceToken.IsMissing);
             Assert.False(oc.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(1, oc.Initializer.Expressions.Count);
@@ -1029,8 +1029,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(ac.Type);
             Assert.Equal("a[]", ac.Type.ToString());
             Assert.NotNull(ac.Initializer);
-            Assert.NotNull(ac.Initializer.OpenBraceToken);
-            Assert.NotNull(ac.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, ac.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, ac.Initializer.CloseBraceToken);
             Assert.False(ac.Initializer.OpenBraceToken.IsMissing);
             Assert.False(ac.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(1, ac.Initializer.Expressions.Count);
@@ -1051,8 +1051,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(ac.Type);
             Assert.Equal("a[]", ac.Type.ToString());
             Assert.NotNull(ac.Initializer);
-            Assert.NotNull(ac.Initializer.OpenBraceToken);
-            Assert.NotNull(ac.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, ac.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, ac.Initializer.CloseBraceToken);
             Assert.False(ac.Initializer.OpenBraceToken.IsMissing);
             Assert.False(ac.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(3, ac.Initializer.Expressions.Count);
@@ -1075,8 +1075,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(ac.Type);
             Assert.Equal("a[][,][,,]", ac.Type.ToString());
             Assert.NotNull(ac.Initializer);
-            Assert.NotNull(ac.Initializer.OpenBraceToken);
-            Assert.NotNull(ac.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, ac.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, ac.Initializer.CloseBraceToken);
             Assert.False(ac.Initializer.OpenBraceToken.IsMissing);
             Assert.False(ac.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(1, ac.Initializer.Expressions.Count);
@@ -1095,8 +1095,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var ac = (ImplicitArrayCreationExpressionSyntax)expr;
             Assert.NotNull(ac.Initializer);
-            Assert.NotNull(ac.Initializer.OpenBraceToken);
-            Assert.NotNull(ac.Initializer.CloseBraceToken);
+            Assert.NotEqual(default, ac.Initializer.OpenBraceToken);
+            Assert.NotEqual(default, ac.Initializer.CloseBraceToken);
             Assert.False(ac.Initializer.OpenBraceToken.IsMissing);
             Assert.False(ac.Initializer.CloseBraceToken.IsMissing);
             Assert.Equal(1, ac.Initializer.Expressions.Count);
@@ -1114,9 +1114,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var ac = (AnonymousObjectCreationExpressionSyntax)expr;
-            Assert.NotNull(ac.NewKeyword);
-            Assert.NotNull(ac.OpenBraceToken);
-            Assert.NotNull(ac.CloseBraceToken);
+            Assert.NotEqual(default, ac.NewKeyword);
+            Assert.NotEqual(default, ac.OpenBraceToken);
+            Assert.NotEqual(default, ac.CloseBraceToken);
             Assert.False(ac.OpenBraceToken.IsMissing);
             Assert.False(ac.CloseBraceToken.IsMissing);
             Assert.Equal(2, ac.Initializers.Count);
@@ -1136,20 +1136,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var am = (AnonymousMethodExpressionSyntax)expr;
 
-            Assert.NotNull(am.DelegateKeyword);
+            Assert.NotEqual(default, am.DelegateKeyword);
             Assert.False(am.DelegateKeyword.IsMissing);
 
             Assert.NotNull(am.ParameterList);
-            Assert.NotNull(am.ParameterList.OpenParenToken);
-            Assert.NotNull(am.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, am.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, am.ParameterList.CloseParenToken);
             Assert.False(am.ParameterList.OpenParenToken.IsMissing);
             Assert.False(am.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(1, am.ParameterList.Parameters.Count);
             Assert.Equal("int a", am.ParameterList.Parameters[0].ToString());
 
             Assert.NotNull(am.Block);
-            Assert.NotNull(am.Block.OpenBraceToken);
-            Assert.NotNull(am.Block.CloseBraceToken);
+            Assert.NotEqual(default, am.Block.OpenBraceToken);
+            Assert.NotEqual(default, am.Block.CloseBraceToken);
             Assert.False(am.Block.OpenBraceToken.IsMissing);
             Assert.False(am.Block.CloseBraceToken.IsMissing);
             Assert.Equal(0, am.Block.Statements.Count);
@@ -1167,19 +1167,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var am = (AnonymousMethodExpressionSyntax)expr;
 
-            Assert.NotNull(am.DelegateKeyword);
+            Assert.NotEqual(default, am.DelegateKeyword);
             Assert.False(am.DelegateKeyword.IsMissing);
 
             Assert.NotNull(am.ParameterList);
-            Assert.NotNull(am.ParameterList.OpenParenToken);
-            Assert.NotNull(am.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, am.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, am.ParameterList.CloseParenToken);
             Assert.False(am.ParameterList.OpenParenToken.IsMissing);
             Assert.False(am.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, am.ParameterList.Parameters.Count);
 
             Assert.NotNull(am.Block);
-            Assert.NotNull(am.Block.OpenBraceToken);
-            Assert.NotNull(am.Block.CloseBraceToken);
+            Assert.NotEqual(default, am.Block.OpenBraceToken);
+            Assert.NotEqual(default, am.Block.CloseBraceToken);
             Assert.False(am.Block.OpenBraceToken.IsMissing);
             Assert.False(am.Block.CloseBraceToken.IsMissing);
             Assert.Equal(0, am.Block.Statements.Count);
@@ -1197,14 +1197,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, expr.Errors().Length);
             var am = (AnonymousMethodExpressionSyntax)expr;
 
-            Assert.NotNull(am.DelegateKeyword);
+            Assert.NotEqual(default, am.DelegateKeyword);
             Assert.False(am.DelegateKeyword.IsMissing);
 
             Assert.Null(am.ParameterList);
 
             Assert.NotNull(am.Block);
-            Assert.NotNull(am.Block.OpenBraceToken);
-            Assert.NotNull(am.Block.CloseBraceToken);
+            Assert.NotEqual(default, am.Block.OpenBraceToken);
+            Assert.NotEqual(default, am.Block.CloseBraceToken);
             Assert.False(am.Block.OpenBraceToken.IsMissing);
             Assert.False(am.Block.CloseBraceToken.IsMissing);
             Assert.Equal(0, am.Block.Statements.Count);
@@ -1221,7 +1221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (SimpleLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.Parameter.Identifier);
+            Assert.NotEqual(default, lambda.Parameter.Identifier);
             Assert.False(lambda.Parameter.Identifier.IsMissing);
             Assert.Equal("a", lambda.Parameter.Identifier.ToString());
             Assert.NotNull(lambda.Body);
@@ -1239,7 +1239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (SimpleLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.Parameter.Identifier);
+            Assert.NotEqual(default, lambda.Parameter.Identifier);
             Assert.False(lambda.Parameter.Identifier.IsMissing);
             Assert.Equal("a", lambda.Parameter.Identifier.ToString());
             Assert.Equal(SyntaxKind.RefExpression, lambda.Body.Kind());
@@ -1257,7 +1257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (SimpleLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.Parameter.Identifier);
+            Assert.NotEqual(default, lambda.Parameter.Identifier);
             Assert.False(lambda.Parameter.Identifier.IsMissing);
             Assert.Equal("a", lambda.Parameter.Identifier.ToString());
             Assert.NotNull(lambda.Body);
@@ -1277,8 +1277,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, lambda.ParameterList.Parameters.Count);
@@ -1297,8 +1297,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, lambda.ParameterList.Parameters.Count);
@@ -1317,8 +1317,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(0, lambda.ParameterList.Parameters.Count);
@@ -1339,8 +1339,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(1, lambda.ParameterList.Parameters.Count);
@@ -1363,8 +1363,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(2, lambda.ParameterList.Parameters.Count);
@@ -1390,8 +1390,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(1, lambda.ParameterList.Parameters.Count);
@@ -1415,8 +1415,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var lambda = (ParenthesizedLambdaExpressionSyntax)expr;
-            Assert.NotNull(lambda.ParameterList.OpenParenToken);
-            Assert.NotNull(lambda.ParameterList.CloseParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.OpenParenToken);
+            Assert.NotEqual(default, lambda.ParameterList.CloseParenToken);
             Assert.False(lambda.ParameterList.OpenParenToken.IsMissing);
             Assert.False(lambda.ParameterList.CloseParenToken.IsMissing);
             Assert.Equal(1, lambda.ParameterList.Parameters.Count);
@@ -1442,8 +1442,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var tuple = (TupleExpressionSyntax)expr;
-            Assert.NotNull(tuple.OpenParenToken);
-            Assert.NotNull(tuple.CloseParenToken);
+            Assert.NotEqual(default, tuple.OpenParenToken);
+            Assert.NotEqual(default, tuple.CloseParenToken);
             Assert.False(tuple.OpenParenToken.IsMissing);
             Assert.False(tuple.CloseParenToken.IsMissing);
             Assert.Equal(2, tuple.Arguments.Count);
@@ -1462,8 +1462,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(text, expr.ToString());
             Assert.Equal(0, expr.Errors().Length);
             var tuple = (TupleExpressionSyntax)expr;
-            Assert.NotNull(tuple.OpenParenToken);
-            Assert.NotNull(tuple.CloseParenToken);
+            Assert.NotEqual(default, tuple.OpenParenToken);
+            Assert.NotEqual(default, tuple.CloseParenToken);
             Assert.False(tuple.OpenParenToken.IsMissing);
             Assert.False(tuple.CloseParenToken.IsMissing);
             Assert.Equal(2, tuple.Arguments.Count);
@@ -1487,18 +1487,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, qs.Body.Clauses.Count);
 
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.Equal(SyntaxKind.FromKeyword, fs.FromKeyword.Kind());
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.Equal(SyntaxKind.SelectKeyword, ss.SelectKeyword.Kind());
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("b", ss.Expression.ToString());
@@ -1521,18 +1521,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.NotNull(fs.Type);
             Assert.Equal("T", fs.Type.ToString());
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("b", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1555,23 +1555,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("b", ss.Expression.ToString());
 
             Assert.NotNull(qs.Body.Continuation);
             Assert.Equal(SyntaxKind.QueryContinuation, qs.Body.Continuation.Kind());
-            Assert.NotNull(qs.Body.Continuation.IntoKeyword);
+            Assert.NotEqual(default, qs.Body.Continuation.IntoKeyword);
             Assert.Equal(SyntaxKind.IntoKeyword, qs.Body.Continuation.IntoKeyword.Kind());
             Assert.False(qs.Body.Continuation.IntoKeyword.IsMissing);
             Assert.Equal("c", qs.Body.Continuation.Identifier.ToString());
@@ -1582,7 +1582,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.Continuation.Body.SelectOrGroup.Kind());
             ss = (SelectClauseSyntax)qs.Body.Continuation.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("d", ss.Expression.ToString());
 
@@ -1605,17 +1605,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.WhereClause, qs.Body.Clauses[0].Kind());
             var ws = (WhereClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(ws.WhereKeyword);
+            Assert.NotEqual(default, ws.WhereKeyword);
             Assert.Equal(SyntaxKind.WhereKeyword, ws.WhereKeyword.Kind());
             Assert.False(ws.WhereKeyword.IsMissing);
             Assert.NotNull(ws.Condition);
@@ -1623,7 +1623,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1645,28 +1645,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             Assert.Equal(SyntaxKind.FromClause, qs.Body.Clauses[0].Kind());
             fs = (FromClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("b", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("B", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1688,30 +1688,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             Assert.Equal(SyntaxKind.LetClause, qs.Body.Clauses[0].Kind());
             var ls = (LetClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(ls.LetKeyword);
+            Assert.NotEqual(default, ls.LetKeyword);
             Assert.Equal(SyntaxKind.LetKeyword, ls.LetKeyword.Kind());
             Assert.False(ls.LetKeyword.IsMissing);
-            Assert.NotNull(ls.Identifier);
+            Assert.NotEqual(default, ls.Identifier);
             Assert.Equal("b", ls.Identifier.ToString());
-            Assert.NotNull(ls.EqualsToken);
+            Assert.NotEqual(default, ls.EqualsToken);
             Assert.False(ls.EqualsToken.IsMissing);
             Assert.NotNull(ls.Expression);
             Assert.Equal("B", ls.Expression.ToString());
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1733,18 +1733,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             Assert.Equal(SyntaxKind.OrderByClause, qs.Body.Clauses[0].Kind());
             var obs = (OrderByClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(obs.OrderByKeyword);
+            Assert.NotEqual(default, obs.OrderByKeyword);
             Assert.Equal(SyntaxKind.OrderByKeyword, obs.OrderByKeyword.Kind());
             Assert.False(obs.OrderByKeyword.IsMissing);
             Assert.Equal(1, obs.Orderings.Count);
@@ -1756,7 +1756,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1778,18 +1778,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             Assert.Equal(SyntaxKind.OrderByClause, qs.Body.Clauses[0].Kind());
             var obs = (OrderByClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(obs.OrderByKeyword);
+            Assert.NotEqual(default, obs.OrderByKeyword);
             Assert.False(obs.OrderByKeyword.IsMissing);
             Assert.Equal(2, obs.Orderings.Count);
 
@@ -1805,7 +1805,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1827,23 +1827,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             Assert.Equal(SyntaxKind.OrderByClause, qs.Body.Clauses[0].Kind());
             var obs = (OrderByClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(obs.OrderByKeyword);
+            Assert.NotEqual(default, obs.OrderByKeyword);
             Assert.False(obs.OrderByKeyword.IsMissing);
             Assert.Equal(1, obs.Orderings.Count);
 
             var os = (OrderingSyntax)obs.Orderings[0];
-            Assert.NotNull(os.AscendingOrDescendingKeyword);
+            Assert.NotEqual(default, os.AscendingOrDescendingKeyword);
             Assert.Equal(SyntaxKind.AscendingKeyword, os.AscendingOrDescendingKeyword.Kind());
             Assert.False(os.AscendingOrDescendingKeyword.IsMissing);
             Assert.Equal(SyntaxKind.AscendingKeyword, os.AscendingOrDescendingKeyword.ContextualKind());
@@ -1853,7 +1853,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1875,23 +1875,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
 
             Assert.Equal(SyntaxKind.OrderByClause, qs.Body.Clauses[0].Kind());
             var obs = (OrderByClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(obs.OrderByKeyword);
+            Assert.NotEqual(default, obs.OrderByKeyword);
             Assert.False(obs.OrderByKeyword.IsMissing);
             Assert.Equal(1, obs.Orderings.Count);
 
             var os = (OrderingSyntax)obs.Orderings[0];
-            Assert.NotNull(os.AscendingOrDescendingKeyword);
+            Assert.NotEqual(default, os.AscendingOrDescendingKeyword);
             Assert.Equal(SyntaxKind.DescendingKeyword, os.AscendingOrDescendingKeyword.Kind());
             Assert.False(os.AscendingOrDescendingKeyword.IsMissing);
             Assert.Equal(SyntaxKind.DescendingKeyword, os.AscendingOrDescendingKeyword.ContextualKind());
@@ -1901,7 +1901,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -1922,22 +1922,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, qs.Body.Clauses.Count);
 
             var fs = qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.GroupClause, qs.Body.SelectOrGroup.Kind());
             var gbs = (GroupClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(gbs.GroupKeyword);
+            Assert.NotEqual(default, gbs.GroupKeyword);
             Assert.Equal(SyntaxKind.GroupKeyword, gbs.GroupKeyword.Kind());
             Assert.False(gbs.GroupKeyword.IsMissing);
             Assert.NotNull(gbs.GroupExpression);
             Assert.Equal("b", gbs.GroupExpression.ToString());
-            Assert.NotNull(gbs.ByKeyword);
+            Assert.NotEqual(default, gbs.ByKeyword);
             Assert.Equal(SyntaxKind.ByKeyword, gbs.ByKeyword.Kind());
             Assert.False(gbs.ByKeyword.IsMissing);
             Assert.NotNull(gbs.ByExpression);
@@ -1961,28 +1961,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, qs.Body.Clauses.Count);
 
             var fs = qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.GroupClause, qs.Body.SelectOrGroup.Kind());
             var gbs = (GroupClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(gbs.GroupKeyword);
+            Assert.NotEqual(default, gbs.GroupKeyword);
             Assert.False(gbs.GroupKeyword.IsMissing);
             Assert.NotNull(gbs.GroupExpression);
             Assert.Equal("b", gbs.GroupExpression.ToString());
-            Assert.NotNull(gbs.ByKeyword);
+            Assert.NotEqual(default, gbs.ByKeyword);
             Assert.False(gbs.ByKeyword.IsMissing);
             Assert.NotNull(gbs.ByExpression);
             Assert.Equal("c", gbs.ByExpression.ToString());
 
             Assert.NotNull(qs.Body.Continuation);
             Assert.Equal(SyntaxKind.QueryContinuation, qs.Body.Continuation.Kind());
-            Assert.NotNull(qs.Body.Continuation.IntoKeyword);
+            Assert.NotEqual(default, qs.Body.Continuation.IntoKeyword);
             Assert.False(qs.Body.Continuation.IntoKeyword.IsMissing);
             Assert.Equal("d", qs.Body.Continuation.Identifier.ToString());
 
@@ -1992,7 +1992,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.Continuation.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.Continuation.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("e", ss.Expression.ToString());
 
@@ -2015,32 +2015,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.JoinClause, qs.Body.Clauses[0].Kind());
             var js = (JoinClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(js.JoinKeyword);
+            Assert.NotEqual(default, js.JoinKeyword);
             Assert.Equal(SyntaxKind.JoinKeyword, js.JoinKeyword.Kind());
             Assert.False(js.JoinKeyword.IsMissing);
             Assert.Null(js.Type);
-            Assert.NotNull(js.Identifier);
+            Assert.NotEqual(default, js.Identifier);
             Assert.Equal("b", js.Identifier.ToString());
-            Assert.NotNull(js.InKeyword);
+            Assert.NotEqual(default, js.InKeyword);
             Assert.False(js.InKeyword.IsMissing);
             Assert.NotNull(js.InExpression);
             Assert.Equal("B", js.InExpression.ToString());
-            Assert.NotNull(js.OnKeyword);
+            Assert.NotEqual(default, js.OnKeyword);
             Assert.Equal(SyntaxKind.OnKeyword, js.OnKeyword.Kind());
             Assert.False(js.OnKeyword.IsMissing);
             Assert.NotNull(js.LeftExpression);
             Assert.Equal("a", js.LeftExpression.ToString());
-            Assert.NotNull(js.EqualsKeyword);
+            Assert.NotEqual(default, js.EqualsKeyword);
             Assert.Equal(SyntaxKind.EqualsKeyword, js.EqualsKeyword.Kind());
             Assert.False(js.EqualsKeyword.IsMissing);
             Assert.NotNull(js.RightExpression);
@@ -2049,7 +2049,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -2071,32 +2071,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.NotNull(fs.Type);
             Assert.Equal("Ta", fs.Type.ToString());
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.JoinClause, qs.Body.Clauses[0].Kind());
             var js = (JoinClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(js.JoinKeyword);
+            Assert.NotEqual(default, js.JoinKeyword);
             Assert.False(js.JoinKeyword.IsMissing);
             Assert.NotNull(js.Type);
             Assert.Equal("Tb", js.Type.ToString());
-            Assert.NotNull(js.Identifier);
+            Assert.NotEqual(default, js.Identifier);
             Assert.Equal("b", js.Identifier.ToString());
-            Assert.NotNull(js.InKeyword);
+            Assert.NotEqual(default, js.InKeyword);
             Assert.False(js.InKeyword.IsMissing);
             Assert.NotNull(js.InExpression);
             Assert.Equal("B", js.InExpression.ToString());
-            Assert.NotNull(js.OnKeyword);
+            Assert.NotEqual(default, js.OnKeyword);
             Assert.False(js.OnKeyword.IsMissing);
             Assert.NotNull(js.LeftExpression);
             Assert.Equal("a", js.LeftExpression.ToString());
-            Assert.NotNull(js.EqualsKeyword);
+            Assert.NotEqual(default, js.EqualsKeyword);
             Assert.False(js.EqualsKeyword.IsMissing);
             Assert.NotNull(js.RightExpression);
             Assert.Equal("b", js.RightExpression.ToString());
@@ -2104,7 +2104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("c", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);
@@ -2126,42 +2126,42 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(SyntaxKind.FromClause, qs.FromClause.Kind());
             var fs = (FromClauseSyntax)qs.FromClause;
-            Assert.NotNull(fs.FromKeyword);
+            Assert.NotEqual(default, fs.FromKeyword);
             Assert.False(fs.FromKeyword.IsMissing);
             Assert.Null(fs.Type);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal("A", fs.Expression.ToString());
 
             Assert.Equal(SyntaxKind.JoinClause, qs.Body.Clauses[0].Kind());
             var js = (JoinClauseSyntax)qs.Body.Clauses[0];
-            Assert.NotNull(js.JoinKeyword);
+            Assert.NotEqual(default, js.JoinKeyword);
             Assert.False(js.JoinKeyword.IsMissing);
             Assert.Null(js.Type);
-            Assert.NotNull(js.Identifier);
+            Assert.NotEqual(default, js.Identifier);
             Assert.Equal("b", js.Identifier.ToString());
-            Assert.NotNull(js.InKeyword);
+            Assert.NotEqual(default, js.InKeyword);
             Assert.False(js.InKeyword.IsMissing);
             Assert.NotNull(js.InExpression);
             Assert.Equal("B", js.InExpression.ToString());
-            Assert.NotNull(js.OnKeyword);
+            Assert.NotEqual(default, js.OnKeyword);
             Assert.False(js.OnKeyword.IsMissing);
             Assert.NotNull(js.LeftExpression);
             Assert.Equal("a", js.LeftExpression.ToString());
-            Assert.NotNull(js.EqualsKeyword);
+            Assert.NotEqual(default, js.EqualsKeyword);
             Assert.False(js.EqualsKeyword.IsMissing);
             Assert.NotNull(js.RightExpression);
             Assert.Equal("b", js.RightExpression.ToString());
             Assert.NotNull(js.Into);
-            Assert.NotNull(js.Into.IntoKeyword);
+            Assert.NotEqual(default, js.Into.IntoKeyword);
             Assert.False(js.Into.IntoKeyword.IsMissing);
-            Assert.NotNull(js.Into.Identifier);
+            Assert.NotEqual(default, js.Into.Identifier);
             Assert.Equal("c", js.Into.Identifier.ToString());
 
             Assert.Equal(SyntaxKind.SelectClause, qs.Body.SelectOrGroup.Kind());
             var ss = (SelectClauseSyntax)qs.Body.SelectOrGroup;
-            Assert.NotNull(ss.SelectKeyword);
+            Assert.NotEqual(default, ss.SelectKeyword);
             Assert.False(ss.SelectKeyword.IsMissing);
             Assert.Equal("d", ss.Expression.ToString());
             Assert.Null(qs.Body.Continuation);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/NameParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/NameParsingTests.cs
@@ -688,7 +688,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "\u0915\u094d\u200d\u0937";
             var tok = SyntaxFactory.ParseToken(text);
 
-            Assert.NotNull(tok);
+            Assert.NotEqual(default, tok);
             Assert.Equal(text, tok.ToString());
             Assert.NotEqual(text, tok.ValueText);
             Assert.Equal("\u0915\u094d\u0937", tok.ValueText); //formatting character \u200d removed
@@ -704,7 +704,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var text = "x\u00ady";
             var tok = SyntaxFactory.ParseToken(text);
 
-            Assert.NotNull(tok);
+            Assert.NotEqual(default, tok);
             Assert.Equal(text, tok.ToString());
             Assert.NotEqual(text, tok.ValueText);
             Assert.Equal("xy", tok.ValueText); // formatting character SOFT HYPHEN (U+00AD) removed

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -4445,7 +4445,7 @@ class C
             var ds = (LocalDeclarationStatementSyntax)ms.Body.Statements[0];
             Assert.Equal(1, ds.Declaration.Variables.Count);
             Assert.NotEqual(SyntaxKind.None, ds.Declaration.Variables[0].Initializer.Kind());
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal(SyntaxKind.AnonymousObjectCreationExpression, ds.Declaration.Variables[0].Initializer.Value.Kind());
             Assert.Equal(1, file.Errors().Length);
@@ -5550,9 +5550,9 @@ class C
             Assert.Equal(SyntaxKind.PropertyDeclaration, agg.Members[0].Kind());
             var pd = (PropertyDeclarationSyntax)agg.Members[0];
             Assert.NotNull(pd.AccessorList);
-            Assert.NotNull(pd.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.OpenBraceToken);
             Assert.False(pd.AccessorList.OpenBraceToken.IsMissing);
-            Assert.NotNull(pd.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.CloseBraceToken);
             Assert.False(pd.AccessorList.CloseBraceToken.IsMissing);
             Assert.Equal(0, pd.AccessorList.Accessors.Count);
             Assert.Equal(0, file.Errors().Length);
@@ -5575,9 +5575,9 @@ class C
             Assert.Equal(SyntaxKind.MethodDeclaration, agg.Members[1].Kind());
             var pd = (PropertyDeclarationSyntax)agg.Members[0];
             Assert.NotNull(pd.AccessorList);
-            Assert.NotNull(pd.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.OpenBraceToken);
             Assert.False(pd.AccessorList.OpenBraceToken.IsMissing);
-            Assert.NotNull(pd.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.CloseBraceToken);
             Assert.True(pd.AccessorList.CloseBraceToken.IsMissing);
             Assert.Equal(0, pd.AccessorList.Accessors.Count);
             Assert.Equal(1, file.Errors().Length);
@@ -5600,18 +5600,18 @@ class C
             Assert.Equal(SyntaxKind.MethodDeclaration, agg.Members[1].Kind());
             var pd = (PropertyDeclarationSyntax)agg.Members[0];
             Assert.NotNull(pd.AccessorList);
-            Assert.NotNull(pd.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.OpenBraceToken);
             Assert.False(pd.AccessorList.OpenBraceToken.IsMissing);
-            Assert.NotNull(pd.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.CloseBraceToken);
             Assert.True(pd.AccessorList.CloseBraceToken.IsMissing);
             Assert.Equal(1, pd.AccessorList.Accessors.Count);
             var acc = pd.AccessorList.Accessors[0];
             Assert.Equal(SyntaxKind.GetAccessorDeclaration, acc.Kind());
-            Assert.NotNull(acc.Keyword);
+            Assert.NotEqual(default, acc.Keyword);
             Assert.False(acc.Keyword.IsMissing);
             Assert.Equal(SyntaxKind.GetKeyword, acc.Keyword.Kind());
             Assert.Null(acc.Body);
-            Assert.NotNull(acc.SemicolonToken);
+            Assert.NotEqual(default, acc.SemicolonToken);
             Assert.True(acc.SemicolonToken.IsMissing);
 
             Assert.Equal(2, file.Errors().Length);
@@ -5635,21 +5635,21 @@ class C
             Assert.Equal(SyntaxKind.ClassDeclaration, agg.Members[1].Kind());
             var pd = (PropertyDeclarationSyntax)agg.Members[0];
             Assert.NotNull(pd.AccessorList);
-            Assert.NotNull(pd.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.OpenBraceToken);
             Assert.False(pd.AccessorList.OpenBraceToken.IsMissing);
-            Assert.NotNull(pd.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.CloseBraceToken);
             Assert.True(pd.AccessorList.CloseBraceToken.IsMissing);
             Assert.Equal(1, pd.AccessorList.Accessors.Count);
             var acc = pd.AccessorList.Accessors[0];
             Assert.Equal(SyntaxKind.GetAccessorDeclaration, acc.Kind());
-            Assert.NotNull(acc.Keyword);
+            Assert.NotEqual(default, acc.Keyword);
             Assert.False(acc.Keyword.IsMissing);
             Assert.Equal(SyntaxKind.GetKeyword, acc.Keyword.Kind());
             Assert.NotNull(acc.Body);
-            Assert.NotNull(acc.Body.OpenBraceToken);
+            Assert.NotEqual(default, acc.Body.OpenBraceToken);
             Assert.False(acc.Body.OpenBraceToken.IsMissing);
             Assert.Equal(0, acc.Body.Statements.Count);
-            Assert.NotNull(acc.Body.CloseBraceToken);
+            Assert.NotEqual(default, acc.Body.CloseBraceToken);
             Assert.True(acc.Body.CloseBraceToken.IsMissing);
             Assert.Equal(SyntaxKind.None, acc.SemicolonToken.Kind());
 
@@ -5674,21 +5674,21 @@ class C
             Assert.Equal(SyntaxKind.ClassDeclaration, agg.Members[1].Kind());
             var pd = (PropertyDeclarationSyntax)agg.Members[0];
             Assert.NotNull(pd.AccessorList);
-            Assert.NotNull(pd.AccessorList.OpenBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.OpenBraceToken);
             Assert.False(pd.AccessorList.OpenBraceToken.IsMissing);
-            Assert.NotNull(pd.AccessorList.CloseBraceToken);
+            Assert.NotEqual(default, pd.AccessorList.CloseBraceToken);
             Assert.True(pd.AccessorList.CloseBraceToken.IsMissing);
             Assert.Equal(1, pd.AccessorList.Accessors.Count);
             var acc = pd.AccessorList.Accessors[0];
             Assert.Equal(SyntaxKind.GetAccessorDeclaration, acc.Kind());
-            Assert.NotNull(acc.Keyword);
+            Assert.NotEqual(default, acc.Keyword);
             Assert.False(acc.Keyword.IsMissing);
             Assert.Equal(SyntaxKind.GetKeyword, acc.Keyword.Kind());
             Assert.NotNull(acc.Body);
-            Assert.NotNull(acc.Body.OpenBraceToken);
+            Assert.NotEqual(default, acc.Body.OpenBraceToken);
             Assert.False(acc.Body.OpenBraceToken.IsMissing);
             Assert.Equal(0, acc.Body.Statements.Count);
-            Assert.NotNull(acc.Body.CloseBraceToken);
+            Assert.NotEqual(default, acc.Body.CloseBraceToken);
             Assert.True(acc.Body.CloseBraceToken.IsMissing);
             Assert.Equal(SyntaxKind.None, acc.SemicolonToken.Kind());
 
@@ -5776,9 +5776,9 @@ class C
             var md = (MethodDeclarationSyntax)agg.Members[0];
 
             Assert.NotNull(md.Body);
-            Assert.NotNull(md.Body.OpenBraceToken);
+            Assert.NotEqual(default, md.Body.OpenBraceToken);
             Assert.False(md.Body.OpenBraceToken.IsMissing);
-            Assert.NotNull(md.Body.CloseBraceToken);
+            Assert.NotEqual(default, md.Body.CloseBraceToken);
             Assert.False(md.Body.CloseBraceToken.IsMissing);
             Assert.Equal(1, md.Body.Statements.Count);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, md.Body.Statements[0].Kind());
@@ -5792,7 +5792,7 @@ class C
             Assert.Equal(SyntaxKind.FromClause, qx.FromClause.Kind());
             Assert.Equal(SyntaxKind.OrderByClause, qx.Body.Clauses[0].Kind());
             var oc = (OrderByClauseSyntax)qx.Body.Clauses[0];
-            Assert.NotNull(oc.OrderByKeyword);
+            Assert.NotEqual(default, oc.OrderByKeyword);
             Assert.False(oc.OrderByKeyword.IsMissing);
             Assert.Equal(1, oc.Orderings.Count);
             Assert.NotNull(oc.Orderings[0].Expression);
@@ -5821,9 +5821,9 @@ class C
             var md = (MethodDeclarationSyntax)agg.Members[0];
 
             Assert.NotNull(md.Body);
-            Assert.NotNull(md.Body.OpenBraceToken);
+            Assert.NotEqual(default, md.Body.OpenBraceToken);
             Assert.False(md.Body.OpenBraceToken.IsMissing);
-            Assert.NotNull(md.Body.CloseBraceToken);
+            Assert.NotEqual(default, md.Body.CloseBraceToken);
             Assert.False(md.Body.CloseBraceToken.IsMissing);
             Assert.Equal(1, md.Body.Statements.Count);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, md.Body.Statements[0].Kind());
@@ -5837,7 +5837,7 @@ class C
             Assert.Equal(SyntaxKind.FromClause, qx.FromClause.Kind());
             Assert.Equal(SyntaxKind.OrderByClause, qx.Body.Clauses[0].Kind());
             var oc = (OrderByClauseSyntax)qx.Body.Clauses[0];
-            Assert.NotNull(oc.OrderByKeyword);
+            Assert.NotEqual(default, oc.OrderByKeyword);
             Assert.False(oc.OrderByKeyword.IsMissing);
             Assert.Equal(1, oc.Orderings.Count);
             Assert.NotNull(oc.Orderings[0].Expression);
@@ -5865,9 +5865,9 @@ class C
             var md = (MethodDeclarationSyntax)agg.Members[0];
 
             Assert.NotNull(md.Body);
-            Assert.NotNull(md.Body.OpenBraceToken);
+            Assert.NotEqual(default, md.Body.OpenBraceToken);
             Assert.False(md.Body.OpenBraceToken.IsMissing);
-            Assert.NotNull(md.Body.CloseBraceToken);
+            Assert.NotEqual(default, md.Body.CloseBraceToken);
             Assert.False(md.Body.CloseBraceToken.IsMissing);
             Assert.Equal(1, md.Body.Statements.Count);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, md.Body.Statements[0].Kind());
@@ -5881,7 +5881,7 @@ class C
             Assert.Equal(SyntaxKind.FromClause, qx.FromClause.Kind());
             Assert.Equal(SyntaxKind.OrderByClause, qx.Body.Clauses[0].Kind());
             var oc = (OrderByClauseSyntax)qx.Body.Clauses[0];
-            Assert.NotNull(oc.OrderByKeyword);
+            Assert.NotEqual(default, oc.OrderByKeyword);
             Assert.False(oc.OrderByKeyword.IsMissing);
             Assert.Equal(2, oc.Orderings.Count);
             Assert.NotNull(oc.Orderings[0].Expression);
@@ -5915,9 +5915,9 @@ class C
             var md = (MethodDeclarationSyntax)agg.Members[0];
 
             Assert.NotNull(md.Body);
-            Assert.NotNull(md.Body.OpenBraceToken);
+            Assert.NotEqual(default, md.Body.OpenBraceToken);
             Assert.False(md.Body.OpenBraceToken.IsMissing);
-            Assert.NotNull(md.Body.CloseBraceToken);
+            Assert.NotEqual(default, md.Body.CloseBraceToken);
             Assert.True(md.Body.CloseBraceToken.IsMissing);
             Assert.Equal(1, md.Body.Statements.Count);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, md.Body.Statements[0].Kind());
@@ -5931,7 +5931,7 @@ class C
             Assert.Equal(SyntaxKind.FromClause, qx.FromClause.Kind());
             Assert.Equal(SyntaxKind.OrderByClause, qx.Body.Clauses[0].Kind());
             var oc = (OrderByClauseSyntax)qx.Body.Clauses[0];
-            Assert.NotNull(oc.OrderByKeyword);
+            Assert.NotEqual(default, oc.OrderByKeyword);
             Assert.False(oc.OrderByKeyword.IsMissing);
             Assert.Equal(1, oc.Orderings.Count);
             Assert.NotNull(oc.Orderings[0].Expression);
@@ -5963,9 +5963,9 @@ class C
             var md = (MethodDeclarationSyntax)agg.Members[0];
 
             Assert.NotNull(md.Body);
-            Assert.NotNull(md.Body.OpenBraceToken);
+            Assert.NotEqual(default, md.Body.OpenBraceToken);
             Assert.False(md.Body.OpenBraceToken.IsMissing);
-            Assert.NotNull(md.Body.CloseBraceToken);
+            Assert.NotEqual(default, md.Body.CloseBraceToken);
             Assert.True(md.Body.CloseBraceToken.IsMissing);
             Assert.Equal(1, md.Body.Statements.Count);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, md.Body.Statements[0].Kind());
@@ -5979,7 +5979,7 @@ class C
             Assert.Equal(SyntaxKind.FromClause, qx.FromClause.Kind());
             Assert.Equal(SyntaxKind.OrderByClause, qx.Body.Clauses[0].Kind());
             var oc = (OrderByClauseSyntax)qx.Body.Clauses[0];
-            Assert.NotNull(oc.OrderByKeyword);
+            Assert.NotEqual(default, oc.OrderByKeyword);
             Assert.False(oc.OrderByKeyword.IsMissing);
             Assert.Equal(1, oc.Orderings.Count);
             Assert.NotNull(oc.Orderings[0].Expression);
@@ -6010,9 +6010,9 @@ class C
             var md = (MethodDeclarationSyntax)agg.Members[0];
 
             Assert.NotNull(md.Body);
-            Assert.NotNull(md.Body.OpenBraceToken);
+            Assert.NotEqual(default, md.Body.OpenBraceToken);
             Assert.False(md.Body.OpenBraceToken.IsMissing);
-            Assert.NotNull(md.Body.CloseBraceToken);
+            Assert.NotEqual(default, md.Body.CloseBraceToken);
             Assert.True(md.Body.CloseBraceToken.IsMissing);
             Assert.Equal(1, md.Body.Statements.Count);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, md.Body.Statements[0].Kind());
@@ -6026,7 +6026,7 @@ class C
             Assert.Equal(SyntaxKind.FromClause, qx.FromClause.Kind());
             Assert.Equal(SyntaxKind.OrderByClause, qx.Body.Clauses[0].Kind());
             var oc = (OrderByClauseSyntax)qx.Body.Clauses[0];
-            Assert.NotNull(oc.OrderByKeyword);
+            Assert.NotEqual(default, oc.OrderByKeyword);
             Assert.False(oc.OrderByKeyword.IsMissing);
             Assert.Equal(2, oc.Orderings.Count);
             Assert.NotNull(oc.Orderings[0].Expression);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.InvocationExpression, es.Expression.Kind());
             Assert.Equal(SyntaxKind.IdentifierName, ((InvocationExpressionSyntax)es.Expression).Expression.Kind());
             Assert.Equal("a()", es.Expression.ToString());
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.InvocationExpression, es.Expression.Kind());
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, ((InvocationExpressionSyntax)es.Expression).Expression.Kind());
             Assert.Equal("a.b()", es.Expression.ToString());
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.InvocationExpression, es.Expression.Kind());
             Assert.Equal(SyntaxKind.GenericName, ((InvocationExpressionSyntax)es.Expression).Expression.Kind());
             Assert.Equal("a<b>()", es.Expression.ToString());
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.InvocationExpression, es.Expression.Kind());
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, ((InvocationExpressionSyntax)es.Expression).Expression.Kind());
             Assert.Equal("a<b>.c()", es.Expression.ToString());
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.InvocationExpression, es.Expression.Kind());
             Assert.Equal(SyntaxKind.SimpleMemberAccessExpression, ((InvocationExpressionSyntax)es.Expression).Expression.Kind());
             Assert.Equal("a.b<c>()", es.Expression.ToString());
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var es = (ExpressionStatementSyntax)statement;
             Assert.NotNull(es.Expression);
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
 
             var opKind = SyntaxFacts.GetPostfixUnaryExpression(kind);
@@ -191,12 +191,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -221,12 +221,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)ds.Declaration.Type).Identifier.Kind());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -255,12 +255,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.None, tt.Elements[1].Identifier.Kind());
             Assert.Equal(2, tt.Elements.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -297,12 +297,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("l", tt.Elements[1].Identifier.ToString());
             Assert.Equal(3, tt.Elements.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -327,12 +327,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)ds.Declaration.Type).Identifier.Kind());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -353,12 +353,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T<a>", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("b", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -379,12 +379,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T.X.Y", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -405,12 +405,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T<t>.X<x>.Y<y>", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -431,12 +431,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T[][,][,,]", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -457,12 +457,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T*", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -483,12 +483,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T?", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -509,21 +509,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(3, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[1].Identifier);
             Assert.Equal("b", ds.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[1].ArgumentList);
             Assert.Null(ds.Declaration.Variables[1].Initializer);
 
-            Assert.NotNull(ds.Declaration.Variables[2].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[2].Identifier);
             Assert.Equal("c", ds.Declaration.Variables[2].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[2].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -544,16 +544,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -574,31 +574,31 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(3, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("va", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[1].Identifier);
             Assert.Equal("b", ds.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[1].ArgumentList);
-            Assert.NotNull(ds.Declaration.Variables[1].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[1].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[1].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[1].Initializer.Value);
             Assert.Equal("vb", ds.Declaration.Variables[1].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.Declaration.Variables[2].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[2].Identifier);
             Assert.Equal("c", ds.Declaration.Variables[2].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[2].ArgumentList);
-            Assert.NotNull(ds.Declaration.Variables[2].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[2].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[2].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[2].Initializer.Value);
             Assert.Equal("vc", ds.Declaration.Variables[2].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -619,17 +619,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal(SyntaxKind.ArrayInitializerExpression, ds.Declaration.Variables[0].Initializer.Value.Kind());
             Assert.Equal("{b, c}", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -651,16 +651,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -683,16 +683,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -715,16 +715,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -747,16 +747,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.NotNull(ds.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.False(ds.Declaration.Variables[0].Initializer.EqualsToken.IsMissing);
             Assert.NotNull(ds.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", ds.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -777,12 +777,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("ref T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             Assert.Null(ds.Declaration.Variables[0].Initializer);
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -803,17 +803,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("ref T", ds.Declaration.Type.ToString());
             Assert.Equal(1, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             var initializer = ds.Declaration.Variables[0].Initializer as EqualsValueClauseSyntax;
             Assert.NotNull(initializer);
-            Assert.NotNull(initializer.EqualsToken);
+            Assert.NotEqual(default, initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
             Assert.Equal(SyntaxKind.RefExpression, initializer.Value.Kind());
             Assert.Equal("ref b", initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -834,27 +834,27 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("ref T", ds.Declaration.Type.ToString());
             Assert.Equal(2, ds.Declaration.Variables.Count);
 
-            Assert.NotNull(ds.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].ArgumentList);
             var initializer = ds.Declaration.Variables[0].Initializer as EqualsValueClauseSyntax;
             Assert.NotNull(initializer);
-            Assert.NotNull(initializer.EqualsToken);
+            Assert.NotEqual(default, initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
             Assert.Equal(SyntaxKind.RefExpression, initializer.Value.Kind());
             Assert.Equal("ref b", initializer.Value.ToString());
 
-            Assert.NotNull(ds.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, ds.Declaration.Variables[1].Identifier);
             Assert.Equal("c", ds.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[1].ArgumentList);
             initializer = ds.Declaration.Variables[1].Initializer as EqualsValueClauseSyntax;
             Assert.NotNull(initializer);
-            Assert.NotNull(initializer.EqualsToken);
+            Assert.NotEqual(default, initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
             Assert.Equal(SyntaxKind.RefExpression, initializer.Value.Kind());
             Assert.Equal("ref d", initializer.Value.ToString());
 
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
             Assert.False(ds.SemicolonToken.IsMissing);
         }
 
@@ -870,9 +870,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (FixedStatementSyntax)statement;
-            Assert.NotNull(fs.FixedKeyword);
+            Assert.NotEqual(default, fs.FixedKeyword);
             Assert.False(fs.FixedKeyword.IsMissing);
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.False(fs.FixedKeyword.IsMissing);
             Assert.NotNull(fs.Declaration);
             Assert.Equal(SyntaxKind.VariableDeclaration, fs.Declaration.Kind());
@@ -897,9 +897,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (FixedStatementSyntax)statement;
-            Assert.NotNull(fs.FixedKeyword);
+            Assert.NotEqual(default, fs.FixedKeyword);
             Assert.False(fs.FixedKeyword.IsMissing);
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.False(fs.FixedKeyword.IsMissing);
             Assert.NotNull(fs.Declaration);
             Assert.Equal(SyntaxKind.VariableDeclaration, fs.Declaration.Kind());
@@ -927,9 +927,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (FixedStatementSyntax)statement;
-            Assert.NotNull(fs.FixedKeyword);
+            Assert.NotEqual(default, fs.FixedKeyword);
             Assert.False(fs.FixedKeyword.IsMissing);
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.False(fs.FixedKeyword.IsMissing);
             Assert.NotNull(fs.Declaration);
             Assert.Equal(SyntaxKind.VariableDeclaration, fs.Declaration.Kind());
@@ -955,7 +955,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var es = (EmptyStatementSyntax)statement;
-            Assert.NotNull(es.SemicolonToken);
+            Assert.NotEqual(default, es.SemicolonToken);
             Assert.False(es.SemicolonToken.IsMissing);
         }
 
@@ -971,9 +971,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ls = (LabeledStatementSyntax)statement;
-            Assert.NotNull(ls.Identifier);
+            Assert.NotEqual(default, ls.Identifier);
             Assert.Equal("label", ls.Identifier.ToString());
-            Assert.NotNull(ls.ColonToken);
+            Assert.NotEqual(default, ls.ColonToken);
             Assert.Equal(SyntaxKind.ColonToken, ls.ColonToken.Kind());
             Assert.NotNull(ls.Statement);
             Assert.Equal(SyntaxKind.EmptyStatement, ls.Statement.Kind());
@@ -992,10 +992,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var b = (BreakStatementSyntax)statement;
-            Assert.NotNull(b.BreakKeyword);
+            Assert.NotEqual(default, b.BreakKeyword);
             Assert.False(b.BreakKeyword.IsMissing);
             Assert.Equal(SyntaxKind.BreakKeyword, b.BreakKeyword.Kind());
-            Assert.NotNull(b.SemicolonToken);
+            Assert.NotEqual(default, b.SemicolonToken);
             Assert.False(b.SemicolonToken.IsMissing);
         }
 
@@ -1011,10 +1011,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var cs = (ContinueStatementSyntax)statement;
-            Assert.NotNull(cs.ContinueKeyword);
+            Assert.NotEqual(default, cs.ContinueKeyword);
             Assert.False(cs.ContinueKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ContinueKeyword, cs.ContinueKeyword.Kind());
-            Assert.NotNull(cs.SemicolonToken);
+            Assert.NotEqual(default, cs.SemicolonToken);
             Assert.False(cs.SemicolonToken.IsMissing);
         }
 
@@ -1030,13 +1030,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var gs = (GotoStatementSyntax)statement;
-            Assert.NotNull(gs.GotoKeyword);
+            Assert.NotEqual(default, gs.GotoKeyword);
             Assert.False(gs.GotoKeyword.IsMissing);
             Assert.Equal(SyntaxKind.GotoKeyword, gs.GotoKeyword.Kind());
             Assert.Equal(SyntaxKind.None, gs.CaseOrDefaultKeyword.Kind());
             Assert.NotNull(gs.Expression);
             Assert.Equal("label", gs.Expression.ToString());
-            Assert.NotNull(gs.SemicolonToken);
+            Assert.NotEqual(default, gs.SemicolonToken);
             Assert.False(gs.SemicolonToken.IsMissing);
         }
 
@@ -1052,15 +1052,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var gs = (GotoStatementSyntax)statement;
-            Assert.NotNull(gs.GotoKeyword);
+            Assert.NotEqual(default, gs.GotoKeyword);
             Assert.False(gs.GotoKeyword.IsMissing);
             Assert.Equal(SyntaxKind.GotoKeyword, gs.GotoKeyword.Kind());
-            Assert.NotNull(gs.CaseOrDefaultKeyword);
+            Assert.NotEqual(default, gs.CaseOrDefaultKeyword);
             Assert.False(gs.CaseOrDefaultKeyword.IsMissing);
             Assert.Equal(SyntaxKind.CaseKeyword, gs.CaseOrDefaultKeyword.Kind());
             Assert.NotNull(gs.Expression);
             Assert.Equal("label", gs.Expression.ToString());
-            Assert.NotNull(gs.SemicolonToken);
+            Assert.NotEqual(default, gs.SemicolonToken);
             Assert.False(gs.SemicolonToken.IsMissing);
         }
 
@@ -1076,14 +1076,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var gs = (GotoStatementSyntax)statement;
-            Assert.NotNull(gs.GotoKeyword);
+            Assert.NotEqual(default, gs.GotoKeyword);
             Assert.False(gs.GotoKeyword.IsMissing);
             Assert.Equal(SyntaxKind.GotoKeyword, gs.GotoKeyword.Kind());
-            Assert.NotNull(gs.CaseOrDefaultKeyword);
+            Assert.NotEqual(default, gs.CaseOrDefaultKeyword);
             Assert.False(gs.CaseOrDefaultKeyword.IsMissing);
             Assert.Equal(SyntaxKind.DefaultKeyword, gs.CaseOrDefaultKeyword.Kind());
             Assert.Null(gs.Expression);
-            Assert.NotNull(gs.SemicolonToken);
+            Assert.NotEqual(default, gs.SemicolonToken);
             Assert.False(gs.SemicolonToken.IsMissing);
         }
 
@@ -1099,11 +1099,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var rs = (ReturnStatementSyntax)statement;
-            Assert.NotNull(rs.ReturnKeyword);
+            Assert.NotEqual(default, rs.ReturnKeyword);
             Assert.False(rs.ReturnKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ReturnKeyword, rs.ReturnKeyword.Kind());
             Assert.Null(rs.Expression);
-            Assert.NotNull(rs.SemicolonToken);
+            Assert.NotEqual(default, rs.SemicolonToken);
             Assert.False(rs.SemicolonToken.IsMissing);
         }
 
@@ -1119,12 +1119,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var rs = (ReturnStatementSyntax)statement;
-            Assert.NotNull(rs.ReturnKeyword);
+            Assert.NotEqual(default, rs.ReturnKeyword);
             Assert.False(rs.ReturnKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ReturnKeyword, rs.ReturnKeyword.Kind());
             Assert.NotNull(rs.Expression);
             Assert.Equal("a", rs.Expression.ToString());
-            Assert.NotNull(rs.SemicolonToken);
+            Assert.NotEqual(default, rs.SemicolonToken);
             Assert.False(rs.SemicolonToken.IsMissing);
         }
 
@@ -1140,15 +1140,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ys = (YieldStatementSyntax)statement;
-            Assert.NotNull(ys.YieldKeyword);
+            Assert.NotEqual(default, ys.YieldKeyword);
             Assert.False(ys.YieldKeyword.IsMissing);
             Assert.Equal(SyntaxKind.YieldKeyword, ys.YieldKeyword.Kind());
-            Assert.NotNull(ys.ReturnOrBreakKeyword);
+            Assert.NotEqual(default, ys.ReturnOrBreakKeyword);
             Assert.False(ys.ReturnOrBreakKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ReturnKeyword, ys.ReturnOrBreakKeyword.Kind());
             Assert.NotNull(ys.Expression);
             Assert.Equal("a", ys.Expression.ToString());
-            Assert.NotNull(ys.SemicolonToken);
+            Assert.NotEqual(default, ys.SemicolonToken);
             Assert.False(ys.SemicolonToken.IsMissing);
         }
 
@@ -1164,14 +1164,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ys = (YieldStatementSyntax)statement;
-            Assert.NotNull(ys.YieldKeyword);
+            Assert.NotEqual(default, ys.YieldKeyword);
             Assert.False(ys.YieldKeyword.IsMissing);
             Assert.Equal(SyntaxKind.YieldKeyword, ys.YieldKeyword.Kind());
-            Assert.NotNull(ys.ReturnOrBreakKeyword);
+            Assert.NotEqual(default, ys.ReturnOrBreakKeyword);
             Assert.False(ys.ReturnOrBreakKeyword.IsMissing);
             Assert.Equal(SyntaxKind.BreakKeyword, ys.ReturnOrBreakKeyword.Kind());
             Assert.Null(ys.Expression);
-            Assert.NotNull(ys.SemicolonToken);
+            Assert.NotEqual(default, ys.SemicolonToken);
             Assert.False(ys.SemicolonToken.IsMissing);
         }
 
@@ -1187,11 +1187,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (ThrowStatementSyntax)statement;
-            Assert.NotNull(ts.ThrowKeyword);
+            Assert.NotEqual(default, ts.ThrowKeyword);
             Assert.False(ts.ThrowKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ThrowKeyword, ts.ThrowKeyword.ContextualKind());
             Assert.Null(ts.Expression);
-            Assert.NotNull(ts.SemicolonToken);
+            Assert.NotEqual(default, ts.SemicolonToken);
             Assert.False(ts.SemicolonToken.IsMissing);
         }
 
@@ -1207,12 +1207,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (ThrowStatementSyntax)statement;
-            Assert.NotNull(ts.ThrowKeyword);
+            Assert.NotEqual(default, ts.ThrowKeyword);
             Assert.False(ts.ThrowKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ThrowKeyword, ts.ThrowKeyword.ContextualKind());
             Assert.NotNull(ts.Expression);
             Assert.Equal("a", ts.Expression.ToString());
-            Assert.NotNull(ts.SemicolonToken);
+            Assert.NotEqual(default, ts.SemicolonToken);
             Assert.False(ts.SemicolonToken.IsMissing);
         }
 
@@ -1228,19 +1228,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (TryStatementSyntax)statement;
-            Assert.NotNull(ts.TryKeyword);
+            Assert.NotEqual(default, ts.TryKeyword);
             Assert.False(ts.TryKeyword.IsMissing);
             Assert.NotNull(ts.Block);
 
             Assert.Equal(1, ts.Catches.Count);
-            Assert.NotNull(ts.Catches[0].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[0].CatchKeyword);
             Assert.NotNull(ts.Catches[0].Declaration);
-            Assert.NotNull(ts.Catches[0].Declaration.OpenParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[0].Declaration.Type);
             Assert.Equal("T", ts.Catches[0].Declaration.Type.ToString());
-            Assert.NotNull(ts.Catches[0].Declaration.Identifier);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.Identifier);
             Assert.Equal("e", ts.Catches[0].Declaration.Identifier.ToString());
-            Assert.NotNull(ts.Catches[0].Declaration.CloseParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[0].Block);
 
             Assert.Null(ts.Finally);
@@ -1258,18 +1258,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (TryStatementSyntax)statement;
-            Assert.NotNull(ts.TryKeyword);
+            Assert.NotEqual(default, ts.TryKeyword);
             Assert.False(ts.TryKeyword.IsMissing);
             Assert.NotNull(ts.Block);
 
             Assert.Equal(1, ts.Catches.Count);
-            Assert.NotNull(ts.Catches[0].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[0].CatchKeyword);
             Assert.NotNull(ts.Catches[0].Declaration);
-            Assert.NotNull(ts.Catches[0].Declaration.OpenParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[0].Declaration.Type);
             Assert.Equal("T", ts.Catches[0].Declaration.Type.ToString());
             Assert.Equal(ts.Catches[0].Declaration.Identifier.Kind(), SyntaxKind.None);
-            Assert.NotNull(ts.Catches[0].Declaration.CloseParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[0].Block);
 
             Assert.Null(ts.Finally);
@@ -1287,12 +1287,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (TryStatementSyntax)statement;
-            Assert.NotNull(ts.TryKeyword);
+            Assert.NotEqual(default, ts.TryKeyword);
             Assert.False(ts.TryKeyword.IsMissing);
             Assert.NotNull(ts.Block);
 
             Assert.Equal(1, ts.Catches.Count);
-            Assert.NotNull(ts.Catches[0].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[0].CatchKeyword);
             Assert.Null(ts.Catches[0].Declaration);
             Assert.NotNull(ts.Catches[0].Block);
 
@@ -1311,31 +1311,31 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (TryStatementSyntax)statement;
-            Assert.NotNull(ts.TryKeyword);
+            Assert.NotEqual(default, ts.TryKeyword);
             Assert.False(ts.TryKeyword.IsMissing);
             Assert.NotNull(ts.Block);
 
             Assert.Equal(3, ts.Catches.Count);
 
-            Assert.NotNull(ts.Catches[0].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[0].CatchKeyword);
             Assert.NotNull(ts.Catches[0].Declaration);
-            Assert.NotNull(ts.Catches[0].Declaration.OpenParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[0].Declaration.Type);
             Assert.Equal("T", ts.Catches[0].Declaration.Type.ToString());
-            Assert.NotNull(ts.Catches[0].Declaration.Identifier);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.Identifier);
             Assert.Equal("e", ts.Catches[0].Declaration.Identifier.ToString());
-            Assert.NotNull(ts.Catches[0].Declaration.CloseParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[0].Block);
 
-            Assert.NotNull(ts.Catches[1].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[1].CatchKeyword);
             Assert.NotNull(ts.Catches[1].Declaration);
-            Assert.NotNull(ts.Catches[1].Declaration.OpenParenToken);
+            Assert.NotEqual(default, ts.Catches[1].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[1].Declaration.Type);
             Assert.Equal("T2", ts.Catches[1].Declaration.Type.ToString());
-            Assert.NotNull(ts.Catches[1].Declaration.CloseParenToken);
+            Assert.NotEqual(default, ts.Catches[1].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[1].Block);
 
-            Assert.NotNull(ts.Catches[2].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[2].CatchKeyword);
             Assert.Null(ts.Catches[2].Declaration);
             Assert.NotNull(ts.Catches[2].Block);
 
@@ -1354,14 +1354,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (TryStatementSyntax)statement;
-            Assert.NotNull(ts.TryKeyword);
+            Assert.NotEqual(default, ts.TryKeyword);
             Assert.False(ts.TryKeyword.IsMissing);
             Assert.NotNull(ts.Block);
 
             Assert.Equal(0, ts.Catches.Count);
 
             Assert.NotNull(ts.Finally);
-            Assert.NotNull(ts.Finally.FinallyKeyword);
+            Assert.NotEqual(default, ts.Finally.FinallyKeyword);
             Assert.NotNull(ts.Finally.Block);
         }
 
@@ -1377,36 +1377,36 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ts = (TryStatementSyntax)statement;
-            Assert.NotNull(ts.TryKeyword);
+            Assert.NotEqual(default, ts.TryKeyword);
             Assert.False(ts.TryKeyword.IsMissing);
             Assert.NotNull(ts.Block);
 
             Assert.Equal(3, ts.Catches.Count);
 
-            Assert.NotNull(ts.Catches[0].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[0].CatchKeyword);
             Assert.NotNull(ts.Catches[0].Declaration);
-            Assert.NotNull(ts.Catches[0].Declaration.OpenParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[0].Declaration.Type);
             Assert.Equal("T", ts.Catches[0].Declaration.Type.ToString());
-            Assert.NotNull(ts.Catches[0].Declaration.Identifier);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.Identifier);
             Assert.Equal("e", ts.Catches[0].Declaration.Identifier.ToString());
-            Assert.NotNull(ts.Catches[0].Declaration.CloseParenToken);
+            Assert.NotEqual(default, ts.Catches[0].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[0].Block);
 
-            Assert.NotNull(ts.Catches[1].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[1].CatchKeyword);
             Assert.NotNull(ts.Catches[1].Declaration);
-            Assert.NotNull(ts.Catches[1].Declaration.OpenParenToken);
+            Assert.NotEqual(default, ts.Catches[1].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[1].Declaration.Type);
             Assert.Equal("T2", ts.Catches[1].Declaration.Type.ToString());
-            Assert.NotNull(ts.Catches[1].Declaration.CloseParenToken);
+            Assert.NotEqual(default, ts.Catches[1].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[1].Block);
 
-            Assert.NotNull(ts.Catches[2].CatchKeyword);
+            Assert.NotEqual(default, ts.Catches[2].CatchKeyword);
             Assert.Null(ts.Catches[2].Declaration);
             Assert.NotNull(ts.Catches[2].Block);
 
             Assert.NotNull(ts.Finally);
-            Assert.NotNull(ts.Finally.FinallyKeyword);
+            Assert.NotEqual(default, ts.Finally.FinallyKeyword);
             Assert.NotNull(ts.Finally.Block);
         }
 
@@ -1422,7 +1422,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var cs = (CheckedStatementSyntax)statement;
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.CheckedKeyword, cs.Keyword.Kind());
             Assert.NotNull(cs.Block);
         }
@@ -1439,7 +1439,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var cs = (CheckedStatementSyntax)statement;
-            Assert.NotNull(cs.Keyword);
+            Assert.NotEqual(default, cs.Keyword);
             Assert.Equal(SyntaxKind.UncheckedKeyword, cs.Keyword.Kind());
             Assert.NotNull(cs.Block);
         }
@@ -1456,7 +1456,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UnsafeStatementSyntax)statement;
-            Assert.NotNull(us.UnsafeKeyword);
+            Assert.NotEqual(default, us.UnsafeKeyword);
             Assert.Equal(SyntaxKind.UnsafeKeyword, us.UnsafeKeyword.Kind());
             Assert.NotNull(us.Block);
         }
@@ -1473,11 +1473,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ws = (WhileStatementSyntax)statement;
-            Assert.NotNull(ws.WhileKeyword);
+            Assert.NotEqual(default, ws.WhileKeyword);
             Assert.Equal(SyntaxKind.WhileKeyword, ws.WhileKeyword.Kind());
-            Assert.NotNull(ws.OpenParenToken);
+            Assert.NotEqual(default, ws.OpenParenToken);
             Assert.NotNull(ws.Condition);
-            Assert.NotNull(ws.CloseParenToken);
+            Assert.NotEqual(default, ws.CloseParenToken);
             Assert.Equal("a", ws.Condition.ToString());
             Assert.NotNull(ws.Statement);
             Assert.Equal(SyntaxKind.Block, ws.Statement.Kind());
@@ -1495,17 +1495,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ds = (DoStatementSyntax)statement;
-            Assert.NotNull(ds.DoKeyword);
+            Assert.NotEqual(default, ds.DoKeyword);
             Assert.Equal(SyntaxKind.DoKeyword, ds.DoKeyword.Kind());
             Assert.NotNull(ds.Statement);
-            Assert.NotNull(ds.WhileKeyword);
+            Assert.NotEqual(default, ds.WhileKeyword);
             Assert.Equal(SyntaxKind.WhileKeyword, ds.WhileKeyword.Kind());
             Assert.Equal(SyntaxKind.Block, ds.Statement.Kind());
-            Assert.NotNull(ds.OpenParenToken);
+            Assert.NotEqual(default, ds.OpenParenToken);
             Assert.NotNull(ds.Condition);
-            Assert.NotNull(ds.CloseParenToken);
+            Assert.NotEqual(default, ds.CloseParenToken);
             Assert.Equal("a", ds.Condition.ToString());
-            Assert.NotNull(ds.SemicolonToken);
+            Assert.NotEqual(default, ds.SemicolonToken);
         }
 
         [Fact]
@@ -1520,17 +1520,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.Null(fs.Declaration);
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1546,28 +1546,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.NotNull(fs.Declaration);
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("T", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("0", fs.Declaration.Variables[0].Initializer.Value.ToString());
 
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1583,10 +1583,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.NotNull(fs.Declaration);
             Assert.NotNull(fs.Declaration.Type);
@@ -1594,19 +1594,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.IdentifierName, fs.Declaration.Type.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)fs.Declaration.Type).Identifier.Kind());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("0", fs.Declaration.Variables[0].Initializer.Value.ToString());
 
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1622,36 +1622,36 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.NotNull(fs.Declaration);
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("T", fs.Declaration.Type.ToString());
             Assert.Equal(2, fs.Declaration.Variables.Count);
 
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("0", fs.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(fs.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[1].Identifier);
             Assert.Equal("b", fs.Declaration.Variables[1].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[1].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[1].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[1].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[1].Initializer.Value);
             Assert.Equal("1", fs.Declaration.Variables[1].Initializer.Value.ToString());
 
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1731,20 +1731,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.Null(fs.Declaration);
             Assert.Equal(1, fs.Initializers.Count);
             Assert.Equal("a = 0", fs.Initializers[0].ToString());
 
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1760,21 +1760,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.Null(fs.Declaration);
             Assert.Equal(2, fs.Initializers.Count);
             Assert.Equal("a = 0", fs.Initializers[0].ToString());
             Assert.Equal("b = 1", fs.Initializers[1].ToString());
 
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1790,21 +1790,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.Null(fs.Declaration);
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
 
             Assert.NotNull(fs.Condition);
             Assert.Equal("a", fs.Condition.ToString());
 
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
             Assert.Equal(0, fs.Incrementors.Count);
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1820,21 +1820,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.Null(fs.Declaration);
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
 
             Assert.Equal(1, fs.Incrementors.Count);
             Assert.Equal("a++", fs.Incrementors[0].ToString());
 
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1850,22 +1850,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.Null(fs.Declaration);
             Assert.Equal(0, fs.Initializers.Count);
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.Null(fs.Condition);
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
 
             Assert.Equal(2, fs.Incrementors.Count);
             Assert.Equal("a++", fs.Incrementors[0].ToString());
             Assert.Equal("b++", fs.Incrementors[1].ToString());
 
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1881,34 +1881,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForStatementSyntax)statement;
-            Assert.NotNull(fs.ForKeyword);
+            Assert.NotEqual(default, fs.ForKeyword);
             Assert.False(fs.ForKeyword.IsMissing);
             Assert.Equal(SyntaxKind.ForKeyword, fs.ForKeyword.Kind());
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
 
             Assert.NotNull(fs.Declaration);
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("T", fs.Declaration.Type.ToString());
             Assert.Equal(1, fs.Declaration.Variables.Count);
-            Assert.NotNull(fs.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Identifier);
             Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
-            Assert.NotNull(fs.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, fs.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(fs.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("0", fs.Declaration.Variables[0].Initializer.Value.ToString());
 
             Assert.Equal(0, fs.Initializers.Count);
 
-            Assert.NotNull(fs.FirstSemicolonToken);
+            Assert.NotEqual(default, fs.FirstSemicolonToken);
             Assert.NotNull(fs.Condition);
             Assert.Equal("a < 10", fs.Condition.ToString());
 
-            Assert.NotNull(fs.SecondSemicolonToken);
+            Assert.NotEqual(default, fs.SecondSemicolonToken);
 
             Assert.Equal(1, fs.Incrementors.Count);
             Assert.Equal("a++", fs.Incrementors[0].ToString());
 
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1924,20 +1924,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForEachStatementSyntax)statement;
-            Assert.NotNull(fs.ForEachKeyword);
+            Assert.NotEqual(default, fs.ForEachKeyword);
             Assert.Equal(SyntaxKind.ForEachKeyword, fs.ForEachKeyword.Kind());
 
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.NotNull(fs.Type);
             Assert.Equal("T", fs.Type.ToString());
-            Assert.NotNull(fs.Identifier);
+            Assert.NotEqual(default, fs.Identifier);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal(SyntaxKind.InKeyword, fs.InKeyword.Kind());
             Assert.NotNull(fs.Expression);
             Assert.Equal("b", fs.Expression.ToString());
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1953,24 +1953,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(1, statement.Errors().Length);
 
             var fs = (ForEachStatementSyntax)statement;
-            Assert.NotNull(fs.ForEachKeyword);
+            Assert.NotEqual(default, fs.ForEachKeyword);
             Assert.Equal(SyntaxKind.ForEachKeyword, fs.ForEachKeyword.Kind());
             Assert.True(fs.ForEachKeyword.IsMissing);
             Assert.Equal(fs.ForEachKeyword.TrailingTrivia.Count, 1);
             Assert.Equal(fs.ForEachKeyword.TrailingTrivia[0].Kind(), SyntaxKind.SkippedTokensTrivia);
             Assert.Equal(fs.ForEachKeyword.TrailingTrivia[0].ToString(), "for");
 
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.NotNull(fs.Type);
             Assert.Equal("T", fs.Type.ToString());
-            Assert.NotNull(fs.Identifier);
+            Assert.NotEqual(default, fs.Identifier);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal(SyntaxKind.InKeyword, fs.InKeyword.Kind());
             Assert.NotNull(fs.Expression);
             Assert.Equal("b", fs.Expression.ToString());
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -1986,22 +1986,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForEachStatementSyntax)statement;
-            Assert.NotNull(fs.ForEachKeyword);
+            Assert.NotEqual(default, fs.ForEachKeyword);
             Assert.Equal(SyntaxKind.ForEachKeyword, fs.ForEachKeyword.Kind());
 
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.NotNull(fs.Type);
             Assert.Equal("var", fs.Type.ToString());
             Assert.Equal(SyntaxKind.IdentifierName, fs.Type.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)fs.Type).Identifier.Kind());
-            Assert.NotNull(fs.Identifier);
+            Assert.NotEqual(default, fs.Identifier);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal(SyntaxKind.InKeyword, fs.InKeyword.Kind());
             Assert.NotNull(fs.Expression);
             Assert.Equal("b", fs.Expression.ToString());
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 
@@ -2017,12 +2017,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (IfStatementSyntax)statement;
-            Assert.NotNull(ss.IfKeyword);
+            Assert.NotEqual(default, ss.IfKeyword);
             Assert.Equal(SyntaxKind.IfKeyword, ss.IfKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Condition);
             Assert.Equal("a", ss.Condition.ToString());
-            Assert.NotNull(ss.CloseParenToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
             Assert.NotNull(ss.Statement);
 
             Assert.Null(ss.Else);
@@ -2040,16 +2040,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (IfStatementSyntax)statement;
-            Assert.NotNull(ss.IfKeyword);
+            Assert.NotEqual(default, ss.IfKeyword);
             Assert.Equal(SyntaxKind.IfKeyword, ss.IfKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Condition);
             Assert.Equal("a", ss.Condition.ToString());
-            Assert.NotNull(ss.CloseParenToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
             Assert.NotNull(ss.Statement);
 
             Assert.NotNull(ss.Else);
-            Assert.NotNull(ss.Else.ElseKeyword);
+            Assert.NotEqual(default, ss.Else.ElseKeyword);
             Assert.Equal(SyntaxKind.ElseKeyword, ss.Else.ElseKeyword.Kind());
             Assert.NotNull(ss.Else.Statement);
         }
@@ -2066,25 +2066,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (IfStatementSyntax)statement;
-            Assert.NotNull(ss.IfKeyword);
+            Assert.NotEqual(default, ss.IfKeyword);
             Assert.Equal(SyntaxKind.IfKeyword, ss.IfKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Condition);
             Assert.Equal("a", ss.Condition.ToString());
-            Assert.NotNull(ss.CloseParenToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
             Assert.NotNull(ss.Statement);
 
             Assert.NotNull(ss.Else);
-            Assert.NotNull(ss.Else.ElseKeyword);
+            Assert.NotEqual(default, ss.Else.ElseKeyword);
             Assert.Equal(SyntaxKind.ElseKeyword, ss.Else.ElseKeyword.Kind());
             Assert.NotNull(ss.Else.Statement);
 
             var subIf = (IfStatementSyntax)ss.Else.Statement;
-            Assert.NotNull(subIf.IfKeyword);
+            Assert.NotEqual(default, subIf.IfKeyword);
             Assert.Equal(SyntaxKind.IfKeyword, subIf.IfKeyword.Kind());
             Assert.NotNull(subIf.Condition);
             Assert.Equal("b", subIf.Condition.ToString());
-            Assert.NotNull(subIf.CloseParenToken);
+            Assert.NotEqual(default, subIf.CloseParenToken);
             Assert.NotNull(subIf.Statement);
         }
 
@@ -2100,12 +2100,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ls = (LockStatementSyntax)statement;
-            Assert.NotNull(ls.LockKeyword);
+            Assert.NotEqual(default, ls.LockKeyword);
             Assert.Equal(SyntaxKind.LockKeyword, ls.LockKeyword.Kind());
-            Assert.NotNull(ls.OpenParenToken);
+            Assert.NotEqual(default, ls.OpenParenToken);
             Assert.NotNull(ls.Expression);
             Assert.Equal("a", ls.Expression.ToString());
-            Assert.NotNull(ls.CloseParenToken);
+            Assert.NotEqual(default, ls.CloseParenToken);
             Assert.NotNull(ls.Statement);
         }
 
@@ -2123,15 +2123,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, diags.Length);
 
             var ss = (SwitchStatementSyntax)statement;
-            Assert.NotNull(ss.SwitchKeyword);
+            Assert.NotEqual(default, ss.SwitchKeyword);
             Assert.Equal(SyntaxKind.SwitchKeyword, ss.SwitchKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Expression);
             Assert.Equal("a", ss.Expression.ToString());
-            Assert.NotNull(ss.CloseParenToken);
-            Assert.NotNull(ss.OpenBraceToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
+            Assert.NotEqual(default, ss.OpenBraceToken);
             Assert.Equal(0, ss.Sections.Count);
-            Assert.NotNull(ss.CloseBraceToken);
+            Assert.NotEqual(default, ss.CloseBraceToken);
         }
 
         [Fact]
@@ -2146,27 +2146,27 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (SwitchStatementSyntax)statement;
-            Assert.NotNull(ss.SwitchKeyword);
+            Assert.NotEqual(default, ss.SwitchKeyword);
             Assert.Equal(SyntaxKind.SwitchKeyword, ss.SwitchKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Expression);
             Assert.Equal("a", ss.Expression.ToString());
-            Assert.NotNull(ss.CloseParenToken);
-            Assert.NotNull(ss.OpenBraceToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
+            Assert.NotEqual(default, ss.OpenBraceToken);
 
             Assert.Equal(1, ss.Sections.Count);
             Assert.Equal(1, ss.Sections[0].Labels.Count);
-            Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind());
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
             Assert.NotNull(caseLabelSyntax);
             Assert.NotNull(caseLabelSyntax.Value);
             Assert.Equal("b", caseLabelSyntax.Value.ToString());
-            Assert.NotNull(caseLabelSyntax.ColonToken);
+            Assert.NotEqual(default, caseLabelSyntax.ColonToken);
             Assert.Equal(1, ss.Sections[0].Statements.Count);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
-            Assert.NotNull(ss.CloseBraceToken);
+            Assert.NotEqual(default, ss.CloseBraceToken);
         }
 
         [Fact]
@@ -2181,39 +2181,39 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (SwitchStatementSyntax)statement;
-            Assert.NotNull(ss.SwitchKeyword);
+            Assert.NotEqual(default, ss.SwitchKeyword);
             Assert.Equal(SyntaxKind.SwitchKeyword, ss.SwitchKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Expression);
             Assert.Equal("a", ss.Expression.ToString());
-            Assert.NotNull(ss.CloseParenToken);
-            Assert.NotNull(ss.OpenBraceToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
+            Assert.NotEqual(default, ss.OpenBraceToken);
 
             Assert.Equal(2, ss.Sections.Count);
 
             Assert.Equal(1, ss.Sections[0].Labels.Count);
-            Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind());
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
             Assert.NotNull(caseLabelSyntax);
             Assert.NotNull(caseLabelSyntax.Value);
             Assert.Equal("b", caseLabelSyntax.Value.ToString());
-            Assert.NotNull(caseLabelSyntax.ColonToken);
+            Assert.NotEqual(default, caseLabelSyntax.ColonToken);
             Assert.Equal(1, ss.Sections[0].Statements.Count);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
             Assert.Equal(1, ss.Sections[1].Labels.Count);
-            Assert.NotNull(ss.Sections[1].Labels[0].Keyword);
+            Assert.NotEqual(default, ss.Sections[1].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[1].Labels[0].Keyword.Kind());
             var caseLabelSyntax2 = ss.Sections[1].Labels[0] as CaseSwitchLabelSyntax;
             Assert.NotNull(caseLabelSyntax2);
             Assert.NotNull(caseLabelSyntax2.Value);
             Assert.Equal("c", caseLabelSyntax2.Value.ToString());
-            Assert.NotNull(caseLabelSyntax2.ColonToken);
+            Assert.NotEqual(default, caseLabelSyntax2.ColonToken);
             Assert.Equal(1, ss.Sections[1].Statements.Count);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
-            Assert.NotNull(ss.CloseBraceToken);
+            Assert.NotEqual(default, ss.CloseBraceToken);
         }
 
         [Fact]
@@ -2228,25 +2228,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (SwitchStatementSyntax)statement;
-            Assert.NotNull(ss.SwitchKeyword);
+            Assert.NotEqual(default, ss.SwitchKeyword);
             Assert.Equal(SyntaxKind.SwitchKeyword, ss.SwitchKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
-            Assert.NotNull(ss.Expression);
+            Assert.NotEqual(default, ss.OpenParenToken);
+            Assert.NotEqual(default, ss.Expression);
             Assert.Equal("a", ss.Expression.ToString());
-            Assert.NotNull(ss.CloseParenToken);
-            Assert.NotNull(ss.OpenBraceToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
+            Assert.NotEqual(default, ss.OpenBraceToken);
 
             Assert.Equal(1, ss.Sections.Count);
 
             Assert.Equal(1, ss.Sections[0].Labels.Count);
-            Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.DefaultKeyword, ss.Sections[0].Labels[0].Keyword.Kind());
             Assert.Equal(SyntaxKind.DefaultSwitchLabel, ss.Sections[0].Labels[0].Kind());
-            Assert.NotNull(ss.Sections[0].Labels[0].ColonToken);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].ColonToken);
             Assert.Equal(1, ss.Sections[0].Statements.Count);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
-            Assert.NotNull(ss.CloseBraceToken);
+            Assert.NotEqual(default, ss.CloseBraceToken);
         }
 
         [Fact]
@@ -2261,34 +2261,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (SwitchStatementSyntax)statement;
-            Assert.NotNull(ss.SwitchKeyword);
+            Assert.NotEqual(default, ss.SwitchKeyword);
             Assert.Equal(SyntaxKind.SwitchKeyword, ss.SwitchKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Expression);
             Assert.Equal("a", ss.Expression.ToString());
-            Assert.NotNull(ss.CloseParenToken);
-            Assert.NotNull(ss.OpenBraceToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
+            Assert.NotEqual(default, ss.OpenBraceToken);
 
             Assert.Equal(1, ss.Sections.Count);
 
             Assert.Equal(2, ss.Sections[0].Labels.Count);
-            Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind());
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
             Assert.NotNull(caseLabelSyntax);
             Assert.NotNull(caseLabelSyntax.Value);
             Assert.Equal("b", caseLabelSyntax.Value.ToString());
-            Assert.NotNull(ss.Sections[0].Labels[1].Keyword);
+            Assert.NotEqual(default, ss.Sections[0].Labels[1].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[1].Keyword.Kind());
             var caseLabelSyntax2 = ss.Sections[0].Labels[1] as CaseSwitchLabelSyntax;
             Assert.NotNull(caseLabelSyntax2);
             Assert.NotNull(caseLabelSyntax2.Value);
             Assert.Equal("c", caseLabelSyntax2.Value.ToString());
-            Assert.NotNull(ss.Sections[0].Labels[0].ColonToken);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].ColonToken);
             Assert.Equal(1, ss.Sections[0].Statements.Count);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
-            Assert.NotNull(ss.CloseBraceToken);
+            Assert.NotEqual(default, ss.CloseBraceToken);
         }
 
         [Fact]
@@ -2303,18 +2303,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var ss = (SwitchStatementSyntax)statement;
-            Assert.NotNull(ss.SwitchKeyword);
+            Assert.NotEqual(default, ss.SwitchKeyword);
             Assert.Equal(SyntaxKind.SwitchKeyword, ss.SwitchKeyword.Kind());
-            Assert.NotNull(ss.OpenParenToken);
+            Assert.NotEqual(default, ss.OpenParenToken);
             Assert.NotNull(ss.Expression);
             Assert.Equal("a", ss.Expression.ToString());
-            Assert.NotNull(ss.CloseParenToken);
-            Assert.NotNull(ss.OpenBraceToken);
+            Assert.NotEqual(default, ss.CloseParenToken);
+            Assert.NotEqual(default, ss.OpenBraceToken);
 
             Assert.Equal(1, ss.Sections.Count);
 
             Assert.Equal(1, ss.Sections[0].Labels.Count);
-            Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
+            Assert.NotEqual(default, ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind());
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
             Assert.NotNull(caseLabelSyntax);
@@ -2324,7 +2324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("s1();", ss.Sections[0].Statements[0].ToString());
             Assert.Equal("s2();", ss.Sections[0].Statements[1].ToString());
 
-            Assert.NotNull(ss.CloseBraceToken);
+            Assert.NotEqual(default, ss.CloseBraceToken);
         }
 
         [Fact]
@@ -2339,13 +2339,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
             Assert.Null(us.Declaration);
             Assert.NotNull(us.Expression);
             Assert.Equal("a", us.Expression.ToString());
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -2361,25 +2361,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
 
             Assert.NotNull(us.Declaration);
             Assert.NotNull(us.Declaration.Type);
             Assert.Equal("T", us.Declaration.Type.ToString());
             Assert.Equal(1, us.Declaration.Variables.Count);
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
 
             Assert.Null(us.Expression);
 
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -2395,21 +2395,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
 
             Assert.NotNull(us.Declaration);
             Assert.NotNull(us.Declaration.Type);
             Assert.Equal("T", us.Declaration.Type.ToString());
             Assert.Equal(1, us.Declaration.Variables.Count);
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
-            Assert.NotNull(us.SemicolonToken);
+            Assert.NotEqual(default, us.SemicolonToken);
         }
 
         [Fact]
@@ -2454,9 +2454,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
 
             Assert.NotNull(us.Declaration);
             Assert.NotNull(us.Declaration.Type);
@@ -2464,17 +2464,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.IdentifierName, us.Declaration.Type.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)us.Declaration.Type).Identifier.Kind());
             Assert.Equal(1, us.Declaration.Variables.Count);
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
 
             Assert.Null(us.Expression);
 
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -2490,7 +2490,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
 
             Assert.NotNull(us.Declaration);
@@ -2499,11 +2499,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.IdentifierName, us.Declaration.Type.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)us.Declaration.Type).Identifier.Kind());
             Assert.Equal(1, us.Declaration.Variables.Count);
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
         }
@@ -2525,7 +2525,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("readonly", statement.Errors()[1].Arguments[0]);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
 
             Assert.NotNull(us.Declaration);
@@ -2537,11 +2537,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("public", us.Modifiers[0].ToString());
             Assert.Equal("readonly", us.Modifiers[1].ToString());
             Assert.Equal(1, us.Declaration.Variables.Count);
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
         }
@@ -2619,9 +2619,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.AwaitKeyword);
+            Assert.NotEqual(default, us.AwaitKeyword);
             Assert.Equal(SyntaxKind.AwaitKeyword, us.AwaitKeyword.ContextualKind());
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
 
             Assert.NotNull(us.Declaration);
@@ -2630,11 +2630,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.IdentifierName, us.Declaration.Type.Kind());
             Assert.Equal(SyntaxKind.IdentifierToken, ((IdentifierNameSyntax)us.Declaration.Type).Identifier.Kind());
             Assert.Equal(1, us.Declaration.Variables.Count);
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
         }
@@ -2785,9 +2785,9 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
 
             Assert.NotNull(us.Declaration);
             Assert.NotNull(us.Declaration.Type);
@@ -2795,25 +2795,25 @@ class C
 
             Assert.Equal(2, us.Declaration.Variables.Count);
 
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(us.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[1].Identifier);
             Assert.Equal("c", us.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[1].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[1].Initializer);
-            Assert.NotNull(us.Declaration.Variables[1].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[1].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[1].Initializer.Value);
             Assert.Equal("d", us.Declaration.Variables[1].Initializer.Value.ToString());
 
             Assert.Null(us.Expression);
 
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -2829,7 +2829,7 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
 
             Assert.NotNull(us.Declaration);
@@ -2838,19 +2838,19 @@ class C
 
             Assert.Equal(2, us.Declaration.Variables.Count);
 
-            Assert.NotNull(us.Declaration.Variables[0].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Identifier);
             Assert.Equal("a", us.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[0].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[0].Initializer);
-            Assert.NotNull(us.Declaration.Variables[0].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[0].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[0].Initializer.Value);
             Assert.Equal("b", us.Declaration.Variables[0].Initializer.Value.ToString());
 
-            Assert.NotNull(us.Declaration.Variables[1].Identifier);
+            Assert.NotEqual(default, us.Declaration.Variables[1].Identifier);
             Assert.Equal("c", us.Declaration.Variables[1].Identifier.ToString());
             Assert.Null(us.Declaration.Variables[1].ArgumentList);
             Assert.NotNull(us.Declaration.Variables[1].Initializer);
-            Assert.NotNull(us.Declaration.Variables[1].Initializer.EqualsToken);
+            Assert.NotEqual(default, us.Declaration.Variables[1].Initializer.EqualsToken);
             Assert.NotNull(us.Declaration.Variables[1].Initializer.Value);
             Assert.Equal("d", us.Declaration.Variables[1].Initializer.Value.ToString());
         }
@@ -2910,13 +2910,13 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
             Assert.Null(us.Declaration);
             Assert.NotNull(us.Expression);
             Assert.Equal("f ? x = a : x = b", us.Expression.ToString());
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -2932,7 +2932,7 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
             Assert.NotNull(us.Declaration);
             Assert.Equal("var x = f ? a : b", us.Declaration.ToString());
@@ -2993,13 +2993,13 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
             Assert.NotNull(us.Declaration);
             Assert.Equal("f ? x = a", us.Declaration.ToString());
             Assert.Null(us.Expression);
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -3015,7 +3015,7 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
             Assert.NotNull(us.Declaration);
             Assert.Equal("f ? x = a", us.Declaration.ToString());
@@ -3065,13 +3065,13 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (UsingStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
-            Assert.NotNull(us.OpenParenToken);
+            Assert.NotEqual(default, us.OpenParenToken);
             Assert.NotNull(us.Declaration);
             Assert.Equal("f ? x, y", us.Declaration.ToString());
             Assert.Null(us.Expression);
-            Assert.NotNull(us.CloseParenToken);
+            Assert.NotEqual(default, us.CloseParenToken);
             Assert.NotNull(us.Statement);
         }
 
@@ -3087,7 +3087,7 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var us = (LocalDeclarationStatementSyntax)statement;
-            Assert.NotNull(us.UsingKeyword);
+            Assert.NotEqual(default, us.UsingKeyword);
             Assert.Equal(SyntaxKind.UsingKeyword, us.UsingKeyword.Kind());
             Assert.NotNull(us.Declaration);
             Assert.Equal("f ? x, y", us.Declaration.ToString());
@@ -3363,20 +3363,20 @@ class C
             Assert.Equal(0, statement.Errors().Length);
 
             var fs = (ForEachStatementSyntax)statement;
-            Assert.NotNull(fs.ForEachKeyword);
+            Assert.NotEqual(default, fs.ForEachKeyword);
             Assert.Equal(SyntaxKind.ForEachKeyword, fs.ForEachKeyword.Kind());
 
-            Assert.NotNull(fs.OpenParenToken);
+            Assert.NotEqual(default, fs.OpenParenToken);
             Assert.NotNull(fs.Type);
             Assert.Equal("T", fs.Type.ToString());
-            Assert.NotNull(fs.Identifier);
+            Assert.NotEqual(default, fs.Identifier);
             Assert.Equal("a", fs.Identifier.ToString());
-            Assert.NotNull(fs.InKeyword);
+            Assert.NotEqual(default, fs.InKeyword);
             Assert.False(fs.InKeyword.IsMissing);
             Assert.Equal(SyntaxKind.InKeyword, fs.InKeyword.Kind());
             Assert.NotNull(fs.Expression);
             Assert.Equal("b", fs.Expression.ToString());
-            Assert.NotNull(fs.CloseParenToken);
+            Assert.NotEqual(default, fs.CloseParenToken);
             Assert.NotNull(fs.Statement);
         }
 

--- a/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/AnonymousTypesSymbolTests.cs
@@ -969,7 +969,7 @@ class Query
 
         private void TestAnonymousType(NamedTypeSymbol type, int typeIndex, TypeDescr typeDescr)
         {
-            Assert.NotNull(typeDescr);
+            Assert.NotEqual(default, typeDescr);
             Assert.NotNull(typeDescr.FieldNames);
 
             //  prepare 

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1092,7 +1092,7 @@ dotnet_diagnostic.cs000.severity = none", "Z:\\.editorconfig"));
             {
                 if (expected[i] is null)
                 {
-                    Assert.Null(options[i]);
+                    Assert.NotEqual(default, options[i]);
                 }
                 else
                 {
@@ -1113,7 +1113,7 @@ dotnet_diagnostic.cs000.severity = none", "Z:\\.editorconfig"));
             {
                 if (expected[i] is null)
                 {
-                    Assert.Null(options[i]);
+                    Assert.NotEqual(default, options[i]);
                 }
                 else
                 {

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextSpanTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextSpanTest.cs
@@ -198,12 +198,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TextSpan span2 = new TextSpan(0, 10);
 
             Assert.True(span1.Equals(span2));
-            Assert.NotNull(span1);
+            Assert.NotEqual(default, span1);
             Assert.True(span1 == span2, span1.ToString() + " : " + span2.ToString());
             Assert.False(span1 != span2, span1.ToString() + " : " + span2.ToString());
 
             Assert.True(span2.Equals(span1));
-            Assert.NotNull(span2);
+            Assert.NotEqual(default, span2);
             Assert.True(span2 == span1, span2.ToString() + " : " + span1.ToString());
             Assert.False(span2 != span1, span2.ToString() + " : " + span1.ToString());
         }

--- a/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis
         public bool Equals(SymbolInfo other)
         {
             if (!object.Equals(this.Symbol, other.Symbol) ||
-                _candidateSymbols.IsDefault != _candidateSymbols.IsDefault ||
+                _candidateSymbols.IsDefault != other._candidateSymbols.IsDefault ||
                 this.CandidateReason != other.CandidateReason)
             {
                 return false;

--- a/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
@@ -98,9 +98,14 @@ namespace Microsoft.CodeAnalysis
 
         public bool Equals(SymbolInfo other)
         {
-            return object.Equals(this.Symbol, other.Symbol)
-                && ((_candidateSymbols.IsDefault && other._candidateSymbols.IsDefault) || _candidateSymbols.SequenceEqual(other._candidateSymbols))
-                && this.CandidateReason == other.CandidateReason;
+            if (!object.Equals(this.Symbol, other.Symbol) ||
+                _candidateSymbols.IsDefault != _candidateSymbols.IsDefault ||
+                this.CandidateReason != other.CandidateReason)
+            {
+                return false;
+            }
+
+            return _candidateSymbols.IsDefault || _candidateSymbols.SequenceEqual(other._candidateSymbols);
         }
 
         public override int GetHashCode()

--- a/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
@@ -697,7 +697,7 @@ class C
             End Using
         End Function
 
-        <WpfFact>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/38555")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Async Function VisualBasic_FixupSpanDuringResolvableConflict_NonReferenceConflict() As Task
             Using workspace = CreateWorkspaceWithWaiter(
@@ -1351,7 +1351,7 @@ namespace N
             End Using
         End Function
 
-        <WpfFact>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/38555")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(8334, "https://github.com/dotnet/roslyn/issues/8334")>
         Public Async Function CSharp_FixupSpanDuringResolvableConflict_ComplexificationReordersReferenceSpans() As Task

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -12,7 +12,6 @@ using System.Text;
 using DiffPlex;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -12,6 +12,7 @@ using System.Text;
 using DiffPlex;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/TestWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/TestWriter.cs
@@ -263,7 +263,17 @@ namespace CSharpSyntaxGenerator
                     }
                     else
                     {
-                        WriteLine("Assert.NotNull(node.{0});", field.Name);
+                        if (field.Type == "SyntaxToken" ||
+                            field.Type == "SyntaxTokenList" ||
+                            field.Type.StartsWith("SyntaxList<") ||
+                            field.Type.StartsWith("SeparatedSyntaxList<"))
+                        {
+                            WriteLine("Assert.NotEqual(default, node.{0});", field.Name);
+                        }
+                        else
+                        {
+                            WriteLine("Assert.NotNull(node.{0});", field.Name);
+                        }
                     }
 
                     if (!isGreen)

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/TestWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/TestWriter.cs
@@ -263,12 +263,16 @@ namespace CSharpSyntaxGenerator
                     }
                     else
                     {
-                        if (field.Type == "SyntaxToken" ||
+                        if (field.Type == "SyntaxToken")
+                        {
+                            WriteLine("Assert.NotEqual(default, node.{0});", field.Name);
+                        }
+                        else if (
                             field.Type == "SyntaxTokenList" ||
                             field.Type.StartsWith("SyntaxList<") ||
                             field.Type.StartsWith("SeparatedSyntaxList<"))
                         {
-                            WriteLine("Assert.NotEqual(default, node.{0});", field.Name);
+                            WriteLine("Assert.Equal(default, node.{0});", field.Name);
                         }
                         else
                         {

--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -636,7 +636,7 @@ class C
             var xSymbol = testModel.LookupSymbols(position).First(s => s.Name == "x");
 
             // This should not throw an exception.
-            Assert.NotNull(SymbolKey.Create(xSymbol));
+            Assert.NotEqual(default, SymbolKey.Create(xSymbol));
         }
 
         [Fact]


### PR DESCRIPTION
This enables xUnit analyzer rule xUnit2002 which validates the expression being passed to `Assert.NotNull` is not a value type. The Roslyn code base had ~2,000 violations of this rule mostly due to passing `SyntaxToken` here. Presumably this is a historical artifact from the times when `SyntaxNode` was defined as a `class` instead of `struct`. 

The code was mechanically transformed in the following way:

``` csharp
// old
Assert.NotNull(token);
// new
Assert.NotEqual(default, token)
```

I did give some consideration to just removing all the uses of `Assert.NotNull` when the argument passed in was side effect free (mostly locals). Eventually I decided against this though because I didn't want to mix potentially deleting valuable code with a mechanical transformation. If we do want to remove the non-sense comparisons here we should take that as a separate change.
