### PR TITLE
Fix TakeIncrementalSnapshot crash

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5784,6 +5784,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             var left = node.Left;
             var right = node.Right;
             VisitLValue(left);
+            // we may enter a conditional state for error scenarios on the LHS.
+            Unsplit();
+
             FlowAnalysisAnnotations leftAnnotations = GetLValueAnnotations(left);
             TypeWithAnnotations declaredType = LvalueResultType;
             TypeWithAnnotations leftLValueType = ApplyLValueAnnotations(declaredType, leftAnnotations);


### PR DESCRIPTION
Closes #37868

I can't think of any non-error scenarios where you would go into a conditional state on the LHS of an assignment operator, and learn something meaningful about the nullability of variables. So I fixed the crash by always unsplitting the state after visiting the left side of an assignment operator.