### PR TITLE
Allow selection in move type to file

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
@@ -79,6 +79,40 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_AvailableIncludingDocumentationCommentAndHeader()
+        {
+            var code =
+@"namespace N1
+{
+    [|/// <summary>
+    /// Documentation comment.
+    /// </summary>
+    class Class1|]
+    {
+    }
+}";
+            await TestActionCountAsync(code, count: 2);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_AvailableIncludingDocumentationCommentAndAttributeAndHeader()
+        {
+            var code =
+@"using System;
+namespace N1
+{
+    [|/// <summary>
+    /// Documentation comment.
+    /// </summary>
+    [Obsolete]
+    class Class1|]
+    {
+    }
+}";
+            await TestActionCountAsync(code, count: 2);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
         public async Task MoveType_NotAvailableBeforeType()
         {
             var code =
@@ -121,6 +155,73 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
     }
 
     [|class test1|]
+    {
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableAroundDocumentationCommentAboveHeader()
+        {
+            var code =
+@"namespace N1
+{
+    [|/// <summary>
+    /// Documentation comment.
+    /// </summary>|]
+    class Class1
+    {
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableAroundAttributeAboveHeader()
+        {
+            var code =
+@"using System;
+namespace N1
+{
+    [|[Obsolete]|]
+    class Class1
+    {
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableAroundDocumentationCommentAndAttributeAboveHeader()
+        {
+            var code =
+@"using System;
+namespace N1
+{
+    [|/// <summary>
+    /// Documentation comment.
+    /// </summary>
+    [Obsolete]|]
+    class Class1
+    {
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableInsideDocumentationCommentAndAttributeAboveHeader()
+        {
+            var code =
+@"using System;
+namespace N1
+{
+    /// <summary>
+    /// [|Documentation comment.
+    /// </summary>
+    [Obso|]lete]
+    class Class1
     {
     }
 }";

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MoveType_MissingNotOnHeader1()
+        public async Task MoveType_AvailableBeforeHeader()
         {
             var code =
 @"namespace N1
@@ -34,11 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
     {
     }
 }";
-            await TestMissingInRegularAndScriptAsync(code);
+            await TestActionCountAsync(code, count: 2);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MoveType_MissingNotOnHeader2()
+        public async Task MoveType_AvailableBeforeAttributeOnHeader()
         {
             var code =
 @"namespace N1
@@ -48,17 +48,80 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
     {
     }
 }";
-            await TestMissingInRegularAndScriptAsync(code);
+            await TestActionCountAsync(code, count: 2);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MoveType_MissingNotOnHeader3()
+        public async Task MoveType_AvailableOnHeaderIncludingWhitespaceAndAttribute()
+        {
+            var code =
+@"namespace N1
+{[|
+    [X]
+    class Class1
+    {|]
+    }
+}";
+            await TestActionCountAsync(code, count: 2);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_AvailableAfterHeader()
         {
             var code =
 @"namespace N1
 {
     class Class1
     [||]{
+    }
+}";
+            await TestActionCountAsync(code, count: 2);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableBeforeType()
+        {
+            var code =
+@"[|namespace N1
+{|]
+    class Class1
+    {
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableInsideType()
+        {
+            var code =
+@"namespace N1
+{
+    class Class1
+    {[|
+        void M()
+        {
+        }|]
+    }
+}";
+            await TestMissingInRegularAndScriptAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_NotAvailableAfterType()
+        {
+            var code =
+@"namespace N1
+{
+    class Class1
+    {
+        void M()
+        {
+        }
+    }
+
+    [|class test1|]
+    {
     }
 }";
             await TestMissingInRegularAndScriptAsync(code);

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 @"[|clas|]s Class1 { }
  class Class2 { }";
 
-            await TestMissingInRegularAndScriptAsync(code);
+            await TestActionCountAsync(code, count: 3);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
@@ -99,7 +99,7 @@ class Class2 { }
 @"[|class Class1|] { }
 class Class2 { }";
 
-            await TestMissingInRegularAndScriptAsync(code);
+            await TestActionCountAsync(code, count: 3);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.vb
@@ -17,6 +17,109 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithDefinitionSelected() As Task
+            Dim code =
+<File>
+[|Class Class1|]
+End Class
+</File>.ConvertTestSourceTag()
+
+            'Fixes offered will be rename type to match file, rename file to match type.
+            Await TestActionCountAsync(code, count:=2)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithDefinitionAndAttributeSelected() As Task
+            Dim code =
+"[|<Obsolete>
+Class Class1
+|]
+End Class"
+
+            'Fixes offered will be rename type to match file, rename file to match type.
+            Await TestActionCountAsync(code, count:=2)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithDefinitionAndCommentSelected() As Task
+            Dim code =
+"[|''' <summary>
+''' 
+''' </summary>
+Class Class1
+|]
+End Class"
+
+            'Fixes offered will be rename type to match file, rename file to match type.
+            Await TestActionCountAsync(code, count:=2)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithDefinitionAndAttributeAndCommentSelected() As Task
+            Dim code =
+"[|''' <summary>
+''' 
+''' </summary>
+<Obsolete>
+Class Class1
+|]
+End Class"
+
+            'Fixes offered will be rename type to match file, rename file to match type.
+            Await TestActionCountAsync(code, count:=2)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_InsideClassSelected() As Task
+            Dim code =
+<File>
+Class Class1
+[|
+    Sub Something()
+    End Sub|]
+End Class
+</File>.ConvertTestSourceTag()
+
+            Await TestActionCountAsync(code, count:=0)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithAttributeSelected() As Task
+            Dim code =
+"[|<Obsolete>|]
+Class Class1
+End Class"
+
+            Await TestActionCountAsync(code, count:=0)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithCommentSelected() As Task
+            Dim code =
+"[|''' <summary>
+''' 
+''' </summary>|]
+Class Class1
+End Class"
+
+            Await TestActionCountAsync(code, count:=0)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_WithAttributeAndCommentSelected() As Task
+            Dim code =
+"[|''' <summary>
+''' 
+''' </summary>
+<Obsolete>|]
+Class Class1
+End Class"
+
+            Await TestActionCountAsync(code, count:=0)
+        End Function
+
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
         Public Async Function MoveType_ActionCounts_MoveOnly() As Task
             Dim code =
 <File>

--- a/src/Features/CSharp/Portable/CodeRefactorings/MoveType/CSharpMoveTypeService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/MoveType/CSharpMoveTypeService.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeRefactorings.MoveType;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.MoveType
 {
@@ -15,5 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.MoveType
         public CSharpMoveTypeService()
         {
         }
+
+        protected override async Task<BaseTypeDeclarationSyntax> GetRelevantNodeAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+            => await document.TryGetRelevantNodeAsync<BaseTypeDeclarationSyntax>(textSpan, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             public string TypeName { get; set; }
             public string DocumentNameWithoutExtension { get; set; }
             public bool IsDocumentNameAValidIdentifier { get; set; }
-            public bool IsSelectionOnTypeHeader { get; set; }
 
             private State(SemanticDocument document)
             {
@@ -28,10 +27,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 
             internal static State Generate(
                 SemanticDocument document, TTypeDeclarationSyntax typeDeclaration,
-                bool isSelectionOnTypeHeader, CancellationToken cancellationToken)
+                CancellationToken cancellationToken)
             {
                 var state = new State(document);
-                if (!state.TryInitialize(typeDeclaration, isSelectionOnTypeHeader, cancellationToken))
+                if (!state.TryInitialize(typeDeclaration, cancellationToken))
                 {
                     return null;
                 }
@@ -41,7 +40,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 
             private bool TryInitialize(
                 TTypeDeclarationSyntax typeDeclaration,
-                bool isSelectionOnTypeHeader,
                 CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -65,7 +63,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 
                 TypeNode = typeDeclaration;
                 TypeName = typeSymbol.Name;
-                IsSelectionOnTypeHeader = isSelectionOnTypeHeader;
                 DocumentNameWithoutExtension = Path.GetFileNameWithoutExtension(SemanticDocument.Document.Name);
                 IsDocumentNameAValidIdentifier = syntaxFacts.IsValidIdentifier(DocumentNameWithoutExtension);
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
@@ -71,11 +71,11 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             return modifiedSolution ?? document.Project.Solution;
         }
 
+        protected abstract Task<TTypeDeclarationSyntax> GetRelevantNodeAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+
         private async Task<State> CreateStateAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            var nodeToAnalyze = await document.TryGetRelevantNodeAsync<TTypeDeclarationSyntax>(textSpan, cancellationToken).ConfigureAwait(false);
+            var nodeToAnalyze = await GetRelevantNodeAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
             if (nodeToAnalyze == null)
             {
                 return null;
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             TopLevelTypeDeclarations(root).Skip(1).Any();
 
         private static IEnumerable<TTypeDeclarationSyntax> TopLevelTypeDeclarations(SyntaxNode root) =>
-            root.DescendantNodes(n => (n is TCompilationUnitSyntax || n is TNamespaceDeclarationSyntax))
+            root.DescendantNodes(n => n is TCompilationUnitSyntax || n is TNamespaceDeclarationSyntax)
                 .OfType<TTypeDeclarationSyntax>();
 
         private bool AnyTopLevelTypeMatchesDocumentName(State state, CancellationToken cancellationToken)

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/MoveType/VisualBasicMoveTypeService.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/MoveType/VisualBasicMoveTypeService.vb
@@ -1,8 +1,11 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Composition
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveType
@@ -13,5 +16,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveType
         <ImportingConstructor>
         Public Sub New()
         End Sub
+
+        Protected Overrides Async Function GetRelevantNodeAsync(document As Document, textSpan As TextSpan, cancellationToken As CancellationToken) As Task(Of TypeBlockSyntax)
+            Dim someThing As TypeStatementSyntax = Await document.TryGetRelevantNodeAsync(Of TypeStatementSyntax)(textSpan, cancellationToken).ConfigureAwait(False)
+            Return TryCast(someThing?.Parent, TypeBlockSyntax)
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/MoveType/VisualBasicMoveTypeService.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/MoveType/VisualBasicMoveTypeService.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveType
         End Sub
 
         Protected Overrides Async Function GetRelevantNodeAsync(document As Document, textSpan As TextSpan, cancellationToken As CancellationToken) As Task(Of TypeBlockSyntax)
-            Dim someThing As TypeStatementSyntax = Await document.TryGetRelevantNodeAsync(Of TypeStatementSyntax)(textSpan, cancellationToken).ConfigureAwait(False)
-            Return TryCast(someThing?.Parent, TypeBlockSyntax)
+            Dim typeStatement As TypeStatementSyntax = Await document.TryGetRelevantNodeAsync(Of TypeStatementSyntax)(textSpan, cancellationToken).ConfigureAwait(False)
+            Return TryCast(typeStatement?.Parent, TypeBlockSyntax)
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Currently, move type to file only works if you put the caret in the type name.  So use the new refactoring helpers to define the span where move type to file should be offered.