### PR TITLE
Register DocumentOptionsProvider in Workspace base class

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectFactory.cs
@@ -41,9 +41,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // HACK: Fetch this service to ensure it's still created on the UI thread; once this is moved off we'll need to fix up it's constructor to be free-threaded.
             _visualStudioWorkspaceImpl.Services.GetRequiredService<VisualStudioMetadataReferenceManager>();
 
-            // HACK: since we're on the UI thread, ensure we initialize our options provider which depends on a UI-affinitized experimentation service
-            _visualStudioWorkspaceImpl.EnsureDocumentOptionProvidersInitialized();
-
             var id = ProjectId.CreateNewId(projectSystemName);
             var directoryNameOpt = creationInfo.FilePath != null ? Path.GetDirectoryName(creationInfo.FilePath) : null;
 

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -39,9 +39,8 @@ namespace Microsoft.VisualStudio.LanguageServices
         public RoslynVisualStudioWorkspace(
             ExportProvider exportProvider,
             Lazy<IStreamingFindUsagesPresenter> streamingPresenter,
-            [ImportMany] IEnumerable<IDocumentOptionsProviderFactory> documentOptionsProviderFactories,
             [Import(typeof(SVsServiceProvider))] IAsyncServiceProvider asyncServiceProvider)
-            : base(exportProvider, asyncServiceProvider, documentOptionsProviderFactories)
+            : base(exportProvider, asyncServiceProvider)
         {
             _streamingPresenter = streamingPresenter;
         }

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -86,8 +86,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
 
             <ImportingConstructor>
             Public Sub New(exportProvider As Composition.ExportProvider)
-                MyBase.New(exportProvider,
-                           exportProvider.GetExportedValue(Of MockServiceProvider))
+                MyBase.New(exportProvider, exportProvider.GetExportedValue(Of MockServiceProvider))
             End Sub
 
             Public Overrides Sub DisplayReferencedSymbols(solution As Microsoft.CodeAnalysis.Solution, referencedSymbols As IEnumerable(Of ReferencedSymbol))

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -87,8 +87,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             <ImportingConstructor>
             Public Sub New(exportProvider As Composition.ExportProvider)
                 MyBase.New(exportProvider,
-                           exportProvider.GetExportedValue(Of MockServiceProvider),
-                           exportProvider.GetExportedValues(Of IDocumentOptionsProviderFactory))
+                           exportProvider.GetExportedValue(Of MockServiceProvider))
             End Sub
 
             Public Overrides Sub DisplayReferencedSymbols(solution As Microsoft.CodeAnalysis.Solution, referencedSymbols As IEnumerable(Of ReferencedSymbol))

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -74,6 +75,32 @@ namespace Microsoft.CodeAnalysis
 
             // initialize with empty solution
             _latestSolution = CreateSolution(SolutionId.CreateNewId());
+
+            RegisterDocumentOptionsProviders();
+        }
+
+        /// <summary>
+        /// Register the exported <see cref="IDocumentOptionsProvider"/>s with the <see cref="IOptionService"/>.
+        /// </summary>
+        internal void RegisterDocumentOptionsProviders()
+        {
+            var optionsService = _services.GetService<IOptionService>();
+            if (optionsService is null)
+            {
+                return;
+            }
+
+            var exportProvider = (IMefHostExportProvider)_services.HostServices;
+
+            foreach (var providerFactory in exportProvider.GetExports<IDocumentOptionsProviderFactory>())
+            {
+                var optionsProvider = providerFactory.Value.TryCreate(this);
+
+                if (optionsProvider != null)
+                {
+                    optionsService.RegisterDocumentOptionsProvider(optionsProvider);
+                }
+            }
         }
 
         internal void LogTestMessage(string message)


### PR DESCRIPTION
Register `IDocumentOptionsProviders` in the `Workspace` constructor so that all workspaces get support for .editorconfig parsing.