### PR TITLE
EnC: fix handing of added and design-time-only files

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests;
@@ -99,6 +100,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             }
         }
 
+        private sealed class DesignTimeOnlyDocumentServiceProvider : IDocumentServiceProvider
+        {
+            private sealed class DesignTimeOnlyDocumentPropertiesService : DocumentPropertiesService
+            {
+                public static readonly DesignTimeOnlyDocumentPropertiesService Instance = new DesignTimeOnlyDocumentPropertiesService();
+                public override bool DesignTimeOnly => true;
+            }
+
+            TService IDocumentServiceProvider.GetService<TService>()
+                => DesignTimeOnlyDocumentPropertiesService.Instance is TService documentProperties ?
+                    documentProperties : DefaultTextDocumentServiceProvider.Instance.GetService<TService>();
+        }
+
         [Fact]
         public void ActiveStatementTracking()
         {
@@ -150,6 +164,53 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 diagnostics = await service.GetDocumentDiagnosticsAsync(document2, CancellationToken.None).ConfigureAwait(false);
                 Assert.Empty(diagnostics);
             }
+        }
+
+        [Fact]
+        public async Task RunMode_DesignTimeOnlyDocument()
+        {
+            var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
+
+            using var workspace = TestWorkspace.CreateCSharp("class C1 { void M() { System.Console.WriteLine(1); } }");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+            var documentInfo = DocumentInfo.Create(
+                DocumentId.CreateNewId(project.Id),
+                name: "design-time-only.cs",
+                folders: Array.Empty<string>(),
+                sourceCodeKind: SourceCodeKind.Regular,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class C2 {}"), VersionStamp.Create(), "design-time-only.cs")),
+                filePath: "design-time-only.cs",
+                isGenerated: false,
+                documentServiceProvider: new DesignTimeOnlyDocumentServiceProvider());
+
+            workspace.ChangeSolution(project.Solution.WithProjectOutputFilePath(project.Id, moduleFile.Path).AddDocument(documentInfo));
+            _mockCompilationOutputsService.Outputs.Add(project.Id, new CompilationOutputFiles(moduleFile.Path));
+
+            var service = CreateEditAndContinueService(workspace);
+
+            service.StartDebuggingSession();
+
+            // update a design-time-only source file:
+            var document1 = workspace.CurrentSolution.Projects.Single().Documents.Single(d => d.Id == documentInfo.Id);
+            workspace.ChangeDocument(document1.Id, SourceText.From("class UpdatedC2 {}"));
+            var document2 = workspace.CurrentSolution.Projects.Single().Documents.Single(d => d.Id == documentInfo.Id);
+
+            // no updates:
+            var diagnostics = await service.GetDocumentDiagnosticsAsync(document2, CancellationToken.None).ConfigureAwait(false);
+            Assert.Empty(diagnostics);
+
+            // validate solution update status and emit - changes made in design-time-only documents are ignored:
+            var solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatus);
+
+            service.EndDebuggingSession();
+            VerifyReanalyzeInvocation(workspace, null, ImmutableArray<DocumentId>.Empty, false);
+
+            AssertEx.Equal(new[]
+            {
+                "Debugging_EncSession: SessionId=1|SessionCount=0|EmptySessionCount=0"
+            }, _telemetryLog);
         }
 
         [Fact]
@@ -217,6 +278,48 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
+        public async Task RunMode_FileAdded()
+        {
+            var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
+
+            using var workspace = TestWorkspace.CreateCSharp("class C1 { void M() { System.Console.WriteLine(1); } }");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+            workspace.ChangeSolution(project.Solution.WithProjectOutputFilePath(project.Id, moduleFile.Path));
+            var document1 = workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+            _mockCompilationOutputsService.Outputs.Add(project.Id, new CompilationOutputFiles(moduleFile.Path));
+
+            var service = CreateEditAndContinueService(workspace);
+
+            service.StartDebuggingSession();
+
+            // add a source file:
+            var document2 = project.AddDocument("file2.cs", SourceText.From("class C2 {}"));
+            workspace.ChangeSolution(document2.Project.Solution);
+
+            // no changes in document1:
+            var diagnostics1 = await service.GetDocumentDiagnosticsAsync(document1, CancellationToken.None).ConfigureAwait(false);
+            Assert.Empty(diagnostics1);
+
+            // update in document2:
+            var diagnostics2 = await service.GetDocumentDiagnosticsAsync(document2, CancellationToken.None).ConfigureAwait(false);
+            AssertEx.Equal(new[] { "ENC1003" }, diagnostics2.Select(d => d.Id));
+
+            // validate solution update status and emit - changes made during run mode are ignored:
+            var solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatus);
+
+            service.EndDebuggingSession();
+            VerifyReanalyzeInvocation(workspace, null, ImmutableArray.Create(document2.Id), false);
+
+            AssertEx.Equal(new[]
+            {
+                "Debugging_EncSession: SessionId=1|SessionCount=0|EmptySessionCount=0"
+            }, _telemetryLog);
+        }
+
+        [Fact]
         public async Task RunMode_Diagnostics()
         {
             var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
@@ -269,6 +372,45 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         }
 
         [Fact]
+        public async Task RunMode_DifferentDocumentWithSameContent()
+        {
+            var source = "class C1 { void M1() { System.Console.WriteLine(1); } }";
+            var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
+
+            using var workspace = TestWorkspace.CreateCSharp(source);
+
+            var project = workspace.CurrentSolution.Projects.Single();
+            workspace.ChangeSolution(project.Solution.WithProjectOutputFilePath(project.Id, moduleFile.Path));
+            _mockCompilationOutputsService.Outputs.Add(project.Id, new CompilationOutputFiles(moduleFile.Path));
+
+            var service = CreateEditAndContinueService(workspace);
+
+            service.StartDebuggingSession();
+
+            // update the document
+            var document1 = workspace.CurrentSolution.Projects.Single().Documents.Single();
+            workspace.ChangeDocument(document1.Id, SourceText.From(source));
+            var document2 = workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+            Assert.Equal(document1.Id, document2.Id);
+            Assert.NotSame(document1, document2);
+
+            var diagnostics2 = await service.GetDocumentDiagnosticsAsync(document2, CancellationToken.None).ConfigureAwait(false);
+            Assert.Empty(diagnostics2);
+
+            // validate solution update status and emit - changes made during run mode are ignored:
+            var solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatus);
+
+            service.EndDebuggingSession();
+
+            AssertEx.Equal(new[]
+            {
+                "Debugging_EncSession: SessionId=1|SessionCount=0|EmptySessionCount=0"
+            }, _telemetryLog);
+        }
+
+        [Fact]
         public async Task BreakMode_ProjectThatDoesNotSupportEnC()
         {
             var exportProviderFactory = ExportProviderCache.GetOrCreateExportProviderFactory(
@@ -299,6 +441,46 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 Assert.Equal(SolutionUpdateStatus.None, solutionStatusEmit);
                 Assert.Empty(deltas);
             }
+        }
+
+        [Fact]
+        public async Task BreakMode_DesignTimeOnlyDocument()
+        {
+            var exportProviderFactory = ExportProviderCache.GetOrCreateExportProviderFactory(
+                TestExportProvider.MinimumCatalogWithCSharpAndVisualBasic.WithPart(typeof(DummyLanguageService)));
+
+            using var workspace = TestWorkspace.CreateCSharp("class C {}");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+            var documentInfo = DocumentInfo.Create(
+                DocumentId.CreateNewId(project.Id),
+                name: "design-time-only.cs",
+                folders: Array.Empty<string>(),
+                sourceCodeKind: SourceCodeKind.Regular,
+                loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class D {}"), VersionStamp.Create(), "design-time-only.cs")),
+                filePath: "design-time-only.cs",
+                isGenerated: false,
+                documentServiceProvider: new DesignTimeOnlyDocumentServiceProvider());
+
+            var solution = workspace.CurrentSolution.AddDocument(documentInfo);
+            workspace.ChangeSolution(solution);
+
+            var service = CreateEditAndContinueService(workspace);
+
+            service.StartDebuggingSession();
+            service.StartEditSession();
+
+            // change the source:
+            var document1 = workspace.CurrentSolution.Projects.Single().Documents.Single(d => d.Id == documentInfo.Id);
+            workspace.ChangeDocument(document1.Id, SourceText.From("class E {}"));
+
+            // validate solution update status and emit:
+            var solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatus);
+
+            var (solutionStatusEmit, deltas) = await service.EmitSolutionUpdateAsync(CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatusEmit);
+            Assert.Empty(deltas);
         }
 
         [Fact]
@@ -359,6 +541,52 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                     "Debugging_EncSession_EditSession_EmitDeltaErrorId: SessionId=1|EditSessionId=2|ErrorId=ENC1001"
                 }, _telemetryLog);
             }
+        }
+
+        [Fact]
+        public async Task BreakMode_FileAdded()
+        {
+            var moduleFile = Temp.CreateFile().WriteAllBytes(TestResources.Basic.Members);
+
+            using var workspace = TestWorkspace.CreateCSharp("class C1 { void M() { System.Console.WriteLine(1); } }");
+
+            var project = workspace.CurrentSolution.Projects.Single();
+            workspace.ChangeSolution(project.Solution.WithProjectOutputFilePath(project.Id, moduleFile.Path));
+            var document1 = workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+            _mockDebugeeModuleMetadataProvider.IsEditAndContinueAvailable = (Guid guid, out int errorCode, out string localizedMessage) =>
+            {
+                errorCode = 123;
+                localizedMessage = "*message*";
+                return false;
+            };
+
+            _mockCompilationOutputsService.Outputs.Add(project.Id, new CompilationOutputFiles(moduleFile.Path));
+
+            var service = CreateEditAndContinueService(workspace);
+
+            service.StartDebuggingSession();
+            service.StartEditSession();
+
+            // add a source file:
+            var document2 = project.AddDocument("file2.cs", SourceText.From("class C2 {}"));
+            workspace.ChangeSolution(document2.Project.Solution);
+
+            // update in document2:
+            var diagnostics2 = await service.GetDocumentDiagnosticsAsync(document2, CancellationToken.None).ConfigureAwait(false);
+            AssertEx.Equal(new[] { "ENC2123" }, diagnostics2.Select(d => d.Id));
+
+            // validate solution update status and emit - changes made during run mode are ignored:
+            var solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.Blocked, solutionStatus);
+
+            service.EndEditSession();
+            service.EndDebuggingSession();
+
+            AssertEx.Equal(new[]
+            {
+                "Debugging_EncSession: SessionId=1|SessionCount=0|EmptySessionCount=1"
+            }, _telemetryLog);
         }
 
         [Fact]

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
 
                 // Document does not compile to the assembly (e.g. cshtml files, .g.cs files generated for completion only)
-                if (IsDesignTimeOnlyDocument(document))
+                if (IsDesignTimeOnlyDocument(document) || !document.SupportsSyntaxTree)
                 {
                     return ImmutableArray<Diagnostic>.Empty;
                 }
@@ -201,6 +201,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     // Any changes made in loaded, built projects outside of edit session are rude edits (the application is running):
                     var newSyntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                    Contract.ThrowIfNull(newSyntaxTree);
+
                     var changedSpans = await GetChangedSpansAsync(oldDocument, newSyntaxTree, cancellationToken).ConfigureAwait(false);
                     return GetRunModeDocumentDiagnostics(document, newSyntaxTree, changedSpans);
                 }
@@ -228,6 +230,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         editSession.TrackDocumentWithReportedDiagnostics(document.Id);
 
                         var newSyntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                        Contract.ThrowIfNull(newSyntaxTree);
+
                         var changedSpans = await GetChangedSpansAsync(oldDocument, newSyntaxTree, cancellationToken).ConfigureAwait(false);
 
                         var diagnosticsBuilder = ArrayBuilder<Diagnostic>.GetInstance();

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -273,6 +273,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             if (oldDocument != null)
             {
                 var oldSyntaxTree = await oldDocument.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                Contract.ThrowIfNull(oldSyntaxTree);
+
                 return GetSpansInNewDocument(await GetDocumentTextChangesAsync(oldSyntaxTree, newSyntaxTree, cancellationToken).ConfigureAwait(false));
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.DocumentServiceProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.DocumentServiceProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
     internal sealed partial class ContainedDocument
     {
         // this is to support old venus/razor case before dev16. 
-        // all new razor (asp.NET core after dev16) should use thier own implementation not ours
+        // all new razor (asp.NET core after dev16) should use their own implementation not ours
         public class DocumentServiceProvider : IDocumentServiceProvider
         {
             private readonly SpanMapper _spanMapper;
@@ -45,6 +45,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     return excerpter;
                 }
 
+                if (DesignTimeOnlyDocumentPropertiesService.Instance is TService documentPropertiesService)
+                {
+                    return documentPropertiesService;
+                }
+
                 // ask the default document service provider
                 return DefaultTextDocumentServiceProvider.Instance.GetService<TService>();
             }
@@ -52,6 +57,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             private static ITextSnapshot GetRoslynSnapshot(SourceText sourceText)
             {
                 return sourceText.FindCorrespondingEditorTextSnapshot();
+            }
+
+            private sealed class DesignTimeOnlyDocumentPropertiesService : DocumentPropertiesService
+            {
+                public static readonly DesignTimeOnlyDocumentPropertiesService Instance = new DesignTimeOnlyDocumentPropertiesService();
+                public override bool DesignTimeOnly => true;
             }
 
             private class SpanMapper : ISpanMappingService

--- a/src/VisualStudio/Core/Test/Venus/DocumentServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Venus/DocumentServiceTests.vb
@@ -95,6 +95,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Venus
                 ' which will use thier own implementation of these services
                 Assert.True(documentOperations.CanApplyChange)
                 Assert.True(documentOperations.SupportDiagnostics)
+
+                Dim documentProperties = service.GetService(Of DocumentPropertiesService)
+                Assert.True(documentProperties.DesignTimeOnly)
             End Using
         End Sub
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/DocumentPropertiesService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/DocumentPropertiesService.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Host
+{
+    /// <summary>
+    /// Extensible document properties specified via a document service.
+    /// </summary>
+    internal class DocumentPropertiesService : IDocumentService
+    {
+        public static readonly DocumentPropertiesService Default = new DocumentPropertiesService();
+
+        /// <summary>
+        /// True if the source code contained in the document is only used in design-time (e.g. for completion),
+        /// but is not passed to the compiler when the containing project is built.
+        /// </summary>
+        public virtual bool DesignTimeOnly => false;
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentOperationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentOperationService.cs
@@ -3,9 +3,8 @@
 namespace Microsoft.CodeAnalysis.Host
 {
     /// <summary>
-    /// provide various operations for this document
-    /// 
-    /// I followed name from EditorOperation for now. 
+    /// TODO: Merge into <see cref="DocumentPropertiesService"/>.
+    /// Used by Razor via IVT.
     /// </summary>
     internal interface IDocumentOperationService : IDocumentService
     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DefaultTextDocumentServiceProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DefaultTextDocumentServiceProvider.cs
@@ -18,9 +18,14 @@ namespace Microsoft.CodeAnalysis
             // right now, it doesn't implement much services but we expect it to implements all 
             // document services in future so that we can remove all if branches in feature code
             // but just delegate work to default document services.
-            if (DocumentOperationService.Instance is TService service)
+            if (DocumentOperationService.Instance is TService documentOperationService)
             {
-                return service;
+                return documentOperationService;
+            }
+
+            if (DocumentPropertiesService.Default is TService documentPropertiesService)
+            {
+                return documentPropertiesService;
             }
 
             return default;


### PR DESCRIPTION
Adds a `DesignTimeOnly` flag to `DocumentOperationService` that is set for documents created for design-time only purposes (.cshtml, intellisense-only .g.cs files) and not included in the compilation when the assembly is built. This allows the EnC service to ignore changes in such files.

Also fixes an issue in EnC analysis where a NRE might have been thrown when a file was added during run mode. 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/976731
Fixes https://github.com/aspnet/AspNetCore/issues/13284
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/793522
