### PR TITLE
Detect when type/field declared in an interface shadows a member from base interface.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// See SymbolPreparer::checkIfaceHiding.
         /// </remarks>
-        private static OverriddenOrHiddenMembersResult MakeInterfaceOverriddenOrHiddenMembers(Symbol member, bool memberIsFromSomeCompilation)
+        internal static OverriddenOrHiddenMembersResult MakeInterfaceOverriddenOrHiddenMembers(Symbol member, bool memberIsFromSomeCompilation)
         {
             Debug.Assert(!member.IsAccessor());
 
@@ -518,84 +518,111 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     int otherMemberArity = otherMember.GetMemberArity();
                     if (otherMemberArity == memberArity || (memberKind == SymbolKind.Method && otherMemberArity == 0))
                     {
-                        AddHiddenMemberIfApplicable(ref hiddenBuilder, member.Kind, otherMember);
+                        AddHiddenMemberIfApplicable(ref hiddenBuilder, memberKind, otherMember);
                     }
                 }
                 else if (!currTypeHasExactMatch)
                 {
-                    if (exactMatchComparer.Equals(member, otherMember))
+                    switch (memberKind)
                     {
-                        currTypeHasExactMatch = true;
-                        currTypeBestMatch = otherMember;
-                    }
-                    else if (fallbackComparer.Equals(member, otherMember))
-                    {
-                        // If this method is from source, we'll also consider methods that match
-                        // without regard to custom modifiers.  If there's more than one, we'll
-                        // choose the one with the fewest custom modifiers.
-                        int methodCustomModifierCount = CustomModifierCount(otherMember);
-                        if (methodCustomModifierCount < minCustomModifierCount)
-                        {
-                            Debug.Assert(memberIsFromSomeCompilation || minCustomModifierCount == int.MaxValue, "Metadata members require exact custom modifier matches.");
-                            minCustomModifierCount = methodCustomModifierCount;
+                        case SymbolKind.Field:
+                            currTypeHasExactMatch = true;
                             currTypeBestMatch = otherMember;
-                        }
-                    }
-                    else
-                    {
-                        currTypeHasSameKindNonMatch = true;
+                            break;
+                        case SymbolKind.NamedType:
+                            if (otherMember.GetMemberArity() == memberArity)
+                            {
+                                currTypeHasExactMatch = true;
+                                currTypeBestMatch = otherMember;
+                            }
+                            break;
+
+                        default:
+                            if (exactMatchComparer.Equals(member, otherMember))
+                            {
+                                currTypeHasExactMatch = true;
+                                currTypeBestMatch = otherMember;
+                            }
+                            else if (fallbackComparer.Equals(member, otherMember))
+                            {
+                                // If this method is from source, we'll also consider methods that match
+                                // without regard to custom modifiers.  If there's more than one, we'll
+                                // choose the one with the fewest custom modifiers.
+                                int methodCustomModifierCount = CustomModifierCount(otherMember);
+                                if (methodCustomModifierCount < minCustomModifierCount)
+                                {
+                                    Debug.Assert(memberIsFromSomeCompilation || minCustomModifierCount == int.MaxValue, "Metadata members require exact custom modifier matches.");
+                                    minCustomModifierCount = methodCustomModifierCount;
+                                    currTypeBestMatch = otherMember;
+                                }
+                            }
+                            else
+                            {
+                                currTypeHasSameKindNonMatch = true;
+                            }
+
+                            break;
                     }
                 }
             }
 
-            // If the member is from metadata, then even a fallback match is an exact match.
-            // We just declined to set the flag at the time in case there was a "better" exact match.
-            // Having said that, there's no reason to update the flag, since no-one will consume it.
-            // if (!memberIsFromSomeCompilation && ((object)currTypeBestMatch != null)) currTypeHasExactMatch = true;
-
-            // There's a special case where we have to go back and fix up our best match.
-            // If member is from source, then it has no custom modifiers (at least,
-            // until it copies them from the member it overrides, which we're trying to
-            // compute now).  Therefore, an exact match will be one that has no custom
-            // modifiers in/on its parameters.  The best match may, however, have custom
-            // modifiers in/on its (return) type, since that wasn't considered during the
-            // signature comparison.  If that is the case, then we need to make sure that
-            // there isn't another inexact match (i.e. same signature ignoring custom 
-            // modifiers) with fewer custom modifiers.
-            // NOTE: If member is constructed, then it has already inherited custom modifiers
-            // from the underlying member and this cleanup is unnecessary.  That's why we're
-            // checking member.IsDefinition in addition to memberIsFromSomeCompilation.
-            if (currTypeHasExactMatch && memberIsFromSomeCompilation && member.IsDefinition && TypeOrReturnTypeHasCustomModifiers(currTypeBestMatch))
+            switch (memberKind)
             {
+                case SymbolKind.Field:
+                case SymbolKind.NamedType:
+                    break;
+
+                default:
+                    // If the member is from metadata, then even a fallback match is an exact match.
+                    // We just declined to set the flag at the time in case there was a "better" exact match.
+                    // Having said that, there's no reason to update the flag, since no-one will consume it.
+                    // if (!memberIsFromSomeCompilation && ((object)currTypeBestMatch != null)) currTypeHasExactMatch = true;
+
+                    // There's a special case where we have to go back and fix up our best match.
+                    // If member is from source, then it has no custom modifiers (at least,
+                    // until it copies them from the member it overrides, which we're trying to
+                    // compute now).  Therefore, an exact match will be one that has no custom
+                    // modifiers in/on its parameters.  The best match may, however, have custom
+                    // modifiers in/on its (return) type, since that wasn't considered during the
+                    // signature comparison.  If that is the case, then we need to make sure that
+                    // there isn't another inexact match (i.e. same signature ignoring custom 
+                    // modifiers) with fewer custom modifiers.
+                    // NOTE: If member is constructed, then it has already inherited custom modifiers
+                    // from the underlying member and this cleanup is unnecessary.  That's why we're
+                    // checking member.IsDefinition in addition to memberIsFromSomeCompilation.
+                    if (currTypeHasExactMatch && memberIsFromSomeCompilation && member.IsDefinition && TypeOrReturnTypeHasCustomModifiers(currTypeBestMatch))
+                    {
 #if DEBUG
-                // If there were custom modifiers on the parameters, then the match wouldn't have been
-                // exact and so we would already have applied the custom modifier count as a tie-breaker.
-                foreach (ParameterSymbol param in currTypeBestMatch.GetParameters())
-                {
-                    Debug.Assert(!(param.TypeWithAnnotations.CustomModifiers.Any() || param.RefCustomModifiers.Any()));
-                    Debug.Assert(!param.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds: false));
-                }
+                        // If there were custom modifiers on the parameters, then the match wouldn't have been
+                        // exact and so we would already have applied the custom modifier count as a tie-breaker.
+                        foreach (ParameterSymbol param in currTypeBestMatch.GetParameters())
+                        {
+                            Debug.Assert(!(param.TypeWithAnnotations.CustomModifiers.Any() || param.RefCustomModifiers.Any()));
+                            Debug.Assert(!param.Type.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds: false));
+                        }
 #endif
 
-                Symbol minCustomModifierMatch = currTypeBestMatch;
+                        Symbol minCustomModifierMatch = currTypeBestMatch;
 
-                foreach (Symbol otherMember in currType.GetMembers(member.Name))
-                {
-                    if (otherMember.Kind == currTypeBestMatch.Kind && !ReferenceEquals(otherMember, currTypeBestMatch))
-                    {
-                        if (MemberSignatureComparer.CSharpOverrideComparer.Equals(otherMember, currTypeBestMatch))
+                        foreach (Symbol otherMember in currType.GetMembers(member.Name))
                         {
-                            int customModifierCount = CustomModifierCount(otherMember);
-                            if (customModifierCount < minCustomModifierCount)
+                            if (otherMember.Kind == currTypeBestMatch.Kind && !ReferenceEquals(otherMember, currTypeBestMatch))
                             {
-                                minCustomModifierCount = customModifierCount;
-                                minCustomModifierMatch = otherMember;
+                                if (MemberSignatureComparer.CSharpOverrideComparer.Equals(otherMember, currTypeBestMatch))
+                                {
+                                    int customModifierCount = CustomModifierCount(otherMember);
+                                    if (customModifierCount < minCustomModifierCount)
+                                    {
+                                        minCustomModifierCount = customModifierCount;
+                                        minCustomModifierMatch = otherMember;
+                                    }
+                                }
                             }
                         }
-                    }
-                }
 
-                currTypeBestMatch = minCustomModifierMatch;
+                        currTypeBestMatch = minCustomModifierMatch;
+                    }
+                    break;
             }
         }
 
@@ -619,7 +646,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if ((object)representativeMember != null)
             {
-                bool needToSearchForRelated = !representativeMember.ContainingType.IsDefinition || representativeMember.IsIndexer();
+                bool needToSearchForRelated = representativeMember.Kind != SymbolKind.Field && representativeMember.Kind != SymbolKind.NamedType &&
+                                              (!representativeMember.ContainingType.IsDefinition || representativeMember.IsIndexer());
 
                 if (isOverride)
                 {
@@ -788,6 +816,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private static void FindOtherHiddenMembersInContainingType(SymbolKind hidingMemberKind, Symbol representativeMember, ref ArrayBuilder<Symbol> hiddenBuilder)
         {
             Debug.Assert((object)representativeMember != null);
+            Debug.Assert(representativeMember.Kind != SymbolKind.Field);
+            Debug.Assert(representativeMember.Kind != SymbolKind.NamedType);
             Debug.Assert(representativeMember.Kind == SymbolKind.Property || !representativeMember.ContainingType.IsDefinition);
 
             IEqualityComparer<Symbol> comparer = MemberSignatureComparer.CSharpCustomModifierOverrideComparer;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -634,15 +634,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void CheckNewModifier(Symbol symbol, bool isNew, DiagnosticBag diagnostics)
         {
-            // for error cases
-            if ((object)this.BaseTypeNoUseSiteDiagnostics == null)
-            {
-                return;
-            }
+            Debug.Assert(symbol.Kind == SymbolKind.Field || symbol.Kind == SymbolKind.NamedType);
 
             // Do not give warnings about missing 'new' modifier for implicitly declared members,
             // e.g. backing fields for auto-properties
             if (symbol.IsImplicitlyDeclared)
+            {
+                return;
+            }
+
+            if (symbol.ContainingType.IsInterface)
+            {
+                CheckNonOverrideMember(symbol, isNew,
+                                       OverriddenOrHiddenMembersHelpers.MakeInterfaceOverriddenOrHiddenMembers(symbol, memberIsFromSomeCompilation: true),
+                                       diagnostics, out _);
+                return;
+            }
+
+            // for error cases
+            if ((object)this.BaseTypeNoUseSiteDiagnostics == null)
             {
                 return;
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -55991,5 +55991,784 @@ interface I5 : I3, I1
             compilation1.VerifyDiagnostics();
             CompileAndVerify(compilation1);
         }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_33()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    { }
+}
+
+interface I3 : I1
+{
+    interface I2
+    {
+    }
+}
+
+class C1
+{
+    public interface I4
+    { }
+}
+
+class C3 : C1
+{
+    public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            compilation1.VerifyDiagnostics(
+                // (10,15): warning CS0108: 'I3.I2' hides inherited member 'I1.I2'. Use the new keyword if hiding was intended.
+                //     interface I2
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1.I2").WithLocation(10, 15),
+                // (23,22): warning CS0108: 'C3.I4' hides inherited member 'C1.I4'. Use the new keyword if hiding was intended.
+                //     public interface I4
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1.I4").WithLocation(23, 22)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_34()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    { }
+}
+
+interface I3 : I1
+{
+    new interface I2
+    {
+    }
+}
+
+class C1
+{
+    public interface I4
+    { }
+}
+
+class C3 : C1
+{
+    new public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation1).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_35()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void I2();
+}
+
+interface I3 : I1
+{
+    interface I2
+    {
+    }
+}
+
+class C1
+{
+    public void I4()
+    { }
+}
+
+class C3 : C1
+{
+    public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            compilation1.VerifyDiagnostics(
+                // (9,15): warning CS0108: 'I3.I2' hides inherited member 'I1.I2()'. Use the new keyword if hiding was intended.
+                //     interface I2
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1.I2()").WithLocation(9, 15),
+                // (22,22): warning CS0108: 'C3.I4' hides inherited member 'C1.I4()'. Use the new keyword if hiding was intended.
+                //     public interface I4
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1.I4()").WithLocation(22, 22)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_36()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void I2();
+}
+
+interface I3 : I1
+{
+    new interface I2
+    {
+    }
+}
+
+class C1
+{
+    public void I4()
+    { }
+}
+
+class C3 : C1
+{
+    new public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation1).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_37()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    {
+    }
+}
+
+interface I3 : I1
+{
+    void I2();
+}
+
+class C1
+{
+    public interface I4
+    {
+    }
+}
+
+class C3 : C1
+{
+    public void I4()
+    { }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            compilation1.VerifyDiagnostics(
+                // (11,10): warning CS0108: 'I3.I2()' hides inherited member 'I1.I2'. Use the new keyword if hiding was intended.
+                //     void I2();
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2()", "I1.I2").WithLocation(11, 10),
+                // (23,17): warning CS0108: 'C3.I4()' hides inherited member 'C1.I4'. Use the new keyword if hiding was intended.
+                //     public void I4()
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4()", "C1.I4").WithLocation(23, 17)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_38()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    {
+    }
+}
+
+interface I3 : I1
+{
+    new void I2();
+}
+
+class C1
+{
+    public interface I4
+    {
+    }
+}
+
+class C3 : C1
+{
+    new public void I4()
+    { }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation1).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_39()
+        {
+            var source1 =
+@"
+interface I1
+{
+    static int I2 = 0;
+}
+
+interface I3 : I1
+{
+    static int I2 = 1;
+}
+
+class C1
+{
+    public static int I4 = 2;
+}
+
+class C3 : C1
+{
+    public static int I4 = 3;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (9,16): warning CS0108: 'I3.I2' hides inherited member 'I1.I2'. Use the new keyword if hiding was intended.
+                //     static int I2 = 1;
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1.I2").WithLocation(9, 16),
+                // (19,23): warning CS0108: 'C3.I4' hides inherited member 'C1.I4'. Use the new keyword if hiding was intended.
+                //     public static int I4 = 3;
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1.I4").WithLocation(19, 23)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_40()
+        {
+            var source1 =
+@"
+interface I1
+{
+    static int I2 = 0;
+}
+
+interface I3 : I1
+{
+    new static int I2 = 1;
+}
+
+class C1
+{
+    public static int I4 = 2;
+}
+
+class C3 : C1
+{
+    new public static int I4 = 3;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_41()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void I2();
+}
+
+interface I3 : I1
+{
+    static int I2 = 0;
+}
+
+class C1
+{
+    public void I4()
+    { }
+}
+
+class C3 : C1
+{
+    public static int I4 = 1;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (9,16): warning CS0108: 'I3.I2' hides inherited member 'I1.I2()'. Use the new keyword if hiding was intended.
+                //     static int I2 = 0;
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1.I2()").WithLocation(9, 16),
+                // (20,23): warning CS0108: 'C3.I4' hides inherited member 'C1.I4()'. Use the new keyword if hiding was intended.
+                //     public static int I4 = 1;
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1.I4()").WithLocation(20, 23)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_42()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void I2();
+}
+
+interface I3 : I1
+{
+    new static int I2 = 0;
+}
+
+class C1
+{
+    public void I4()
+    { }
+}
+
+class C3 : C1
+{
+    new public static int I4 = 1;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_43()
+        {
+            var source1 =
+@"
+interface I1
+{
+    static int I2 = 0;
+}
+
+interface I3 : I1
+{
+    void I2();
+}
+
+class C1
+{
+    public static int I4 = 1;
+}
+
+class C3 : C1
+{
+    public void I4()
+    { }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (9,10): warning CS0108: 'I3.I2()' hides inherited member 'I1.I2'. Use the new keyword if hiding was intended.
+                //     void I2();
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2()", "I1.I2").WithLocation(9, 10),
+                // (19,17): warning CS0108: 'C3.I4()' hides inherited member 'C1.I4'. Use the new keyword if hiding was intended.
+                //     public void I4()
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4()", "C1.I4").WithLocation(19, 17)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_44()
+        {
+            var source1 =
+@"
+interface I1
+{
+    static int I2 = 0;
+}
+
+interface I3 : I1
+{
+    new void I2();
+}
+
+class C1
+{
+    public static int I4 = 1;
+}
+
+class C3 : C1
+{
+    new public void I4()
+    { }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_45()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    { }
+}
+
+interface I3 : I1
+{
+    interface I2<T>
+    {
+    }
+}
+
+class C1
+{
+    public interface I4
+    { }
+}
+
+class C3 : C1
+{
+    public interface I4<T>
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation1).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_46()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    { }
+}
+
+interface I3 : I1
+{
+    new interface I2<T>
+    {
+    }
+}
+
+class C1
+{
+    public interface I4
+    { }
+}
+
+class C3 : C1
+{
+    public new interface I4<T>
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            compilation1.VerifyDiagnostics(
+                // (10,19): warning CS0109: The member 'I3.I2<T>' does not hide an accessible member. The new keyword is not required.
+                //     new interface I2<T>
+                Diagnostic(ErrorCode.WRN_NewNotRequired, "I2").WithArguments("I3.I2<T>").WithLocation(10, 19),
+                // (23,26): warning CS0109: The member 'C3.I4<T>' does not hide an accessible member. The new keyword is not required.
+                //     public new interface I4<T>
+                Diagnostic(ErrorCode.WRN_NewNotRequired, "I4").WithArguments("C3.I4<T>").WithLocation(23, 26)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_47()
+        {
+            var source1 =
+@"
+interface I1<T>
+{
+    interface I2
+    { }
+
+    interface I2<U>
+    { }
+}
+
+interface I3 : I1<int>
+{
+    interface I2
+    {
+    }
+}
+
+class C1<T>
+{
+    public interface I4
+    { }
+
+    public interface I4<U>
+    { }
+}
+
+class C3 : C1<int>
+{
+    public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular);
+
+            compilation1.VerifyDiagnostics(
+                // (13,15): warning CS0108: 'I3.I2' hides inherited member 'I1<int>.I2'. Use the new keyword if hiding was intended.
+                //     interface I2
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1<int>.I2").WithLocation(13, 15),
+                // (29,22): warning CS0108: 'C3.I4' hides inherited member 'C1<int>.I4'. Use the new keyword if hiding was intended.
+                //     public interface I4
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1<int>.I4").WithLocation(29, 22)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_48()
+        {
+            var source1 =
+@"
+interface I1
+{
+    static int I2 = 1;
+}
+
+interface I3 : I1
+{
+    interface I2
+    {
+    }
+}
+
+class C1
+{
+    public static int I4 = 2;
+}
+
+class C3 : C1
+{
+    public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (9,15): warning CS0108: 'I3.I2' hides inherited member 'I1.I2'. Use the new keyword if hiding was intended.
+                //     interface I2
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1.I2").WithLocation(9, 15),
+                // (21,22): warning CS0108: 'C3.I4' hides inherited member 'C1.I4'. Use the new keyword if hiding was intended.
+                //     public interface I4
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1.I4").WithLocation(21, 22)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_49()
+        {
+            var source1 =
+@"
+interface I1
+{
+    static int I2 = 1;
+}
+
+interface I3 : I1
+{
+    new interface I2
+    {
+    }
+}
+
+class C1
+{
+    public static int I4 = 2;
+}
+
+class C3 : C1
+{
+    new public interface I4
+    {
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_50()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    { }
+}
+
+interface I3 : I1
+{
+    static int I2 = 0;
+}
+
+class C1
+{
+    public interface I4
+    { }
+}
+
+class C3 : C1
+{
+    public static int I4 = 2;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (10,16): warning CS0108: 'I3.I2' hides inherited member 'I1.I2'. Use the new keyword if hiding was intended.
+                //     static int I2 = 0;
+                Diagnostic(ErrorCode.WRN_NewRequired, "I2").WithArguments("I3.I2", "I1.I2").WithLocation(10, 16),
+                // (21,23): warning CS0108: 'C3.I4' hides inherited member 'C1.I4'. Use the new keyword if hiding was intended.
+                //     public static int I4 = 2;
+                Diagnostic(ErrorCode.WRN_NewRequired, "I4").WithArguments("C3.I4", "C1.I4").WithLocation(21, 23)
+                );
+        }
+
+        [Fact]
+        [WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")]
+        public void NestedTypes_51()
+        {
+            var source1 =
+@"
+interface I1
+{
+    interface I2
+    { }
+}
+
+interface I3 : I1
+{
+    new static int I2 = 0;
+}
+
+class C1
+{
+    public interface I4
+    { }
+}
+
+class C3 : C1
+{
+    new public static int I4 = 2;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/DefaultInterfaceImplementationTests.vb
@@ -1680,6 +1680,184 @@ BC37310: Target runtime doesn't support 'Protected', 'Protected Friend', or 'Pri
 </expected>)
         End Sub
 
+        <Fact>
+        <WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")>
+        Public Sub Field_11()
+
+            Dim csSource =
+"
+public interface I1
+{
+    static string M1 = ""I1.M1"";
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+Public Interface I2
+    Inherits I1
+
+    class M1
+    End Class
+End Interface
+
+Class C1
+    Public Shared M2 As String = ""
+End Class
+
+Class C2
+    Inherits C1
+
+    public class M2
+    End Class
+End Class
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+            comp1.AssertTheseDiagnostics(
+<error>
+BC40004: class 'M1' conflicts with variable 'M1' in the base interface 'I1' and should be declared 'Shadows'.
+    class M1
+          ~~
+BC40004: class 'M2' conflicts with variable 'M2' in the base class 'C1' and should be declared 'Shadows'.
+    public class M2
+                 ~~
+</error>)
+        End Sub
+
+        <Fact>
+        <WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")>
+        Public Sub Field_12()
+
+            Dim csSource =
+"
+public interface I1
+{
+    static string M1 = ""I1.M1"";
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+Public Interface I2
+    Inherits I1
+
+    Shadows class M1
+    End Class
+End Interface
+
+Class C1
+    Public Shared M2 As String = ""
+End Class
+
+Class C2
+    Inherits C1
+
+    Shadows public class M2
+    End Class
+End Class
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+            CompileAndVerify(comp1, verify:=VerifyOnMonoOrCoreClr).VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        <WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")>
+        Public Sub Field_13()
+
+            Dim csSource =
+"
+public interface I1
+{
+    static string M1 = ""I1.M1"";
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+Public Interface I2
+    Inherits I1
+
+    Sub M1()
+End Interface
+
+
+Class C1
+    Public Shared M2 As String = ""
+End Class
+
+Class C2
+    Inherits C1
+
+    public Sub M2()
+    End Sub
+End Class
+
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+            comp1.AssertTheseDiagnostics(
+<error>
+BC40004: sub 'M1' conflicts with variable 'M1' in the base interface 'I1' and should be declared 'Shadows'.
+    Sub M1()
+        ~~
+BC40004: sub 'M2' conflicts with variable 'M2' in the base class 'C1' and should be declared 'Shadows'.
+    public Sub M2()
+               ~~
+</error>)
+        End Sub
+
+        <Fact>
+        <WorkItem(38711, "https://github.com/dotnet/roslyn/issues/38711")>
+        Public Sub Field_14()
+
+            Dim csSource =
+"
+public interface I1
+{
+    static string M1 = ""I1.M1"";
+}
+"
+            Dim csCompilation = GetCSharpCompilation(csSource).EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file name="c.vb"><![CDATA[
+Public Interface I2
+    Inherits I1
+
+    Shadows Sub M1()
+End Interface
+
+
+Class C1
+    Public Shared M2 As String = ""
+End Class
+
+Class C2
+    Inherits C1
+
+    Shadows public Sub M2()
+    End Sub
+End Class
+
+]]></file>
+</compilation>
+
+            Dim comp1 = CreateCompilation(source1, targetFramework:=TargetFramework.NetStandardLatest, references:={csCompilation})
+            CompileAndVerify(comp1, verify:=VerifyOnMonoOrCoreClr).VerifyDiagnostics()
+        End Sub
+
         Private Const NoPiaAttributes As String = "
 namespace System.Runtime.InteropServices
 {


### PR DESCRIPTION
Fixes #38711.