### PR TITLE
Reuse previously resolved missing assembly metadata objects when identity doesn't match

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -323,6 +323,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var validatedReferences = ValidateReferences<CSharpCompilationReference>(references);
 
+            // We can't reuse the whole Reference Manager entirely (reuseReferenceManager = false)
+            // because the set of references of this submission differs from the previous one.
+            // The submission inherits references of the previous submission, adds the previous submission reference
+            // and may add more references passed explicitly or via #r.
+            //
+            // TODO: Consider reusing some results of the assembly binding to improve perf
+            // since most of the binding work is similar.
+
             var compilation = new CSharpCompilation(
                 assemblyName,
                 options,

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis
                         }
 
                         // One attempt for resolution succeeded. The attempt is cached in implicitReferenceResolutions, so further attempts won't fail and add it back.
-                        // Since the failures tracked in resolutionFailures do not affect binding thre is no need to revert any decisions made so far.
+                        // Since the failures tracked in resolutionFailures do not affect binding there is no need to revert any decisions made so far.
                         resolutionFailures.Remove(binding.ReferenceIdentity);
 
                         // The resolver may return different version than we asked for, so it may happen that 

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Binding.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -59,6 +58,10 @@ namespace Microsoft.CodeAnalysis
         /// <param name="implicitlyResolvedReferenceMap">
         /// Maps indices of implicitly resolved references to the corresponding indices of resolved assemblies in <paramref name="allAssemblies"/> (explicit + implicit).
         /// </param>
+        /// <param name="implicitReferenceResolutions">
+        /// Map of implicit reference resolutions performed in the preceding script compilation. 
+        /// Output contains additional implicit resolutions performed during binding of this script compilation references.
+        /// </param>
         /// <param name="resolutionDiagnostics">
         /// Any diagnostics reported while resolving missing assemblies.
         /// </param>
@@ -95,6 +98,7 @@ namespace Microsoft.CodeAnalysis
             out ImmutableArray<AssemblyData> allAssemblies,
             out ImmutableArray<MetadataReference> implicitlyResolvedReferences,
             out ImmutableArray<ResolvedReference> implicitlyResolvedReferenceMap,
+            ref ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> implicitReferenceResolutions,
             [In, Out] DiagnosticBag resolutionDiagnostics,
             out bool hasCircularReference,
             out int corLibraryIndex)
@@ -128,6 +132,7 @@ namespace Microsoft.CodeAnalysis
                         out allAssemblies,
                         out implicitlyResolvedReferences,
                         out implicitlyResolvedReferenceMap,
+                        ref implicitReferenceResolutions,
                         resolutionDiagnostics);
                 }
                 else
@@ -198,6 +203,7 @@ namespace Microsoft.CodeAnalysis
             out ImmutableArray<AssemblyData> allAssemblies,
             out ImmutableArray<MetadataReference> metadataReferences,
             out ImmutableArray<ResolvedReference> resolvedReferences,
+            ref ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> implicitReferenceResolutions,
             DiagnosticBag resolutionDiagnostics)
         {
             Debug.Assert(explicitAssemblies[0] is AssemblyDataForAssemblyBeingBuilt);
@@ -209,22 +215,8 @@ namespace Microsoft.CodeAnalysis
 
             var implicitAssemblies = ArrayBuilder<AssemblyData>.GetInstance();
 
-            // tracks identities we already asked the resolver to resolve:
-            var requestedIdentities = PooledHashSet<AssemblyIdentity>.GetInstance();
-
-            PooledDictionary<AssemblyIdentity, PortableExecutableReference> previouslyResolvedAssembliesOpt = null;
-
-            // Avoid resolving previously resolved missing references. If we call to the resolver again we would create new assembly symbols for them,
-            // which would not match the previously created ones. As a result we would get duplicate PE types and conversion errors.
-            var previousScriptCompilation = compilation.ScriptCompilationInfo?.PreviousScriptCompilation;
-            if (previousScriptCompilation != null)
-            {
-                previouslyResolvedAssembliesOpt = PooledDictionary<AssemblyIdentity, PortableExecutableReference>.GetInstance();
-                foreach (var entry in previousScriptCompilation.GetBoundReferenceManager().GetImplicitlyResolvedAssemblyReferences())
-                {
-                    previouslyResolvedAssembliesOpt.Add(entry.Key, entry.Value);
-                }
-            }
+            // assembly identities whose resolution failed for all attempted requesting references:
+            var resolutionFailures = PooledHashSet<AssemblyIdentity>.GetInstance();
 
             var metadataReferencesBuilder = ArrayBuilder<MetadataReference>.GetInstance();
 
@@ -243,9 +235,7 @@ namespace Microsoft.CodeAnalysis
             {
                 while (referenceBindingsToProcess.Count > 0)
                 {
-                    var referenceAndBindings = referenceBindingsToProcess.Pop();
-                    var requestingReference = referenceAndBindings.Item1;
-                    var bindings = referenceAndBindings.Item2;
+                    var (requestingReference, bindings) = referenceBindingsToProcess.Pop();
 
                     foreach (var binding in bindings)
                     {
@@ -255,26 +245,22 @@ namespace Microsoft.CodeAnalysis
                             continue;
                         }
 
-                        if (!requestedIdentities.Add(binding.ReferenceIdentity))
+                        if (!TryResolveMissingReference(
+                            requestingReference,
+                            binding.ReferenceIdentity,
+                            ref implicitReferenceResolutions,
+                            resolver,
+                            resolutionDiagnostics,
+                            out AssemblyIdentity resolvedAssemblyIdentity,
+                            out AssemblyMetadata resolvedAssemblyMetadata,
+                            out PortableExecutableReference resolvedReference))
                         {
+                            resolutionFailures.Add(binding.ReferenceIdentity);
                             continue;
                         }
 
-                        PortableExecutableReference resolvedReference;
-                        if (previouslyResolvedAssembliesOpt == null || !previouslyResolvedAssembliesOpt.TryGetValue(binding.ReferenceIdentity, out resolvedReference))
-                        {
-                            resolvedReference = resolver.ResolveMissingAssembly(requestingReference, binding.ReferenceIdentity);
-                            if (resolvedReference == null)
-                            {
-                                continue;
-                            }
-                        }
-
-                        var data = ResolveMissingAssembly(binding.ReferenceIdentity, resolvedReference, importOptions, resolutionDiagnostics);
-                        if (data == null)
-                        {
-                            continue;
-                        }
+                        // one attempt for resolution succeeded (the attempt is cached in implicitReferenceResolutions, so further attempts won't fail and add it back):
+                        resolutionFailures.Remove(binding.ReferenceIdentity);
 
                         // The resolver may return different version than we asked for, so it may happen that 
                         // it returns the same identity for two different input identities (e.g. if a higher version 
@@ -285,7 +271,7 @@ namespace Microsoft.CodeAnalysis
                         // -1 for assembly being built:
                         int index = explicitAssemblyCount - 1 + metadataReferencesBuilder.Count;
 
-                        var existingReference = TryAddAssembly(data.Identity, resolvedReference, index, resolutionDiagnostics, Location.None, assemblyReferencesBySimpleName, supersedeLowerVersions);
+                        var existingReference = TryAddAssembly(resolvedAssemblyIdentity, resolvedReference, index, resolutionDiagnostics, Location.None, assemblyReferencesBySimpleName, supersedeLowerVersions);
                         if (existingReference != null)
                         {
                             MergeReferenceProperties(existingReference, resolvedReference, resolutionDiagnostics, ref lazyAliasMap);
@@ -293,12 +279,20 @@ namespace Microsoft.CodeAnalysis
                         }
 
                         metadataReferencesBuilder.Add(resolvedReference);
+
+                        var data = CreateAssemblyDataForResolvedMissingAssembly(resolvedAssemblyMetadata, resolvedReference, importOptions);
                         implicitAssemblies.Add(data);
 
                         var referenceBinding = data.BindAssemblyReferences(explicitAssemblies, IdentityComparer);
                         referenceBindings.Add(referenceBinding);
                         referenceBindingsToProcess.Push((resolvedReference, new ArraySegment<AssemblyReferenceBinding>(referenceBinding)));
                     }
+                }
+
+                // record failures for resolution in subsequent submissions: 
+                foreach (var assemblyIdentity in resolutionFailures)
+                {
+                    implicitReferenceResolutions = implicitReferenceResolutions.Add(assemblyIdentity, null);
                 }
 
                 if (implicitAssemblies.Count == 0)
@@ -349,10 +343,9 @@ namespace Microsoft.CodeAnalysis
             finally
             {
                 implicitAssemblies.Free();
-                requestedIdentities.Free();
                 referenceBindingsToProcess.Free();
                 metadataReferencesBuilder.Free();
-                previouslyResolvedAssembliesOpt?.Free();
+                resolutionFailures.Free();
             }
         }
 
@@ -464,37 +457,108 @@ namespace Microsoft.CodeAnalysis
             referenceBindings[0] = bindingsOfAssemblyBeingBuilt.ToArrayAndFree();
         }
 
-        internal AssemblyData ResolveMissingAssembly(
+        /// <summary>
+        /// Resolve <paramref name="referenceIdentity"/> using a given <paramref name="resolver"/>.
+        /// 
+        /// We make sure not to query the resolver for the same identity multiple times (across submissions).
+        /// Doing so ensures that we don't create multiple assembly symbols within the same chain of script compilations 
+        /// for the same implicitly resolved identity. Failure to do so results in cast errors like "can't convert T to T".
+        /// 
+        /// The method only records successful resolution results by updating <paramref name="implicitReferenceResolutions"/>.
+        /// Failures are only recorded after all resolution attempts have been completed.
+        /// 
+        /// This approach addresses teh following scenario. Consider a script:
+        /// <code>
+        ///   #r "dir1\a.dll"
+        ///   #r "dir2\b.dll"
+        /// </code>
+        /// where both a.dll and b.dll reference x.dll, which is present only in dir2. Let's assume the resolver first 
+        /// attempts to resolve "x" referenced from "dir1\a.dll". The resolver may fail to find the dependency if it only
+        /// looks up the directory containing the referencing assembly (dir1). If we recorded and this failure immediately
+        /// we would not call the resolver to resolve "x" within the context of "dir2\b.dll" (or any other referencing assembly). 
+        /// 
+        /// This behavior would ensure consistency and if the types from x.dll do leak thru to the script compilation, but it 
+        /// would result in a missing assembly error. By recording the failure after all resolution attempts are complete
+        /// we also achieve a consistent behavior but are able to bind the reference to "x.dll". Besides, this approach
+        /// also avoids dependency on the order in which we evaluate the assembly references.
+        /// </summary>
+        private bool TryResolveMissingReference(
+            MetadataReference requestingReference,
             AssemblyIdentity referenceIdentity,
-            PortableExecutableReference peReference,
-            MetadataImportOptions importOptions,
-            DiagnosticBag diagnostics)
+            ref ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> implicitReferenceResolutions,
+            MetadataReferenceResolver resolver,
+            DiagnosticBag resolutionDiagnostics,
+            out AssemblyIdentity resolvedAssemblyIdentity,
+            out AssemblyMetadata resolvedAssemblyMetadata,
+            out PortableExecutableReference resolvedReference)
         {
-            var metadata = GetMetadata(peReference, MessageProvider, Location.None, diagnostics);
-            Debug.Assert(metadata != null || diagnostics.HasAnyErrors());
+            resolvedAssemblyIdentity = null;
+            resolvedAssemblyMetadata = null;
 
-            if (metadata == null)
+            // Check if we have resolved a missing assembly of the given identity in a previous submission:
+            if (implicitReferenceResolutions.TryGetValue(referenceIdentity, out var previouslyResolvedReference))
             {
-                return null;
+                resolvedReference = previouslyResolvedReference;
+
+                if (previouslyResolvedReference == null)
+                {
+                    return false;
+                }
+
+                resolvedAssemblyMetadata = GetAssemblyMetadata(previouslyResolvedReference, resolutionDiagnostics);
+                resolvedAssemblyIdentity = referenceIdentity;
+                return resolvedAssemblyMetadata != null;
             }
 
-            var assemblyMetadata = metadata as AssemblyMetadata;
-            if (assemblyMetadata?.IsValidAssembly() != true)
+            // Use the resolver to find the missing reference.
+            // Note that the resolver may return an assembly of a different identity than requested, e.g. a higher version.
+            resolvedReference = resolver.ResolveMissingAssembly(requestingReference, referenceIdentity);
+            if (resolvedReference == null)
             {
-                diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_MetadataFileNotAssembly, Location.None, peReference.Display));
-                return null;
+                return false;
             }
 
-            var assembly = assemblyMetadata.GetAssembly();
+            resolvedAssemblyMetadata = GetAssemblyMetadata(resolvedReference, resolutionDiagnostics);
+            if (resolvedAssemblyMetadata == null)
+            {
+                return false;
+            }
+
+            var resolvedAssembly = resolvedAssemblyMetadata.GetAssembly();
 
             // Allow reference and definition identities to differ in version, but not other properties:
-            if (IdentityComparer.Compare(referenceIdentity, assembly.Identity) == AssemblyIdentityComparer.ComparisonResult.NotEquivalent)
+            if (IdentityComparer.Compare(referenceIdentity, resolvedAssembly.Identity) == AssemblyIdentityComparer.ComparisonResult.NotEquivalent)
             {
-                return null;
+                return false;
             }
 
+            resolvedAssemblyIdentity = resolvedAssembly.Identity;
+
+            // Check again if we have resolved a missing assembly with the same identity as the one returned by the resolver.
+            // If so, use the one we already resolved.
+            if (implicitReferenceResolutions.TryGetValue(resolvedAssemblyIdentity, out previouslyResolvedReference))
+            {
+                if (previouslyResolvedReference == null)
+                {
+                    return false;
+                }
+
+                resolvedAssemblyMetadata = GetAssemblyMetadata(previouslyResolvedReference, resolutionDiagnostics);
+                resolvedReference = previouslyResolvedReference;
+                return resolvedAssemblyMetadata != null;
+            }
+
+            implicitReferenceResolutions = implicitReferenceResolutions.Add(resolvedAssemblyIdentity, resolvedReference);
+            return true;
+        }
+
+        private AssemblyData CreateAssemblyDataForResolvedMissingAssembly(
+            AssemblyMetadata assemblyMetadata,
+            PortableExecutableReference peReference,
+            MetadataImportOptions importOptions)
+        {
             return CreateAssemblyDataForFile(
-                assembly,
+                assemblyMetadata.GetAssembly(),
                 assemblyMetadata.CachedSymbols,
                 peReference.DocumentationProvider,
                 SimpleAssemblyName,

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -116,11 +116,11 @@ namespace Microsoft.CodeAnalysis
         private ImmutableArray<MetadataReference> _lazyExplicitReferences;
 
         /// <summary>
-        /// Stores teh results of implicit reference resolutions.
+        /// Stores the results of implicit reference resolutions.
         /// If <see cref="MetadataReferenceResolver.ResolveMissingAssemblies"/> is true the reference manager attempts to resolve assembly identities,
         /// that do not match any explicit metadata references passed to the compilation (or specified via #r directive).
         /// For each such assembly identity <see cref="MetadataReferenceResolver.ResolveMissingAssembly(MetadataReference, AssemblyIdentity)"/> is called
-        /// and its result is captured in this map. Both the original requested identity as well as the actual identity of the resolved assembly are captured in the map.
+        /// and its result is captured in this map.
         /// The map also stores failures - the reference is null if the assembly of the given identity is not found by the resolver.
         /// This is important to maintain consistency, especially across multiple submissions (e.g. the reference is not found during compilation of the first submission
         /// but then it is available when the second submission is compiled).

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.State.cs
@@ -41,8 +41,7 @@ namespace Microsoft.CodeAnalysis
 
         internal abstract MetadataReference GetMetadataReference(IAssemblySymbol assemblySymbol);
         internal abstract ImmutableArray<MetadataReference> ExplicitReferences { get; }
-        internal abstract ImmutableArray<MetadataReference> ImplicitReferences { get; }
-        internal abstract IEnumerable<KeyValuePair<AssemblyIdentity, PortableExecutableReference>> GetImplicitlyResolvedAssemblyReferences();
+        internal abstract ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> ImplicitReferenceResolutions { get; }
     }
 
     internal partial class CommonReferenceManager<TCompilation, TAssemblySymbol> : CommonReferenceManager
@@ -115,7 +114,18 @@ namespace Microsoft.CodeAnalysis
         private ImmutableArray<MetadataReference> _lazyDirectiveReferences;
 
         private ImmutableArray<MetadataReference> _lazyExplicitReferences;
-        private ImmutableArray<MetadataReference> _lazyImplicitReferences;
+
+        /// <summary>
+        /// Stores teh results of implicit reference resolutions.
+        /// If <see cref="MetadataReferenceResolver.ResolveMissingAssemblies"/> is true the reference manager attempts to resolve assembly identities,
+        /// that do not match any explicit metadata references passed to the compilation (or specified via #r directive).
+        /// For each such assembly identity <see cref="MetadataReferenceResolver.ResolveMissingAssembly(MetadataReference, AssemblyIdentity)"/> is called
+        /// and its result is captured in this map. Both the original requested identity as well as the actual identity of the resolved assembly are captured in the map.
+        /// The map also stores failures - the reference is null if the assembly of the given identity is not found by the resolver.
+        /// This is important to maintain consistency, especially across multiple submissions (e.g. the reference is not found during compilation of the first submission
+        /// but then it is available when the second submission is compiled).
+        /// </summary>
+        private ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> _lazyImplicitReferenceResolutions;
 
         /// <summary>
         /// Diagnostics produced during reference resolution and binding.
@@ -235,12 +245,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal override ImmutableArray<MetadataReference> ImplicitReferences
+        internal override ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> ImplicitReferenceResolutions
         {
             get
             {
                 AssertBound();
-                return _lazyImplicitReferences;
+                return _lazyImplicitReferenceResolutions;
             }
         }
 
@@ -323,7 +333,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(_lazyReferencedModuleIndexMap == null);
             Debug.Assert(_lazyReferenceDirectiveMap == null);
             Debug.Assert(_lazyDirectiveReferences.IsDefault);
-            Debug.Assert(_lazyImplicitReferences.IsDefault);
+            Debug.Assert(_lazyImplicitReferenceResolutions == null);
             Debug.Assert(_lazyExplicitReferences.IsDefault);
             Debug.Assert(_lazyReferencedModules.IsDefault);
             Debug.Assert(_lazyReferencedModulesReferences.IsDefault);
@@ -342,7 +352,7 @@ namespace Microsoft.CodeAnalysis
             Debug.Assert(_lazyReferencedModuleIndexMap != null);
             Debug.Assert(_lazyReferenceDirectiveMap != null);
             Debug.Assert(!_lazyDirectiveReferences.IsDefault);
-            Debug.Assert(!_lazyImplicitReferences.IsDefault);
+            Debug.Assert(_lazyImplicitReferenceResolutions != null);
             Debug.Assert(!_lazyExplicitReferences.IsDefault);
             Debug.Assert(!_lazyReferencedModules.IsDefault);
             Debug.Assert(!_lazyReferencedModulesReferences.IsDefault);
@@ -377,7 +387,7 @@ namespace Microsoft.CodeAnalysis
             IDictionary<(string, string), MetadataReference> boundReferenceDirectiveMap,
             ImmutableArray<MetadataReference> directiveReferences,
             ImmutableArray<MetadataReference> explicitReferences,
-            ImmutableArray<MetadataReference> implicitReferences,
+            ImmutableDictionary<AssemblyIdentity, PortableExecutableReference> implicitReferenceResolutions,
             bool containsCircularReferences,
             ImmutableArray<Diagnostic> diagnostics,
             TAssemblySymbol corLibraryOpt,
@@ -399,7 +409,7 @@ namespace Microsoft.CodeAnalysis
             _lazyReferenceDirectiveMap = boundReferenceDirectiveMap;
             _lazyDirectiveReferences = directiveReferences;
             _lazyExplicitReferences = explicitReferences;
-            _lazyImplicitReferences = implicitReferences;
+            _lazyImplicitReferenceResolutions = implicitReferenceResolutions;
 
             _lazyCorLibraryOpt = corLibraryOpt;
             _lazyReferencedModules = referencedModules;
@@ -675,14 +685,6 @@ namespace Microsoft.CodeAnalysis
         {
             var aliases = AliasesOfReferencedAssemblies[referencedAssemblyIndex];
             return aliases.Length == 0 || aliases.IndexOf(MetadataReferenceProperties.GlobalAlias, StringComparer.Ordinal) >= 0;
-        }
-
-        internal override IEnumerable<KeyValuePair<AssemblyIdentity, PortableExecutableReference>> GetImplicitlyResolvedAssemblyReferences()
-        {
-            foreach (PortableExecutableReference reference in ImplicitReferences)
-            {
-                yield return KeyValuePairUtil.Create(ReferencedAssemblies[ReferencedAssembliesMap[reference]].Identity, reference);
-            }
         }
 
         #endregion

--- a/src/Scripting/CSharpTest.Desktop/InteractiveSessionReferencesTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/InteractiveSessionReferencesTests.cs
@@ -19,14 +19,11 @@ using Xunit;
 using AssertEx = PortableTestUtils::Roslyn.Test.Utilities.AssertEx;
 using TestBase = PortableTestUtils::Roslyn.Test.Utilities.TestBase;
 using WorkItemAttribute = PortableTestUtils::Roslyn.Test.Utilities.WorkItemAttribute;
+using static Microsoft.CodeAnalysis.Scripting.TestCompilationFactory;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Test
 {
-    using static TestCompilationFactory;
-    using DiagnosticExtensions = PortableTestUtils::Microsoft.CodeAnalysis.DiagnosticExtensions;
-    using TestReferences = PortableTestUtils::TestReferences;
-
-    public class InteractiveSessionTests : TestBase
+    public class InteractiveSessionReferencesTests : TestBase
     {
         private static readonly CSharpCompilationOptions s_signedDll =
            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_ce65828c82a341f2);
@@ -235,7 +232,7 @@ System.Diagnostics.Process.GetCurrentProcess()
             Assert.NotNull(process);
         }
 
-        private static Lazy<bool> s_isSystemV2AndV4Available = new Lazy<bool>(() =>
+        private static readonly Lazy<bool> s_isSystemV2AndV4Available = new Lazy<bool>(() =>
         {
             string path;
             return GlobalAssemblyCache.Instance.ResolvePartialName("System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", out path) != null &&
@@ -1117,7 +1114,7 @@ public class C
             var libFile = Temp.CreateFile("lib").WriteAllBytes(lib.EmitToArray());
 
             var s0 = await CSharpScript.RunAsync("C c;", ScriptOptions.Default.WithReferences(libFile.Path));
-            var s1 = await s0.ContinueWithAsync("c = new C()");
+            await s0.ContinueWithAsync("c = new C()");
         }
     }
 }

--- a/src/Scripting/CSharpTest/InteractiveSessionReferencesTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionReferencesTests.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using static Microsoft.CodeAnalysis.Scripting.TestCompilationFactory;
+
+namespace Microsoft.CodeAnalysis.CSharp.Scripting.Test
+{
+    public class InteractiveSessionReferencesTests : TestBase
+    {
+        /// <summary>
+        /// Test adding a reference to NetStandard 2.0 library.
+        /// Validates that we resolve all references correctly in the first and the subsequent submissions.
+        /// </summary>
+        [Fact]
+        [WorkItem(345, "https://github.com/dotnet/try/issues/345")]
+        public async Task LibraryReference_NetStandard20()
+        {
+            var libSource = @"
+public class C
+{
+    public readonly int X = 1;
+}
+";
+            var libImage = CreateCSharpCompilation(libSource, TargetFrameworkUtil.NetStandard20References, "lib").EmitToArray();
+
+            var dir = Temp.CreateDirectory();
+            var libFile = dir.CreateFile("lib.dll").WriteAllBytes(libImage);
+
+            var s0 = CSharpScript.Create($@"
+#r ""{libFile.Path}""
+int F(C c) => c.X;
+");
+            var s1 = s0.ContinueWith($@"
+F(new C())
+");
+            var diagnostics = s1.Compile();
+            Assert.Empty(diagnostics);
+
+            var result = await s1.EvaluateAsync();
+            Assert.Equal(1, (int)result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task LibraryReference_MissingDependency_MultipleResolveAttempts(bool swapReferences)
+        {
+            var libASource = @"
+public class A
+{
+    public readonly int X = D.Y;
+}
+";
+            var libBSource = @"
+public class B
+{
+    public readonly int X = D.Y;
+}
+";
+            var libDSource = @"
+public class D
+{
+    public static readonly int Y = 1;
+}
+";
+
+            var dir = Temp.CreateDirectory();
+
+            // 1\a.dll
+            // 2\{b.dll, d.dll}
+            var dir1 = dir.CreateDirectory("1");
+            var dir2 = dir.CreateDirectory("2");
+
+            var libDImage = CreateCSharpCompilation(libDSource, TargetFrameworkUtil.NetStandard20References, "libD").EmitToArray();
+            var libDFile = dir2.CreateFile("libD.dll").WriteAllBytes(libDImage);
+            var libDRef = MetadataReference.CreateFromFile(libDFile.Path);
+
+            var libAImage = CreateCSharpCompilation(libASource, TargetFrameworkUtil.NetStandard20References.Concat(libDRef), "libA").EmitToArray();
+            var libAFile = dir1.CreateFile("libA.dll").WriteAllBytes(libAImage);
+
+            var libBImage = CreateCSharpCompilation(libBSource, TargetFrameworkUtil.NetStandard20References.Concat(libDRef), "libB").EmitToArray();
+            var libBFile = dir2.CreateFile("libB.dll").WriteAllBytes(libBImage);
+
+            var r1 = swapReferences ? libBFile.Path : libAFile.Path;
+            var r2 = swapReferences ? libAFile.Path : libBFile.Path;
+
+            var s0 = CSharpScript.Create($@"
+#r ""{r1}""
+#r ""{r2}""
+new A().X + new B().X
+");
+            var diagnostics0 = s0.Compile();
+            Assert.Empty(diagnostics0);
+
+            var result = await s0.EvaluateAsync();
+            Assert.Equal(2, (int)result);
+        }
+
+        [Fact]
+        public void LibraryReference_MissingDependency()
+        {
+            var libASource = @"
+public class C
+{
+    public readonly int X = D.Y;
+}
+";
+            var libBSource = @"
+public class D
+{
+    public static readonly int Y = 1;
+    public static readonly int Z = 2;
+}
+";
+
+            var dir = Temp.CreateDirectory();
+            var libBImage = CreateCSharpCompilation(libBSource, TargetFrameworkUtil.NetStandard20References, "libB").EmitToArray();
+
+            // store the reference under a different file name, so that it is not found by the resolver:
+            var libBFile = dir.CreateFile("libB1.dll").WriteAllBytes(libBImage);
+            var libBRef = MetadataReference.CreateFromFile(libBFile.Path);
+
+            var libAImage = CreateCSharpCompilation(libASource, TargetFrameworkUtil.NetStandard20References.Concat(libBRef), "libA").EmitToArray();
+            var libAFile = dir.CreateFile("libA.dll").WriteAllBytes(libAImage);
+
+            var s0 = CSharpScript.Create($@"
+#r ""{libAFile.Path}""
+int F(C c) => c.X;
+");
+            var diagnostics0 = s0.Compile();
+            Assert.Empty(diagnostics0);
+
+            File.Move(libBFile.Path, Path.Combine(dir.Path, "libB.dll"));
+
+            var s1 = s0.ContinueWith($@"
+F(new C())
+");
+            var diagnostics1 = s1.Compile();
+            Assert.Empty(diagnostics1);
+
+            var m = s1.GetCompilation().Assembly.Modules.Single();
+            Assert.False(m.ReferencedAssemblies.Any(a => a.Name == "libB"));
+            var missingB = m.ReferencedAssemblySymbols.Single(a => a.Name == "libA").Modules.Single().ReferencedAssemblySymbols.Single(a => a.Name == "libB");
+            Assert.IsType(typeof(MissingAssemblySymbol), missingB);
+        }
+    }
+}

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -97,25 +97,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         }
 
         [Fact]
-        public void TestCreateScriptDelegate()
+        public async Task TestCreateScriptDelegate()
         {
             // create a delegate for the entire script
             var script = CSharpScript.Create("1 + 2");
             var fn = script.CreateDelegate();
 
             Assert.Equal(3, fn().Result);
-            Assert.ThrowsAsync<ArgumentException>("globals", () => fn(new object()));
+            await Assert.ThrowsAsync<ArgumentException>("globals", () => fn(new object()));
         }
 
         [Fact]
-        public void TestCreateScriptDelegateWithGlobals()
+        public async Task TestCreateScriptDelegateWithGlobals()
         {
             // create a delegate for the entire script
             var script = CSharpScript.Create<int>("X + Y", globalsType: typeof(Globals));
             var fn = script.CreateDelegate();
 
-            Assert.ThrowsAsync<ArgumentException>("globals", () => fn());
-            Assert.ThrowsAsync<ArgumentException>("globals", () => fn(new object()));
+            await Assert.ThrowsAsync<ArgumentException>("globals", () => fn());
+            await Assert.ThrowsAsync<ArgumentException>("globals", () => fn(new object()));
             Assert.Equal(4, fn(new Globals { X = 1, Y = 3 }).Result);
         }
 
@@ -178,9 +178,9 @@ F();");
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/170")]
-        public void TestRunDynamicVoidScriptWithTerminatingSemicolon()
+        public async Task TestRunDynamicVoidScriptWithTerminatingSemicolon()
         {
-            var result = CSharpScript.RunAsync(@"
+            await CSharpScript.RunAsync(@"
 class SomeClass
 {
     public void Do()
@@ -193,9 +193,9 @@ d.Do();"
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/170")]
-        public void TestRunDynamicVoidScriptWithoutTerminatingSemicolon()
+        public async Task TestRunDynamicVoidScriptWithoutTerminatingSemicolon()
         {
-            var result = CSharpScript.RunAsync(@"
+            await CSharpScript.RunAsync(@"
 class SomeClass
 {
     public void Do()
@@ -300,30 +300,30 @@ throw e;", globals: new ScriptTests());
         }
 
         [Fact]
-        public void TestRunCreatedScriptWithUnexpectedGlobals()
+        public async Task TestRunCreatedScriptWithUnexpectedGlobals()
         {
             var script = CSharpScript.Create("X + Y");
 
             // Global variables passed to a script without a global type
-            Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new Globals { X = 1, Y = 2 }));
+            await Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new Globals { X = 1, Y = 2 }));
         }
 
         [Fact]
-        public void TestRunCreatedScriptWithoutGlobals()
+        public async Task TestRunCreatedScriptWithoutGlobals()
         {
             var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
 
             //  The script requires access to global variables but none were given
-            Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync());
+            await Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync());
         }
 
         [Fact]
-        public void TestRunCreatedScriptWithMismatchedGlobals()
+        public async Task TestRunCreatedScriptWithMismatchedGlobals()
         {
             var script = CSharpScript.Create("X + Y", globalsType: typeof(Globals));
 
             //  The globals of type 'System.Object' is not assignable to 'Microsoft.CodeAnalysis.CSharp.Scripting.Test.ScriptTests+Globals'
-            Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new object()));
+            await Assert.ThrowsAsync<ArgumentException>("globals", () => script.RunAsync(new object()));
         }
 
         [Fact]
@@ -354,7 +354,7 @@ throw e;", globals: new ScriptTests());
         [Fact]
         public async Task TestRepl()
         {
-            string[] submissions = new[]
+            var submissions = new[]
             {
                 "int x = 100;",
                 "int y = x * x;",

--- a/src/Scripting/Core/Hosting/AssemblyLoader/InteractiveAssemblyLoader.cs
+++ b/src/Scripting/Core/Hosting/AssemblyLoader/InteractiveAssemblyLoader.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                     {
                         // Desktop FX: A weak-named assembly conflicts with another weak-named assembly of the same simple name,
                         // unless we find an assembly whose identity matches exactly and whose content is exactly the same.
-                        // TODO: We shouldn't block this on CoreCLR.
+                        // TODO: We shouldn't block this on CoreCLR. https://github.com/dotnet/roslyn/issues/38621
 
                         if (!identity.IsStrongName)
                         {
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                         );
                     }
 
-                    // TODO: Desktop FX only
+                    // TODO: Desktop FX only https://github.com/dotnet/roslyn/issues/38621
                     if (!conflictingLoadedAssemblyOpt.IsDefault)
                     {
                         // error: attempt to load an assembly with the same identity as already loaded assembly but different content

--- a/src/Scripting/CoreTestUtilities/TestCompilationFactory.cs
+++ b/src/Scripting/CoreTestUtilities/TestCompilationFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.VisualBasic;
 
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Scripting
                 new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         }
 
-        internal static Compilation CreateCSharpCompilation(string source, MetadataReference[] references, string assemblyName = null, CSharpCompilationOptions options = null)
+        internal static Compilation CreateCSharpCompilation(string source, IEnumerable<MetadataReference> references, string assemblyName = null, CSharpCompilationOptions options = null)
         {
             return CSharpCompilation.Create(
                 assemblyName ?? Guid.NewGuid().ToString(),


### PR DESCRIPTION
Fixes https://github.com/dotnet/try/issues/345.

**Background**
When the compiler is resolving compilation references and encounters a reference whose assembly identity does not match any of the explicitly given references it falls back to a Reference Resolver. In regular compilation an error is reported since there is no Reference Resolver. Interactive compiler supplies a resolver that attempts to find the missing reference. 

Once the missing reference is found the compiler adds it to the list of implicitly resolved assemblies and if the same missing assembly identity is referenced later (by a subsequent submission) it reuses the assembly symbol from this list, so that we don't end up loading multiple instances of the same missing assembly. [1]

The resolver may find an assembly that matches the name of the missing reference but doesn't match the version exactly. This is expected as a newer version of the assembly may be available than was referenced and the compiler correctly binds to the newer version. 

**Issues** 
The first submission added a reference to a netstandard20 library on .NET Core and the subsequent submission referenced a type from that library. The reference resolution in the compilation corresponding to the second submission ended up adding a new, distinct reference to the library, instead of reusing the one that was already resolved for the first submission compilation.

This was caused by mismatch in versions of some of the facades transitively referenced by the library thru `netstandard.dll` reference and resolved thru the missing reference resolution mechanism. The facades ware referenced with different versions than the actual versions available in the set of references the Reference Resolver resolved missing references from. The compiler ended up using two distinct instances of the same facade assembly metadata. An assembly symbol is only reused if all its transitively referenced assemblies match. In this case the library assembly symbol wasn't reused because some of the facade assembly symbols did not match.

The problem was that the mechanism [1] didn't reuse missing assembly metadata with a different version than what was requested. The fix is to reuse all successful resolutions based on referenced identity.

Another issue found during testing is handing resolution failures. We did not remember that a resolution of a given assembly identity failed and attempted to resolve the assembly again in the next submission. This may lead to inconsistencies and the same "can't convert T to T" errors since first submission might have a missing assembly symbol and next might create a real assembly symbol for the same assembly identity. The fix is to capture both successful and failed resolution results.