### PR TITLE
Export limited semantic model in liveshare scenario to avoid null ptrs

### DIFF
--- a/src/Tools/ExternalAccess/LiveShare/LocalForwarders/CSharpRemoteCompilationFactoryService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/LocalForwarders/CSharpRemoteCompilationFactoryService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare
+{
+    [ExportLanguageServiceFactory(typeof(ICompilationFactoryService), StringConstants.CSharpLspLanguageName), Shared]
+    internal class CSharpRemoteCompilationFactoryService : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return languageServices.GetOriginalLanguageService<ICompilationFactoryService>();
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/LiveShare/LocalForwarders/VBRemoteCompilationFactoryService.cs
+++ b/src/Tools/ExternalAccess/LiveShare/LocalForwarders/VBRemoteCompilationFactoryService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.LiveShare.LocalForwarders
+{
+    [ExportLanguageServiceFactory(typeof(ICompilationFactoryService), StringConstants.VBLspLanguageName), Shared]
+    internal class VBRemoteCompilationFactoryService : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return languageServices.GetOriginalLanguageService<ICompilationFactoryService>();
+        }
+    }
+}


### PR DESCRIPTION
Export a compilation factory for C#_LSP and VB_LSP.  This prevents the semantic model from being missing.

An additional side benefit is that if a generic type has been defined in a file opened on the guest, brace completion works for `<`.

Long term solution for these mainly typing/syntactic services is TBD.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/982486