### PR TITLE
Use IContentType.IsOfType when checking for content type matches

### DIFF
--- a/src/EditorFeatures/Core/CommandHandlers/ExecuteInInteractiveCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/ExecuteInInteractiveCommandHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
         private Lazy<IExecuteInInteractiveCommandHandler> GetCommandHandler(ITextBuffer textBuffer)
         {
             return _executeInInteractiveHandlers
-                .Where(handler => handler.Metadata.ContentTypes.Contains(textBuffer.ContentType.TypeName))
+                .Where(handler => handler.Metadata.ContentTypes.Any(textBuffer.ContentType.IsOfType))
                 .SingleOrDefault();
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/CodeCleanup/CodeCleanupFixerProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/CodeCleanup/CodeCleanupFixerProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeCleanup
         public IReadOnlyCollection<ICodeCleanUpFixer> GetFixers(IContentType contentType)
         {
             var fixers = _codeCleanUpFixers
-               .Where(handler => handler.Metadata.ContentTypes.Contains(contentType.TypeName)).ToList();
+               .Where(handler => handler.Metadata.ContentTypes.Any(contentType.IsOfType)).ToList();
 
             return fixers.ConvertAll(l => l.Value);
         }


### PR DESCRIPTION
A bug found while investigating https://github.com/dotnet/roslyn/issues/36984, was that the CodeCleanupFixerProvider was providing no fixers due to expecting an exact match of the text buffer's content type. It is recommended to use `IsOfType` to perform the comparison and this is how we check ContentTypes elsewhere.