### PR TITLE
Don't include nullable type information for object creation completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -616,5 +616,25 @@ class C
 ";
             await VerifyItemExistsAsync(markup, "A");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NullableTypeCreation()
+        {
+            var markup =
+@"#nullable enable
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        void M()
+        {
+            object? o;
+            o = new $$
+        }
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "object");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
@@ -78,6 +78,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return (symbol.Name, "", symbol.Name);
             }
 
+            if (symbol is INamespaceOrTypeSymbol namespaceOrTypeSymbol)
+            {
+                return base.GetDisplayAndSuffixAndInsertionText(namespaceOrTypeSymbol.WithoutNullability(), context);
+            }
+
             return base.GetDisplayAndSuffixAndInsertionText(symbol, context);
         }
 


### PR DESCRIPTION
The type inferrer now includes nullable information, but we don't always want to include that. Nullability is not useful for object creation, since you can't create a new `object?`. 

Fixes #38508 

