### PR TITLE
A C# option to indent/not indent `namespace` contents

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -430,6 +430,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Indent namespace contents.
+        /// </summary>
+        internal static string Indent_namespace_contents {
+            get {
+                return ResourceManager.GetString("Indent_namespace_contents", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Indent open and close braces.
         /// </summary>
         internal static string Indent_open_and_close_braces {

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -150,6 +150,9 @@
   <data name="Indent_block_contents" xml:space="preserve">
     <value>Indent block contents</value>
   </data>
+  <data name="Indent_namespace_contents" xml:space="preserve">
+    <value>Indent namespace contents</value>
+  </data>
   <data name="Indent_open_and_close_braces" xml:space="preserve">
     <value>Indent open and close braces</value>
   </data>

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -199,6 +199,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             }
         }
 
+        public int Indent_NamespaceContents
+        {
+            get { return GetBooleanOption(CSharpFormattingOptions.IndentNamespace); }
+            set { SetBooleanOption(CSharpFormattingOptions.IndentNamespace, value); }
+        }
+
         public int Indent_UnindentLabels
         {
             get

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/IndentationViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/IndentationViewModel.cs
@@ -61,6 +61,16 @@ class MyClass
     }
 }";
 
+        private const string NamespacePreview = @"
+//[
+namespace MyNamespace {
+    class MyClass
+    {
+    }
+
+}
+//]";
+
         private const string GotoLabelPreview = @"
 class MyClass
 {
@@ -80,6 +90,7 @@ class MyClass
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentSwitchCaseSection, CSharpVSResources.Indent_case_contents, SwitchCasePreview, this, optionStore));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentSwitchCaseSectionWhenBlock, CSharpVSResources.Indent_case_contents_when_block, SwitchCaseWhenBlockPreview, this, optionStore));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentSwitchSection, CSharpVSResources.Indent_case_labels, SwitchCasePreview, this, optionStore));
+            Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentNamespace, CSharpVSResources.Indent_namespace_contents, NamespacePreview, this, optionStore));
 
             Items.Add(new TextBlock() { Text = CSharpVSResources.Label_Indentation });
 

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -291,6 +291,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 EditorConfigStorageLocation.ForBoolOption("csharp_indent_block_contents"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentBlock")});
 
+        public static Option<bool> IndentNamespace { get; } = CreateOption(
+            CSharpFormattingOptionGroups.Indentation, nameof(IndentNamespace),
+            defaultValue: IndentBlock.DefaultValue,
+            storageLocations: new OptionStorageLocation[] {
+                EditorConfigStorageLocation.ForBoolOption("csharp_indent_namespace_contents"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentNamespace")});
+
         public static Option<bool> IndentSwitchSection { get; } = CreateOption(
             CSharpFormattingOptionGroups.Indentation, nameof(IndentSwitchSection),
             defaultValue: true,

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -207,6 +207,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            if (node is NamespaceDeclarationSyntax && !optionSet.GetOption(CSharpFormattingOptions.IndentNamespace))
+            {
+                // do not add indent operation for namespace
+                return;
+            }
+
             AddIndentBlockOperation(list, bracePair.Item1.GetNextToken(includeZeroWidth: true), bracePair.Item2.GetPreviousToken(includeZeroWidth: true));
         }
 

--- a/src/Workspaces/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentNamespace.get -> Microsoft.CodeAnalysis.Options.Option<bool>

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -1427,6 +1427,64 @@ l:
 }", changedOptionSet: changingOptions);
         }
 
+        [Fact]
+        public async Task IndentNamespaceOn()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>
+            {
+                {  IndentNamespace, true },
+            };
+
+            await AssertFormatAsync(
+code:
+@"namespace MyNamespace
+{
+using System;
+class MyClass
+{
+    int f;
+}
+}",
+expected:
+@"namespace MyNamespace
+{
+    using System;
+    class MyClass
+    {
+        int f;
+    }
+}", changedOptionSet: changingOptions);
+        }
+
+        [Fact]
+        public async Task NoIndentNamespace()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>
+            {
+                {  IndentNamespace, false },
+            };
+
+            await AssertFormatAsync(
+code:
+@"namespace MyNamespace
+{
+    using System;
+    class MyClass
+        {
+        int f;
+        }
+}",
+expected:
+@"namespace MyNamespace
+{
+using System;
+class MyClass
+{
+    int f;
+}
+}", changedOptionSet: changingOptions);
+        }
+
         [WorkItem(20009, "https://github.com/dotnet/roslyn/issues/20009")]
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task NoIndentSwitch_NoIndentCase_NoIndentWhenBlock()


### PR DESCRIPTION
Added a C# formatting option to enable/disable (enabled by default) indentation for `namespace` contents.

Having this off is very useful for a couple of scenarios:
1. small screens, such as laptop screens
2. diff viewing, when two files have to be shown side by side (GitHub for example often has to wrap C# code because of long lines)

For example, with option off:
```csharp
namespace MyNamespace {

using System;

class MyClass
{
    int f;
}
}
```

Option on:
```csharp
namespace MyNamespace {

  using System;

  class MyClass
  {
    int f;
  }
}
```

Closes #24129