### PR TITLE
Support reinferring indexers

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -3206,6 +3206,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     break;
 
+                case BoundKind.IndexOrRangePatternIndexerAccess:
+                    {
+                        var indexerAccess = (BoundIndexOrRangePatternIndexerAccess)boundNode;
+
+                        resultKind = indexerAccess.ResultKind;
+
+                        // The only time a BoundIndexOrRangePatternIndexerAccess is created, overload resolution succeeded
+                        // and returned only 1 result
+                        Debug.Assert(indexerAccess.PatternSymbol is object);
+                        symbols = ImmutableArray.Create<Symbol>(indexerAccess.PatternSymbol);
+                    }
+                    break;
+
                 case BoundKind.EventAssignmentOperator:
                     var eventAssignment = (BoundEventAssignmentOperator)boundNode;
                     isDynamic = eventAssignment.IsDynamic;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -672,11 +672,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     _updatedSymbolMapOpt[key] = updatedSymbol;
                 }
-                else if (_updatedSymbolMapOpt.TryGetValue(key, out var currentSymbol) && (object)currentSymbol != updatedSymbol)
+                else
                 {
                     // If the symbol is reset, remove the updated symbol so we don't needlessly update the
-                    // bound node later on.
-                    _updatedSymbolMapOpt.Remove(key);
+                    // bound node later on. We do this unconditionally, as Remove will just return false
+                    // if the key wasn't in the dictionary.
+                    _ = _updatedSymbolMapOpt.Remove(key);
                 }
             }
         }
@@ -6255,6 +6256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var resultType = ApplyUnconditionalAnnotations(indexer.TypeWithAnnotations.ToTypeWithState(), GetRValueAnnotations(indexer));
             SetResult(node, resultType, indexer.TypeWithAnnotations);
+            SetUpdatedSymbol(node, node.Indexer, indexer);
             return null;
         }
 
@@ -6274,6 +6276,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             SetLvalueResultType(node, patternSymbol.GetTypeOrReturnType());
+            SetUpdatedSymbol(node, node.PatternSymbol, patternSymbol);
             return null;
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             return CompileAndVerify(comp, expectedOutput: expectedOutput);
         }
 
-        private (SemanticModel model, List<ElementAccessExpressionSyntax> accesses) GetModelAndAccesses(CSharpCompilation comp)
+        private static (SemanticModel model, List<ElementAccessExpressionSyntax> accesses) GetModelAndAccesses(CSharpCompilation comp)
         {
             var syntaxTree = comp.SyntaxTrees[0];
             var root = syntaxTree.GetRoot();
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             return (model, root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToList());
         }
 
-        private void VerifyIndexCall(IMethodSymbol symbol, string methodName, string containingTypeName)
+        private static void VerifyIndexCall(IMethodSymbol symbol, string methodName, string containingTypeName)
         {
             Assert.NotNull(symbol);
             Assert.Equal(methodName, symbol.Name);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -15,6 +18,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
                 new[] { s, TestSources.GetSubArray, },
                 expectedOutput is null ? TestOptions.ReleaseDll : TestOptions.ReleaseExe);
             return CompileAndVerify(comp, expectedOutput: expectedOutput);
+        }
+
+        private (SemanticModel model, List<ElementAccessExpressionSyntax> accesses) GetModelAndAccesses(CSharpCompilation comp)
+        {
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            return (model, root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToList());
+        }
+
+        private void VerifyIndexCall(IMethodSymbol symbol, string methodName, string containingTypeName)
+        {
+            Assert.NotNull(symbol);
+            Assert.Equal(methodName, symbol.Name);
+            Assert.Equal(2, symbol.Parameters.Length);
+            Assert.Equal(containingTypeName, symbol.ContainingType.Name);
         }
 
         [Fact]
@@ -88,6 +108,16 @@ abcd");
   IL_0053:  blt.s      IL_0039
   IL_0055:  ret
 }");
+
+            var (model, elementAccesses) = GetModelAndAccesses(comp);
+
+            var info = model.GetSymbolInfo(elementAccesses[0]);
+            var substringCall = (IMethodSymbol)info.Symbol;
+            info = model.GetSymbolInfo(elementAccesses[1]);
+            var sliceCall = (IMethodSymbol)info.Symbol;
+
+            VerifyIndexCall(substringCall, "Substring", "String");
+            VerifyIndexCall(sliceCall, "Slice", "ReadOnlySpan");
         }
 
         [Fact]
@@ -118,6 +148,9 @@ class C
 }";
             var comp = CreateCompilationWithIndexAndRangeAndSpan(src, TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: "throws");
+
+            var (model, accesses) = GetModelAndAccesses(comp);
+            VerifyIndexCall((IMethodSymbol)model.GetSymbolInfo(accesses[0]).Symbol, "Slice", "Span");
         }
 
         [Fact]
@@ -194,6 +227,19 @@ class C
   IL_0054:  call       ""void System.Console.WriteLine(int)""
   IL_0059:  ret
 }");
+
+            var (model, accesses) = GetModelAndAccesses(comp);
+
+            foreach (var access in accesses)
+            {
+                var info = model.GetSymbolInfo(access);
+                var property = (IPropertySymbol)info.Symbol;
+
+                Assert.NotNull(property);
+                Assert.True(property.IsIndexer);
+                Assert.Equal(SpecialType.System_Int32, property.Parameters[0].Type.SpecialType);
+                Assert.Equal("S", property.ContainingType.Name);
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -137,7 +137,9 @@ class C
             var typeInfo = model.GetTypeInfo(indexerAccess);
             Assert.Equal(SpecialType.System_Int32, typeInfo.Type.SpecialType);
             var symbolInfo = model.GetSymbolInfo(indexerAccess);
-            Assert.Null(symbolInfo.Symbol);
+            var propertySymbol = (IPropertySymbol)symbolInfo.Symbol;
+            Assert.NotNull(symbolInfo.Symbol);
+            Assert.True(propertySymbol.IsIndexer);
             Assert.Empty(symbolInfo.CandidateSymbols);
 
             indexerAccess = accesses[1];
@@ -145,7 +147,9 @@ class C
             typeInfo = model.GetTypeInfo(indexerAccess);
             Assert.Equal(SpecialType.System_Char, typeInfo.Type.SpecialType);
             symbolInfo = model.GetSymbolInfo(indexerAccess);
-            Assert.Null(symbolInfo.Symbol);
+            Assert.NotNull(symbolInfo.Symbol);
+            Assert.Equal(SymbolKind.Method, symbolInfo.Symbol.Kind);
+            Assert.Equal("Slice", symbolInfo.Symbol.Name);
             Assert.Empty(symbolInfo.CandidateSymbols);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -2719,5 +2719,167 @@ static class CExt
                 Assert.Equal(annotation, methodSymbol.TypeArgumentNullableAnnotations[0]);
             }
         }
+
+        [Fact]
+        public void GetSymbolInfo_ReinferredIndexer()
+        {
+            var source = @"
+class C<T, U>
+{
+    public T this[U u] { get => throw null!; set => throw null!; }
+    
+    public static void M(object? o1, object o2)
+    {
+        var c1 = CExt.Create(o1, o2);
+        c1[o1] = o2;
+        _ = c1[o1];
+        
+        var c2 = CExt.Create(o2, o1);
+        c2[o2] = o1;
+        _ = c2[o2];
+        
+        var c3 = CExt.Create(o1 ?? o2, o2);
+        c3[o1] = o2;
+        _ = c3[o1];
+    }
+}
+static class CExt
+{
+    public static C<T, U> Create<T, U>(T t, U u) => throw null!;
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics(
+                // (9,12): warning CS8604: Possible null reference argument for parameter 'u' in 'object? C<object?, object>.this[object u]'.
+                //         c1[o1] = o2;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "o1").WithArguments("u", "object? C<object?, object>.this[object u]").WithLocation(9, 12),
+                // (10,16): warning CS8604: Possible null reference argument for parameter 'u' in 'object? C<object?, object>.this[object u]'.
+                //         _ = c1[o1];
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "o1").WithArguments("u", "object? C<object?, object>.this[object u]").WithLocation(10, 16),
+                // (13,18): warning CS8601: Possible null reference assignment.
+                //         c2[o2] = o1;
+                Diagnostic(ErrorCode.WRN_NullReferenceAssignment, "o1").WithLocation(13, 18),
+                // (17,12): warning CS8604: Possible null reference argument for parameter 'u' in 'object C<object, object>.this[object u]'.
+                //         c3[o1] = o2;
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "o1").WithArguments("u", "object C<object, object>.this[object u]").WithLocation(17, 12),
+                // (18,16): warning CS8604: Possible null reference argument for parameter 'u' in 'object C<object, object>.this[object u]'.
+                //         _ = c3[o1];
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "o1").WithArguments("u", "object C<object, object>.this[object u]").WithLocation(18, 16));
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var indexers = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray();
+            verifyAnnotation(indexers.AsSpan().Slice(0, 2), PublicNullableAnnotation.Annotated, PublicNullableAnnotation.NotAnnotated);
+            verifyAnnotation(indexers.AsSpan().Slice(2, 2), PublicNullableAnnotation.NotAnnotated, PublicNullableAnnotation.Annotated);
+            verifyAnnotation(indexers.AsSpan().Slice(4, 2), PublicNullableAnnotation.NotAnnotated, PublicNullableAnnotation.NotAnnotated);
+
+            void verifyAnnotation(Span<ElementAccessExpressionSyntax> indexers, PublicNullableAnnotation firstAnnotation, PublicNullableAnnotation secondAnnotation)
+            {
+                var propertySymbol = (IPropertySymbol)model.GetSymbolInfo(indexers[0]).Symbol;
+                verifyIndexer(propertySymbol);
+                propertySymbol = (IPropertySymbol)model.GetSymbolInfo(indexers[1]).Symbol;
+                verifyIndexer(propertySymbol);
+
+                void verifyIndexer(IPropertySymbol propertySymbol)
+                {
+                    Assert.True(propertySymbol.IsIndexer);
+                    Assert.Equal(firstAnnotation, propertySymbol.NullableAnnotation);
+                    Assert.Equal(secondAnnotation, propertySymbol.Parameters[0].NullableAnnotation);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetSymbolInfo_IndexReinferred()
+        {
+            var source = @"
+class C<T>
+{
+    public int Length { get; }
+    public T this[int i] { get => throw null!; set => throw null!; }
+    public static C<TT> Create<TT>(TT t) => throw null!;
+
+    public static void M(object? o)
+    {
+        var c1 = Create(o);
+        c1[^1] = new object();
+        _ = c1[^1];
+
+        var c2 = Create(o ?? new object());
+        c2[^1] = new object();
+        _ = c2[^1];
+    }
+}";
+
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var elementAccesses = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray();
+            verifyAnnotation(elementAccesses.AsSpan().Slice(0, 2), PublicNullableAnnotation.Annotated);
+            verifyAnnotation(elementAccesses.AsSpan().Slice(2, 2), PublicNullableAnnotation.NotAnnotated);
+
+            void verifyAnnotation(Span<ElementAccessExpressionSyntax> indexers, PublicNullableAnnotation annotation)
+            {
+                var propertySymbol = (IPropertySymbol)model.GetSymbolInfo(indexers[0]).Symbol;
+                verifyIndexer(propertySymbol);
+                propertySymbol = (IPropertySymbol)model.GetSymbolInfo(indexers[1]).Symbol;
+                verifyIndexer(propertySymbol);
+
+                void verifyIndexer(IPropertySymbol propertySymbol)
+                {
+                    Assert.True(propertySymbol.IsIndexer);
+                    Assert.Equal(annotation, propertySymbol.NullableAnnotation);
+                }
+            }
+        }
+
+        [Fact]
+        public void GetSymbolInfo_PatternReinferred()
+        {
+
+            var source = @"
+using System;
+
+class C<T>
+{
+    public int Length { get; }
+    public Span<T> Slice(int start, int length) => throw null!;
+    public static C<TT> Create<TT>(TT t) => throw null!;
+
+    public static void M(object? o)
+    {
+        var c1 = Create(o);
+        _ = c1[..^1];
+
+        var c2 = Create(o ?? new object());
+        _ = c2[..^1];
+    }
+}";
+
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var elementAccesses = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray();
+            verifyAnnotation(elementAccesses[0], PublicNullableAnnotation.Annotated);
+            verifyAnnotation(elementAccesses[1], PublicNullableAnnotation.NotAnnotated);
+
+            void verifyAnnotation(ElementAccessExpressionSyntax indexer, PublicNullableAnnotation annotation)
+            {
+                var propertySymbol = (IMethodSymbol)model.GetSymbolInfo(indexer).Symbol;
+                Assert.NotNull(propertySymbol);
+                var spanType = (INamedTypeSymbol)propertySymbol.ReturnType;
+                Assert.Equal(annotation, spanType.TypeArgumentNullableAnnotations[0]);
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -2770,10 +2770,10 @@ static class CExt
             var root = syntaxTree.GetRoot();
             var model = comp.GetSemanticModel(syntaxTree);
 
-            var indexers = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray();
-            verifyAnnotation(indexers.AsSpan().Slice(0, 2), PublicNullableAnnotation.Annotated, PublicNullableAnnotation.NotAnnotated);
-            verifyAnnotation(indexers.AsSpan().Slice(2, 2), PublicNullableAnnotation.NotAnnotated, PublicNullableAnnotation.Annotated);
-            verifyAnnotation(indexers.AsSpan().Slice(4, 2), PublicNullableAnnotation.NotAnnotated, PublicNullableAnnotation.NotAnnotated);
+            var indexers = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray().AsSpan();
+            verifyAnnotation(indexers.Slice(0, 2), PublicNullableAnnotation.Annotated, PublicNullableAnnotation.NotAnnotated);
+            verifyAnnotation(indexers.Slice(2, 2), PublicNullableAnnotation.NotAnnotated, PublicNullableAnnotation.Annotated);
+            verifyAnnotation(indexers.Slice(4, 2), PublicNullableAnnotation.NotAnnotated, PublicNullableAnnotation.NotAnnotated);
 
             void verifyAnnotation(Span<ElementAccessExpressionSyntax> indexers, PublicNullableAnnotation firstAnnotation, PublicNullableAnnotation secondAnnotation)
             {
@@ -2820,9 +2820,9 @@ class C<T>
             var root = syntaxTree.GetRoot();
             var model = comp.GetSemanticModel(syntaxTree);
 
-            var elementAccesses = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray();
-            verifyAnnotation(elementAccesses.AsSpan().Slice(0, 2), PublicNullableAnnotation.Annotated);
-            verifyAnnotation(elementAccesses.AsSpan().Slice(2, 2), PublicNullableAnnotation.NotAnnotated);
+            var elementAccesses = root.DescendantNodes().OfType<ElementAccessExpressionSyntax>().ToArray().AsSpan();
+            verifyAnnotation(elementAccesses.Slice(0, 2), PublicNullableAnnotation.Annotated);
+            verifyAnnotation(elementAccesses.Slice(2, 2), PublicNullableAnnotation.NotAnnotated);
 
             void verifyAnnotation(Span<ElementAccessExpressionSyntax> indexers, PublicNullableAnnotation annotation)
             {
@@ -2840,7 +2840,7 @@ class C<T>
         }
 
         [Fact]
-        public void GetSymbolInfo_PatternReinferred()
+        public void GetSymbolInfo_RangeReinferred()
         {
 
             var source = @"


### PR DESCRIPTION
We now reinfer indexer nullability. Additionally, `GetSymbolInfo` was returning no information for range and pattern-based indexers, this has now been fixed to return the actual property or method symbol being used in those cases. @dotnet/roslyn-compiler for review. @jasonmalinowski and @ryzngard for the nullable api change, as well as for the general change for indexers and ranges. This might cause you to encounter symbols where you aren't currently.