### PR TITLE
Adjust dependency tracking for types with respect to added ability to nest types into interfaces.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal static class BaseTypeAnalysis
     {
-        internal static bool ClassDependsOn(NamedTypeSymbol depends, NamedTypeSymbol on)
+        internal static bool TypeDependsOn(NamedTypeSymbol depends, NamedTypeSymbol on)
         {
             Debug.Assert((object)depends != null);
             Debug.Assert((object)on != null);
@@ -281,21 +281,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 default:
                     return (ThreeState.True, hasGenerics);
             }
-        }
-
-        internal static bool InterfaceDependsOn(NamedTypeSymbol depends, NamedTypeSymbol on)
-        {
-            Debug.Assert((object)depends != null);
-            Debug.Assert((object)on != null);
-            Debug.Assert(on.IsDefinition);
-
-            var hs = PooledHashSet<Symbol>.GetInstance();
-            TypeDependsClosure(depends, depends.DeclaringCompilation, hs);
-
-            var result = hs.Contains(on);
-            hs.Free();
-
-            return result;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -1692,7 +1692,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return null;
             }
 
-            if (BaseTypeAnalysis.ClassDependsOn(declaredBase, this))
+            if (BaseTypeAnalysis.TypeDependsOn(declaredBase, this))
             {
                 return CyclicInheritanceError(this, declaredBase);
             }
@@ -1711,7 +1711,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
 
             return declaredInterfaces
-                .SelectAsArray(t => BaseTypeAnalysis.InterfaceDependsOn(t, this) ? CyclicInheritanceError(this, t) : t);
+                .SelectAsArray(t => BaseTypeAnalysis.TypeDependsOn(t, this) ? CyclicInheritanceError(this, t) : t);
         }
 
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         }
                     }
 
-                    if ((object)acyclicBase != null && BaseTypeAnalysis.ClassDependsOn(acyclicBase, this))
+                    if ((object)acyclicBase != null && BaseTypeAnalysis.TypeDependsOn(acyclicBase, this))
                     {
                         return CyclicInheritanceError(this, acyclicBase);
                     }
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 }
 
                 ImmutableArray<NamedTypeSymbol> result = declaredInterfaces
-                    .SelectAsArray(t => BaseTypeAnalysis.InterfaceDependsOn(t, this) ? CyclicInheritanceError(this, t) : t);
+                    .SelectAsArray(t => BaseTypeAnalysis.TypeDependsOn(t, this) ? CyclicInheritanceError(this, t) : t);
 
                 ImmutableInterlocked.InterlockedCompareExchange(ref _lazyInterfaces, result, default(ImmutableArray<NamedTypeSymbol>));
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -569,7 +569,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (!isClass)
                 {
-                    if (BaseTypeAnalysis.InterfaceDependsOn(depends: t, on: this))
+                    if (BaseTypeAnalysis.TypeDependsOn(depends: t, on: this))
                     {
                         result.Add(new ExtendedErrorTypeSymbol(t, LookupResultKind.NotReferencable,
                             diagnostics.Add(ErrorCode.ERR_CycleInInterfaceInheritance, Locations[0], this, t)));
@@ -650,7 +650,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (BaseTypeAnalysis.ClassDependsOn(declaredBase, this))
+            if (BaseTypeAnalysis.TypeDependsOn(declaredBase, this))
             {
                 return new ExtendedErrorTypeSymbol(declaredBase, LookupResultKind.NotReferencable,
                     diagnostics.Add(ErrorCode.ERR_CircularBase, Locations[0], declaredBase, this));

--- a/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
@@ -202,11 +202,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return ConsList(Of DependencyDesc).Empty
             End If
 
-            If visited.Contains(current) Then
+            If Not visited.Add(current) Then
                 ' we have seen this already
                 Return Nothing
-            Else
-                visited.Add(current)
             End If
 
             Dim currentNamedType = TryCast(currentDef, NamedTypeSymbol)


### PR DESCRIPTION
Related to #34704.

**We used to have the following rules:**

"When a class B derives from a class A, it is a compile-time error for A to depend on B. A class **directly depends on** its direct base class (if any) and **directly depends on** the ~~**class**~~ within which it is immediately nested (if any). Given this definition, the complete set of ~~**classes**~~ upon which a class depends is the reflexive and transitive closure of the **directly depends on** relationship."

It is a compile-time error for an interface to directly or indirectly inherit from itself.
The **base interfaces** of an interface are the explicit base interfaces and their base interfaces. In other words, the set of base interfaces is the complete transitive closure of the explicit base interfaces, their explicit base interfaces, and so on.

**Since we added ability to nest types into interfaces, we are adjusting them as follows:**

When a class B derives from a class A, it is a compile-time error for A to depend on B. A class **directly depends on** its direct base class (if any) and **directly depends on** the _**type**_ within which it is immediately nested (if any).

When an interface IB extends an interface IA, it is a compile-time error for IA to depend on IB. An interface **directly depends on** its direct base interfaces (if any) and **directly depends on** the type within which it is immediately nested (if any).

Given these definitions, the complete set of **types** upon which a type depends is the reflexive and transitive closure of the **directly depends on** relationship.