### PR TITLE
Add FIPS AppContextSwitchOverrides to some executable projects

### DIFF
--- a/src/Compilers/CSharp/csc/App.config
+++ b/src/Compilers/CSharp/csc/App.config
@@ -6,6 +6,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <gcServer enabled="true" />
     <gcConcurrent enabled="false"/>
   </runtime>

--- a/src/Compilers/Server/VBCSCompiler/App.config
+++ b/src/Compilers/Server/VBCSCompiler/App.config
@@ -6,6 +6,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <gcServer enabled="true"/>
     <gcConcurrent enabled="false"/>
   </runtime>

--- a/src/Compilers/VisualBasic/vbc/App.config
+++ b/src/Compilers/VisualBasic/vbc/App.config
@@ -6,6 +6,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <gcServer enabled="true" />
     <gcConcurrent enabled="false"/>
   </runtime>

--- a/src/Interactive/csi/App.config
+++ b/src/Interactive/csi/App.config
@@ -3,6 +3,7 @@
 
 <configuration>
   <startup>
+    <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
 </configuration>

--- a/src/Interactive/vbi/App.config
+++ b/src/Interactive/vbi/App.config
@@ -3,6 +3,7 @@
 
 <configuration>
   <startup>
+    <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
 </configuration>


### PR DESCRIPTION
I added to csc, vbc, and VBCSCompiler because I assume those are the ones that use crypto (to strong name assemblies, etc). I tried out a csc built with these settings and used `/keyfile` to strong name an assembly. It just worked for me, but I don't know if there are more changes or testing needed. /cc @jaredpar.