### PR TITLE
Support for reinferred lambdas in GetSymbolInfo and GetDeclaredSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -81,7 +81,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 updatedSymbol = sym;
             }
-            // On merge, replace with RoslynDebug.Assert and remove suppression
             RoslynDebug.Assert(updatedSymbol is object);
 
             switch (updatedSymbol)

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -76,16 +76,87 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (sym is null) return sym;
 
-            if (_updatedSymbols.TryGetValue((expr, sym), out var updatedSymbol))
+            Symbol? updatedSymbol = null;
+            if (_snapshotManager?.TryGetUpdatedSymbol(expr, sym, out updatedSymbol) != true)
             {
-                Debug.Assert(updatedSymbol is object);
-                return (T)updatedSymbol;
+                updatedSymbol = sym;
+            }
+            // On merge, replace with RoslynDebug.Assert and remove suppression
+            Debug.Assert(updatedSymbol is object);
+
+            switch (updatedSymbol)
+            {
+                case LambdaSymbol lambda:
+                    return (T)remapLambda((BoundLambda)expr, lambda);
+
+                case SourceLocalSymbol local:
+                    return (T)remapLocal(local);
+
+                case ParameterSymbol param:
+                    if (_remappedSymbols.TryGetValue(param, out var updatedParam))
+                    {
+                        return (T)updatedParam;
+                    }
+                    break;
             }
 
-            return sym;
+            return (T)updatedSymbol!;
+
+            Symbol remapLambda(BoundLambda boundLambda, LambdaSymbol lambda)
+            {
+                var updatedDelegateType = _snapshotManager!.GetUpdatedDelegateTypeForLambda(lambda);
+
+                if (!_remappedSymbols.TryGetValue(lambda.ContainingSymbol, out Symbol? updatedContaining) && updatedDelegateType is null)
+                {
+                    return lambda;
+                }
+
+                LambdaSymbol updatedLambda;
+                if (updatedDelegateType is null)
+                {
+                    Debug.Assert(updatedContaining is object);
+                    updatedLambda = boundLambda.CreateLambdaSymbol(updatedContaining, lambda.ReturnTypeWithAnnotations, lambda.ParameterTypesWithAnnotations, lambda.ParameterRefKinds, lambda.RefKind);
+                }
+                else
+                {
+                    Debug.Assert(updatedDelegateType is object);
+                    updatedLambda = boundLambda.CreateLambdaSymbol(updatedDelegateType, updatedContaining ?? lambda.ContainingSymbol);
+                }
+
+                _remappedSymbols.Add(lambda, updatedLambda);
+
+                Debug.Assert(lambda.ParameterCount == updatedLambda.ParameterCount);
+                for (int i = 0; i < lambda.ParameterCount; i++)
+                {
+                    _remappedSymbols.Add(lambda.Parameters[i], updatedLambda.Parameters[i]);
+                }
+
+                return updatedLambda;
+            }
+
+            Symbol remapLocal(SourceLocalSymbol local)
+            {
+                if (_remappedSymbols.TryGetValue(local, out var updatedLocal))
+                {
+                    return updatedLocal;
+                }
+
+                var updatedType = _snapshotManager!.GetUpdatedTypeForLocalSymbol((SourceLocalSymbol)local);
+
+                if (!_remappedSymbols.TryGetValue(local.ContainingSymbol, out Symbol? updatedContaining) && !updatedType.HasValue)
+                {
+                    // Map the local to itself so we don't have to search again in the future
+                    _remappedSymbols.Add(local, local);
+                    return local;
+                }
+
+                updatedLocal = new UpdatedContainingSymbolAndNullableAnnotationLocal(local, updatedContaining ?? local.ContainingSymbol, updatedType ?? local.TypeWithAnnotations);
+                _remappedSymbols.Add(local, updatedLocal);
+                return updatedLocal;
+            }
         }
 
-        private ImmutableArray<T> GetUpdatedArray<T>(BoundNode expr, ImmutableArray<T> symbols) where T : Symbol
+        private ImmutableArray<T> GetUpdatedArray<T>(BoundNode expr, ImmutableArray<T> symbols) where T : Symbol?
         {
             if (symbols.IsDefaultOrEmpty)
             {
@@ -96,15 +167,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool foundUpdate = false;
             foreach (var originalSymbol in symbols)
             {
-                if (_updatedSymbols.TryGetValue((expr, originalSymbol), out var updatedSymbol))
+                T updatedSymbol = null!;
+                if (originalSymbol is object)
                 {
-                    foundUpdate = true;
-                    builder.Add((T)updatedSymbol);
+                    updatedSymbol = GetUpdatedSymbol(expr, originalSymbol);
+                    Debug.Assert(updatedSymbol is object);
+                    if ((object)originalSymbol != updatedSymbol)
+                    {
+                        foundUpdate = true;
+                    }
                 }
-                else
-                {
-                    builder.Add(originalSymbol);
-                }
+
+                builder.Add(updatedSymbol);
             }
 
             if (foundUpdate)

--- a/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/NullabilityRewriter.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 updatedSymbol = sym;
             }
             // On merge, replace with RoslynDebug.Assert and remove suppression
-            Debug.Assert(updatedSymbol is object);
+            RoslynDebug.Assert(updatedSymbol is object);
 
             switch (updatedSymbol)
             {
@@ -100,11 +100,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            return (T)updatedSymbol!;
+            return (T)updatedSymbol;
 
             Symbol remapLambda(BoundLambda boundLambda, LambdaSymbol lambda)
             {
-                var updatedDelegateType = _snapshotManager!.GetUpdatedDelegateTypeForLambda(lambda);
+                var updatedDelegateType = _snapshotManager?.GetUpdatedDelegateTypeForLambda(lambda);
 
                 if (!_remappedSymbols.TryGetValue(lambda.ContainingSymbol, out Symbol? updatedContaining) && updatedDelegateType is null)
                 {
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return updatedLocal;
                 }
 
-                var updatedType = _snapshotManager!.GetUpdatedTypeForLocalSymbol((SourceLocalSymbol)local);
+                var updatedType = _snapshotManager?.GetUpdatedTypeForLocalSymbol(local);
 
                 if (!_remappedSymbols.TryGetValue(local.ContainingSymbol, out Symbol? updatedContaining) && !updatedType.HasValue)
                 {

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeWithAnnotations> parameterTypes,
             ImmutableArray<RefKind> parameterRefKinds)
         {
-            (var lambdaSymbol, var block, var lambdaBodyBinder, var diagnostics) = BindWithDelegateAndReturnType(parameterTypes, parameterRefKinds, returnType: default);
+            (var lambdaSymbol, var block, var lambdaBodyBinder, var diagnostics) = BindWithParameterAndReturnType(parameterTypes, parameterRefKinds, returnType: default);
             var returnTypes = ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)>.GetInstance();
             BoundLambda.BlockReturns.GetReturnTypes(returnTypes, block);
             var inferredReturnType = BoundLambda.InferReturnType(returnTypes, _unboundLambda, lambdaBodyBinder.Compilation, lambdaBodyBinder.Conversions, delegateType, lambdaSymbol.IsAsync);
@@ -674,10 +674,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeWithAnnotations returnType)
         {
             var cacheKey = ReturnInferenceCacheKey.Create(delegateType, IsAsync);
-            return BindWithDelegateAndReturnType(cacheKey.ParameterTypes, cacheKey.ParameterRefKinds, returnType);
+            return BindWithParameterAndReturnType(cacheKey.ParameterTypes, cacheKey.ParameterRefKinds, returnType);
         }
 
-        private (LambdaSymbol lambdaSymbol, BoundBlock block, ExecutableCodeBinder lambdaBodyBinder, DiagnosticBag diagnostics) BindWithDelegateAndReturnType(
+        private (LambdaSymbol lambdaSymbol, BoundBlock block, ExecutableCodeBinder lambdaBodyBinder, DiagnosticBag diagnostics) BindWithParameterAndReturnType(
             ImmutableArray<TypeWithAnnotations> parameterTypes,
             ImmutableArray<RefKind> parameterRefKinds,
             TypeWithAnnotations returnType)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1596,7 +1596,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // This name mapped to something unique.  We don't need to proceed
                     // with a costly lookup.  Just add it straight to the results.
-                    results.Add(uniqueSymbol);
+                    results.Add(RemapSymbolIfNecessary(uniqueSymbol));
                 }
                 else
                 {
@@ -1656,21 +1656,49 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (!wasError)
                     {
-                        results.Add(singleSymbol);
+                        results.Add(RemapSymbolIfNecessary(singleSymbol));
                     }
                     else
                     {
-                        results.AddRange(lookupResult.Symbols);
+                        foreach (var symbol in lookupResult.Symbols)
+                        {
+                            results.Add(RemapSymbolIfNecessary(symbol));
+                        }
                     }
                 }
                 else
                 {
-                    results.AddRange(lookupResult.Symbols);
+                    foreach (var symbol in lookupResult.Symbols)
+                    {
+                        results.Add(RemapSymbolIfNecessary(symbol));
+                    }
                 }
             }
 
             lookupResult.Free();
         }
+
+        private Symbol RemapSymbolIfNecessary(Symbol symbol)
+        {
+            if (!Compilation.NullableSemanticAnalysisEnabled) return symbol;
+
+            switch (symbol)
+            {
+                case LocalSymbol _:
+                case ParameterSymbol _:
+                case MethodSymbol { MethodKind: MethodKind.LambdaMethod }:
+                    return RemapSymbolIfNecessaryCore(symbol);
+
+                default:
+                    return symbol;
+            }
+        }
+
+        /// <summary>
+        /// Remaps a local, parameter, localfunction, or lambda symbol, if that symbol or its containing
+        /// symbols were reinferred. This should only be called when nullable semantic analysis is enabled.
+        /// </summary>
+        internal abstract Symbol RemapSymbolIfNecessaryCore(Symbol symbol);
 
         private static ImmutableArray<Symbol> FilterNotReferencable(ImmutableArray<Symbol> sealedResults)
         {
@@ -2523,7 +2551,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AliasSymbol aliasOpt;
             var attributeType = (NamedTypeSymbol)binder.BindType(attribute.Name, diagnostics, out aliasOpt).Type;
             diagnostics.Free();
-            speculativeModel = AttributeSemanticModel.CreateSpeculative((SyntaxTreeSemanticModel)this, attribute, attributeType, aliasOpt, binder, position);
+            speculativeModel = ((SyntaxTreeSemanticModel)this).CreateSpeculativeAttributeSemanticModel(position, attribute, binder, aliasOpt, attributeType);
             return true;
         }
 
@@ -3018,9 +3046,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             LocalSymbol local = foreachBinder.GetDeclaredLocalsForScope(forEachStatement).FirstOrDefault();
-            return ((object)local != null && local.DeclarationKind == LocalDeclarationKind.ForEachIterationVariable)
-                ? GetAdjustedLocalSymbol(local, forEachStatement.SpanStart)
-                : null;
+            return local is SourceLocalSymbol { DeclarationKind: LocalDeclarationKind.ForEachIterationVariable } sourceLocal
+                ? GetAdjustedLocalSymbol(sourceLocal)
+                : local;
         }
 
         /// <summary>
@@ -3028,9 +3056,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// if the analysis affects the local.
         /// </summary>
         /// <param name="originalSymbol">The original symbol from initial binding.</param>
-        /// <param name="position">The position the local was declared at.</param>
+        /// 
         /// <returns>The nullability-adjusted local, or the original symbol if the nullability analysis made no adjustments or was not run.</returns>
-        internal abstract LocalSymbol GetAdjustedLocalSymbol(LocalSymbol originalSymbol, int position);
+        internal abstract LocalSymbol GetAdjustedLocalSymbol(SourceLocalSymbol originalSymbol);
 
         /// <summary>
         /// Given a catch declaration, get the symbol for the exception variable

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.SpeculativeMemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.SpeculativeMemberSemanticModel.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// Creates a speculative SemanticModel for a TypeSyntax node at a position within an existing MemberSemanticModel.
             /// </summary>
-            public SpeculativeMemberSemanticModel(SyntaxTreeSemanticModel parentSemanticModel, Symbol owner, TypeSyntax root, Binder rootBinder, NullableWalker.SnapshotManager snapshotManagerOpt, int position)
-                : base(root, owner, rootBinder, containingSemanticModelOpt: null, parentSemanticModelOpt: parentSemanticModel, snapshotManagerOpt, speculatedPosition: position)
+            public SpeculativeMemberSemanticModel(SyntaxTreeSemanticModel parentSemanticModel, Symbol owner, TypeSyntax root, Binder rootBinder, NullableWalker.SnapshotManager snapshotManagerOpt, ImmutableDictionary<Symbol, Symbol> parentRemappedSymbolsOpt, int position)
+                : base(root, owner, rootBinder, containingSemanticModelOpt: null, parentSemanticModelOpt: parentSemanticModel, snapshotManagerOpt, parentRemappedSymbolsOpt, speculatedPosition: position)
             {
             }
 
@@ -30,10 +30,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _parentSnapshotManagerOpt;
             }
 
-            protected override BoundNode RewriteNullableBoundNodesWithSnapshots(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool createSnapshots, out NullableWalker.SnapshotManager snapshotManager)
+            protected override BoundNode RewriteNullableBoundNodesWithSnapshots(
+                BoundNode boundRoot,
+                Binder binder,
+                DiagnosticBag diagnostics,
+                bool createSnapshots,
+                out NullableWalker.SnapshotManager snapshotManager,
+                ref ImmutableDictionary<Symbol, Symbol> remappedSymbols)
             {
                 Debug.Assert(boundRoot.Syntax is TypeSyntax);
-                return NullableWalker.AnalyzeAndRewrite(Compilation, MemberSymbol as MethodSymbol, boundRoot, binder, diagnostics, createSnapshots: false, out snapshotManager);
+                return NullableWalker.AnalyzeAndRewrite(Compilation, MemberSymbol as MethodSymbol, boundRoot, binder, diagnostics, createSnapshots: false, out snapshotManager, ref remappedSymbols);
             }
 
             internal override bool TryGetSpeculativeSemanticModelCore(SyntaxTreeSemanticModel parentModel, int position, ConstructorInitializerSyntax constructorInitializer, out SemanticModel speculativeModel)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -683,9 +683,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private LocalFunctionSymbol GetDeclaredLocalFunction(LocalFunctionStatementSyntax declarationSyntax)
         {
-            // If nullable semantic analysis is enabled, we need to potentially reinfer the containing symbol
-            // of a local function, as it could be in a reinferred lambda. For an example, see
-            // GetSymbolInfo_NestedLambdaReinference_LocalFunctionInLambda
             var originalSymbol = GetDeclaredLocalFunction(this.GetEnclosingBinder(GetAdjustedNodePosition(declarationSyntax)), declarationSyntax.Identifier);
             return GetRemappedSymbol(originalSymbol);
         }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -27,8 +27,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // The bound nodes associated with a syntax node, from highest in the tree to lowest.
         private readonly Dictionary<SyntaxNode, ImmutableArray<BoundNode>> _guardedNodeMap = new Dictionary<SyntaxNode, ImmutableArray<BoundNode>>();
         private Dictionary<SyntaxNode, BoundStatement> _lazyGuardedSynthesizedStatementsMap;
-        private ConcurrentDictionary<LocalSymbol, LocalSymbol> _analyzedVariableTypesOpt;
         private NullableWalker.SnapshotManager _lazySnapshotManager;
+        private ImmutableDictionary<Symbol, Symbol> _lazyRemappedSymbols;
+        private readonly ImmutableDictionary<Symbol, Symbol> _parentRemappedSymbolsOpt;
         /// <summary>
         /// Only used when this is a speculative semantic model.
         /// </summary>
@@ -54,6 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SyntaxTreeSemanticModel containingSemanticModelOpt,
             SyntaxTreeSemanticModel parentSemanticModelOpt,
             NullableWalker.SnapshotManager snapshotManagerOpt,
+            ImmutableDictionary<Symbol, Symbol> parentRemappedSymbolsOpt,
             int speculatedPosition)
         {
             Debug.Assert(root != null);
@@ -70,13 +72,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             _containingSemanticModelOpt = containingSemanticModelOpt;
             _parentSemanticModelOpt = parentSemanticModelOpt;
             _parentSnapshotManagerOpt = snapshotManagerOpt;
+            _parentRemappedSymbolsOpt = parentRemappedSymbolsOpt;
             _speculatedPosition = speculatedPosition;
 
             _operationFactory = new Lazy<CSharpOperationFactory>(() => new CSharpOperationFactory(this));
-            if (Compilation.NullableSemanticAnalysisEnabled)
-            {
-                _analyzedVariableTypesOpt = new ConcurrentDictionary<LocalSymbol, LocalSymbol>();
-            }
         }
 
         public override CSharpCompilation Compilation
@@ -155,6 +154,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _lazySnapshotManager;
         }
 
+        internal ImmutableDictionary<Symbol, Symbol> GetRemappedSymbols()
+        {
+            EnsureNullabilityAnalysisPerformedIfNecessary();
+            Debug.Assert(_lazyRemappedSymbols is object || !Compilation.NullableSemanticAnalysisEnabled);
+            return _lazyRemappedSymbols;
+        }
+
         internal sealed override bool TryGetSpeculativeSemanticModelCore(SyntaxTreeSemanticModel parentModel, int position, TypeSyntax type, SpeculativeBindingOption bindingOption, out SemanticModel speculativeModel)
         {
             var expression = SyntaxFactory.GetStandaloneExpression(type);
@@ -162,7 +168,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var binder = this.GetSpeculativeBinder(position, expression, bindingOption);
             if (binder != null)
             {
-                speculativeModel = new SpeculativeMemberSemanticModel(parentModel, _memberSymbol, type, binder, GetSnapshotManager(), position);
+                speculativeModel = new SpeculativeMemberSemanticModel(parentModel, _memberSymbol, type, binder, GetSnapshotManager(), GetRemappedSymbols(), position);
                 return true;
             }
 
@@ -194,7 +200,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             expression = SyntaxFactory.GetStandaloneExpression(expression);
             binder = GetEnclosingBinder(position);
             var boundRoot = binder.BindExpression(expression, _ignoredDiagnostics);
-            return (BoundExpression)NullableWalker.AnalyzeAndRewriteSpeculation(position, boundRoot, binder, GetSnapshotManager(), takeNewSnapshots: false, newSnapshots: out _);
+            ImmutableDictionary<Symbol, Symbol> ignored = null;
+            return (BoundExpression)NullableWalker.AnalyzeAndRewriteSpeculation(position, boundRoot, binder, GetSnapshotManager(), newSnapshots: out _, remappedSymbols: ref ignored);
         }
 
         private Binder GetEnclosingBinderInternalWithinRoot(SyntaxNode node, int position)
@@ -589,7 +596,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override ISymbol GetDeclaredSymbol(LocalFunctionStatementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
         {
             CheckSyntaxNode(declarationSyntax);
-            return GetDeclaredLocalFunction(declarationSyntax, declarationSyntax.Identifier);
+            return GetDeclaredLocalFunction(declarationSyntax);
         }
 
         public override ISymbol GetDeclaredSymbol(MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
@@ -660,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (local.IdentifierToken == declaredIdentifier)
                     {
-                        return GetAdjustedLocalSymbol(local, declarationSyntax.SpanStart);
+                        return GetAdjustedLocalSymbol((SourceLocalSymbol)local);
                     }
                 }
             }
@@ -668,41 +675,37 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override LocalSymbol GetAdjustedLocalSymbol(LocalSymbol local, int position)
+#nullable enable
+        internal override LocalSymbol GetAdjustedLocalSymbol(SourceLocalSymbol local)
         {
-            Debug.Assert(local is SourceLocalSymbol);
-            LocalSymbol adjustedLocal;
-            if (Compilation.NullableSemanticAnalysisEnabled)
-            {
-                if (!_analyzedVariableTypesOpt.TryGetValue(local, out adjustedLocal))
-                {
-                    var types = GetSnapshotManager().GetVariableTypesForPosition(position);
-
-                    // If the local was not inferred, it does not get an entry in this dictionary. Save the local mapped
-                    // to itself to avoid needing to enter this code path in the future.
-                    if (types.TryGetValue(local, out TypeWithAnnotations type))
-                    {
-                        adjustedLocal = _analyzedVariableTypesOpt.GetOrAdd(local, ((SourceLocalSymbol)local).WithAnalyzedType(type));
-                    }
-                    else
-                    {
-                        _analyzedVariableTypesOpt.TryAdd(local, local);
-                        adjustedLocal = local;
-                    }
-                }
-            }
-            else
-            {
-                adjustedLocal = local;
-            }
-
-            return adjustedLocal;
+            return GetRemappedSymbol<LocalSymbol>(local);
         }
 
-        private LocalFunctionSymbol GetDeclaredLocalFunction(LocalFunctionStatementSyntax declarationSyntax, SyntaxToken declaredIdentifier)
+        private LocalFunctionSymbol GetDeclaredLocalFunction(LocalFunctionStatementSyntax declarationSyntax)
         {
-            return GetDeclaredLocalFunction(this.GetEnclosingBinder(GetAdjustedNodePosition(declarationSyntax)), declaredIdentifier);
+            // If nullable semantic analysis is enabled, we need to potentially reinfer the containing symbol
+            // of a local function, as it could be in a reinferred lambda. For an example, see
+            // GetSymbolInfo_NestedLambdaReinference_LocalFunctionInLambda
+            var originalSymbol = GetDeclaredLocalFunction(this.GetEnclosingBinder(GetAdjustedNodePosition(declarationSyntax)), declarationSyntax.Identifier);
+            return GetRemappedSymbol(originalSymbol);
         }
+
+        private T GetRemappedSymbol<T>(T originalSymbol) where T : Symbol
+        {
+            if (!Compilation.NullableSemanticAnalysisEnabled) return originalSymbol;
+
+            EnsureNullabilityAnalysisPerformedIfNecessary();
+            if (_lazyRemappedSymbols is null) return originalSymbol;
+
+            if (_lazyRemappedSymbols.TryGetValue(originalSymbol, out Symbol remappedSymbol))
+            {
+                Debug.Assert(remappedSymbol is object);
+                return (T)remappedSymbol;
+            }
+
+            return originalSymbol;
+        }
+#nullable restore
 
         private static LocalFunctionSymbol GetDeclaredLocalFunction(Binder enclosingBinder, SyntaxToken declaredIdentifier)
         {
@@ -1458,15 +1461,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _guardedNodeMap.TryGetValue(syntax, out result) ? result : default(ImmutableArray<BoundNode>);
         }
 
-        protected void UnguardedAddBoundTreeForStandaloneSyntax(SyntaxNode syntax, BoundNode bound, NullableWalker.SnapshotManager manager = null)
+        protected void UnguardedAddBoundTreeForStandaloneSyntax(SyntaxNode syntax, BoundNode bound, NullableWalker.SnapshotManager manager = null, ImmutableDictionary<Symbol, Symbol> remappedSymbols = null)
         {
             using (_nodeMapLock.DisposableWrite())
             {
-                GuardedAddBoundTreeForStandaloneSyntax(syntax, bound, manager);
+                GuardedAddBoundTreeForStandaloneSyntax(syntax, bound, manager, remappedSymbols);
             }
         }
 
-        protected void GuardedAddBoundTreeForStandaloneSyntax(SyntaxNode syntax, BoundNode bound, NullableWalker.SnapshotManager manager = null)
+        protected void GuardedAddBoundTreeForStandaloneSyntax(SyntaxNode syntax, BoundNode bound, NullableWalker.SnapshotManager manager = null, ImmutableDictionary<Symbol, Symbol> remappedSymbols = null)
         {
             Debug.Assert(_nodeMapLock.IsWriteLockHeld);
             bool alreadyInTree = false;
@@ -1498,10 +1501,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                   // Supporting attributes is tracked by
                                                   // https://github.com/dotnet/roslyn/issues/36066
                                                   this is AttributeSemanticModel)) ||
-                             (manager is object && syntax == Root && Compilation.NullableSemanticAnalysisEnabled && _lazySnapshotManager is null));
+                             (manager is object && remappedSymbols is object && syntax == Root && Compilation.NullableSemanticAnalysisEnabled && _lazySnapshotManager is null));
                 if (manager is object)
                 {
                     _lazySnapshotManager = manager;
+                    _lazyRemappedSymbols = remappedSymbols;
                 }
             }
         }
@@ -1711,7 +1715,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // https://github.com/dotnet/roslyn/issues/35038: We need to do a rewrite here, and create a test that can hit this.
 #if DEBUG
                 var diagnostics = new DiagnosticBag();
-                _ = RewriteNullableBoundNodesWithSnapshots(boundOuterExpression, incrementalBinder, diagnostics, takeSnapshots: false, snapshotManager: out _);
+                ImmutableDictionary<Symbol, Symbol> ignored = null;
+                _ = RewriteNullableBoundNodesWithSnapshots(boundOuterExpression, incrementalBinder, diagnostics, takeSnapshots: false, snapshotManager: out _, remappedSymbols: ref ignored);
 #endif
 
                 nodes = GuardedAddBoundTreeAndGetBoundNodeFromMap(lambdaOrQuery, boundOuterExpression);
@@ -1958,25 +1963,35 @@ done:
                     return;
                 }
 
-                boundRoot = NullableWalker.AnalyzeAndRewriteSpeculation(_speculatedPosition, boundRoot, binder, _parentSnapshotManagerOpt, takeNewSnapshots: true, out var newSnapshots);
-                GuardedAddBoundTreeForStandaloneSyntax(bindableRoot, boundRoot, newSnapshots);
+                var remappedSymbols = _parentRemappedSymbolsOpt;
+                boundRoot = NullableWalker.AnalyzeAndRewriteSpeculation(_speculatedPosition, boundRoot, binder, _parentSnapshotManagerOpt, out var newSnapshots, ref remappedSymbols);
+                GuardedAddBoundTreeForStandaloneSyntax(bindableRoot, boundRoot, newSnapshots, remappedSymbols);
             }
 
             void bindAndRewrite()
             {
-                boundRoot = RewriteNullableBoundNodesWithSnapshots(boundRoot, binder, diagnostics, takeSnapshots: true, out var snapshotManager);
+                var remappedSymbols = _parentRemappedSymbolsOpt;
+                boundRoot = RewriteNullableBoundNodesWithSnapshots(boundRoot, binder, diagnostics, takeSnapshots: true, out var snapshotManager, ref remappedSymbols);
 #if DEBUG
                 // Don't actually cache the results if the nullable analysis is not enabled in debug mode.
                 if (!Compilation.NullableSemanticAnalysisEnabled) return;
 #endif
-                GuardedAddBoundTreeForStandaloneSyntax(bindableRoot, boundRoot, snapshotManager);
+                GuardedAddBoundTreeForStandaloneSyntax(bindableRoot, boundRoot, snapshotManager, remappedSymbols);
             }
         }
 
+#nullable enable
         /// <summary>
         /// Rewrites the given bound node with nullability information, and returns snapshots for later speculative analysis at positions inside this member.
         /// </summary>
-        protected abstract BoundNode RewriteNullableBoundNodesWithSnapshots(BoundNode boundRoot, Binder binder, DiagnosticBag diagnostics, bool takeSnapshots, out NullableWalker.SnapshotManager snapshotManager);
+        protected abstract BoundNode RewriteNullableBoundNodesWithSnapshots(
+            BoundNode boundRoot,
+            Binder binder,
+            DiagnosticBag diagnostics,
+            bool takeSnapshots,
+            out NullableWalker.SnapshotManager snapshotManager,
+            ref ImmutableDictionary<Symbol, Symbol>? remappedSymbols);
+#nullable restore
 
         /// <summary>
         /// Get all bounds nodes associated with a node, ordered from highest to lowest in the bound tree.
@@ -2231,6 +2246,29 @@ foundParent:;
             }
 
             return bindableParent;
+        }
+
+        internal override Symbol RemapSymbolIfNecessaryCore(Symbol symbol)
+        {
+            Debug.Assert(symbol is LocalSymbol ||
+                         symbol is ParameterSymbol ||
+                         symbol is MethodSymbol { MethodKind: MethodKind.LambdaMethod });
+            Debug.Assert(Compilation.NullableSemanticAnalysisEnabled);
+            EnsureNullabilityAnalysisPerformedIfNecessary();
+
+            if (_lazyRemappedSymbols is null)
+            {
+                return symbol;
+            }
+
+            if (_lazyRemappedSymbols.TryGetValue(symbol, out var remappedSymbol))
+            {
+                return remappedSymbol;
+            }
+            else
+            {
+                return symbol;
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -740,6 +740,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return GetSpeculativelyBoundExpressionWithoutNullability(position, expression, bindingOption, out binder, out crefSymbols);
         }
 
+        internal AttributeSemanticModel CreateSpeculativeAttributeSemanticModel(int position, AttributeSyntax attribute, Binder binder, AliasSymbol aliasOpt, NamedTypeSymbol attributeType)
+        {
+            var memberModel = Compilation.NullableSemanticAnalysisEnabled ? GetMemberModel(position) : null;
+            return AttributeSemanticModel.CreateSpeculative(this, attribute, attributeType, aliasOpt, binder, memberModel?.GetRemappedSymbols(), position);
+        }
+
         private MemberSemanticModel GetMemberModel(int position)
         {
             AssertPositionAdjusted(position);
@@ -909,8 +915,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return ImmutableInterlocked.GetOrAdd(ref _memberModels, attribute,
-                                                 (node, binder) => CreateModelForAttribute(binder, (AttributeSyntax)node),
-                                                 containing.GetEnclosingBinder(attribute.SpanStart));
+                                                 (node, binderAndModel) => CreateModelForAttribute(binderAndModel.binder, (AttributeSyntax)node, binderAndModel.model),
+                                                 (binder: containing.GetEnclosingBinder(attribute.SpanStart), model: containing));
         }
 
         private static bool IsInDocumentationComment(SyntaxNode node)
@@ -951,11 +957,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                                 tuple.parameterSymbol,
                                                                 tuple.containing.GetEnclosingBinder(tuple.paramDecl.SpanStart).
                                                                     CreateBinderForParameterDefaultValue(tuple.parameterSymbol,
-                                                                                            (EqualsValueClauseSyntax)equalsValue)),
+                                                                                            (EqualsValueClauseSyntax)equalsValue),
+                                                                tuple.containing.GetRemappedSymbols()),
                                                          (compilation: this.Compilation,
-                                                          paramDecl: paramDecl,
-                                                          parameterSymbol: parameterSymbol,
-                                                          containing: containing)
+                                                          paramDecl,
+                                                          parameterSymbol,
+                                                          containing)
                                                          );
                 }
             }
@@ -1086,7 +1093,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     this,
                                     parameterDecl,
                                     parameterSymbol,
-                                    defaultOuter().CreateBinderForParameterDefaultValue(parameterSymbol, (EqualsValueClauseSyntax)node));
+                                    defaultOuter().CreateBinderForParameterDefaultValue(parameterSymbol, (EqualsValueClauseSyntax)node),
+                                    parentRemappedSymbolsOpt: null);
                             }
 
                         case SyntaxKind.EnumMemberDeclaration:
@@ -1162,13 +1170,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case SyntaxKind.Attribute:
-                    return CreateModelForAttribute(defaultOuter(), (AttributeSyntax)node);
+                    return CreateModelForAttribute(defaultOuter(), (AttributeSyntax)node, containingModel: null);
             }
 
             return null;
         }
 
-        private AttributeSemanticModel CreateModelForAttribute(Binder enclosingBinder, AttributeSyntax attribute)
+        private AttributeSemanticModel CreateModelForAttribute(Binder enclosingBinder, AttributeSyntax attribute, MemberSemanticModel containingModel)
         {
             AliasSymbol aliasOpt;
             DiagnosticBag discarded = DiagnosticBag.GetInstance();
@@ -1180,7 +1188,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 attribute,
                 attributeType,
                 aliasOpt,
-                enclosingBinder.WithAdditionalFlags(BinderFlags.AttributeArgument));
+                enclosingBinder.WithAdditionalFlags(BinderFlags.AttributeArgument),
+                containingModel?.GetRemappedSymbols());
         }
 
         private SourceMemberFieldSymbol GetDeclaredFieldSymbol(VariableDeclaratorSyntax variableDecl)
@@ -1776,8 +1785,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return binder?.LookupDeclaredField(declarationSyntax);
         }
 
-        internal override LocalSymbol GetAdjustedLocalSymbol(LocalSymbol originalSymbol, int position) =>
-            GetMemberModel(position)?.GetAdjustedLocalSymbol(originalSymbol, position) ?? originalSymbol;
+        internal override LocalSymbol GetAdjustedLocalSymbol(SourceLocalSymbol originalSymbol)
+        {
+            var position = originalSymbol.IdentifierToken.SpanStart;
+            return GetMemberModel(position)?.GetAdjustedLocalSymbol(originalSymbol) ?? originalSymbol;
+        }
 
         /// <summary>
         /// Given a labeled statement syntax, get the corresponding label symbol.
@@ -2233,6 +2245,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             MemberSemanticModel memberModel = GetMemberModel(node);
             return memberModel?.GetDeconstructionInfo(node) ?? default;
+        }
+
+        internal override Symbol RemapSymbolIfNecessaryCore(Symbol symbol)
+        {
+            if (!(symbol is LocalSymbol || symbol is ParameterSymbol || symbol is MethodSymbol)
+                || symbol.Locations.IsDefaultOrEmpty)
+            {
+                return symbol;
+            }
+
+            var memberModel = GetMemberModel(symbol.Locations[0].SourceSpan.Start);
+            return memberModel?.RemapSymbolIfNecessaryCore(symbol) ?? symbol;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1674,15 +1674,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundNode methodBody = bodyBinder.BindMethodBody(syntaxNode, diagnostics);
                     BoundNode methodBodyForSemanticModel = methodBody;
                     NullableWalker.SnapshotManager snapshotManager = null;
+                    ImmutableDictionary<Symbol, Symbol> remappedSymbols = null;
                     if (bodyBinder.Compilation.NullableSemanticAnalysisEnabled)
                     {
                         // Currently, we're passing an empty DiagnosticBag here because the flow analysis pass later will
                         // also run the nullable walker, and issue duplicate warnings. We should try to only run the pass
                         // once.
                         // https://github.com/dotnet/roslyn/issues/35041
-                        methodBodyForSemanticModel = NullableWalker.AnalyzeAndRewrite(bodyBinder.Compilation, method, methodBody, bodyBinder, new DiagnosticBag(), createSnapshots: true, out snapshotManager);
+                        methodBodyForSemanticModel = NullableWalker.AnalyzeAndRewrite(bodyBinder.Compilation, method, methodBody, bodyBinder, new DiagnosticBag(), createSnapshots: true, out snapshotManager, ref remappedSymbols);
                     }
-                    forSemanticModel = new MethodBodySemanticModel.InitialState(syntaxNode, methodBodyForSemanticModel, bodyBinder, snapshotManager);
+                    forSemanticModel = new MethodBodySemanticModel.InitialState(syntaxNode, methodBodyForSemanticModel, bodyBinder, snapshotManager, remappedSymbols);
 
                     switch (methodBody.Kind)
                     {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -18,16 +18,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         private sealed class DebugVerifier : BoundTreeWalker
         {
             private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> _analyzedNullabilityMap;
-            private readonly ImmutableDictionary<(BoundNode, Symbol), Symbol> _updatedMethodSymbols;
-            private readonly SnapshotManager _snapshotManager;
+            private readonly SnapshotManager? _snapshotManager;
             private readonly HashSet<BoundExpression> _visitedExpressions = new HashSet<BoundExpression>();
             private int _recursionDepth;
 
-            private DebugVerifier(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, ImmutableDictionary<(BoundNode, Symbol), Symbol> updatedMethodSymbols, SnapshotManager snapshotManager)
+            private DebugVerifier(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, SnapshotManager? snapshotManager)
             {
                 _analyzedNullabilityMap = analyzedNullabilityMap;
                 _snapshotManager = snapshotManager;
-                _updatedMethodSymbols = updatedMethodSymbols;
             }
 
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
@@ -35,26 +33,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false; // Same behavior as NullableWalker
             }
 
-            public static void Verify(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, ImmutableDictionary<(BoundNode, Symbol), Symbol> updatedMethodSymbols, SnapshotManager snapshotManagerOpt, BoundNode node)
+            public static void Verify(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> analyzedNullabilityMap, SnapshotManager? snapshotManagerOpt, BoundNode node)
             {
-                var verifier = new DebugVerifier(analyzedNullabilityMap, updatedMethodSymbols, snapshotManagerOpt);
+                var verifier = new DebugVerifier(analyzedNullabilityMap, snapshotManagerOpt);
                 verifier.Visit(node);
-
-                foreach (var ((expr, originalSymbol), updatedSymbol) in updatedMethodSymbols)
-                {
-                    Debug.Assert((object)originalSymbol != updatedSymbol, $"Recorded exact same symbol for {expr.Syntax}");
-                    Debug.Assert(originalSymbol is object, $"Recorded null original symbol for {expr.Syntax}");
-                    Debug.Assert(updatedSymbol is object, $"Recorded null updated symbol for {expr.Syntax}");
-                    Debug.Assert(areSymbolsIdentical(originalSymbol, updatedSymbol), @$"Symbol for `{expr.Syntax}` changed:
-Was {originalSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}
-Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
-
-                    static bool areSymbolsIdentical(Symbol original, Symbol updated) => (original, updated) switch
-                    {
-                        (FieldSymbol { IsTupleField: true } originalField, FieldSymbol { IsTupleField: true } updatedField) => originalField.Type.Equals(updatedField.Type, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames),
-                        _ => original.Equals(updated, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames)
-                    };
-                }
+                snapshotManagerOpt?.VerifyUpdatedSymbols();
 
                 // Can't just remove nodes from _analyzedNullabilityMap and verify no nodes remaining because nodes can be reused.
                 Debug.Assert(verifier._analyzedNullabilityMap.Count == verifier._visitedExpressions.Count, $"Visited {verifier._visitedExpressions.Count} nodes, expected to visit {verifier._analyzedNullabilityMap.Count}");

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
@@ -12,6 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class NullableWalker
     {
+#nullable enable
         internal sealed class SnapshotManager
         {
             /// <summary>
@@ -25,12 +26,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             private readonly ImmutableArray<(int position, Snapshot snapshot)> _incrementalSnapshots;
 
+            private readonly ImmutableDictionary<(BoundNode?, Symbol), Symbol> _updatedSymbolsMap;
+
             private static readonly Func<(int position, Snapshot snapshot), int, int> BinarySearchComparer = (current, target) => current.position.CompareTo(target);
 
-            private SnapshotManager(ImmutableArray<SharedWalkerState> walkerSharedStates, ImmutableArray<(int position, Snapshot snapshot)> incrementalSnapshots)
+            private SnapshotManager(ImmutableArray<SharedWalkerState> walkerSharedStates, ImmutableArray<(int position, Snapshot snapshot)> incrementalSnapshots, ImmutableDictionary<(BoundNode?, Symbol), Symbol> updatedSymbolsMap)
             {
                 _walkerSharedStates = walkerSharedStates;
                 _incrementalSnapshots = incrementalSnapshots;
+                _updatedSymbolsMap = updatedSymbolsMap;
 
 #if DEBUG
                 Debug.Assert(!incrementalSnapshots.IsDefaultOrEmpty);
@@ -49,35 +53,52 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundNode nodeToAnalyze,
                 Binder binder,
                 ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMap,
-                ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMap,
                 SnapshotManager.Builder newManagerOpt)
             {
                 Snapshot incrementalSnapshot = GetSnapshotForPosition(position);
                 var sharedState = _walkerSharedStates[incrementalSnapshot.SharedStateIndex];
                 var variableState = new VariableState(sharedState.VariableSlot, sharedState.VariableBySlot, sharedState.VariableTypes, incrementalSnapshot.VariableState.Clone());
-                var method = sharedState.Symbol as MethodSymbol;
                 return (new NullableWalker(binder.Compilation,
                                            sharedState.Symbol,
-                                           useMethodSignatureParameterTypes: !(method is null),
-                                           method,
+                                           useDelegateInvokeParameterTypes: false,
+                                           delegateInvokeMethodOpt: null,
                                            nodeToAnalyze,
                                            binder,
                                            binder.Conversions,
                                            variableState,
                                            returnTypesOpt: null,
                                            analyzedNullabilityMap,
-                                           updatedSymbolMap,
                                            snapshotBuilderOpt: newManagerOpt,
                                            isSpeculative: true),
                         variableState,
                         sharedState.Symbol);
             }
 
-            internal ImmutableDictionary<Symbol, TypeWithAnnotations> GetVariableTypesForPosition(int position)
+            internal TypeWithAnnotations? GetUpdatedTypeForLocalSymbol(SourceLocalSymbol symbol)
             {
-                var snapshot = GetSnapshotForPosition(position);
+                var snapshot = GetSnapshotForPosition(symbol.IdentifierToken.SpanStart);
                 var sharedState = _walkerSharedStates[snapshot.SharedStateIndex];
-                return sharedState.VariableTypes;
+                if (sharedState.VariableTypes.TryGetValue(symbol, out var updatedType))
+                {
+                    return updatedType;
+                }
+
+                return default;
+            }
+
+            internal NamedTypeSymbol? GetUpdatedDelegateTypeForLambda(LambdaSymbol lambda)
+            {
+                if (_updatedSymbolsMap.TryGetValue((null, lambda), out var updatedDelegate))
+                {
+                    return (NamedTypeSymbol)updatedDelegate;
+                }
+
+                return null;
+            }
+
+            internal bool TryGetUpdatedSymbol(BoundNode node, Symbol symbol, out Symbol updatedSymbol)
+            {
+                return _updatedSymbolsMap.TryGetValue((node, symbol), out updatedSymbol);
             }
 
             private Snapshot GetSnapshotForPosition(int position)
@@ -113,11 +134,42 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 Debug.Assert(_walkerSharedStates.Length > _incrementalSnapshots[position].snapshot.SharedStateIndex, $"Did not find shared state for {node} `{node.Syntax}`.");
             }
+
+            internal void VerifyUpdatedSymbols()
+            {
+                foreach (var ((expr, originalSymbol), updatedSymbol) in _updatedSymbolsMap)
+                {
+                    var debugText = expr?.Syntax.ToFullString() ?? originalSymbol.ToDisplayString();
+                    Debug.Assert((object)originalSymbol != updatedSymbol, $"Recorded exact same symbol for {debugText}");
+                    Debug.Assert(originalSymbol is object, $"Recorded null original symbol for {debugText}");
+                    Debug.Assert(updatedSymbol is object, $"Recorded null updated symbol for {debugText}");
+                    Debug.Assert(AreCloseEnough(originalSymbol, updatedSymbol), @$"Symbol for `{debugText}` changed:
+Was {originalSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}
+Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
+                }
+            }
 #endif
 
             internal sealed class Builder
             {
+                /// <summary>
+                /// Contains the map of expression and original symbol to reinferred symbols, used by the optional
+                /// rewriter phase of the compiler.
+                /// </summary>
+                /// <remarks>
+                /// Lambda symbols are  mapped to the NameTypeSymbol of the delegate type they were reinferred to,
+                /// and are stored with a null node. The LambdaSymbol itself is position-independent, and does not
+                /// need any more information to serve as a key.
+                /// All other symbol types are stored mapped to exactly the same type as was provided.
+                /// </remarks>
+                private readonly ImmutableDictionary<(BoundNode?, Symbol), Symbol>.Builder _updatedSymbolMap = ImmutableDictionary.CreateBuilder<(BoundNode?, Symbol), Symbol>(ExpressionAndSymbolEqualityComparer.Instance, SymbolEqualityComparer.ConsiderEverything);
 
+                /// <summary>
+                /// Shared walker states are the parts of the walker state that are not unique at a single position,
+                /// but are instead used by all snapshots. Each shared state corresponds to one invocation of Analyze,
+                /// so entering a lambda or local function will create a new state here. The indexes in this array
+                /// correspond to <see cref="Snapshot.SharedStateIndex"/>.
+                /// </summary>
                 private readonly ArrayBuilder<SharedWalkerState> _walkerStates = ArrayBuilder<SharedWalkerState>.GetInstance();
                 /// <summary>
                 /// Snapshots are kept in a dictionary of position -> snapshot at that position. These are stored in descending order.
@@ -137,9 +189,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(_symbolToSlot.Count == _walkerStates.Count);
                     Debug.Assert(_symbolToSlot.Count > 0);
                     _symbolToSlot.Free();
-                    var snapshotsArray = Roslyn.Utilities.EnumerableExtensions.SelectAsArray<KeyValuePair<int, Snapshot>, (int, Snapshot)>(_incrementalSnapshots, (kvp) => (kvp.Key, kvp.Value));
+                    var snapshotsArray = EnumerableExtensions.SelectAsArray<KeyValuePair<int, Snapshot>, (int, Snapshot)>(_incrementalSnapshots, (kvp) => (kvp.Key, kvp.Value));
 
-                    return new SnapshotManager(_walkerStates.ToImmutableAndFree(), snapshotsArray);
+                    var updatedSymbols = _updatedSymbolMap.ToImmutable();
+                    return new SnapshotManager(_walkerStates.ToImmutableAndFree(), snapshotsArray, updatedSymbols);
                 }
 
                 internal int EnterNewWalker(Symbol symbol)
@@ -179,6 +232,31 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Note that we can't use Add here, as this is potentially not the stable
                     // state of this node and we could get updated states later.
                     _incrementalSnapshots[node.Syntax.SpanStart] = new Snapshot(currentState.Clone(), _currentWalkerSlot);
+                }
+
+                internal void SetUpdatedSymbol(BoundNode node, Symbol originalSymbol, Symbol updatedSymbol)
+                {
+#if DEBUG
+                    Debug.Assert(AreCloseEnough(originalSymbol, updatedSymbol));
+#endif
+                    _updatedSymbolMap[GetKey(node, originalSymbol)] = updatedSymbol;
+                }
+
+                internal void RemoveSymbolIfPresent(BoundNode node, Symbol symbol)
+                {
+                    _updatedSymbolMap.Remove(GetKey(node, symbol));
+                }
+
+                private (BoundNode?, Symbol) GetKey(BoundNode node, Symbol symbol)
+                {
+                    if (node is BoundLambda && symbol is LambdaSymbol)
+                    {
+                        return (null, symbol);
+                    }
+                    else
+                    {
+                        return (node, symbol);
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.SnapshotManager.cs
@@ -157,7 +157,7 @@ Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
                 /// rewriter phase of the compiler.
                 /// </summary>
                 /// <remarks>
-                /// Lambda symbols are  mapped to the NameTypeSymbol of the delegate type they were reinferred to,
+                /// Lambda symbols are mapped to the NameTypeSymbol of the delegate type they were reinferred to,
                 /// and are stored with a null node. The LambdaSymbol itself is position-independent, and does not
                 /// need any more information to serve as a key.
                 /// All other symbol types are stored mapped to exactly the same type as was provided.
@@ -247,7 +247,7 @@ Now {updatedSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}");
                     _updatedSymbolMap.Remove(GetKey(node, symbol));
                 }
 
-                private (BoundNode?, Symbol) GetKey(BoundNode node, Symbol symbol)
+                private static (BoundNode?, Symbol) GetKey(BoundNode node, Symbol symbol)
                 {
                     if (node is BoundLambda && symbol is LambdaSymbol)
                     {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -132,13 +132,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Use the the parameter types and nullability from _methodSignatureOpt for initial
         /// parameter state. If false, the signature of _member is used instead.
         /// </summary>
-        private readonly bool _useMethodSignatureParameterTypes;
+        private readonly bool _useDelegateInvokeParameterTypes;
 
         /// <summary>
         /// Method signature used for return type or parameter types. Distinct from _member
         /// signature when _member is a lambda and type is inferred from MethodTypeInferrer.
         /// </summary>
-        private readonly MethodSymbol _methodSignatureOpt;
+        private readonly MethodSymbol _delegateInvokeMethod;
 
         /// <summary>
         /// Return statements and the result types from analyzing the returned expressions. Used when inferring lambda return type in MethodTypeInferrer.
@@ -156,12 +156,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// compiler.
         /// </summary>
         private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)>.Builder _analyzedNullabilityMapOpt;
-
-        /// <summary>
-        /// Contains the map of expression and original symbol to reinferred symbols, used by the optional
-        /// rewriter phase of the compiler.
-        /// </summary>
-        private readonly ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder _updatedSymbolMapOpt;
 
         /// <summary>
         /// Manages creating snapshots of the walker as appropriate. Null if we're not taking snapshots of
@@ -343,27 +337,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         private NullableWalker(
             CSharpCompilation compilation,
             Symbol symbol,
-            bool useMethodSignatureParameterTypes,
-            MethodSymbol methodSignatureOpt,
+            bool useDelegateInvokeParameterTypes,
+            MethodSymbol delegateInvokeMethodOpt,
             BoundNode node,
             Binder binder,
             Conversions conversions,
             VariableState initialState,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)> returnTypesOpt,
             ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMapOpt,
-            ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMapOpt,
             SnapshotManager.Builder snapshotBuilderOpt,
             bool isSpeculative = false)
             // Members of variables are tracked up to a fixed depth, to avoid cycles. The
             // maxSlotDepth value is arbitrary but large enough to allow most scenarios.
             : base(compilation, symbol, node, EmptyStructTypeCache.CreatePrecise(), trackUnassignments: true, maxSlotDepth: 5)
         {
+            Debug.Assert(!useDelegateInvokeParameterTypes || delegateInvokeMethodOpt is object);
             _binder = binder;
             _conversions = (Conversions)conversions.WithNullability(true);
-            _useMethodSignatureParameterTypes = (object)methodSignatureOpt != null && useMethodSignatureParameterTypes;
-            _methodSignatureOpt = methodSignatureOpt;
+            _useDelegateInvokeParameterTypes = useDelegateInvokeParameterTypes;
+            _delegateInvokeMethod = delegateInvokeMethodOpt;
             _analyzedNullabilityMapOpt = analyzedNullabilityMapOpt;
-            _updatedSymbolMapOpt = updatedSymbolMapOpt;
             _returnTypesOpt = returnTypesOpt;
             _snapshotBuilderOpt = snapshotBuilderOpt;
             _isSpeculative = isSpeculative;
@@ -450,14 +443,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversions,
                 diagnostics,
                 useMethodSignatureParameterTypes: false,
-                methodSignatureOpt: method,
+                delegateInvokeMethodOpt: null,
                 initialState: null,
                 analyzedNullabilityMapOpt: null,
-                updatedSymbolMapOpt: null,
                 snapshotBuilderOpt: null,
                 returnTypesOpt: null);
         }
 
+#nullable enable
         internal static BoundNode AnalyzeAndRewrite(
             CSharpCompilation compilation,
             Symbol symbol,
@@ -465,11 +458,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder binder,
             DiagnosticBag diagnostics,
             bool createSnapshots,
-            out SnapshotManager snapshotManager)
+            out SnapshotManager? snapshotManager,
+            ref ImmutableDictionary<Symbol, Symbol>? remappedSymbols)
         {
             var analyzedNullabilities = ImmutableDictionary.CreateBuilder<BoundExpression, (NullabilityInfo, TypeSymbol)>(EqualityComparer<BoundExpression>.Default, NullabilityInfoTypeComparer.Instance);
-            var updatedSymbols = ImmutableDictionary.CreateBuilder<(BoundNode, Symbol), Symbol>(ExpressionAndSymbolEqualityComparer.Instance, SymbolEqualityComparer.ConsiderEverything);
-            var methodSymbol = symbol as MethodSymbol;
             // Attributes don't have a symbol, which is what SnapshotBuilder uses as an index for maintaining global state.
             // Until we have a workaround for this, disable snapshots for null symbols.
             // https://github.com/dotnet/roslyn/issues/36066
@@ -481,26 +473,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binder,
                 binder.Conversions,
                 diagnostics,
-                useMethodSignatureParameterTypes: !(methodSymbol is null),
-                methodSignatureOpt: methodSymbol,
+                useMethodSignatureParameterTypes: false,
+                delegateInvokeMethodOpt: null,
                 initialState: null,
                 analyzedNullabilities,
-                updatedSymbols,
                 snapshotBuilder,
                 returnTypesOpt: null);
 
             var analyzedNullabilitiesMap = analyzedNullabilities.ToImmutable();
-            var updatedSymbolsMap = updatedSymbols.ToImmutable();
             snapshotManager = snapshotBuilder?.ToManagerAndFree();
 
 #if DEBUG
             // https://github.com/dotnet/roslyn/issues/34993 Enable for all calls
             if (compilation.NullableSemanticAnalysisEnabled)
             {
-                DebugVerifier.Verify(analyzedNullabilitiesMap, updatedSymbolsMap, snapshotManager, node);
+                DebugVerifier.Verify(analyzedNullabilitiesMap, snapshotManager, node);
             }
 #endif
-            return new NullabilityRewriter(analyzedNullabilitiesMap, updatedSymbolsMap).Visit(node);
+            return Rewrite(analyzedNullabilitiesMap, snapshotManager, node, ref remappedSymbols);
         }
 
         internal static BoundNode AnalyzeAndRewriteSpeculation(
@@ -508,13 +498,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundNode node,
             Binder binder,
             SnapshotManager originalSnapshots,
-            bool takeNewSnapshots,
-            out SnapshotManager newSnapshots)
+            out SnapshotManager newSnapshots,
+            ref ImmutableDictionary<Symbol, Symbol>? remappedSymbols)
         {
             var analyzedNullabilities = ImmutableDictionary.CreateBuilder<BoundExpression, (NullabilityInfo, TypeSymbol)>(EqualityComparer<BoundExpression>.Default, NullabilityInfoTypeComparer.Instance);
-            var updatedSymbols = ImmutableDictionary.CreateBuilder<(BoundNode, Symbol), Symbol>(ExpressionAndSymbolEqualityComparer.Instance, SymbolEqualityComparer.ConsiderEverything);
-            var newSnapshotBuilder = takeNewSnapshots ? new SnapshotManager.Builder() : null;
-            var (walker, initialState, symbol) = originalSnapshots.RestoreWalkerToAnalyzeNewNode(position, node, binder, analyzedNullabilities, updatedSymbols, newSnapshotBuilder);
+            var newSnapshotBuilder = new SnapshotManager.Builder();
+            var (walker, initialState, symbol) = originalSnapshots.RestoreWalkerToAnalyzeNewNode(position, node, binder, analyzedNullabilities, newSnapshotBuilder);
             try
             {
                 Analyze(walker, symbol, diagnostics: null, initialState, snapshotBuilderOpt: newSnapshotBuilder);
@@ -525,18 +514,33 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var analyzedNullabilitiesMap = analyzedNullabilities.ToImmutable();
-            var updatedSymbolsMap = updatedSymbols.ToImmutable();
-            newSnapshots = newSnapshotBuilder?.ToManagerAndFree();
+            newSnapshots = newSnapshotBuilder.ToManagerAndFree();
 
 #if DEBUG
             if (binder.Compilation.NullableSemanticAnalysisEnabled)
             {
-                DebugVerifier.Verify(analyzedNullabilitiesMap, updatedSymbolsMap, newSnapshots, node);
+                DebugVerifier.Verify(analyzedNullabilitiesMap, newSnapshots, node);
             }
 #endif
 
-            return new NullabilityRewriter(analyzedNullabilitiesMap, updatedSymbolsMap).Visit(node);
+            return Rewrite(analyzedNullabilitiesMap, newSnapshots, node, ref remappedSymbols);
         }
+
+        private static BoundNode Rewrite(ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)> updatedNullabilities, SnapshotManager? snapshotManager, BoundNode node, ref ImmutableDictionary<Symbol, Symbol>? remappedSymbols)
+        {
+            var remappedSymbolsBuilder = ImmutableDictionary.CreateBuilder<Symbol, Symbol>(SymbolEqualityComparer.ConsiderEverything, SymbolEqualityComparer.ConsiderEverything);
+            if (remappedSymbols is object)
+            {
+                // When we're rewriting for the speculative model, there will be a set of originally-mapped symbols, and we need to
+                // use them in addition to any symbols found during this pass of the walker.
+                remappedSymbolsBuilder.AddRange(remappedSymbols);
+            }
+            var rewriter = new NullabilityRewriter(updatedNullabilities, snapshotManager, remappedSymbolsBuilder);
+            var rewrittenNode = rewriter.Visit(node);
+            remappedSymbols = remappedSymbolsBuilder.ToImmutable();
+            return rewrittenNode;
+        }
+#nullable restore
 
         internal static void AnalyzeIfNeeded(
             Binder binder,
@@ -557,10 +561,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binder.Conversions,
                 diagnostics,
                 useMethodSignatureParameterTypes: false,
-                methodSignatureOpt: null,
+                delegateInvokeMethodOpt: null,
                 initialState: null,
                 analyzedNullabilityMapOpt: null,
-                updatedSymbolMapOpt: null,
                 snapshotBuilderOpt: null,
                 returnTypesOpt: null);
         }
@@ -570,10 +573,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundLambda lambda,
             Conversions conversions,
             DiagnosticBag diagnostics,
-            MethodSymbol delegateInvokeMethod,
+            MethodSymbol delegateInvokeMethodOpt,
             VariableState initialState,
             ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMapOpt,
-            ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMapOpt,
             SnapshotManager.Builder snapshotBuilderOpt,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)> returnTypesOpt)
         {
@@ -584,11 +586,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 lambda.Binder,
                 conversions,
                 diagnostics,
-                useMethodSignatureParameterTypes: !lambda.UnboundLambda.HasExplicitlyTypedParameterList,
-                methodSignatureOpt: delegateInvokeMethod,
+                useMethodSignatureParameterTypes: delegateInvokeMethodOpt is object && !lambda.UnboundLambda.HasExplicitlyTypedParameterList,
+                delegateInvokeMethodOpt: delegateInvokeMethodOpt,
                 initialState,
                 analyzedNullabilityMapOpt,
-                updatedSymbolMapOpt,
                 snapshotBuilderOpt,
                 returnTypesOpt);
         }
@@ -601,26 +602,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             Conversions conversions,
             DiagnosticBag diagnostics,
             bool useMethodSignatureParameterTypes,
-            MethodSymbol methodSignatureOpt,
+            MethodSymbol delegateInvokeMethodOpt,
             VariableState initialState,
             ImmutableDictionary<BoundExpression, (NullabilityInfo, TypeSymbol)>.Builder analyzedNullabilityMapOpt,
-            ImmutableDictionary<(BoundNode, Symbol), Symbol>.Builder updatedSymbolMapOpt,
             SnapshotManager.Builder snapshotBuilderOpt,
             ArrayBuilder<(BoundReturnStatement, TypeWithAnnotations)> returnTypesOpt)
         {
             Debug.Assert(diagnostics != null);
             var walker = new NullableWalker(compilation,
-                                                    symbol,
-                                                    useMethodSignatureParameterTypes,
-                                                    methodSignatureOpt,
-                                                    node,
-                                                    binder,
-                                                    conversions,
-                                                    initialState,
-                                                    returnTypesOpt,
-                                                    analyzedNullabilityMapOpt,
-                                                    updatedSymbolMapOpt,
-                                                    snapshotBuilderOpt);
+                                            symbol,
+                                            useMethodSignatureParameterTypes,
+                                            delegateInvokeMethodOpt,
+                                            node,
+                                            binder,
+                                            conversions,
+                                            initialState,
+                                            returnTypesOpt,
+                                            analyzedNullabilityMapOpt,
+                                            snapshotBuilderOpt);
 
             try
             {
@@ -670,19 +669,34 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void SetUpdatedSymbol(BoundNode node, Symbol originalSymbol, Symbol updatedSymbol)
         {
-            if (_updatedSymbolMapOpt is object)
+            var lambdaisExactMatch = false;
+            if (node is BoundLambda boundLambda && originalSymbol is LambdaSymbol l && updatedSymbol is NamedTypeSymbol n)
             {
-                var key = (node, originalSymbol);
-                if ((object)originalSymbol != updatedSymbol)
+                if (!AreLambdaAndNewDelegateSimilar(l, n))
                 {
-                    _updatedSymbolMapOpt[key] = updatedSymbol;
+                    return;
                 }
-                else
+
+                lambdaisExactMatch = updatedSymbol.Equals(boundLambda.Type.GetDelegateType(), TypeCompareKind.ConsiderEverything);
+            }
+
+#if DEBUG
+            Debug.Assert(node is object);
+            Debug.Assert(AreCloseEnough(originalSymbol, updatedSymbol), $"Attempting to set {node.Syntax} from {originalSymbol.ToDisplayString()} to {updatedSymbol.ToDisplayString()}");
+#endif
+
+            if (_snapshotBuilderOpt is object)
+            {
+                if (Symbol.Equals(originalSymbol, updatedSymbol, TypeCompareKind.ConsiderEverything) || lambdaisExactMatch)
                 {
                     // If the symbol is reset, remove the updated symbol so we don't needlessly update the
                     // bound node later on. We do this unconditionally, as Remove will just return false
                     // if the key wasn't in the dictionary.
-                    _ = _updatedSymbolMapOpt.Remove(key);
+                    _snapshotBuilderOpt.RemoveSymbolIfPresent(node, originalSymbol);
+                }
+                else
+                {
+                    _snapshotBuilderOpt.SetUpdatedSymbol(node, originalSymbol, updatedSymbol);
                 }
             }
         }
@@ -1341,14 +1355,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void EnterParameters()
         {
-            var methodSymbol = _symbol as MethodSymbol;
-            if (methodSymbol is null)
+            if (!(_symbol is MethodSymbol methodSymbol))
             {
                 return;
             }
 
             var methodParameters = methodSymbol.Parameters;
-            var signatureParameters = _useMethodSignatureParameterTypes ? _methodSignatureOpt.Parameters : methodParameters;
+            var signatureParameters = (_useDelegateInvokeParameterTypes ? _delegateInvokeMethod : methodSymbol).Parameters;
+
             for (int i = 0; i < methodParameters.Length; i++)
             {
                 var parameter = methodParameters[i];
@@ -1446,7 +1460,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            var returnType = (_methodSignatureOpt ?? method).ReturnTypeWithAnnotations;
+            var returnType = (_delegateInvokeMethod ?? method).ReturnTypeWithAnnotations;
             Debug.Assert((object)returnType != LambdaSymbol.ReturnTypeIsBeingInferred);
 
             if (returnType.IsVoidType())
@@ -1700,7 +1714,33 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return AnonymousTypeManager.GetAnonymousTypePropertyTypesWithAnnotations(type).Any(t => canIgnoreAnyType(t.Type));
             }
         }
+
+        private static bool AreCloseEnough(Symbol original, Symbol updated)
+        {
+            // When https://github.com/dotnet/roslyn/issues/38195 is fixed, this workaround needs to be removed
+            if (original is ConstructedMethodSymbol || updated is ConstructedMethodSymbol)
+            {
+                return AreCloseEnough(original.OriginalDefinition, updated.OriginalDefinition);
+            }
+
+            return (original, updated) switch
+            {
+                (LambdaSymbol l, NamedTypeSymbol n) _ when n.IsDelegateType() => AreLambdaAndNewDelegateSimilar(l, n),
+                (FieldSymbol { IsTupleField: true, TupleElementIndex: var oi } originalField, FieldSymbol { IsTupleField: true, TupleElementIndex: var ui } updatedField) =>
+                    originalField.Type.Equals(updatedField.Type, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames) && oi == ui,
+                _ => original.Equals(updated, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames)
+            };
+
+        }
 #endif
+
+        private static bool AreLambdaAndNewDelegateSimilar(LambdaSymbol l, NamedTypeSymbol n)
+        {
+            var invokeMethod = n.DelegateInvokeMethod;
+            return invokeMethod.Parameters.SequenceEqual(l.Parameters,
+                        (p1, p2) => p1.Type.Equals(p2.Type, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames)) &&
+                   invokeMethod.ReturnType.Equals(l.ReturnType, TypeCompareKind.AllNullableIgnoreOptions | TypeCompareKind.IgnoreTupleNames);
+        }
 
         public override BoundNode Visit(BoundNode node)
         {
@@ -2166,15 +2206,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var walker = new NullableWalker(compilation,
                                             symbol: null,
-                                            useMethodSignatureParameterTypes: false,
-                                            methodSignatureOpt: null,
+                                            useDelegateInvokeParameterTypes: false,
+                                            delegateInvokeMethodOpt: null,
                                             node,
                                             binder: null,
                                             conversions: conversions,
                                             initialState: null,
                                             returnTypesOpt: null,
                                             analyzedNullabilityMapOpt: null,
-                                            updatedSymbolMapOpt: null,
                                             snapshotBuilderOpt: null);
 
             int n = returns.Count;
@@ -5681,7 +5720,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!_disableNullabilityAnalysis)
             {
                 var bag = new DiagnosticBag();
-                VisitLambda(node, node.Type.GetDelegateType(), bag);
+                VisitLambda(node, delegateTypeOpt: null, bag);
                 bag.Free();
             }
             SetNotNullResult(node);
@@ -5692,13 +5731,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(delegateTypeOpt?.IsDelegateType() != false);
             var analyzedNullabilityMap = _analyzedNullabilityMapOpt;
-            var updatedSymbolMap = _updatedSymbolMapOpt;
             var snapshotBuilder = _snapshotBuilderOpt;
             if (_disableNullabilityAnalysis)
             {
                 analyzedNullabilityMap = null;
-                updatedSymbolMap = null;
                 snapshotBuilder = null;
+            }
+            else if (_snapshotBuilderOpt is object && delegateTypeOpt is object && !node.UnboundLambda.HasExplicitlyTypedParameterList)
+            {
+                SetUpdatedSymbol(node, node.Symbol, delegateTypeOpt);
             }
 
             Analyze(
@@ -5709,7 +5750,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 delegateTypeOpt?.DelegateInvokeMethod,
                 initialState: initialState ?? GetVariableState(State.Clone()),
                 analyzedNullabilityMap,
-                updatedSymbolMap,
                 snapshotBuilder,
                 returnTypesOpt: null);
         }
@@ -5730,12 +5770,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (body != null)
             {
                 var analyzedNullabilityMap = _analyzedNullabilityMapOpt;
-                var updatedSymbolMap = _updatedSymbolMapOpt;
                 var snapshotBuilder = _snapshotBuilderOpt;
                 if (_disableNullabilityAnalysis)
                 {
                     analyzedNullabilityMap = null;
-                    updatedSymbolMap = null;
                     snapshotBuilder = null;
                 }
 
@@ -5746,10 +5784,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         _conversions,
                         Diagnostics,
                         useMethodSignatureParameterTypes: false,
-                        methodSignatureOpt: null,
+                        delegateInvokeMethodOpt: null,
                         initialState: GetVariableState(this.TopState()),
                         analyzedNullabilityMap,
-                        updatedSymbolMap,
                         snapshotBuilder,
                         returnTypesOpt: null);
             }
@@ -7630,7 +7667,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return null;
             }
-            var method = _methodSignatureOpt ?? (MethodSymbol)_symbol;
+            var method = _delegateInvokeMethod ?? (MethodSymbol)_symbol;
             TypeWithAnnotations elementType = InMethodBinder.GetIteratorElementTypeFromReturnType(compilation, RefKind.None,
                 method.ReturnType, errorLocationNode: null, diagnostics: null).elementType;
 
@@ -7856,15 +7893,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private sealed class ExpressionAndSymbolEqualityComparer : IEqualityComparer<(BoundNode expr, Symbol sym)>
+        private sealed class ExpressionAndSymbolEqualityComparer : IEqualityComparer<(BoundNode? expr, Symbol sym)>
         {
             internal static readonly ExpressionAndSymbolEqualityComparer Instance = new ExpressionAndSymbolEqualityComparer();
 
             private ExpressionAndSymbolEqualityComparer() { }
 
-            public bool Equals((BoundNode expr, Symbol sym) x, (BoundNode expr, Symbol sym) y)
+            public bool Equals((BoundNode? expr, Symbol sym) x, (BoundNode? expr, Symbol sym) y)
             {
-                Debug.Assert(x is ({ }, { }) && y is ({ }, { }));
+                Debug.Assert(x.sym is object && y.sym is object);
 
                 // We specifically use reference equality for the symbols here because the BoundNode should be immutable.
                 // We should be storing and retrieving the exact same instance of the symbol, not just an "equivalent"
@@ -7872,9 +7909,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return x.expr == y.expr && (object)x.sym == y.sym;
             }
 
-            public int GetHashCode((BoundNode expr, Symbol sym) obj)
+            public int GetHashCode((BoundNode? expr, Symbol sym) obj)
             {
-                Debug.Assert(obj is ({ }, { }));
+                Debug.Assert(obj.sym is object);
                 return Hash.Combine(obj.expr, obj.sym.GetHashCode());
             }
         }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -10058,30 +10058,38 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed partial class NullabilityRewriter : BoundTreeRewriter
     {
         private readonly ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> _updatedNullabilities;
-        private readonly ImmutableDictionary<(BoundNode, Symbol), Symbol> _updatedSymbols;
+        private readonly NullableWalker.SnapshotManager? _snapshotManager;
+        private readonly ImmutableDictionary<Symbol, Symbol>.Builder _remappedSymbols;
 
-        public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities, ImmutableDictionary<(BoundNode, Symbol), Symbol> updatedSymbols)
+        public NullabilityRewriter(ImmutableDictionary<BoundExpression, (NullabilityInfo Info, TypeSymbol Type)> updatedNullabilities, NullableWalker.SnapshotManager? snapshotManager, ImmutableDictionary<Symbol, Symbol>.Builder remappedSymbols)
         {
             _updatedNullabilities = updatedNullabilities;
-            _updatedSymbols = updatedSymbols;
+            _snapshotManager = snapshotManager;
+            _remappedSymbols = remappedSymbols;
         }
 
         public override BoundNode? VisitFieldEqualsValue(BoundFieldEqualsValue node)
         {
+            FieldSymbol field = GetUpdatedSymbol(node, node.Field);
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(GetUpdatedSymbol(node, node.Field), node.Locals, value);
+            return node.Update(field, locals, value);
         }
 
         public override BoundNode? VisitPropertyEqualsValue(BoundPropertyEqualsValue node)
         {
+            PropertySymbol property = GetUpdatedSymbol(node, node.Property);
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(GetUpdatedSymbol(node, node.Property), node.Locals, value);
+            return node.Update(property, locals, value);
         }
 
         public override BoundNode? VisitParameterEqualsValue(BoundParameterEqualsValue node)
         {
+            ParameterSymbol parameter = GetUpdatedSymbol(node, node.Parameter);
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(GetUpdatedSymbol(node, node.Parameter), node.Locals, value);
+            return node.Update(parameter, locals, value);
         }
 
         public override BoundNode? VisitDeconstructValuePlaceholder(BoundDeconstructValuePlaceholder node)
@@ -10175,6 +10183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitBadExpression(BoundBadExpression node)
         {
+            ImmutableArray<Symbol?> symbols = GetUpdatedArray(node, node.Symbols);
             ImmutableArray<BoundExpression> childBoundNodes = this.VisitList(node.ChildBoundNodes);
             BoundBadExpression updatedNode;
 
@@ -10234,34 +10243,38 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitUnaryOperator(BoundUnaryOperator node)
         {
+            MethodSymbol? methodOpt = GetUpdatedSymbol(node, node.MethodOpt);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = GetUpdatedArray(node, node.OriginalUserDefinedOperatorsOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundUnaryOperator updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, GetUpdatedSymbol(node, node.MethodOpt), node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, methodOpt, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, GetUpdatedSymbol(node, node.MethodOpt), node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, node.ConstantValueOpt, methodOpt, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitIncrementOperator(BoundIncrementOperator node)
         {
+            MethodSymbol? methodOpt = GetUpdatedSymbol(node, node.MethodOpt);
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = GetUpdatedArray(node, node.OriginalUserDefinedOperatorsOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundIncrementOperator updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.OperatorKind, operand, GetUpdatedSymbol(node, node.MethodOpt), node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, methodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.OperatorKind, operand, GetUpdatedSymbol(node, node.MethodOpt), node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
+                updatedNode = node.Update(node.OperatorKind, operand, methodOpt, node.OperandConversion, node.ResultConversion, node.ResultKind, node.OriginalUserDefinedOperatorsOpt, node.Type);
             }
             return updatedNode;
         }
@@ -10320,17 +10333,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitRefTypeOperator(BoundRefTypeOperator node)
         {
+            MethodSymbol? getTypeFromHandle = GetUpdatedSymbol(node, node.GetTypeFromHandle);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundRefTypeOperator updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.GetTypeFromHandle), infoAndType.Type);
+                updatedNode = node.Update(operand, getTypeFromHandle, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.GetTypeFromHandle), node.Type);
+                updatedNode = node.Update(operand, getTypeFromHandle, node.Type);
             }
             return updatedNode;
         }
@@ -10371,35 +10385,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitFromEndIndexExpression(BoundFromEndIndexExpression node)
         {
+            MethodSymbol? methodOpt = GetUpdatedSymbol(node, node.MethodOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundFromEndIndexExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.MethodOpt), infoAndType.Type);
+                updatedNode = node.Update(operand, methodOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.MethodOpt), node.Type);
+                updatedNode = node.Update(operand, methodOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitRangeExpression(BoundRangeExpression node)
         {
+            MethodSymbol? methodOpt = GetUpdatedSymbol(node, node.MethodOpt);
             BoundExpression? leftOperandOpt = (BoundExpression?)this.Visit(node.LeftOperandOpt);
             BoundExpression? rightOperandOpt = (BoundExpression?)this.Visit(node.RightOperandOpt);
             BoundRangeExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, GetUpdatedSymbol(node, node.MethodOpt), infoAndType.Type);
+                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, methodOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, GetUpdatedSymbol(node, node.MethodOpt), node.Type);
+                updatedNode = node.Update(leftOperandOpt, rightOperandOpt, methodOpt, node.Type);
             }
             return updatedNode;
         }
@@ -10424,6 +10440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitCompoundAssignmentOperator(BoundCompoundAssignmentOperator node)
         {
+            ImmutableArray<MethodSymbol> originalUserDefinedOperatorsOpt = GetUpdatedArray(node, node.OriginalUserDefinedOperatorsOpt);
             BoundExpression left = (BoundExpression)this.Visit(node.Left);
             BoundExpression right = (BoundExpression)this.Visit(node.Right);
             BoundCompoundAssignmentOperator updatedNode;
@@ -10585,30 +10602,36 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitTypeOfOperator(BoundTypeOfOperator node)
         {
+            MethodSymbol? getTypeFromHandle = GetUpdatedSymbol(node, node.GetTypeFromHandle);
             BoundTypeExpression sourceType = (BoundTypeExpression)this.Visit(node.SourceType);
             BoundTypeOfOperator updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(sourceType, GetUpdatedSymbol(node, node.GetTypeFromHandle), infoAndType.Type);
+                updatedNode = node.Update(sourceType, getTypeFromHandle, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(sourceType, GetUpdatedSymbol(node, node.GetTypeFromHandle), node.Type);
+                updatedNode = node.Update(sourceType, getTypeFromHandle, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitMethodDefIndex(BoundMethodDefIndex node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            MethodSymbol method = GetUpdatedSymbol(node, node.Method);
+            BoundMethodDefIndex updatedNode;
 
-            BoundMethodDefIndex updatedNode = node.Update(GetUpdatedSymbol(node, node.Method), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(method, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(method, node.Type);
+            }
             return updatedNode;
         }
 
@@ -10674,25 +10697,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitMethodInfo(BoundMethodInfo node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            MethodSymbol method = GetUpdatedSymbol(node, node.Method);
+            MethodSymbol? getMethodFromHandle = GetUpdatedSymbol(node, node.GetMethodFromHandle);
+            BoundMethodInfo updatedNode;
 
-            BoundMethodInfo updatedNode = node.Update(GetUpdatedSymbol(node, node.Method), GetUpdatedSymbol(node, node.GetMethodFromHandle), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(method, getMethodFromHandle, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(method, getMethodFromHandle, node.Type);
+            }
             return updatedNode;
         }
 
         public override BoundNode? VisitFieldInfo(BoundFieldInfo node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            FieldSymbol field = GetUpdatedSymbol(node, node.Field);
+            MethodSymbol? getFieldFromHandle = GetUpdatedSymbol(node, node.GetFieldFromHandle);
+            BoundFieldInfo updatedNode;
 
-            BoundFieldInfo updatedNode = node.Update(GetUpdatedSymbol(node, node.Field), GetUpdatedSymbol(node, node.GetFieldFromHandle), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(field, getFieldFromHandle, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(field, getFieldFromHandle, node.Type);
+            }
             return updatedNode;
         }
 
@@ -10780,6 +10815,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitConversion(BoundConversion node)
         {
+            ImmutableArray<MethodSymbol> originalUserDefinedConversionsOpt = GetUpdatedArray(node, node.OriginalUserDefinedConversionsOpt);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundConversion updatedNode;
 
@@ -10797,17 +10833,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitReadOnlySpanFromArray(BoundReadOnlySpanFromArray node)
         {
+            MethodSymbol conversionMethod = GetUpdatedSymbol(node, node.ConversionMethod);
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             BoundReadOnlySpanFromArray updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.ConversionMethod), infoAndType.Type);
+                updatedNode = node.Update(operand, conversionMethod, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(operand, GetUpdatedSymbol(node, node.ConversionMethod), node.Type);
+                updatedNode = node.Update(operand, conversionMethod, node.Type);
             }
             return updatedNode;
         }
@@ -10843,54 +10880,151 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitFixedLocalCollectionInitializer(BoundFixedLocalCollectionInitializer node)
         {
+            TypeSymbol elementPointerType = GetUpdatedSymbol(node, node.ElementPointerType);
+            MethodSymbol? getPinnableOpt = GetUpdatedSymbol(node, node.GetPinnableOpt);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             BoundFixedLocalCollectionInitializer updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.ElementPointerType), node.ElementPointerTypeConversion, expression, GetUpdatedSymbol(node, node.GetPinnableOpt), infoAndType.Type);
+                updatedNode = node.Update(elementPointerType, node.ElementPointerTypeConversion, expression, getPinnableOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.ElementPointerType), node.ElementPointerTypeConversion, expression, GetUpdatedSymbol(node, node.GetPinnableOpt), node.Type);
+                updatedNode = node.Update(elementPointerType, node.ElementPointerTypeConversion, expression, getPinnableOpt, node.Type);
             }
             return updatedNode;
         }
 
+        public override BoundNode? VisitBlock(BoundBlock node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            ImmutableArray<LocalFunctionSymbol> localFunctions = GetUpdatedArray(node, node.LocalFunctions);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
+            return node.Update(locals, localFunctions, statements);
+        }
+
+        public override BoundNode? VisitScope(BoundScope node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
+            return node.Update(locals, statements);
+        }
+
+        public override BoundNode? VisitStateMachineScope(BoundStateMachineScope node)
+        {
+            ImmutableArray<StateMachineFieldSymbol> fields = GetUpdatedArray(node, node.Fields);
+            BoundStatement statement = (BoundStatement)this.Visit(node.Statement);
+            return node.Update(fields, statement);
+        }
+
+        public override BoundNode? VisitLocalDeclaration(BoundLocalDeclaration node)
+        {
+            LocalSymbol localSymbol = GetUpdatedSymbol(node, node.LocalSymbol);
+            BoundTypeExpression? declaredTypeOpt = (BoundTypeExpression?)this.Visit(node.DeclaredTypeOpt);
+            BoundExpression? initializerOpt = (BoundExpression?)this.Visit(node.InitializerOpt);
+            ImmutableArray<BoundExpression> argumentsOpt = this.VisitList(node.ArgumentsOpt);
+            return node.Update(localSymbol, declaredTypeOpt, initializerOpt, argumentsOpt, node.InferredType);
+        }
+
         public override BoundNode? VisitUsingLocalDeclarations(BoundUsingLocalDeclarations node)
         {
+            MethodSymbol disposeMethodOpt = GetUpdatedSymbol(node, node.DisposeMethodOpt);
             ImmutableArray<BoundLocalDeclaration> localDeclarations = this.VisitList(node.LocalDeclarations);
-            return node.Update(GetUpdatedSymbol(node, node.DisposeMethodOpt), node.IDisposableConversion, node.AwaitOpt, localDeclarations);
+            return node.Update(disposeMethodOpt, node.IDisposableConversion, node.AwaitOpt, localDeclarations);
         }
 
         public override BoundNode? VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
         {
+            LocalFunctionSymbol symbol = GetUpdatedSymbol(node, node.Symbol);
             BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
             BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
-            return node.Update(GetUpdatedSymbol(node, node.Symbol), blockBody, expressionBody);
+            return node.Update(symbol, blockBody, expressionBody);
+        }
+
+        public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
+        {
+            ImmutableArray<LocalSymbol> innerLocals = GetUpdatedArray(node, node.InnerLocals);
+            ImmutableArray<LocalFunctionSymbol> innerLocalFunctions = GetUpdatedArray(node, node.InnerLocalFunctions);
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
+            ImmutableArray<BoundSwitchSection> switchSections = this.VisitList(node.SwitchSections);
+            BoundDecisionDag decisionDag = node.DecisionDag;
+            BoundSwitchLabel? defaultLabel = (BoundSwitchLabel?)this.Visit(node.DefaultLabel);
+            return node.Update(expression, innerLocals, innerLocalFunctions, switchSections, decisionDag, defaultLabel, node.BreakLabel);
         }
 
         public override BoundNode? VisitSwitchDispatch(BoundSwitchDispatch node)
         {
+            MethodSymbol? equalityMethod = GetUpdatedSymbol(node, node.EqualityMethod);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
-            return node.Update(expression, node.Cases, node.DefaultLabel, GetUpdatedSymbol(node, node.EqualityMethod));
+            return node.Update(expression, node.Cases, node.DefaultLabel, equalityMethod);
+        }
+
+        public override BoundNode? VisitDoStatement(BoundDoStatement node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(locals, condition, body, node.BreakLabel, node.ContinueLabel);
+        }
+
+        public override BoundNode? VisitWhileStatement(BoundWhileStatement node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(locals, condition, body, node.BreakLabel, node.ContinueLabel);
+        }
+
+        public override BoundNode? VisitForStatement(BoundForStatement node)
+        {
+            ImmutableArray<LocalSymbol> outerLocals = GetUpdatedArray(node, node.OuterLocals);
+            ImmutableArray<LocalSymbol> innerLocals = GetUpdatedArray(node, node.InnerLocals);
+            BoundStatement? initializer = (BoundStatement?)this.Visit(node.Initializer);
+            BoundExpression? condition = (BoundExpression?)this.Visit(node.Condition);
+            BoundStatement? increment = (BoundStatement?)this.Visit(node.Increment);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(outerLocals, initializer, innerLocals, condition, increment, body, node.BreakLabel, node.ContinueLabel);
+        }
+
+        public override BoundNode? VisitForEachStatement(BoundForEachStatement node)
+        {
+            ImmutableArray<LocalSymbol> iterationVariables = GetUpdatedArray(node, node.IterationVariables);
+            BoundTypeExpression iterationVariableType = (BoundTypeExpression)this.Visit(node.IterationVariableType);
+            BoundExpression? iterationErrorExpressionOpt = (BoundExpression?)this.Visit(node.IterationErrorExpressionOpt);
+            BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
+            BoundForEachDeconstructStep? deconstructionOpt = (BoundForEachDeconstructStep?)this.Visit(node.DeconstructionOpt);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(node.EnumeratorInfoOpt, node.ElementConversion, iterationVariableType, iterationVariables, iterationErrorExpressionOpt, expression, deconstructionOpt, node.AwaitOpt, body, node.Checked, node.BreakLabel, node.ContinueLabel);
         }
 
         public override BoundNode? VisitUsingStatement(BoundUsingStatement node)
         {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            MethodSymbol? disposeMethodOpt = GetUpdatedSymbol(node, node.DisposeMethodOpt);
             BoundMultipleLocalDeclarations? declarationsOpt = (BoundMultipleLocalDeclarations?)this.Visit(node.DeclarationsOpt);
             BoundExpression? expressionOpt = (BoundExpression?)this.Visit(node.ExpressionOpt);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(node.Locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body, node.AwaitOpt, GetUpdatedSymbol(node, node.DisposeMethodOpt));
+            return node.Update(locals, declarationsOpt, expressionOpt, node.IDisposableConversion, body, node.AwaitOpt, disposeMethodOpt);
+        }
+
+        public override BoundNode? VisitFixedStatement(BoundFixedStatement node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            BoundMultipleLocalDeclarations declarations = (BoundMultipleLocalDeclarations)this.Visit(node.Declarations);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(locals, declarations, body);
         }
 
         public override BoundNode? VisitCatchBlock(BoundCatchBlock node)
         {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            TypeSymbol? exceptionTypeOpt = GetUpdatedSymbol(node, node.ExceptionTypeOpt);
             BoundExpression? exceptionSourceOpt = (BoundExpression?)this.Visit(node.ExceptionSourceOpt);
             BoundExpression? exceptionFilterOpt = (BoundExpression?)this.Visit(node.ExceptionFilterOpt);
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
-            return node.Update(node.Locals, exceptionSourceOpt, GetUpdatedSymbol(node, node.ExceptionTypeOpt), exceptionFilterOpt, body, node.IsSynthesizedAsyncCatchAll);
+            return node.Update(locals, exceptionSourceOpt, exceptionTypeOpt, exceptionFilterOpt, body, node.IsSynthesizedAsyncCatchAll);
         }
 
         public override BoundNode? VisitLiteral(BoundLiteral node)
@@ -10955,54 +11089,70 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLocal(BoundLocal node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            LocalSymbol localSymbol = GetUpdatedSymbol(node, node.LocalSymbol);
+            BoundLocal updatedNode;
 
-            BoundLocal updatedNode = node.Update(node.LocalSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(localSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(localSymbol, node.DeclarationKind, node.ConstantValueOpt, node.IsNullableUnknown, node.Type);
+            }
             return updatedNode;
         }
 
         public override BoundNode? VisitPseudoVariable(BoundPseudoVariable node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            LocalSymbol localSymbol = GetUpdatedSymbol(node, node.LocalSymbol);
+            BoundPseudoVariable updatedNode;
 
-            BoundPseudoVariable updatedNode = node.Update(node.LocalSymbol, node.EmitExpressions, infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(localSymbol, node.EmitExpressions, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(localSymbol, node.EmitExpressions, node.Type);
+            }
             return updatedNode;
         }
 
         public override BoundNode? VisitRangeVariable(BoundRangeVariable node)
         {
+            RangeVariableSymbol rangeVariableSymbol = GetUpdatedSymbol(node, node.RangeVariableSymbol);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundRangeVariable updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.RangeVariableSymbol), value, infoAndType.Type);
+                updatedNode = node.Update(rangeVariableSymbol, value, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.RangeVariableSymbol), value, node.Type);
+                updatedNode = node.Update(rangeVariableSymbol, value, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitParameter(BoundParameter node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            ParameterSymbol parameterSymbol = GetUpdatedSymbol(node, node.ParameterSymbol);
+            BoundParameter updatedNode;
 
-            BoundParameter updatedNode = node.Update(GetUpdatedSymbol(node, node.ParameterSymbol), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(parameterSymbol, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(parameterSymbol, node.Type);
+            }
             return updatedNode;
         }
 
@@ -11016,6 +11166,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundLabel updatedNode = node.Update(node.Label, infoAndType.Type);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
+        }
+
+        public override BoundNode? VisitSwitchExpressionArm(BoundSwitchExpressionArm node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
+            BoundExpression? whenClause = (BoundExpression?)this.Visit(node.WhenClause);
+            BoundExpression value = (BoundExpression)this.Visit(node.Value);
+            return node.Update(locals, pattern, whenClause, value, node.Label);
         }
 
         public override BoundNode? VisitUnconvertedSwitchExpression(BoundUnconvertedSwitchExpression node)
@@ -11039,6 +11198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitConvertedSwitchExpression(BoundConvertedSwitchExpression node)
         {
+            TypeSymbol naturalTypeOpt = GetUpdatedSymbol(node, node.NaturalTypeOpt);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundSwitchExpressionArm> switchArms = this.VisitList(node.SwitchArms);
             BoundDecisionDag decisionDag = node.DecisionDag;
@@ -11046,38 +11206,50 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.NaturalTypeOpt), node.WasTargetTyped, expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, infoAndType.Type);
+                updatedNode = node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.NaturalTypeOpt), node.WasTargetTyped, expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.Type);
+                updatedNode = node.Update(naturalTypeOpt, node.WasTargetTyped, expression, switchArms, decisionDag, node.DefaultLabel, node.ReportedNotExhaustive, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitDagDeconstructEvaluation(BoundDagDeconstructEvaluation node)
         {
+            MethodSymbol deconstructMethod = GetUpdatedSymbol(node, node.DeconstructMethod);
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(GetUpdatedSymbol(node, node.DeconstructMethod), input);
+            return node.Update(deconstructMethod, input);
         }
 
         public override BoundNode? VisitDagFieldEvaluation(BoundDagFieldEvaluation node)
         {
+            FieldSymbol field = GetUpdatedSymbol(node, node.Field);
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(GetUpdatedSymbol(node, node.Field), input);
+            return node.Update(field, input);
         }
 
         public override BoundNode? VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node)
         {
+            PropertySymbol property = GetUpdatedSymbol(node, node.Property);
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(GetUpdatedSymbol(node, node.Property), input);
+            return node.Update(property, input);
         }
 
         public override BoundNode? VisitDagIndexEvaluation(BoundDagIndexEvaluation node)
         {
+            PropertySymbol property = GetUpdatedSymbol(node, node.Property);
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
-            return node.Update(GetUpdatedSymbol(node, node.Property), node.Index, input);
+            return node.Update(property, node.Index, input);
+        }
+
+        public override BoundNode? VisitSwitchSection(BoundSwitchSection node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            ImmutableArray<BoundSwitchLabel> switchLabels = this.VisitList(node.SwitchLabels);
+            ImmutableArray<BoundStatement> statements = this.VisitList(node.Statements);
+            return node.Update(locals, switchLabels, statements);
         }
 
         public override BoundNode? VisitSequencePointExpression(BoundSequencePointExpression node)
@@ -11099,36 +11271,38 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitSequence(BoundSequence node)
         {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
             ImmutableArray<BoundExpression> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundSequence updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Locals, sideEffects, value, infoAndType.Type);
+                updatedNode = node.Update(locals, sideEffects, value, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Locals, sideEffects, value, node.Type);
+                updatedNode = node.Update(locals, sideEffects, value, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitSpillSequence(BoundSpillSequence node)
         {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
             ImmutableArray<BoundStatement> sideEffects = this.VisitList(node.SideEffects);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundSpillSequence updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Locals, sideEffects, value, infoAndType.Type);
+                updatedNode = node.Update(locals, sideEffects, value, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Locals, sideEffects, value, node.Type);
+                updatedNode = node.Update(locals, sideEffects, value, node.Type);
             }
             return updatedNode;
         }
@@ -11152,18 +11326,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitDynamicInvocation(BoundDynamicInvocation node)
         {
+            ImmutableArray<MethodSymbol> applicableMethods = GetUpdatedArray(node, node.ApplicableMethods);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundDynamicInvocation updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, GetUpdatedArray(node, node.ApplicableMethods), expression, arguments, infoAndType.Type);
+                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableMethods, expression, arguments, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, GetUpdatedArray(node, node.ApplicableMethods), expression, arguments, node.Type);
+                updatedNode = node.Update(node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableMethods, expression, arguments, node.Type);
             }
             return updatedNode;
         }
@@ -11188,6 +11363,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
+            MethodSymbol? hasValueMethodOpt = GetUpdatedSymbol(node, node.HasValueMethodOpt);
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundExpression whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
             BoundExpression? whenNullOpt = (BoundExpression?)this.Visit(node.WhenNullOpt);
@@ -11195,12 +11371,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, infoAndType.Type);
+                updatedNode = node.Update(receiver, hasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, node.Type);
+                updatedNode = node.Update(receiver, hasValueMethodOpt, whenNotNull, whenNullOpt, node.Id, node.Type);
             }
             return updatedNode;
         }
@@ -11237,106 +11413,115 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitMethodGroup(BoundMethodGroup node)
         {
+            ImmutableArray<MethodSymbol> methods = GetUpdatedArray(node, node.Methods);
+            Symbol? lookupSymbolOpt = GetUpdatedSymbol(node, node.LookupSymbolOpt);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundMethodGroup updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, GetUpdatedArray(node, node.Methods), GetUpdatedSymbol(node, node.LookupSymbolOpt), node.LookupError, node.Flags, receiverOpt, node.ResultKind);
+                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, methods, lookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, GetUpdatedArray(node, node.Methods), GetUpdatedSymbol(node, node.LookupSymbolOpt), node.LookupError, node.Flags, receiverOpt, node.ResultKind);
+                updatedNode = node.Update(node.TypeArgumentsOpt, node.Name, methods, lookupSymbolOpt, node.LookupError, node.Flags, receiverOpt, node.ResultKind);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitPropertyGroup(BoundPropertyGroup node)
         {
+            ImmutableArray<PropertySymbol> properties = GetUpdatedArray(node, node.Properties);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundPropertyGroup updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedArray(node, node.Properties), receiverOpt, node.ResultKind);
+                updatedNode = node.Update(properties, receiverOpt, node.ResultKind);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedArray(node, node.Properties), receiverOpt, node.ResultKind);
+                updatedNode = node.Update(properties, receiverOpt, node.ResultKind);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitCall(BoundCall node)
         {
+            MethodSymbol method = GetUpdatedSymbol(node, node.Method);
+            ImmutableArray<MethodSymbol> originalMethodsOpt = GetUpdatedArray(node, node.OriginalMethodsOpt);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundCall updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Method), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Method), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, node.Type);
+                updatedNode = node.Update(receiverOpt, method, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.IsDelegateCall, node.Expanded, node.InvokedAsExtensionMethod, node.ArgsToParamsOpt, node.ResultKind, node.OriginalMethodsOpt, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
+            EventSymbol @event = GetUpdatedSymbol(node, node.Event);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundEventAssignmentOperator updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Event), node.IsAddition, node.IsDynamic, receiverOpt, argument, infoAndType.Type);
+                updatedNode = node.Update(@event, node.IsAddition, node.IsDynamic, receiverOpt, argument, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Event), node.IsAddition, node.IsDynamic, receiverOpt, argument, node.Type);
+                updatedNode = node.Update(@event, node.IsAddition, node.IsDynamic, receiverOpt, argument, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitAttribute(BoundAttribute node)
         {
+            MethodSymbol? constructor = GetUpdatedSymbol(node, node.Constructor);
             ImmutableArray<BoundExpression> constructorArguments = this.VisitList(node.ConstructorArguments);
             ImmutableArray<BoundExpression> namedArguments = this.VisitList(node.NamedArguments);
             BoundAttribute updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, infoAndType.Type);
+                updatedNode = node.Update(constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, node.Type);
+                updatedNode = node.Update(constructor, constructorArguments, node.ConstructorArgumentNamesOpt, node.ConstructorArgumentsToParamsOpt, node.ConstructorExpanded, namedArguments, node.ResultKind, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitObjectCreationExpression(BoundObjectCreationExpression node)
         {
+            MethodSymbol constructor = GetUpdatedSymbol(node, node.Constructor);
+            ImmutableArray<MethodSymbol> constructorsGroup = GetUpdatedArray(node, node.ConstructorsGroup);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase? initializerExpressionOpt = (BoundObjectInitializerExpressionBase?)this.Visit(node.InitializerExpressionOpt);
             BoundObjectCreationExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), GetUpdatedArray(node, node.ConstructorsGroup), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(constructor, constructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), GetUpdatedArray(node, node.ConstructorsGroup), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, node.Type);
+                updatedNode = node.Update(constructor, constructorsGroup, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ConstantValueOpt, initializerExpressionOpt, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
@@ -11378,18 +11563,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
+            ImmutableArray<MethodSymbol> applicableMethods = GetUpdatedArray(node, node.ApplicableMethods);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerExpressionBase? initializerExpressionOpt = (BoundObjectInitializerExpressionBase?)this.Visit(node.InitializerExpressionOpt);
             BoundDynamicObjectCreationExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, GetUpdatedArray(node, node.ApplicableMethods), infoAndType.Type);
+                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, applicableMethods, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, GetUpdatedArray(node, node.ApplicableMethods), node.Type);
+                updatedNode = node.Update(node.Name, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, initializerExpressionOpt, applicableMethods, node.Type);
             }
             return updatedNode;
         }
@@ -11431,30 +11617,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitObjectInitializerMember(BoundObjectInitializerMember node)
         {
+            Symbol? memberSymbol = GetUpdatedSymbol(node, node.MemberSymbol);
+            TypeSymbol receiverType = GetUpdatedSymbol(node, node.ReceiverType);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundObjectInitializerMember updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.MemberSymbol), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, GetUpdatedSymbol(node, node.ReceiverType), node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(memberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, receiverType, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.MemberSymbol), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, GetUpdatedSymbol(node, node.ReceiverType), node.BinderOpt, node.Type);
+                updatedNode = node.Update(memberSymbol, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.ResultKind, receiverType, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitDynamicObjectInitializerMember(BoundDynamicObjectInitializerMember node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            TypeSymbol receiverType = GetUpdatedSymbol(node, node.ReceiverType);
+            BoundDynamicObjectInitializerMember updatedNode;
 
-            BoundDynamicObjectInitializerMember updatedNode = node.Update(node.MemberName, GetUpdatedSymbol(node, node.ReceiverType), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(node.MemberName, receiverType, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(node.MemberName, receiverType, node.Type);
+            }
             return updatedNode;
         }
 
@@ -11478,36 +11671,38 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitCollectionElementInitializer(BoundCollectionElementInitializer node)
         {
+            MethodSymbol addMethod = GetUpdatedSymbol(node, node.AddMethod);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundExpression? implicitReceiverOpt = (BoundExpression?)this.Visit(node.ImplicitReceiverOpt);
             BoundCollectionElementInitializer updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.AddMethod), arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, infoAndType.Type);
+                updatedNode = node.Update(addMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.AddMethod), arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, node.Type);
+                updatedNode = node.Update(addMethod, arguments, implicitReceiverOpt, node.Expanded, node.ArgsToParamsOpt, node.InvokedAsExtensionMethod, node.ResultKind, node.BinderOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitDynamicCollectionElementInitializer(BoundDynamicCollectionElementInitializer node)
         {
+            ImmutableArray<MethodSymbol> applicableMethods = GetUpdatedArray(node, node.ApplicableMethods);
             BoundExpression expression = (BoundExpression)this.Visit(node.Expression);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundDynamicCollectionElementInitializer updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedArray(node, node.ApplicableMethods), expression, arguments, infoAndType.Type);
+                updatedNode = node.Update(applicableMethods, expression, arguments, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedArray(node, node.ApplicableMethods), expression, arguments, node.Type);
+                updatedNode = node.Update(applicableMethods, expression, arguments, node.Type);
             }
             return updatedNode;
         }
@@ -11526,31 +11721,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitAnonymousObjectCreationExpression(BoundAnonymousObjectCreationExpression node)
         {
+            MethodSymbol constructor = GetUpdatedSymbol(node, node.Constructor);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             ImmutableArray<BoundAnonymousPropertyDeclaration> declarations = this.VisitList(node.Declarations);
             BoundAnonymousObjectCreationExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), arguments, declarations, infoAndType.Type);
+                updatedNode = node.Update(constructor, arguments, declarations, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.Constructor), arguments, declarations, node.Type);
+                updatedNode = node.Update(constructor, arguments, declarations, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitAnonymousPropertyDeclaration(BoundAnonymousPropertyDeclaration node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            PropertySymbol property = GetUpdatedSymbol(node, node.Property);
+            BoundAnonymousPropertyDeclaration updatedNode;
 
-            BoundAnonymousPropertyDeclaration updatedNode = node.Update(GetUpdatedSymbol(node, node.Property), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(property, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(property, node.Type);
+            }
             return updatedNode;
         }
 
@@ -11573,17 +11774,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
         {
+            MethodSymbol? methodOpt = GetUpdatedSymbol(node, node.MethodOpt);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundDelegateCreationExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(argument, GetUpdatedSymbol(node, node.MethodOpt), node.IsExtensionMethod, infoAndType.Type);
+                updatedNode = node.Update(argument, methodOpt, node.IsExtensionMethod, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(argument, GetUpdatedSymbol(node, node.MethodOpt), node.IsExtensionMethod, node.Type);
+                updatedNode = node.Update(argument, methodOpt, node.IsExtensionMethod, node.Type);
             }
             return updatedNode;
         }
@@ -11625,171 +11827,187 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitStackAllocArrayCreation(BoundStackAllocArrayCreation node)
         {
+            TypeSymbol elementType = GetUpdatedSymbol(node, node.ElementType);
             BoundExpression count = (BoundExpression)this.Visit(node.Count);
             BoundArrayInitialization? initializerOpt = (BoundArrayInitialization?)this.Visit(node.InitializerOpt);
             BoundStackAllocArrayCreation updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.ElementType), count, initializerOpt, infoAndType.Type);
+                updatedNode = node.Update(elementType, count, initializerOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.ElementType), count, initializerOpt, node.Type);
+                updatedNode = node.Update(elementType, count, initializerOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitConvertedStackAllocExpression(BoundConvertedStackAllocExpression node)
         {
+            TypeSymbol elementType = GetUpdatedSymbol(node, node.ElementType);
             BoundExpression count = (BoundExpression)this.Visit(node.Count);
             BoundArrayInitialization? initializerOpt = (BoundArrayInitialization?)this.Visit(node.InitializerOpt);
             BoundConvertedStackAllocExpression updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.ElementType), count, initializerOpt, infoAndType.Type);
+                updatedNode = node.Update(elementType, count, initializerOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.ElementType), count, initializerOpt, node.Type);
+                updatedNode = node.Update(elementType, count, initializerOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitFieldAccess(BoundFieldAccess node)
         {
+            FieldSymbol fieldSymbol = GetUpdatedSymbol(node, node.FieldSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundFieldAccess updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.FieldSymbol), node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, fieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.FieldSymbol), node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, node.Type);
+                updatedNode = node.Update(receiverOpt, fieldSymbol, node.ConstantValueOpt, node.ResultKind, node.IsByValue, node.IsDeclaration, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitHoistedFieldAccess(BoundHoistedFieldAccess node)
         {
-            if (!_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
-            {
-                return node;
-            }
+            FieldSymbol fieldSymbol = GetUpdatedSymbol(node, node.FieldSymbol);
+            BoundHoistedFieldAccess updatedNode;
 
-            BoundHoistedFieldAccess updatedNode = node.Update(GetUpdatedSymbol(node, node.FieldSymbol), infoAndType.Type);
-            updatedNode.TopLevelNullability = infoAndType.Info;
+            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
+            {
+                updatedNode = node.Update(fieldSymbol, infoAndType.Type);
+                updatedNode.TopLevelNullability = infoAndType.Info;
+            }
+            else
+            {
+                updatedNode = node.Update(fieldSymbol, node.Type);
+            }
             return updatedNode;
         }
 
         public override BoundNode? VisitPropertyAccess(BoundPropertyAccess node)
         {
+            PropertySymbol propertySymbol = GetUpdatedSymbol(node, node.PropertySymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundPropertyAccess updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.PropertySymbol), node.ResultKind, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, propertySymbol, node.ResultKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.PropertySymbol), node.ResultKind, node.Type);
+                updatedNode = node.Update(receiverOpt, propertySymbol, node.ResultKind, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitEventAccess(BoundEventAccess node)
         {
+            EventSymbol eventSymbol = GetUpdatedSymbol(node, node.EventSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             BoundEventAccess updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.EventSymbol), node.IsUsableAsField, node.ResultKind, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, eventSymbol, node.IsUsableAsField, node.ResultKind, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.EventSymbol), node.IsUsableAsField, node.ResultKind, node.Type);
+                updatedNode = node.Update(receiverOpt, eventSymbol, node.IsUsableAsField, node.ResultKind, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitIndexerAccess(BoundIndexerAccess node)
         {
+            PropertySymbol indexer = GetUpdatedSymbol(node, node.Indexer);
+            ImmutableArray<PropertySymbol> originalIndexersOpt = GetUpdatedArray(node, node.OriginalIndexersOpt);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundIndexerAccess updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Indexer), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, GetUpdatedSymbol(node, node.Indexer), arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, node.Type);
+                updatedNode = node.Update(receiverOpt, indexer, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, node.Expanded, node.ArgsToParamsOpt, node.BinderOpt, node.UseSetterForDefaultArgumentGeneration, node.OriginalIndexersOpt, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitIndexOrRangePatternIndexerAccess(BoundIndexOrRangePatternIndexerAccess node)
         {
+            PropertySymbol lengthOrCountProperty = GetUpdatedSymbol(node, node.LengthOrCountProperty);
+            Symbol patternSymbol = GetUpdatedSymbol(node, node.PatternSymbol);
             BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
             BoundExpression argument = (BoundExpression)this.Visit(node.Argument);
             BoundIndexOrRangePatternIndexerAccess updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.LengthOrCountProperty), GetUpdatedSymbol(node, node.PatternSymbol), argument, infoAndType.Type);
+                updatedNode = node.Update(receiver, lengthOrCountProperty, patternSymbol, argument, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiver, GetUpdatedSymbol(node, node.LengthOrCountProperty), GetUpdatedSymbol(node, node.PatternSymbol), argument, node.Type);
+                updatedNode = node.Update(receiver, lengthOrCountProperty, patternSymbol, argument, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitDynamicIndexerAccess(BoundDynamicIndexerAccess node)
         {
+            ImmutableArray<PropertySymbol> applicableIndexers = GetUpdatedArray(node, node.ApplicableIndexers);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             ImmutableArray<BoundExpression> arguments = this.VisitList(node.Arguments);
             BoundDynamicIndexerAccess updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, GetUpdatedArray(node, node.ApplicableIndexers), infoAndType.Type);
+                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableIndexers, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, GetUpdatedArray(node, node.ApplicableIndexers), node.Type);
+                updatedNode = node.Update(receiverOpt, arguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt, applicableIndexers, node.Type);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitLambda(BoundLambda node)
         {
+            LambdaSymbol symbol = GetUpdatedSymbol(node, node.Symbol);
             UnboundLambda unboundLambda = node.UnboundLambda;
             BoundBlock body = (BoundBlock)this.Visit(node.Body);
             BoundLambda updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(unboundLambda, GetUpdatedSymbol(node, node.Symbol), body, node.Diagnostics, node.Binder, infoAndType.Type);
+                updatedNode = node.Update(unboundLambda, symbol, body, node.Diagnostics, node.Binder, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(unboundLambda, GetUpdatedSymbol(node, node.Symbol), body, node.Diagnostics, node.Binder, node.Type);
+                updatedNode = node.Update(unboundLambda, symbol, body, node.Diagnostics, node.Binder, node.Type);
             }
             return updatedNode;
         }
@@ -11808,6 +12026,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitQueryClause(BoundQueryClause node)
         {
+            RangeVariableSymbol? definedSymbol = GetUpdatedSymbol(node, node.DefinedSymbol);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
             BoundExpression? operation = node.Operation;
             BoundExpression? cast = node.Cast;
@@ -11816,12 +12035,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(value, GetUpdatedSymbol(node, node.DefinedSymbol), operation, cast, node.Binder, unoptimizedForm, infoAndType.Type);
+                updatedNode = node.Update(value, definedSymbol, operation, cast, node.Binder, unoptimizedForm, infoAndType.Type);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(value, GetUpdatedSymbol(node, node.DefinedSymbol), operation, cast, node.Binder, unoptimizedForm, node.Type);
+                updatedNode = node.Update(value, definedSymbol, operation, cast, node.Binder, unoptimizedForm, node.Type);
             }
             return updatedNode;
         }
@@ -11900,41 +12119,52 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitConstantPattern(BoundConstantPattern node)
         {
+            TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
             BoundExpression value = (BoundExpression)this.Visit(node.Value);
-            return node.Update(value, node.ConstantValue, GetUpdatedSymbol(node, node.InputType));
+            return node.Update(value, node.ConstantValue, inputType);
         }
 
         public override BoundNode? VisitDiscardPattern(BoundDiscardPattern node)
         {
-            return node.Update(GetUpdatedSymbol(node, node.InputType));
+            TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
+            return node.Update(inputType);
         }
 
         public override BoundNode? VisitDeclarationPattern(BoundDeclarationPattern node)
         {
+            Symbol? variable = GetUpdatedSymbol(node, node.Variable);
+            TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             BoundTypeExpression? declaredType = (BoundTypeExpression?)this.Visit(node.DeclaredType);
-            return node.Update(GetUpdatedSymbol(node, node.Variable), variableAccess, declaredType, node.IsVar, GetUpdatedSymbol(node, node.InputType));
+            return node.Update(variable, variableAccess, declaredType, node.IsVar, inputType);
         }
 
         public override BoundNode? VisitRecursivePattern(BoundRecursivePattern node)
         {
+            MethodSymbol? deconstructMethod = GetUpdatedSymbol(node, node.DeconstructMethod);
+            Symbol? variable = GetUpdatedSymbol(node, node.Variable);
+            TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
             BoundTypeExpression? declaredType = (BoundTypeExpression?)this.Visit(node.DeclaredType);
             ImmutableArray<BoundSubpattern> deconstruction = this.VisitList(node.Deconstruction);
             ImmutableArray<BoundSubpattern> properties = this.VisitList(node.Properties);
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
-            return node.Update(declaredType, GetUpdatedSymbol(node, node.DeconstructMethod), deconstruction, properties, GetUpdatedSymbol(node, node.Variable), variableAccess, GetUpdatedSymbol(node, node.InputType));
+            return node.Update(declaredType, deconstructMethod, deconstruction, properties, variable, variableAccess, inputType);
         }
 
         public override BoundNode? VisitITuplePattern(BoundITuplePattern node)
         {
+            MethodSymbol getLengthMethod = GetUpdatedSymbol(node, node.GetLengthMethod);
+            MethodSymbol getItemMethod = GetUpdatedSymbol(node, node.GetItemMethod);
+            TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
             ImmutableArray<BoundSubpattern> subpatterns = this.VisitList(node.Subpatterns);
-            return node.Update(GetUpdatedSymbol(node, node.GetLengthMethod), GetUpdatedSymbol(node, node.GetItemMethod), subpatterns, GetUpdatedSymbol(node, node.InputType));
+            return node.Update(getLengthMethod, getItemMethod, subpatterns, inputType);
         }
 
         public override BoundNode? VisitSubpattern(BoundSubpattern node)
         {
+            Symbol? symbol = GetUpdatedSymbol(node, node.Symbol);
             BoundPattern pattern = (BoundPattern)this.Visit(node.Pattern);
-            return node.Update(GetUpdatedSymbol(node, node.Symbol), pattern);
+            return node.Update(symbol, pattern);
         }
 
         public override BoundNode? VisitDiscardExpression(BoundDiscardExpression node)
@@ -11968,34 +12198,36 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode? VisitOutVariablePendingInference(OutVariablePendingInference node)
         {
+            Symbol variableSymbol = GetUpdatedSymbol(node, node.VariableSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             OutVariablePendingInference updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
+                updatedNode = node.Update(variableSymbol, receiverOpt);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
+                updatedNode = node.Update(variableSymbol, receiverOpt);
             }
             return updatedNode;
         }
 
         public override BoundNode? VisitDeconstructionVariablePendingInference(DeconstructionVariablePendingInference node)
         {
+            Symbol variableSymbol = GetUpdatedSymbol(node, node.VariableSymbol);
             BoundExpression? receiverOpt = (BoundExpression?)this.Visit(node.ReceiverOpt);
             DeconstructionVariablePendingInference updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol Type) infoAndType))
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
+                updatedNode = node.Update(variableSymbol, receiverOpt);
                 updatedNode.TopLevelNullability = infoAndType.Info;
             }
             else
             {
-                updatedNode = node.Update(GetUpdatedSymbol(node, node.VariableSymbol), receiverOpt);
+                updatedNode = node.Update(variableSymbol, receiverOpt);
             }
             return updatedNode;
         }
@@ -12010,6 +12242,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             OutDeconstructVarPendingInference updatedNode = node.Update();
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
+        }
+
+        public override BoundNode? VisitConstructorMethodBody(BoundConstructorMethodBody node)
+        {
+            ImmutableArray<LocalSymbol> locals = GetUpdatedArray(node, node.Locals);
+            BoundExpressionStatement? initializer = (BoundExpressionStatement?)this.Visit(node.Initializer);
+            BoundBlock? blockBody = (BoundBlock?)this.Visit(node.BlockBody);
+            BoundBlock? expressionBody = (BoundBlock?)this.Visit(node.ExpressionBody);
+            return node.Update(locals, initializer, blockBody, expressionBody);
         }
 
         public override BoundNode? VisitExpressionWithNullability(BoundExpressionWithNullability node)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -375,13 +375,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if ((object)this == symbol) return true;
 
-            var lambda = symbol as LambdaSymbol;
-            return (object)lambda != null
+            return symbol is LambdaSymbol lambda
                 && lambda._syntax == _syntax
                 && lambda._refKind == _refKind
                 && TypeSymbol.Equals(lambda.ReturnType, this.ReturnType, compareKind)
-                && System.Linq.ImmutableArrayExtensions.SequenceEqual(lambda.ParameterTypesWithAnnotations, this.ParameterTypesWithAnnotations, (p1, p2) => p1.Type.Equals(p2.Type))
-                && Equals(lambda.ContainingSymbol, this.ContainingSymbol);
+                && ParameterTypesWithAnnotations.SequenceEqual(lambda.ParameterTypesWithAnnotations, compareKind,
+                                                               (p1, p2, compareKind) => p1.Equals(p2, compareKind))
+                && lambda.ContainingSymbol.Equals(ContainingSymbol, compareKind);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class UpdatedContainingSymbolAndNullableAnnotationLocal : LocalSymbol
+    {
+        internal UpdatedContainingSymbolAndNullableAnnotationLocal(SourceLocalSymbol underlyingLocal, Symbol updatedContainingSymbol, TypeWithAnnotations updatedType)
+        {
+            Debug.Assert(underlyingLocal is object);
+            Debug.Assert(updatedContainingSymbol is object);
+            UnderlyingLocal = underlyingLocal;
+            ContainingSymbol = updatedContainingSymbol;
+            TypeWithAnnotations = updatedType;
+        }
+
+        private SourceLocalSymbol UnderlyingLocal { get; }
+        public override Symbol ContainingSymbol { get; }
+        public override TypeWithAnnotations TypeWithAnnotations { get; }
+
+        public override bool Equals(Symbol other, TypeCompareKind compareKind)
+        {
+            if (other == (object)this)
+            {
+                return true;
+            }
+
+            if (!(other is LocalSymbol otherLocal))
+            {
+                return false;
+            }
+
+            SourceLocalSymbol? otherSource = otherLocal switch
+            {
+                UpdatedContainingSymbolAndNullableAnnotationLocal updated => updated.UnderlyingLocal,
+                SourceLocalSymbol source => source,
+                _ => null
+            };
+
+            if (otherSource is null || !UnderlyingLocal.Equals(otherSource, compareKind))
+            {
+                return false;
+            }
+
+            var ignoreNullable = (compareKind & TypeCompareKind.AllNullableIgnoreOptions) != 0;
+            return ignoreNullable ||
+                (TypeWithAnnotations.Equals(otherLocal.TypeWithAnnotations, compareKind) &&
+                 ContainingSymbol.Equals(otherLocal.ContainingSymbol, compareKind));
+        }
+
+        // The default equality for symbols does not include nullability, so we directly
+        // delegate to the underlying local for its hashcode, as neither TypeWithAnnotations
+        // nor ContainingSymbol will differ from UnderlyingLocal by more than nullability.
+        public override int GetHashCode() => UnderlyingLocal.GetHashCode();
+
+        #region Forwards
+        public override RefKind RefKind => UnderlyingLocal.RefKind;
+        public override ImmutableArray<Location> Locations => UnderlyingLocal.Locations;
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => UnderlyingLocal.DeclaringSyntaxReferences;
+        public override string Name => UnderlyingLocal.Name;
+        public override bool IsImplicitlyDeclared => UnderlyingLocal.IsImplicitlyDeclared;
+        internal override LocalDeclarationKind DeclarationKind => UnderlyingLocal.DeclarationKind;
+        internal override SynthesizedLocalKind SynthesizedKind => UnderlyingLocal.SynthesizedKind;
+        internal override SyntaxNode ScopeDesignatorOpt => UnderlyingLocal.ScopeDesignatorOpt;
+        internal override bool IsImportedFromMetadata => UnderlyingLocal.IsImportedFromMetadata;
+        internal override SyntaxToken IdentifierToken => UnderlyingLocal.IdentifierToken;
+        internal override bool IsPinned => UnderlyingLocal.IsPinned;
+        internal override bool IsCompilerGenerated => UnderlyingLocal.IsCompilerGenerated;
+        internal override uint RefEscapeScope => UnderlyingLocal.RefEscapeScope;
+        internal override uint ValEscapeScope => UnderlyingLocal.ValEscapeScope;
+        internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag? diagnostics = null) =>
+            UnderlyingLocal.GetConstantValue(node, inProgress, diagnostics);
+        internal override ImmutableArray<Diagnostic> GetConstantValueDiagnostics(BoundExpression boundInitValue) =>
+            UnderlyingLocal.GetConstantValueDiagnostics(boundInitValue);
+        internal override SyntaxNode GetDeclaratorSyntax() =>
+            UnderlyingLocal.GetDeclaratorSyntax();
+        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax) =>
+            throw ExceptionUtilities.Unreachable;
+        #endregion
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -9,14 +9,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class UpdatedContainingSymbolAndNullableAnnotationLocal : LocalSymbol
     {
-        internal UpdatedContainingSymbolAndNullableAnnotationLocal(SourceLocalSymbol underlyingLocal, Symbol updatedContainingSymbol, TypeWithAnnotations updatedType)
+        /// <summary>
+        /// Creates a new <see cref="UpdatedContainingSymbolAndNullableAnnotationLocal"/> for testing purposes,
+        /// which does not verify that the containing symbol matches the original containing symbol.
+        /// </summary>
+        internal static UpdatedContainingSymbolAndNullableAnnotationLocal CreateForTest(SourceLocalSymbol underlyingLocal, Symbol updatedContainingSymbol, TypeWithAnnotations updatedType)
+        {
+            return new UpdatedContainingSymbolAndNullableAnnotationLocal(underlyingLocal, updatedContainingSymbol, updatedType, assertContaining: false);
+        }
+
+        private UpdatedContainingSymbolAndNullableAnnotationLocal(SourceLocalSymbol underlyingLocal, Symbol updatedContainingSymbol, TypeWithAnnotations updatedType, bool assertContaining)
         {
             Debug.Assert(underlyingLocal is object);
             Debug.Assert(updatedContainingSymbol is object);
-            Debug.Assert(updatedContainingSymbol.Equals(underlyingLocal.ContainingSymbol, TypeCompareKind.AllNullableIgnoreOptions));
-            _underlyingLocal = underlyingLocal;
+            Debug.Assert(!assertContaining || updatedContainingSymbol.Equals(underlyingLocal.ContainingSymbol, TypeCompareKind.AllNullableIgnoreOptions));
             ContainingSymbol = updatedContainingSymbol;
             TypeWithAnnotations = updatedType;
+            _underlyingLocal = underlyingLocal;
+        }
+
+        internal UpdatedContainingSymbolAndNullableAnnotationLocal(SourceLocalSymbol underlyingLocal, Symbol updatedContainingSymbol, TypeWithAnnotations updatedType)
+            : this(underlyingLocal, updatedContainingSymbol, updatedType, assertContaining: true)
+        {
         }
 
         private readonly SourceLocalSymbol _underlyingLocal;

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -13,12 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(underlyingLocal is object);
             Debug.Assert(updatedContainingSymbol is object);
-            UnderlyingLocal = underlyingLocal;
+            Debug.Assert(updatedContainingSymbol.Equals(underlyingLocal.ContainingSymbol, TypeCompareKind.AllNullableIgnoreOptions));
+            _underlyingLocal = underlyingLocal;
             ContainingSymbol = updatedContainingSymbol;
             TypeWithAnnotations = updatedType;
         }
 
-        private SourceLocalSymbol UnderlyingLocal { get; }
+        private readonly SourceLocalSymbol _underlyingLocal;
         public override Symbol ContainingSymbol { get; }
         public override TypeWithAnnotations TypeWithAnnotations { get; }
 
@@ -36,12 +37,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             SourceLocalSymbol? otherSource = otherLocal switch
             {
-                UpdatedContainingSymbolAndNullableAnnotationLocal updated => updated.UnderlyingLocal,
+                UpdatedContainingSymbolAndNullableAnnotationLocal updated => updated._underlyingLocal,
                 SourceLocalSymbol source => source,
                 _ => null
             };
 
-            if (otherSource is null || !UnderlyingLocal.Equals(otherSource, compareKind))
+            if (otherSource is null || !_underlyingLocal.Equals(otherSource, compareKind))
             {
                 return false;
             }
@@ -55,29 +56,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // The default equality for symbols does not include nullability, so we directly
         // delegate to the underlying local for its hashcode, as neither TypeWithAnnotations
         // nor ContainingSymbol will differ from UnderlyingLocal by more than nullability.
-        public override int GetHashCode() => UnderlyingLocal.GetHashCode();
+        public override int GetHashCode() => _underlyingLocal.GetHashCode();
 
         #region Forwards
-        public override RefKind RefKind => UnderlyingLocal.RefKind;
-        public override ImmutableArray<Location> Locations => UnderlyingLocal.Locations;
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => UnderlyingLocal.DeclaringSyntaxReferences;
-        public override string Name => UnderlyingLocal.Name;
-        public override bool IsImplicitlyDeclared => UnderlyingLocal.IsImplicitlyDeclared;
-        internal override LocalDeclarationKind DeclarationKind => UnderlyingLocal.DeclarationKind;
-        internal override SynthesizedLocalKind SynthesizedKind => UnderlyingLocal.SynthesizedKind;
-        internal override SyntaxNode ScopeDesignatorOpt => UnderlyingLocal.ScopeDesignatorOpt;
-        internal override bool IsImportedFromMetadata => UnderlyingLocal.IsImportedFromMetadata;
-        internal override SyntaxToken IdentifierToken => UnderlyingLocal.IdentifierToken;
-        internal override bool IsPinned => UnderlyingLocal.IsPinned;
-        internal override bool IsCompilerGenerated => UnderlyingLocal.IsCompilerGenerated;
-        internal override uint RefEscapeScope => UnderlyingLocal.RefEscapeScope;
-        internal override uint ValEscapeScope => UnderlyingLocal.ValEscapeScope;
+        public override RefKind RefKind => _underlyingLocal.RefKind;
+        public override ImmutableArray<Location> Locations => _underlyingLocal.Locations;
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _underlyingLocal.DeclaringSyntaxReferences;
+        public override string Name => _underlyingLocal.Name;
+        public override bool IsImplicitlyDeclared => _underlyingLocal.IsImplicitlyDeclared;
+        internal override LocalDeclarationKind DeclarationKind => _underlyingLocal.DeclarationKind;
+        internal override SynthesizedLocalKind SynthesizedKind => _underlyingLocal.SynthesizedKind;
+        internal override SyntaxNode ScopeDesignatorOpt => _underlyingLocal.ScopeDesignatorOpt;
+        internal override bool IsImportedFromMetadata => _underlyingLocal.IsImportedFromMetadata;
+        internal override SyntaxToken IdentifierToken => _underlyingLocal.IdentifierToken;
+        internal override bool IsPinned => _underlyingLocal.IsPinned;
+        internal override bool IsCompilerGenerated => _underlyingLocal.IsCompilerGenerated;
+        internal override uint RefEscapeScope => _underlyingLocal.RefEscapeScope;
+        internal override uint ValEscapeScope => _underlyingLocal.ValEscapeScope;
         internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, DiagnosticBag? diagnostics = null) =>
-            UnderlyingLocal.GetConstantValue(node, inProgress, diagnostics);
+            _underlyingLocal.GetConstantValue(node, inProgress, diagnostics);
         internal override ImmutableArray<Diagnostic> GetConstantValueDiagnostics(BoundExpression boundInitValue) =>
-            UnderlyingLocal.GetConstantValueDiagnostics(boundInitValue);
+            _underlyingLocal.GetConstantValueDiagnostics(boundInitValue);
         internal override SyntaxNode GetDeclaratorSyntax() =>
-            UnderlyingLocal.GetDeclaratorSyntax();
+            _underlyingLocal.GetDeclaratorSyntax();
         internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax) =>
             throw ExceptionUtilities.Unreachable;
         #endregion

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UpdatedContainingSymbolAndNullableAnntotationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UpdatedContainingSymbolAndNullableAnntotationTests.cs
@@ -35,9 +35,9 @@ class C
             // Using a different method as the parent is an accurate enough simulation for these tests of equality.
             var m2 = (Symbol)model.GetDeclaredSymbol(root.DescendantNodes().OfType<MethodDeclarationSyntax>().ElementAt(1));
 
-            var wrappedLocal1 = new UpdatedContainingSymbolAndNullableAnnotationLocal(local1, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.Annotated));
-            var wrappedLocal1a = new UpdatedContainingSymbolAndNullableAnnotationLocal(local1, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.Annotated));
-            var wrappedLocal2 = new UpdatedContainingSymbolAndNullableAnnotationLocal(local2, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.NotAnnotated));
+            var wrappedLocal1 = UpdatedContainingSymbolAndNullableAnnotationLocal.CreateForTest(local1, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.Annotated));
+            var wrappedLocal1a = UpdatedContainingSymbolAndNullableAnnotationLocal.CreateForTest(local1, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.Annotated));
+            var wrappedLocal2 = UpdatedContainingSymbolAndNullableAnnotationLocal.CreateForTest(local2, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.NotAnnotated));
 
             assertEquality(local1, local1, nullableIgnored: true, considerEverything: true);
             assertEquality(local1, wrappedLocal1, nullableIgnored: true, considerEverything: false);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UpdatedContainingSymbolAndNullableAnntotationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UpdatedContainingSymbolAndNullableAnntotationTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class UpdatedContainingSymbolAndNullableAnntotationTests : CSharpTestBase
+    {
+        [Fact]
+        public void LocalSymbols()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        object local1;
+        object? local2;
+    }
+
+    void M2() {}
+}";
+
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+            var varDeclarators = root.DescendantNodes().OfType<VariableDeclaratorSyntax>();
+
+            var local1 = (SourceLocalSymbol)model.GetDeclaredSymbol(varDeclarators.First());
+            var local2 = (SourceLocalSymbol)model.GetDeclaredSymbol(varDeclarators.ElementAt(1));
+            // Using a different method as the parent is an accurate enough simulation for these tests of equality.
+            var m2 = (Symbol)model.GetDeclaredSymbol(root.DescendantNodes().OfType<MethodDeclarationSyntax>().ElementAt(1));
+
+            var wrappedLocal1 = new UpdatedContainingSymbolAndNullableAnnotationLocal(local1, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.Annotated));
+            var wrappedLocal1a = new UpdatedContainingSymbolAndNullableAnnotationLocal(local1, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.Annotated));
+            var wrappedLocal2 = new UpdatedContainingSymbolAndNullableAnnotationLocal(local2, m2, TypeWithAnnotations.Create(local1.Type, NullableAnnotation.NotAnnotated));
+
+            assertEquality(local1, local1, nullableIgnored: true, considerEverything: true);
+            assertEquality(local1, wrappedLocal1, nullableIgnored: true, considerEverything: false);
+            assertEquality(local1, local2, nullableIgnored: false, considerEverything: false);
+            assertEquality(wrappedLocal1, local2, nullableIgnored: false, considerEverything: false);
+            assertEquality(wrappedLocal1, wrappedLocal2, nullableIgnored: false, considerEverything: false);
+            assertEquality(wrappedLocal1, wrappedLocal1, nullableIgnored: true, considerEverything: true);
+            assertEquality(wrappedLocal1, wrappedLocal1a, nullableIgnored: true, considerEverything: true);
+
+            void assertEquality(Symbol symbol1, Symbol symbol2, bool nullableIgnored, bool considerEverything)
+            {
+                Assert.Equal(nullableIgnored, symbol1.Equals(symbol2));
+                Assert.Equal(nullableIgnored, symbol2.Equals(symbol1));
+
+                if (nullableIgnored)
+                {
+                    Assert.Equal(symbol1.GetHashCode(), symbol2.GetHashCode());
+                }
+
+                Assert.Equal(nullableIgnored, symbol1.Equals(symbol2, TypeCompareKind.AllNullableIgnoreOptions));
+                Assert.Equal(nullableIgnored, symbol2.Equals(symbol1, TypeCompareKind.AllNullableIgnoreOptions));
+
+                Assert.Equal(considerEverything, symbol1.Equals(symbol2, TypeCompareKind.ConsiderEverything2));
+                Assert.Equal(considerEverything, symbol2.Equals(symbol1, TypeCompareKind.ConsiderEverything2));
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UpdatedContainingSymbolAndNullableAnntotationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UpdatedContainingSymbolAndNullableAnntotationTests.cs
@@ -49,6 +49,10 @@ class C
 
             void assertEquality(Symbol symbol1, Symbol symbol2, bool nullableIgnored, bool considerEverything)
             {
+                if (considerEverything)
+                {
+                    Assert.True(nullableIgnored, "If considerEverything is true, nullableIgnored should be true as well.");
+                }
                 Assert.Equal(nullableIgnored, symbol1.Equals(symbol2));
                 Assert.Equal(nullableIgnored, symbol2.Equals(symbol1));
 

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -571,5 +571,35 @@ namespace Microsoft.CodeAnalysis
         {
             return items.IsEmpty ? Location.None : items[0];
         }
+
+        internal static bool SequenceEqual<TElement, TArg>(this ImmutableArray<TElement> array1, ImmutableArray<TElement> array2, TArg arg, Func<TElement, TElement, TArg, bool> predicate)
+        {
+            // The framework implementation of SequenceEqual forces a NullRef for default array1 and 2, so we
+            // maintain the same behavior in this extension
+            if (array1.IsDefault)
+            {
+                throw new NullReferenceException();
+            }
+
+            if (array2.IsDefault)
+            {
+                throw new NullReferenceException();
+            }
+
+            if (array1.Length != array2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < array1.Length; i++)
+            {
+                if (!predicate(array1[i], array2[i], arg))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameTagProducerTests.vb
@@ -699,7 +699,7 @@ class C
             End Using
         End Function
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/38555")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/29483")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Async Function VisualBasic_FixupSpanDuringResolvableConflict_NonReferenceConflict() As Task
             Using workspace = CreateWorkspaceWithWaiter(
@@ -1355,7 +1355,7 @@ namespace N
             End Using
         End Function
 
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/38555")>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/29483")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(8334, "https://github.com/dotnet/roslyn/issues/8334")>
         Public Async Function CSharp_FixupSpanDuringResolvableConflict_ComplexificationReordersReferenceSpans() As Task


### PR DESCRIPTION
We now support exposing reinferred lambda symbols via GetSymbolInfo. As part of this, we have to recreate any local or parameter symbols who's `ContainingSymbol` would have been the original lambda symbol. As part of that, I've created a simple reinferred variable tracker as part of the NullableWalker, that is mutable inside a single pass of the walker and has a hierarchy of previous passes. SemanticModel will now use this for getting reinferred local symbols instead of recreating the symbols itself. @dotnet/roslyn-compiler for review.

Closes https://github.com/dotnet/roslyn/issues/38555 by linking to the original bug, and skips a new test.