### PR TITLE
Rewrite reference assemblies to include nullability annotations

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,6 +80,7 @@
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-63011-01</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
+    <MicrosoftNETCoreAppRefVersion>3.0.0-preview9-19423-09</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNetCoreAnalyzersVersion>$(RoslynDiagnosticsNugetPackageVersion)</MicrosoftNetCoreAnalyzersVersion>
     <MicrosoftNETCorePlatformsVersion>2.1.2</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETTestSdkVersion>16.0.1</MicrosoftNETTestSdkVersion>
@@ -195,6 +196,7 @@
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.3</SystemThreadingTasksExtensionsVersion>
     <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
+    <TunnelVisionLabsReferenceAssemblyAnnotatorVersion>1.0.0-alpha.53</TunnelVisionLabsReferenceAssemblyAnnotatorVersion>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftVSSDKVSDConfigToolVersion>16.0.2032702</MicrosoftVSSDKVSDConfigToolVersion>

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -24,6 +24,12 @@
     <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
   </ItemGroup>
 
+  <!-- Nullable reference types -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net472'">
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="$(TunnelVisionLabsReferenceAssemblyAnnotatorVersion)" PrivateAssets="all" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+  </ItemGroup>
+
   <!--
     If the project targets Framework 2.0 reference assemblies provided by Microsoft.NetFramework.ReferenceAssemblies nuget package.
     Use the latest Framework toolset to build, but set msbuild properties below

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -126,6 +126,15 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(MicrosoftVisualStudioThreadingAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
+  <!-- Nullable reference types -->
+  <PropertyGroup>
+    <!-- Do not automatically include NullableAttributes.cs/vb by default -->
+    <GenerateNullableAttributes>false</GenerateNullableAttributes>
+
+    <!-- Specify reference assembly version for the annotator -->
+    <AnnotatedReferenceAssemblyVersion>$(MicrosoftNETCoreAppRefVersion)</AnnotatedReferenceAssemblyVersion>
+  </PropertyGroup>
+
   <!-- Language-specific analyzer packages -->
   <Choose>
     <When Condition="'$(Language)' == 'VB' and '$(RoslynEnforceCodeStyle)' == 'true'">

--- a/src/Compilers/Core/Portable/Collections/Rope.cs
+++ b/src/Compilers/Core/Portable/Collections/Rope.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Two ropes are "the same" if they represent the same sequence of characters.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is Rope other) || Length != other.Length)
                 return false;

--- a/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Classification
             return Hash.Combine(this.ClassificationType, this.TextSpan.GetHashCode());
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ClassifiedSpan &&
                 Equals((ClassifiedSpan)obj);

--- a/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/SemanticModelWorkspaceService/SemanticModelWorkspaceServiceFactory.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.SemanticModelWorkspaceService
                 var projectId = document.Project.Id;
                 var version = await document.Project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
 
-                CompilationSet compilationSet;
+                CompilationSet? compilationSet;
                 using (_gate.DisposableRead())
                 {
                     versionMap.TryGetValue(projectId, out compilationSet);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/LineSpan.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/LineSpan.cs
@@ -29,9 +29,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return this.Start == other.Start && this.End == other.End;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return this.Equals((LineSpan)obj);
+            return obj is LineSpan other
+                && this.Equals(other);
         }
 
         public override int GetHashCode()

--- a/src/Workspaces/Core/Portable/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/IDictionaryExtensions.cs
@@ -13,6 +13,7 @@ namespace Roslyn.Utilities
     {
         // Copied from ConcurrentDictionary since IDictionary doesn't have this useful method
         public static V GetOrAdd<K, V>(this IDictionary<K, V> dictionary, K key, Func<K, V> function)
+            where K : notnull
         {
             if (!dictionary.TryGetValue(key, out var value))
             {
@@ -25,6 +26,7 @@ namespace Roslyn.Utilities
 
         [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey : notnull
         {
             if (dictionary.TryGetValue(key, out var value))
             {
@@ -35,6 +37,7 @@ namespace Roslyn.Utilities
         }
 
         public static void MultiAdd<TKey, TValue, TCollection>(this IDictionary<TKey, TCollection> dictionary, TKey key, TValue value)
+            where TKey : notnull
             where TCollection : ICollection<TValue>, new()
         {
             if (!dictionary.TryGetValue(key, out var collection))
@@ -47,6 +50,7 @@ namespace Roslyn.Utilities
         }
 
         public static void MultiAdd<TKey, TValue>(this IDictionary<TKey, ImmutableArray<TValue>> dictionary, TKey key, TValue value, ImmutableArray<TValue> defaultArray)
+            where TKey : notnull
             where TValue : IEquatable<TValue>
         {
             if (!dictionary.TryGetValue(key, out var collection))
@@ -58,6 +62,7 @@ namespace Roslyn.Utilities
         }
 
         public static void MultiRemove<TKey, TValue, TCollection>(this IDictionary<TKey, TCollection> dictionary, TKey key, TValue value)
+            where TKey : notnull
             where TCollection : ICollection<TValue>
         {
             if (dictionary.TryGetValue(key, out var collection))
@@ -72,6 +77,7 @@ namespace Roslyn.Utilities
         }
 
         public static void MultiRemove<TKey, TValue>(this IDictionary<TKey, ImmutableArray<TValue>> dictionary, TKey key, TValue value)
+            where TKey : notnull
         {
             if (dictionary.TryGetValue(key, out var collection))
             {

--- a/src/Workspaces/Core/Portable/Utilities/IReadOnlyDictionaryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/IReadOnlyDictionaryExtensions.cs
@@ -11,6 +11,7 @@ namespace Roslyn.Utilities
     {
         [return: MaybeNull]
         public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey : notnull
         {
             if (dictionary.TryGetValue(key, out var value))
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -786,7 +786,7 @@ namespace Microsoft.CodeAnalysis
             Contract.ThrowIfFalse(existingId == id);
         }
 
-        public static DocumentId GetDocumentIdForTree(SyntaxTree tree)
+        public static DocumentId? GetDocumentIdForTree(SyntaxTree tree)
         {
             s_syntaxTreeToIdMap.TryGetValue(tree, out var id);
             return id;


### PR DESCRIPTION
Update our **netstandard2.0** and **net472** builds to use new nullability annotations from **netcoreapp3.0** where available. Bugs found by this change were submitted as a separate pull request (#38551).

Submitting this pull request for personal review to see if it works with our CI before discussing it with infrastructure team.