### PR TITLE
Additional logging in the compiler server

### DIFF
--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -631,7 +631,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
     internal interface IServerMutex : IDisposable
     {
         bool TryLock(int timeoutMs);
-        void Unlock();
         bool IsDisposed { get; }
     }
 
@@ -762,16 +761,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return IsLocked = Mutex.WaitOne(timeoutMs);
         }
 
-        public void Unlock()
-        {
-            if (IsDisposed)
-                throw new ObjectDisposedException("Mutex");
-            if (!IsLocked)
-                throw new InvalidOperationException("Lock not held");
-            Mutex.ReleaseMutex();
-            IsLocked = false;
-        }
-
         public void Dispose()
         {
             if (IsDisposed)
@@ -786,6 +775,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             finally
             {
                 Mutex.Dispose();
+                IsLocked = false;
             }
         }
     }
@@ -820,13 +810,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
             if (IsDisposed)
                 throw new ObjectDisposedException("Mutex");
             return HeldMutex.TryLock(timeoutMs);
-        }
-
-        public void Unlock()
-        {
-            if (IsDisposed)
-                throw new ObjectDisposedException("Mutex");
-            HeldMutex.Unlock();
         }
 
         public void Dispose()


### PR DESCRIPTION
The compiler is occasionally crashing on non-Windows operating systems when calling `Mutex.ReleaseMutex`. The exception indicates that `WaitOne` and `ReleaseMutex` call are happening on different threads but that is not possible in the implementation. Even though the code occurs in an `async` method there is no `await` between the two calls hence it should all execute on the same thread. 

The runtime team cannot see a way this can be happening. They have requested that we add more logging here to expose the thread ids on both operations to help them dig into this issue further.

Related:
- https://github.com/dotnet/coreclr/issues/26659
- https://github.com/dotnet/roslyn/issues/37974