### PR TITLE
Change the Using organizer to not use ElasticTrivia for the NewLine

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
@@ -84,7 +85,7 @@ internal class Program
             return AssertCodeCleanupResult(expected, code);
         }
 
-        [Fact]
+        [Fact, WorkItem(36984, "https://github.com/dotnet/roslyn/issues/36984")]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public Task GroupUsings()
         {
@@ -129,7 +130,7 @@ namespace M
             return AssertCodeCleanupResult(expected, code, systemUsingsFirst: false, separateUsingGroups: true);
         }
 
-        [Fact]
+        [Fact, WorkItem(36984, "https://github.com/dotnet/roslyn/issues/36984")]
         [Trait(Traits.Feature, Traits.Features.CodeCleanup)]
         public Task SortAndGroupUsings()
         {

--- a/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesOrganizer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/UsingsAndExternAliasesOrganizer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 {
     internal static partial class UsingsAndExternAliasesOrganizer
     {
-        private static readonly SyntaxTrivia s_newLine = SyntaxFactory.ElasticCarriageReturnLineFeed;
+        private static readonly SyntaxTrivia s_newLine = SyntaxFactory.CarriageReturnLineFeed;
 
         public static void Organize(
             SyntaxList<ExternAliasDirectiveSyntax> externAliasList,

--- a/src/Workspaces/VisualBasic/Portable/Utilities/ImportsOrganizer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/ImportsOrganizer.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
     Partial Friend Class ImportsOrganizer
-        Private Shared ReadOnly s_newLine As SyntaxTrivia = SyntaxFactory.ElasticCarriageReturnLineFeed
+        Private Shared ReadOnly s_newLine As SyntaxTrivia = SyntaxFactory.CarriageReturnLineFeed
 
         Public Shared Function Organize([imports] As SyntaxList(Of ImportsStatementSyntax),
                                         placeSystemNamespaceFirst As Boolean,


### PR DESCRIPTION
Code Cleanup removes and sorts usings prior to running the whitespace formatter. The Using organizer used elastic trivia for the newline that it introduced between using groups which would get eaten by the formatter.

Fixes #36984