### PR TITLE
Change the automation type for inline rename dialog

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardAutomationPeer.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/DashboardAutomationPeer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         protected override AutomationControlType GetAutomationControlTypeCore()
         {
-            return AutomationControlType.Pane;
+            return AutomationControlType.Custom;
         }
     }
 }


### PR DESCRIPTION
JAWS currently will not read the name description if the automation type is Pane. The Inline Rename dialog is pretty custom in functionality, since it doesn't behave exactly like a pane, so moving to custom makes sense. It also allows JAWS to read the current automation name, which includes instructions on how a user can focus the dialog with keyboard. 