### PR TITLE
Cache AnalyzerConfigOptionsResult instances

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1455,6 +1455,40 @@ dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
                     options[2].TreeOptions.Keys.First()));
         }
 
+        [Fact]
+        public void TreesShareOptionsInstances()
+        {
+            var configs = ArrayBuilder<AnalyzerConfig>.GetInstance();
+            configs.Add(Parse(@"
+[*.cs]
+dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
+
+            var options = GetAnalyzerConfigOptions(
+                new[] { "/a.cs", "/b.cs", "/c.cs" },
+                configs);
+            configs.Free();
+
+            Assert.True(
+                object.ReferenceEquals(
+                    options[0].TreeOptions,
+                    options[1].TreeOptions));
+
+            Assert.True(
+                object.ReferenceEquals(
+                    options[0].AnalyzerOptions,
+                    options[1].AnalyzerOptions));
+
+            Assert.True(
+                object.ReferenceEquals(
+                    options[1].TreeOptions,
+                    options[2].TreeOptions));
+
+            Assert.True(
+                object.ReferenceEquals(
+                    options[1].AnalyzerOptions,
+                    options[2].AnalyzerOptions));
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1444,15 +1444,8 @@ dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
 
             Assert.Equal("cs000", options[0].TreeOptions.Keys.Single());
 
-            Assert.True(
-                object.ReferenceEquals(
-                    options[0].TreeOptions.Keys.First(),
-                    options[1].TreeOptions.Keys.First()));
-
-            Assert.True(
-                object.ReferenceEquals(
-                    options[1].TreeOptions.Keys.First(),
-                    options[2].TreeOptions.Keys.First()));
+            Assert.Same(options[0].TreeOptions.Keys.First(), options[1].TreeOptions.Keys.First());
+            Assert.Same(options[1].TreeOptions.Keys.First(), options[2].TreeOptions.Keys.First());
         }
 
         [Fact]
@@ -1468,25 +1461,10 @@ dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
                 configs);
             configs.Free();
 
-            Assert.True(
-                object.ReferenceEquals(
-                    options[0].TreeOptions,
-                    options[1].TreeOptions));
-
-            Assert.True(
-                object.ReferenceEquals(
-                    options[0].AnalyzerOptions,
-                    options[1].AnalyzerOptions));
-
-            Assert.True(
-                object.ReferenceEquals(
-                    options[1].TreeOptions,
-                    options[2].TreeOptions));
-
-            Assert.True(
-                object.ReferenceEquals(
-                    options[1].AnalyzerOptions,
-                    options[2].AnalyzerOptions));
+            Assert.Same(options[0].TreeOptions, options[1].TreeOptions);
+            Assert.Same(options[0].AnalyzerOptions, options[1].AnalyzerOptions);
+            Assert.Same(options[1].TreeOptions, options[2].TreeOptions);
+            Assert.Same(options[1].AnalyzerOptions, options[2].AnalyzerOptions);
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -593,6 +594,31 @@ namespace Microsoft.CodeAnalysis
         internal static Location FirstOrNone(this ImmutableArray<Location> items)
         {
             return items.IsEmpty ? Location.None : items[0];
+        }
+
+        internal sealed class SequenceEqualComparer<T> : IEqualityComparer<ImmutableArray<T>>
+        {
+            public static SequenceEqualComparer<T> Instance { get; } = new SequenceEqualComparer<T>();
+
+            public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
+            {
+                if (x.Length != y.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < x.Length; i++)
+                {
+                    if (!x[i].Equals(y[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(ImmutableArray<T> obj) => Hash.CombineValues(obj);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -595,30 +595,5 @@ namespace Microsoft.CodeAnalysis
         {
             return items.IsEmpty ? Location.None : items[0];
         }
-
-        internal sealed class SequenceEqualComparer<T> : IEqualityComparer<ImmutableArray<T>>
-        {
-            public static SequenceEqualComparer<T> Instance { get; } = new SequenceEqualComparer<T>();
-
-            public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
-            {
-                if (x.Length != y.Length)
-                {
-                    return false;
-                }
-
-                for (int i = 0; i < x.Length; i++)
-                {
-                    if (!x[i].Equals(y[i]))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            public int GetHashCode(ImmutableArray<T> obj) => Hash.CombineValues(obj);
-        }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.AnalyzerConfig;
-using static Microsoft.CodeAnalysis.ImmutableArrayExtensions;
 using AnalyzerOptions = System.Collections.Immutable.ImmutableDictionary<string, string>;
 using TreeOptions = System.Collections.Immutable.ImmutableDictionary<string, Microsoft.CodeAnalysis.ReportDiagnostic>;
 


### PR DESCRIPTION
A common case for editorconfig is for most of the source files to have the same
options specified, which means if we store options for each source file it's
likely we'll have many duplicate sets. This change adds a cache to AnalyzerConfigSet
to try to de-dup identical options dictionaries to a single shared instance.