### PR TITLE
Sort completion list by pattern matching results

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterResult.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterResult.cs
@@ -13,6 +13,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         public readonly CompletionItem CompletionItem;
         public readonly bool MatchedFilterText;
         public readonly string FilterText;
+
+        // In certain cases, there'd be no match but we'd still set `MatchedFilterText` to true,
+        // e.g. when the item is in MRU list. Therefore making this nullable.
         public readonly PatternMatch? PatternMatch;
 
         public FilterResult(CompletionItem completionItem, string filterText, bool matchedFilterText, PatternMatch? patternMatch)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterResult.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterResult.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.PatternMatching;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
@@ -12,12 +13,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         public readonly CompletionItem CompletionItem;
         public readonly bool MatchedFilterText;
         public readonly string FilterText;
+        public readonly PatternMatch? PatternMatch;
 
-        public FilterResult(CompletionItem completionItem, string filterText, bool matchedFilterText)
+        public FilterResult(CompletionItem completionItem, string filterText, bool matchedFilterText, PatternMatch? patternMatch)
         {
             CompletionItem = completionItem;
             MatchedFilterText = matchedFilterText;
             FilterText = filterText;
+            PatternMatch = patternMatch;
         }
 
         public int CompareTo(FilterResult other)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -228,9 +228,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return HandleAllItemsFilteredOut(reason, data.SelectedFilters, completionRules);
             }
 
-            var experimentationService = document.Project.Solution.Workspace.Services.GetService<IExperimentationService>();
+            var experimentationService = document?.Project.Solution.Workspace.Services.GetService<IExperimentationService>();
 
-            var initialListOfItemsToBeIncluded = experimentationService.IsExperimentEnabled(WellKnownExperimentNames.SortCompletionListByMatch)
+            var initialListOfItemsToBeIncluded = experimentationService?.IsExperimentEnabled(WellKnownExperimentNames.SortCompletionListByMatch) == true
                 // Need a stable sorting algorithm to preserve the original order for items with same pattern match score.
                 ? builder.OrderBy(new NullablePatternMatchComparer()).ToImmutableArray()
                 : builder.ToImmutable();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     }
 
                     // Check if the item matches the filter text typed so far.
-                    var matchesFilterText = ItemManager.MatchesFilterText(helper, currentItem, filterText, model.Trigger.Kind, filterReason, recentItems, out var patternMatch);
+                    var matchesFilterText = ItemManager.MatchesFilterText(helper, currentItem, filterText, model.Trigger.Kind, filterReason, recentItems, includeMatchSpans: false, out var patternMatch);
 
                     if (matchesFilterText)
                     {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -140,12 +140,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     }
 
                     // Check if the item matches the filter text typed so far.
-                    var matchesFilterText = ItemManager.MatchesFilterText(helper, currentItem, filterText, model.Trigger.Kind, filterReason, recentItems);
+                    var matchesFilterText = ItemManager.MatchesFilterText(helper, currentItem, filterText, model.Trigger.Kind, filterReason, recentItems, out var patternMatch);
 
                     if (matchesFilterText)
                     {
                         filterResults.Add(new FilterResult(
-                            currentItem, filterText, matchedFilterText: true));
+                            currentItem, filterText, matchedFilterText: true, patternMatch));
                     }
                     else
                     {
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                         if (shouldKeepItem)
                         {
                             filterResults.Add(new FilterResult(
-                                currentItem, filterText, matchedFilterText: false));
+                                currentItem, filterText, matchedFilterText: false, patternMatch));
                         }
                     }
                 }
@@ -250,8 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 }
 
                 var matchingCompletionItems = filterResults.Where(r => r.MatchedFilterText)
-                                                           .Select(t => t.CompletionItem)
-                                                           .AsImmutable();
+                                                           .SelectAsArray(t => (t.CompletionItem, t.PatternMatch));
                 var chosenItems = service.FilterItems(
                     document, matchingCompletionItems, filterText);
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Experiments
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Tags
 Imports Microsoft.CodeAnalysis.Text
@@ -6002,7 +6003,7 @@ namespace NS2
         <WorkItem(35163, "https://github.com/dotnet/roslyn/issues/35163")>
         <MemberData(NameOf(AllCompletionImplementations))>
         <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function NonExpandedItemShouldAlwaysBePreferred_ExpandedItemHasBetterMatch(completionImplementation As CompletionImplementation) As Task
+        Public Async Function NonExpandedItemShouldBePreferred_ExpandedItemHasBetterButNotCompleteMatch(completionImplementation As CompletionImplementation) As Task
             Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
                   <Document><![CDATA[
 namespace NS1
@@ -6015,7 +6016,71 @@ namespace NS1
         }
     }
 
-    public class BitArrayReceiver
+    public class ABar
+    {
+    } 
+}
+
+namespace NS2
+{
+    public class Bar1
+    {
+    }
+}
+]]></Document>)
+
+                Dim expectedText = "
+namespace NS1
+{
+    class C
+    {
+        public void Foo()
+        {
+            ABar
+        }
+    }
+
+    public class ABar
+    {
+    } 
+}
+
+namespace NS2
+{
+    public class Bar1
+    {
+    }
+}
+"
+
+                state.Workspace.Options = state.Workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True) _
+                    .WithChangedOption(CompletionServiceOptions.TimeoutInMillisecondsForImportCompletion, -1)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="ABar")
+                state.SendTab()
+                Assert.Equal(expectedText, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(38253, "https://github.com/dotnet/roslyn/issues/38253")>
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NonExpandedItemShouldBePreferred_BothExpandedAndNonExpandedItemsHaveCompleteMatch(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                  <Document><![CDATA[
+namespace NS1
+{
+    class C
+    {
+        public void Foo()
+        {
+            bar$$
+        }
+    }
+
+    public class Bar
     {
     } 
 }
@@ -6035,11 +6100,11 @@ namespace NS1
     {
         public void Foo()
         {
-            BitArrayReceiver
+            Bar
         }
     }
 
-    public class BitArrayReceiver
+    public class Bar
     {
     } 
 }
@@ -6057,9 +6122,187 @@ namespace NS2
                     .WithChangedOption(CompletionServiceOptions.TimeoutInMillisecondsForImportCompletion, -1)
 
                 state.SendInvokeCompletionList()
-                Await state.AssertSelectedCompletionItem(displayText:="BitArrayReceiver")
+                Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="")
                 state.SendTab()
                 Assert.Equal(expectedText, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(38253, "https://github.com/dotnet/roslyn/issues/38253")>
+        <MemberData(NameOf(AllCompletionImplementations))>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ExpandedItemShouldBePreferred_IfIsOnlyCompleteMatch(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                  <Document><![CDATA[
+namespace NS1
+{
+    class C
+    {
+        public void Foo()
+        {
+            bar$$
+        }
+    }
+
+    public class ABar
+    {
+    } 
+}
+
+namespace NS2
+{
+    public class Bar
+    {
+    }
+}
+]]></Document>)
+
+                Dim expectedText = "
+using NS2;
+
+namespace NS1
+{
+    class C
+    {
+        public void Foo()
+        {
+            Bar
+        }
+    }
+
+    public class ABar
+    {
+    } 
+}
+
+namespace NS2
+{
+    public class Bar
+    {
+    }
+}
+"
+
+                state.Workspace.Options = state.Workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True) _
+                    .WithChangedOption(CompletionServiceOptions.TimeoutInMillisecondsForImportCompletion, -1)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="NS2")
+                state.SendTab()
+                Assert.Equal(expectedText, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WorkItem(38253, "https://github.com/dotnet/roslyn/issues/38253")>
+        <InlineData(CompletionImplementation.Modern)>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SortItemsByPatternMatchIfExperimentEnabled(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+namespace NS
+{
+    class C
+    {
+        void M()
+        {
+            $$
+        }
+    }
+
+    class Task { }
+
+    class BTask1 { }
+    class BTask2 { }
+    class BTask3 { }
+
+
+    class Task1 { }
+    class Task2 { }
+    class Task3 { }
+
+    class ATaAaSaKa { }
+} </Document>, extraExportedTypes:={GetType(TestExperimentationService)}.ToList())
+
+                state.Workspace.Options = state.Workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)
+
+                Dim experimentService = state.GetService(Of TestExperimentationService)()
+                experimentService.SetExperimentOption(WellKnownExperimentNames.SortCompletionListByMatch, True)
+
+                state.SendTypeChars("task")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Task")
+
+                Dim expectedOrder =
+                    {
+                        "Task",
+                        "Task1",
+                        "Task2",
+                        "Task3",
+                        "BTask1",
+                        "BTask2",
+                        "BTask3",
+                        "ATaAaSaKa"
+                    }
+
+                state.AssertItemsInOrder(expectedOrder)
+            End Using
+        End Function
+
+        <WorkItem(38253, "https://github.com/dotnet/roslyn/issues/38253")>
+        <InlineData(CompletionImplementation.Modern)>
+        <WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function SortItemsAlphabeticallyIfExperimentDisabled(completionImplementation As CompletionImplementation) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(completionImplementation,
+                              <Document>
+namespace NS
+{
+    class C
+    {
+        void M()
+        {
+            $$
+        }
+    }
+
+    class Task { }
+
+    class BTask1 { }
+    class BTask2 { }
+    class BTask3 { }
+
+
+    class Task1 { }
+    class Task2 { }
+    class Task3 { }
+
+    class ATaAaSaKa { }
+} </Document>, extraExportedTypes:={GetType(TestExperimentationService)}.ToList())
+
+                state.Workspace.Options = state.Workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)
+
+                Dim experimentService = state.GetService(Of TestExperimentationService)()
+                experimentService.SetExperimentOption(WellKnownExperimentNames.SortCompletionListByMatch, False)
+
+                state.SendTypeChars("task")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="Task")
+
+                Dim expectedOrder =
+                    {
+                        "ATaAaSaKa",
+                        "BTask1",
+                        "BTask2",
+                        "BTask3",
+                        "Task",
+                        "Task1",
+                        "Task2",
+                        "Task3"
+                    }
+
+                state.AssertItemsInOrder(expectedOrder)
             End Using
         End Function
 

--- a/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         }
 
         /// <summary>
-        /// Convert a <see cref="TextSpan"/> instance to a <see cref="TextSpan"/> with additional offset.
+        /// Convert a <see cref="TextSpan"/> instance to a <see cref="Span"/> with an additional offset.
         /// </summary>
         public static Span ToSpan(this TextSpan textSpan, int offset)
         {

--- a/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
@@ -2,7 +2,6 @@
 
 using System.Diagnostics;
 using Microsoft.VisualStudio.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
 {
@@ -14,6 +13,14 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         public static Span ToSpan(this TextSpan textSpan)
         {
             return new Span(textSpan.Start, textSpan.Length);
+        }
+
+        /// <summary>
+        /// Convert a <see cref="TextSpan"/> instance to a <see cref="TextSpan"/> with additional offset.
+        /// </summary>
+        public static Span ToSpan(this TextSpan textSpan, int offset)
+        {
+            return new Span(textSpan.Start + offset, textSpan.Length);
         }
 
         /// <summary>

--- a/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/TextSpanExtensions.cs
@@ -16,11 +16,11 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         }
 
         /// <summary>
-        /// Convert a <see cref="TextSpan"/> instance to a <see cref="Span"/> with an additional offset.
+        /// Add an offset to a <see cref="TextSpan"/>.
         /// </summary>
-        public static Span ToSpan(this TextSpan textSpan, int offset)
+        public static TextSpan MoveTo(this TextSpan textSpan, int offset)
         {
-            return new Span(textSpan.Start + offset, textSpan.Length);
+            return new TextSpan(textSpan.Start + offset, textSpan.Length);
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/CommonCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionService.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PatternMatching;
 using Microsoft.CodeAnalysis.Tags;
 
 namespace Microsoft.CodeAnalysis.Completion
@@ -54,6 +55,12 @@ namespace Microsoft.CodeAnalysis.Completion
         protected static bool IsSnippetItem(CompletionItem item)
         {
             return item.Tags.Contains(WellKnownTags.Snippet);
+        }
+
+        internal override ImmutableArray<CompletionItem> FilterItems(Document document, ImmutableArray<(CompletionItem, PatternMatch?)> itemsWithPatternMatch, string filterText)
+        {
+            var helper = CompletionHelper.GetHelper(document);
+            return CompletionService.FilterItems(helper, itemsWithPatternMatch);
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Completion
             // Always prefer non-expanded item regardless of the pattern matching result.
             // This currently means unimported types will be treated as "2nd tier" results,
             // which forces users to be more explicit about selecting them.
-            var expandedDiff = CompareExpandedItem(item1, item2);
+            var expandedDiff = CompareExpandedItem(item1, match1, item2, match2);
             if (expandedDiff != 0)
             {
                 return expandedDiff;
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.Completion
             return 0;
         }
 
-        private int CompareExpandedItem(CompletionItem item1, CompletionItem item2)
+        private static int CompareExpandedItem(CompletionItem item1, PatternMatch match1, CompletionItem item2, PatternMatch match2)
         {
             var isItem1Expanded = item1.Flags.IsExpanded();
             var isItem2Expanded = item2.Flags.IsExpanded();
@@ -276,7 +276,29 @@ namespace Microsoft.CodeAnalysis.Completion
                 return 0;
             }
 
-            // Non-expanded item is better than expanded item
+            var isItem1ExactMatch = match1.Kind == PatternMatchKind.Exact;
+            var isItem2ExactMatch = match2.Kind == PatternMatchKind.Exact;
+
+            // If neither of the items is an exact match, or both are exact matches,
+            // then we prefer non-expanded item over expanded one.
+            if (!isItem1ExactMatch && !isItem2ExactMatch
+                || match1.Kind == match2.Kind)
+            {
+                return isItem1Expanded ? 1 : -1;
+            }
+
+            // We prefer expanded item over non-expanded one iff the expanded item 
+            // is an exact match whereas the non-expanded one isn't.
+            if (isItem1Expanded && isItem1ExactMatch)
+            {
+                return -1;
+            }
+            else if (isItem2Expanded && isItem2ExactMatch)
+            {
+                return 1;
+            }
+
+            // Non-expanded item is an exact match, so we definitely prefer it.
             return isItem1Expanded ? 1 : -1;
         }
     }

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -281,6 +281,22 @@ namespace Microsoft.CodeAnalysis.Completion
 
             // If neither of the items is an exact match, or both are exact matches,
             // then we prefer non-expanded item over expanded one.
+            // 
+            // For example, suppose we have two types `Namespace1.Cafe` and `Namespace2.Cafe`, and import completion is enabled.
+            // In the scenarios below, `Namespace1.Cafe` would be selected over `Namespace2.Cafe`
+
+            //  using Namespace1;
+            //  class C
+            //  {
+            //      cafe$$
+            //  }
+
+            //  using Namespace1;
+            //  class C
+            //  {
+            //      caf$$
+            //  }
+
             if (!isItem1ExactMatch && !isItem2ExactMatch
                 || match1.Kind == match2.Kind)
             {
@@ -289,6 +305,15 @@ namespace Microsoft.CodeAnalysis.Completion
 
             // We prefer expanded item over non-expanded one iff the expanded item 
             // is an exact match whereas the non-expanded one isn't.
+            // 
+            // For example, suppose we have two types `Namespace1.Cafe1` and `Namespace2.Cafe`, and import completion is enabled.
+            // In the scenarios below, `Namespace2.Cafe` would be selected over `Namespace1.Cafe1`
+
+            //  using Namespace1;
+            //  class C
+            //  {
+            //      cafe$$
+            //  }
             if (isItem1Expanded && isItem1ExactMatch)
             {
                 return -1;
@@ -298,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return 1;
             }
 
-            // Non-expanded item is an exact match, so we definitely prefer it.
+            // Non-expanded item is the only exact match, so we definitely prefer it.
             return isItem1Expanded ? 1 : -1;
         }
     }

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -43,14 +43,13 @@ namespace Microsoft.CodeAnalysis.Completion
         /// results, or false if it should not be.
         /// </summary>
         public bool MatchesPattern(string text, string pattern, CultureInfo culture)
-            => GetMatch(text, pattern, culture) != null;
+            => GetMatch(text, pattern, includeMatchSpans: false, culture) != null;
 
-        private PatternMatch? GetMatch(string text, string pattern, CultureInfo culture)
-            => GetMatch(text, pattern, includeMatchSpans: false, culture: culture);
-
-        private PatternMatch? GetMatch(
-            string completionItemText, string pattern,
-            bool includeMatchSpans, CultureInfo culture)
+        public PatternMatch? GetMatch(
+            string completionItemText,
+            string pattern,
+            bool includeMatchSpans,
+            CultureInfo culture)
         {
             // If the item has a dot in it (i.e. for something like enum completion), then attempt
             // to match what the user wrote against the last portion of the name.  That way if they
@@ -136,9 +135,14 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public int CompareItems(CompletionItem item1, CompletionItem item2, string pattern, CultureInfo culture)
         {
-            var match1 = GetMatch(item1.FilterText, pattern, culture);
-            var match2 = GetMatch(item2.FilterText, pattern, culture);
+            var match1 = GetMatch(item1.FilterText, pattern, includeMatchSpans: false, culture);
+            var match2 = GetMatch(item2.FilterText, pattern, includeMatchSpans: false, culture);
 
+            return CompareItems(item1, match1, item2, match2);
+        }
+
+        public int CompareItems(CompletionItem item1, PatternMatch? match1, CompletionItem item2, PatternMatch? match2)
+        {
             if (match1 != null && match2 != null)
             {
                 var result = CompareMatches(match1.Value, match2.Value, item1, item2);

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.Completion
     [DebuggerDisplay("{DisplayText}")]
     public sealed class CompletionItem : IComparable<CompletionItem>
     {
+        private readonly string _filterText;
+
         /// <summary>
         /// The text that is displayed to the user.
         /// </summary>
@@ -37,7 +39,9 @@ namespace Microsoft.CodeAnalysis.Completion
         /// The text used to determine if the item matches the filter and is show in the list.
         /// This is often the same as <see cref="DisplayText"/> but may be different in certain circumstances.
         /// </summary>
-        public string FilterText { get; }
+        public string FilterText => _filterText ?? DisplayText;
+
+        internal bool HasDifferentFilterText => _filterText != null;
 
         /// <summary>
         /// The text used to determine the order that the item appears in the list.
@@ -107,13 +111,17 @@ namespace Microsoft.CodeAnalysis.Completion
             DisplayText = displayText ?? "";
             DisplayTextPrefix = displayTextPrefix ?? "";
             DisplayTextSuffix = displayTextSuffix ?? "";
-            FilterText = filterText ?? DisplayText;
             SortText = sortText ?? DisplayText;
             InlineDescription = inlineDescription ?? "";
             Span = span;
             Properties = properties ?? ImmutableDictionary<string, string>.Empty;
             Tags = tags.NullToEmpty();
             Rules = rules ?? CompletionItemRules.Default;
+
+            if (!DisplayText.Equals(filterText, StringComparison.Ordinal))
+            {
+                _filterText = filterText;
+            }
         }
 
         // binary back compat overload

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -2,11 +2,13 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PatternMatching;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -175,41 +177,62 @@ namespace Microsoft.CodeAnalysis.Completion
             return FilterItems(helper, items, filterText);
         }
 
+        internal virtual ImmutableArray<CompletionItem> FilterItems(
+           Document document,
+           ImmutableArray<(CompletionItem, PatternMatch?)> itemsWithPatternMatch,
+           string filterText)
+        {
+            // Default implementation just drops the pattern matches and
+            // calls the public overload of FilterItems for compatibility.
+            return FilterItems(document, itemsWithPatternMatch.SelectAsArray(item => item.Item1), filterText);
+        }
+
         internal static ImmutableArray<CompletionItem> FilterItems(
             CompletionHelper completionHelper,
             ImmutableArray<CompletionItem> items,
             string filterText)
         {
-            var bestItems = ArrayBuilder<CompletionItem>.GetInstance();
-            foreach (var item in items)
+            var itemsWithPatternMatch = items.SelectAsArray(
+                item => (item, completionHelper.GetMatch(item.FilterText, filterText, includeMatchSpans: false, CultureInfo.CurrentCulture)));
+
+            return FilterItems(completionHelper, itemsWithPatternMatch);
+        }
+
+        internal static ImmutableArray<CompletionItem> FilterItems(
+            CompletionHelper completionHelper,
+            ImmutableArray<(CompletionItem item, PatternMatch? match)> itemsWithPatternMatch)
+        {
+            var bestItems = ArrayBuilder<(CompletionItem, PatternMatch?)>.GetInstance();
+            foreach (var pair in itemsWithPatternMatch)
             {
                 if (bestItems.Count == 0)
                 {
                     // We've found no good items yet.  So this is the best item currently.
-                    bestItems.Add(item);
+                    bestItems.Add(pair);
                 }
                 else
                 {
-                    var comparison = completionHelper.CompareItems(item, bestItems.First(), filterText, CultureInfo.CurrentCulture);
+                    var (bestItem, bestItemMatch) = bestItems.First();
+                    var comparison = completionHelper.CompareItems(pair.item, pair.match, bestItem, bestItemMatch);
                     if (comparison < 0)
                     {
                         // This item is strictly better than the best items we've found so far.
                         bestItems.Clear();
-                        bestItems.Add(item);
+                        bestItems.Add(pair);
                     }
                     else if (comparison == 0)
                     {
                         // This item is as good as the items we've been collecting.  We'll return 
                         // it and let the controller decide what to do.  (For example, it will
                         // pick the one that has the best MRU index).
-                        bestItems.Add(item);
+                        bestItems.Add(pair);
                     }
                     // otherwise, this item is strictly worse than the ones we've been collecting.
                     // We can just ignore it.
                 }
             }
 
-            return bestItems.ToImmutableAndFree();
+            return bestItems.ToImmutableAndFree().SelectAsArray(itemWithPatternMatch => itemWithPatternMatch.Item1);
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionItem.cs
@@ -37,7 +37,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             var item = CompletionItem.Create(
                  displayText: typeSymbol.Name,
-                 filterText: typeSymbol.Name,
                  sortText: sortTextBuilder.ToStringAndFree(),
                  properties: propertyBuilder?.ToImmutableDictionaryAndFree(),
                  tags: GlyphTags.GetTags(typeSymbol.GetGlyph()),
@@ -62,7 +61,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             return CompletionItem.Create(
                  displayText: attributeNameWithoutSuffix,
-                 filterText: attributeNameWithoutSuffix,
                  sortText: sortTextBuilder.ToStringAndFree(),
                  properties: newProperties,
                  tags: attributeItem.Tags,

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionItem.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             //    it also makes sure type with shorter name shows first, e.g. 'SomeType` before 'SomeTypeWithLongerName'.  
             var sortTextBuilder = PooledStringBuilder.GetInstance();
             sortTextBuilder.Builder.AppendFormat(SortTextFormat, typeSymbol.Name, containingNamespace);
-            
+
             var item = CompletionItem.Create(
                  displayText: typeSymbol.Name,
                  filterText: typeSymbol.Name,

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string TypeImportCompletion = "Roslyn.TypeImportCompletion";
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
         public const string RoslynInlineRenameFile = "Roslyn.FileRename";
+        public const string SortCompletionListByMatch = "Roslyn.SortCompletionListByMatch";
 
         // Syntactic LSP experiment treatments.
         public const string SyntacticExp_Remote = "RoslynLsp";


### PR DESCRIPTION
Address #38253 with two tweaks

1. Sort completion list by pattern matching results first, then by alphabetical order (current behavior is pure alphabetical order)
2. Selection will prefer unimported item with complete match if there's no in-scope items with complete match (current behavior is always prefer in-scope items, even if it has worse matching than unimported items)

---------------------------------

- Ctrl + space, when a complete match exists for both in-scope and unimported items. We will prefer in-scope items. Another impact of this change is, in case there's no complete match, we might end up selecting an in-scope item, with better matched unimported items above the selection (not shown in the gif).

<a href="https://user-images.githubusercontent.com/788783/64370300-0a567c80-cfd3-11e9-8ece-1dffbba1b2ce.gif"><img src="https://user-images.githubusercontent.com/788783/64370300-0a567c80-cfd3-11e9-8ece-1dffbba1b2ce.gif" width="400" /></a>

- Ctrl + J, same scenario as above, Notice all unmatched items remain sorted first by in-scope/unimported and then in alphabetical order *after* all matched items

<a href="https://user-images.githubusercontent.com/788783/64371107-a0d76d80-cfd4-11e9-9d90-c805b16f973d.gif"><img src="https://user-images.githubusercontent.com/788783/64371107-a0d76d80-cfd4-11e9-9d90-c805b16f973d.gif" width="400" /></a>

- Ctrl + space, when only unimport item has a complete match, then it will be selected

<a href="https://user-images.githubusercontent.com/788783/64371278-0c213f80-cfd5-11e9-9a32-e0c953635350.gif"><img src="https://user-images.githubusercontent.com/788783/64371278-0c213f80-cfd5-11e9-9a32-e0c953635350.gif" width="400" /></a>

Since this is a potentially impactful change, hide it behind an experiment for now.
Tag @ivanbasov @CyrusNajmabadi for review. 

FYI @davkean Does this address your feedback?

------------------------------- 

I have done some quick perf analysis, which is based on the following scenario:

1. Open Roslyn.sln, then navigate to the static constructor of `AbstractPersistentStorageTests` class. (I chose this file because it has ~20k items in the list with import completion enabled)
2. Ctrl + space to trigger completion list
3. slowly type "task"
4. slowly delete "task" by using backspace
5. hit "esc" to discard completion list
6. go to step 2 and repeat for another 3 times

This is repeated 3 time, with different roslyn release builds
1. Baseline: built directly from current master-vs-deps branch
2. With experiment disabled: with the change in this PR w/o enabling the experiments
3. With experiment enabled: does one more pass of sorting using pattern match, otherwise identical to build 2 above.

Here's the results (CPU stacks in perfview, with only frames under `ManagedModule!Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion.ItemManager.UpdateCompletionList()` included)

1. Comparing experiment on and off. The extra sorting doesn't show in the diff at all.

![image](https://user-images.githubusercontent.com/788783/64387430-cecaab00-cff0-11e9-963f-e3f0e8134c2f.png)

2. Comparing baseline and with experiment enabled. It seems the perf is better with the change (~~216 ms~~ even better now, see update below), due to calling pattern match fewer times.

![image](https://user-images.githubusercontent.com/788783/64387831-fc642400-cff1-11e9-87e0-c4f18be3a70f.png)

Update: 
with the change in https://github.com/dotnet/roslyn/pull/38499/commits/087bc0a3d72f80acb4cb5758cda7266debafb9d1, now the diff is -569 ms compare to baseline (~2000 vs ~1450)

![image](https://user-images.githubusercontent.com/788783/64393392-02640000-d006-11e9-8208-b6cab51a1920.png)

