### PR TITLE
Enable more xUnit analyzer rules

### DIFF
--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -146,7 +146,6 @@
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="Xunit.Analyzers">
     <Rule Id="xUnit1004" Action="None" /> <!-- allow skipped tests -->
     <Rule Id="xUnit2000" Action="None" /> <!-- "literal or constant value should be first in Assert.Equal" is a valid assert, but very noisy. Will do the refactoring later -->
-    <Rule Id="xUnit2003" Action="None" /> <!-- "do not use Assert.Equal for null value" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2004" Action="None" /> <!-- "do not use Assert.Equal for boolean conditions" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2006" Action="None" /> <!-- "do not use generic Assert.Equal to test string equality" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2007" Action="None" /> <!-- "do not use Assert.IsType(typeof...)" is a valid assert, but very noisy right now -->

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -145,7 +145,6 @@
   </Rules>
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="Xunit.Analyzers">
     <Rule Id="xUnit1004" Action="None" /> <!-- allow skipped tests -->
-    <Rule Id="xUnit2000" Action="None" /> <!-- "literal or constant value should be first in Assert.Equal" is a valid assert, but very noisy. Will do the refactoring later -->
     <Rule Id="xUnit2006" Action="None" /> <!-- "do not use generic Assert.Equal to test string equality" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2009" Action="None" /> <!-- "do not use Assert.True to check for substrings" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2012" Action="None" /> <!-- "do not use Enumerable.Any() to check if a value exists in a collection" is a valid assert, but very noisy right now -->

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -146,7 +146,6 @@
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="Xunit.Analyzers">
     <Rule Id="xUnit1004" Action="None" /> <!-- allow skipped tests -->
     <Rule Id="xUnit2000" Action="None" /> <!-- "literal or constant value should be first in Assert.Equal" is a valid assert, but very noisy. Will do the refactoring later -->
-    <Rule Id="xUnit2004" Action="None" /> <!-- "do not use Assert.Equal for boolean conditions" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2006" Action="None" /> <!-- "do not use generic Assert.Equal to test string equality" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2007" Action="None" /> <!-- "do not use Assert.IsType(typeof...)" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2009" Action="None" /> <!-- "do not use Assert.True to check for substrings" is a valid assert, but very noisy right now -->

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -151,7 +151,6 @@
     <Rule Id="xUnit2009" Action="None" /> <!-- "do not use Assert.True to check for substrings" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2012" Action="None" /> <!-- "do not use Enumerable.Any() to check if a value exists in a collection" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2013" Action="None" /> <!-- "do not use Assert.Equal() to check for collection size" is a valid assert, but very noisy right now -->
-    <Rule Id="xUnit2015" Action="None" /> <!-- "do not use typeof() expression to check the exception type. " is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2017" Action="None" /> <!-- "do not use Contains() to check if a value exists in a collection" is a valid assert, but very noisy right now -->
   </Rules>
   <Rules AnalyzerId="Microsoft.VisualStudio.SDK.Analyzers" RuleNamespace="Microsoft.VisualStudio.SDK.Analyzers">

--- a/eng/config/rulesets/Shipping.ruleset
+++ b/eng/config/rulesets/Shipping.ruleset
@@ -147,7 +147,6 @@
     <Rule Id="xUnit1004" Action="None" /> <!-- allow skipped tests -->
     <Rule Id="xUnit2000" Action="None" /> <!-- "literal or constant value should be first in Assert.Equal" is a valid assert, but very noisy. Will do the refactoring later -->
     <Rule Id="xUnit2006" Action="None" /> <!-- "do not use generic Assert.Equal to test string equality" is a valid assert, but very noisy right now -->
-    <Rule Id="xUnit2007" Action="None" /> <!-- "do not use Assert.IsType(typeof...)" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2009" Action="None" /> <!-- "do not use Assert.True to check for substrings" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2012" Action="None" /> <!-- "do not use Enumerable.Any() to check if a value exists in a collection" is a valid assert, but very noisy right now -->
     <Rule Id="xUnit2013" Action="None" /> <!-- "do not use Assert.Equal() to check for collection size" is a valid assert, but very noisy right now -->

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -6826,7 +6826,7 @@ public class C
             var cmd = CreateCSharpCompiler(null, dir.Path, new[] { "/nologo", "a.cs", "/keycontainer:bbb", });
             var comp = cmd.CreateCompilation(TextWriter.Null, new TouchedFileLogger(), NullErrorLogger.Instance);
 
-            Assert.Equal(comp.Options.StrongNameProvider.GetType(), typeof(DesktopStrongNameProvider));
+            Assert.Equal(typeof(DesktopStrongNameProvider), comp.Options.StrongNameProvider.GetType());
         }
 
         [Fact]
@@ -6848,7 +6848,7 @@ public class C
             var cmd = CreateCSharpCompiler(null, dir.Path, new[] { "/nologo", "a.cs", "/keyFile:key.snk", "/features:UseLegacyStrongNameProvider" });
             var comp = cmd.CreateCompilation(TextWriter.Null, new TouchedFileLogger(), NullErrorLogger.Instance);
 
-            Assert.Equal(comp.Options.StrongNameProvider.GetType(), typeof(DesktopStrongNameProvider));
+            Assert.Equal(typeof(DesktopStrongNameProvider), comp.Options.StrongNameProvider.GetType());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1491,7 +1491,7 @@ class C
         public void LangVersion_DefaultMapsCorrectly()
         {
             LanguageVersion defaultEffectiveVersion = LanguageVersion.Default.MapSpecifiedToEffectiveVersion();
-            Assert.NotEqual(defaultEffectiveVersion, LanguageVersion.Default);
+            Assert.NotEqual(LanguageVersion.Default, defaultEffectiveVersion);
 
             var parsedArgs = DefaultParse(new[] { "/langversion:default", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
@@ -1504,7 +1504,7 @@ class C
         public void LangVersion_LatestMapsCorrectly()
         {
             LanguageVersion latestEffectiveVersion = LanguageVersion.Latest.MapSpecifiedToEffectiveVersion();
-            Assert.NotEqual(latestEffectiveVersion, LanguageVersion.Latest);
+            Assert.NotEqual(LanguageVersion.Latest, latestEffectiveVersion);
 
             var parsedArgs = DefaultParse(new[] { "/langversion:latest", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
@@ -1846,14 +1846,14 @@ class C
             parsedArgs.Errors.Verify();
             Assert.False(parsedArgs.CompilationOptions.DebugPlusMode);
             Assert.True(parsedArgs.EmitPdb);
-            Assert.Equal(parsedArgs.EmitOptions.DebugInformationFormat, DebugInformationFormat.PortablePdb);
+            Assert.Equal(DebugInformationFormat.PortablePdb, parsedArgs.EmitOptions.DebugInformationFormat);
             Assert.Equal(Path.Combine(WorkingDirectory, "a.pdb"), parsedArgs.GetPdbFilePath("a.dll"));
 
             parsedArgs = DefaultParse(new[] { "/debug:embedded", "a.cs" }, WorkingDirectory);
             parsedArgs.Errors.Verify();
             Assert.False(parsedArgs.CompilationOptions.DebugPlusMode);
             Assert.True(parsedArgs.EmitPdb);
-            Assert.Equal(parsedArgs.EmitOptions.DebugInformationFormat, DebugInformationFormat.Embedded);
+            Assert.Equal(DebugInformationFormat.Embedded, parsedArgs.EmitOptions.DebugInformationFormat);
             Assert.Equal(Path.Combine(WorkingDirectory, "a.pdb"), parsedArgs.GetPdbFilePath("a.dll"));
 
             parsedArgs = DefaultParse(new[] { "/debug:PDBONLY", "a.cs" }, WorkingDirectory);
@@ -9057,10 +9057,10 @@ using System.Diagnostics; // Unused.
             Assert.Equal("-_+@%#*^", parsedArgs.EmitOptions.RuntimeMetadataVersion);
 
             var comp = CreateEmptyCompilation(string.Empty);
-            Assert.Equal(ModuleMetadata.CreateFromImage(comp.EmitToArray(new EmitOptions(runtimeMetadataVersion: "v4.0.30319"))).Module.MetadataVersion, "v4.0.30319");
+            Assert.Equal("v4.0.30319", ModuleMetadata.CreateFromImage(comp.EmitToArray(new EmitOptions(runtimeMetadataVersion: "v4.0.30319"))).Module.MetadataVersion);
 
             comp = CreateEmptyCompilation(string.Empty);
-            Assert.Equal(ModuleMetadata.CreateFromImage(comp.EmitToArray(new EmitOptions(runtimeMetadataVersion: "_+@%#*^"))).Module.MetadataVersion, "_+@%#*^");
+            Assert.Equal("_+@%#*^", ModuleMetadata.CreateFromImage(comp.EmitToArray(new EmitOptions(runtimeMetadataVersion: "_+@%#*^"))).Module.MetadataVersion);
         }
 
         [WorkItem(715339, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/715339")]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -709,7 +709,7 @@ class C
             parsedArgs = DefaultParse(new[] { "/win32Manifest:goo", "/noWin32Manifest", "a.cs" }, WorkingDirectory);
             Assert.Equal(0, parsedArgs.Errors.Length);
             Assert.True(parsedArgs.NoWin32Manifest);
-            Assert.Equal(null, parsedArgs.Win32Manifest);
+            Assert.Null(parsedArgs.Win32Manifest);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -7711,11 +7711,11 @@ public class IA
             var compilation = CreateCompilation(source2, new[] { reference1 });
             compilation.VerifyDiagnostics();
             var assembly = compilation.Assembly;
-            Assert.Equal(assembly.GetAttributes().Length, 0);
+            Assert.Equal(0, assembly.GetAttributes().Length);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(type.GetAttributes().Length, 0);
+            Assert.Equal(0, type.GetAttributes().Length);
             var method = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("E").GetMember<PEMethodSymbol>("M");
-            Assert.Equal(method.GetAttributes().Length, 0);
+            Assert.Equal(0, method.GetAttributes().Length);
             Assert.True(method.TestIsExtensionBitSet);
             Assert.True(method.TestIsExtensionBitTrue);
             Assert.True(method.IsExtensionMethod);
@@ -7754,11 +7754,11 @@ public class IA
             compilation.VerifyDiagnostics(); // we now recognize the extension method even without the assembly-level attribute
 
             var assembly = compilation.Assembly;
-            Assert.Equal(assembly.GetAttributes().Length, 0);
+            Assert.Equal(0, assembly.GetAttributes().Length);
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("E");
-            Assert.Equal(type.GetAttributes().Length, 0);
+            Assert.Equal(0, type.GetAttributes().Length);
             var method = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("E").GetMember<PEMethodSymbol>("M");
-            Assert.Equal(method.GetAttributes().Length, 0);
+            Assert.Equal(0, method.GetAttributes().Length);
             Assert.True(method.TestIsExtensionBitSet);
             Assert.True(method.TestIsExtensionBitTrue);
             Assert.True(method.IsExtensionMethod);

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -1003,7 +1003,7 @@ namespace System
             {
                 Assert.NotNull(obsoleteAttribute);
                 Assert.Equal("Types with embedded references are not supported in this version of your compiler.", obsoleteAttribute.Message);
-                Assert.Equal(true, obsoleteAttribute.IsError);
+                Assert.Trueu(obsoleteAttribute.IsError);
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_IsByRefLike.cs
@@ -1003,7 +1003,7 @@ namespace System
             {
                 Assert.NotNull(obsoleteAttribute);
                 Assert.Equal("Types with embedded references are not supported in this version of your compiler.", obsoleteAttribute.Message);
-                Assert.Trueu(obsoleteAttribute.IsError);
+                Assert.True(obsoleteAttribute.IsError);
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NullableContext.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NullableContext.cs
@@ -337,9 +337,9 @@ class Program
         [Fact]
         public void MostCommonNullableValue()
         {
-            Assert.Equal(null, getMostCommonValue());
-            Assert.Equal(null, getMostCommonValue((byte?)null));
-            Assert.Equal(null, getMostCommonValue(null, null));
+            Assert.Null(getMostCommonValue());
+            Assert.Null(getMostCommonValue((byte?)null));
+            Assert.Null(getMostCommonValue(null, null));
             Assert.Equal((byte)0, getMostCommonValue(0));
             Assert.Equal((byte)1, getMostCommonValue(1));
             Assert.Equal((byte)2, getMostCommonValue(2));
@@ -385,20 +385,20 @@ class Program
         [Fact]
         public void GetCommonNullableValue()
         {
-            Assert.Equal(null, getCommonValue());
+            Assert.Null(getCommonValue());
             Assert.Equal((byte)0, getCommonValue(0));
             Assert.Equal((byte)1, getCommonValue(1));
             Assert.Equal((byte)2, getCommonValue(2));
             Assert.Equal((byte)3, getCommonValue(3));
             Assert.Equal((byte)0, getCommonValue(0, 0));
-            Assert.Equal(null, getCommonValue(0, 1));
-            Assert.Equal(null, getCommonValue(1, 0));
+            Assert.Null(getCommonValue(0, 1));
+            Assert.Null(getCommonValue(1, 0));
             Assert.Equal((byte)1, getCommonValue(1, 1));
-            Assert.Equal(null, getCommonValue(1, 2));
+            Assert.Null(getCommonValue(1, 2));
             Assert.Equal((byte)2, getCommonValue(2, 2));
-            Assert.Equal(null, getCommonValue(0, 1, 0));
-            Assert.Equal(null, getCommonValue(1, 0, 1));
-            Assert.Equal(null, getCommonValue(2, 2, 1));
+            Assert.Null(getCommonValue(0, 1, 0));
+            Assert.Null(getCommonValue(1, 0, 1));
+            Assert.Null(getCommonValue(2, 2, 1));
             Assert.Equal((byte)3, getCommonValue(3, 3, 3));
 
             static byte? getCommonValue(params byte[] values)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -1543,7 +1543,7 @@ namespace System.Runtime.CompilerServices
 
             // Attribute cannot be synthesized because ctor has a use-site error (String type missing)
             var attribute = comp.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerDisplayAttribute__ctor);
-            Assert.Equal(null, attribute);
+            Assert.Null(attribute);
 
             // Attribute cannot be synthesized because type in named argument has use-site error (String type missing)
             var attribute2 = comp.TrySynthesizeAttribute(
@@ -1551,7 +1551,7 @@ namespace System.Runtime.CompilerServices
                                 namedArguments: ImmutableArray.Create(new KeyValuePair<WellKnownMember, TypedConstant>(
                                                     WellKnownMember.System_Diagnostics_DebuggerDisplayAttribute__Type,
                                                     new TypedConstant(comp.GetSpecialType(SpecialType.System_String), TypedConstantKind.Primitive, "unused"))));
-            Assert.Equal(null, attribute2);
+            Assert.Null(attribute2);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -2565,8 +2565,8 @@ public class C
                 Assert.Equal(CharSet.Unicode, info.CharacterSet);
                 Assert.True(info.ExactSpelling);
                 Assert.True(info.SetLastError);
-                Assert.Equal(true, info.BestFitMapping);
-                Assert.Equal(true, info.ThrowOnUnmappableCharacter);
+                Assert.True(info.BestFitMapping);
+                Assert.True(info.ThrowOnUnmappableCharacter);
 
                 Assert.Equal(
                     MethodImportAttributes.ExactSpelling |
@@ -4997,8 +4997,8 @@ namespace System
                 // Verify AttributeUsage
                 var attributeUsage = attrType.GetAttributeUsageInfo();
                 Assert.Equal(AttributeTargets.Class, attributeUsage.ValidTargets);
-                Assert.Equal(true, attributeUsage.AllowMultiple);
-                Assert.Equal(true, attributeUsage.Inherited);
+                Assert.True(attributeUsage.AllowMultiple);
+                Assert.True(attributeUsage.Inherited);
             };
 
             // Verify attributes from source and then load metadata to see attributes are written correctly.

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -3170,7 +3170,7 @@ abstract class C
                 foreach (var ca in peReader.CustomAttributes)
                 {
                     var ctor = peReader.GetCustomAttribute(ca).Constructor;
-                    Assert.NotEqual(ctor.Kind, HandleKind.MethodDefinition);
+                    Assert.NotEqual(HandleKind.MethodDefinition, ctor.Kind);
                 }
             });
         }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -2606,8 +2606,8 @@ public class C
                 Assert.Equal(CallingConvention.Winapi, info.CallingConvention);
                 Assert.False(info.ExactSpelling);
                 Assert.False(info.SetLastError);
-                Assert.Equal(null, info.BestFitMapping);
-                Assert.Equal(null, info.ThrowOnUnmappableCharacter);
+                Assert.Null(info.BestFitMapping);
+                Assert.Null(info.ThrowOnUnmappableCharacter);
 
                 var n = c.GetMember<MethodSymbol>("N");
                 Assert.Null(n.GetDllImportData());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -5595,7 +5595,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String" }, ElementTypeNames(tupleWithoutNames));
             Assert.Equal(SymbolKind.NamedType, tupleWithoutNames.Kind);
             Assert.All(tupleWithoutNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         private static ImmutableArray<string> GetTupleElementNames(INamedTypeSymbol tuple)
@@ -5652,7 +5652,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String" }, ElementTypeNames(tupleWithoutNames));
             Assert.Equal(SymbolKind.NamedType, tupleWithoutNames.Kind);
             Assert.All(tupleWithoutNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5671,7 +5671,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String" }, ElementTypeNames(tupleWithNames));
             Assert.Equal(SymbolKind.NamedType, tupleWithNames.Kind);
             Assert.All(tupleWithNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5690,7 +5690,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String", "System.Int32" }, ElementTypeNames(tupleWithSomeNames));
             Assert.Equal(SymbolKind.NamedType, tupleWithSomeNames.Kind);
             Assert.All(tupleWithSomeNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5708,7 +5708,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.Int32" }, ElementTypeNames(tupleWithNames));
             Assert.Equal(SymbolKind.NamedType, tupleWithNames.Kind);
             Assert.All(tupleWithNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5732,7 +5732,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String" },
                         ElementTypeNames(tuple8WithoutNames));
             Assert.All(tuple8WithoutNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5757,7 +5757,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String" },
                         ElementTypeNames(tuple8WithNames));
             Assert.All(tuple8WithNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5782,7 +5782,7 @@ class C
             Assert.Equal(new[] { "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32" },
                         ElementTypeNames(tuple9WithoutNames));
             Assert.All(tuple9WithoutNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5808,7 +5808,7 @@ class C
                         ElementTypeNames(tuple9WithNames));
 
             Assert.All(tuple9WithNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5837,7 +5837,7 @@ class C
                         ElementTypeNames(tuple9WithNames));
 
             Assert.All(tuple9WithNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact]
@@ -5859,7 +5859,7 @@ class C
             Assert.Equal(SymbolKind.NamedType, types[0].Kind);
             Assert.Equal(SymbolKind.ErrorType, types[1].Kind);
             Assert.All(tupleWithoutNames.GetMembers().OfType<IFieldSymbol>().Select(f => f.Locations.FirstOrDefault()),
-                loc => Assert.Equal(loc, null));
+                loc => Assert.Null(loc));
         }
 
         [Fact, WorkItem(13277, "https://github.com/dotnet/roslyn/issues/13277")]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -64,13 +64,13 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             var reader1 = md1.Reader;
 
             var s = MetadataTokens.StringHandle(0);
-            Assert.Equal(reader1.GetString(s), "");
+            Assert.Equal("", reader1.GetString(s));
 
             var b = MetadataTokens.BlobHandle(0);
             Assert.Equal(0, reader1.GetBlobBytes(b).Length);
 
             var us = MetadataTokens.UserStringHandle(0);
-            Assert.Equal(reader1.GetUserString(us), "");
+            Assert.Equal("", reader1.GetUserString(us));
         }
 
         [Fact]
@@ -389,7 +389,7 @@ class Bad : Bad
                 ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, method0, method1)));
 
             var methods = diff1.TestData.GetMethodsByName();
-            Assert.Equal(methods.Count, 1);
+            Assert.Equal(1, methods.Count);
             Assert.True(methods.ContainsKey("C.M2()"));
 
             using var md1 = diff1.GetMetadata();
@@ -2836,7 +2836,7 @@ class C
             var generation0 = EmitBaseline.CreateInitialBaseline(ModuleMetadata.CreateFromImage(bytes0), EmptyLocalsProvider);
 
             var n = compilation0.GetMembers("C.M").Length;
-            Assert.Equal(n, 14);
+            Assert.Equal(14, n);
 
             //static void M(A<B>.B<object> a)
             //{

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -130,7 +130,7 @@ class B
                 default,
                 null);
             var members = compilation1.GetMember<NamedTypeSymbol>("A.B").GetMembers("M");
-            Assert.Equal(members.Length, 2);
+            Assert.Equal(2, members.Length);
             foreach (var member in members)
             {
                 var other = matcher.MapDefinition((Cci.IMethodDefinition)member);
@@ -185,8 +185,8 @@ class C
             var compilation1 = compilation0.WithSource(source);
 
             var member1 = compilation1.GetMember<MethodSymbol>("B.F");
-            Assert.Equal(((PointerTypeSymbol)member1.Parameters[0].Type).PointedAtTypeWithAnnotations.CustomModifiers.Length, 1);
-            Assert.Equal(((ArrayTypeSymbol)member1.ReturnType).ElementTypeWithAnnotations.CustomModifiers.Length, 1);
+            Assert.Equal(1, ((PointerTypeSymbol)member1.Parameters[0].Type).PointedAtTypeWithAnnotations.CustomModifiers.Length);
+            Assert.Equal(1, ((ArrayTypeSymbol)member1.ReturnType).ElementTypeWithAnnotations.CustomModifiers.Length);
 
             var matcher = new CSharpSymbolMatcher(
                 null,
@@ -198,8 +198,8 @@ class C
 
             var other = (MethodSymbol)matcher.MapDefinition(member1);
             Assert.NotNull(other);
-            Assert.Equal(((PointerTypeSymbol)other.Parameters[0].Type).PointedAtTypeWithAnnotations.CustomModifiers.Length, 1);
-            Assert.Equal(((ArrayTypeSymbol)other.ReturnType).ElementTypeWithAnnotations.CustomModifiers.Length, 1);
+            Assert.Equal(1, ((PointerTypeSymbol)other.Parameters[0].Type).PointedAtTypeWithAnnotations.CustomModifiers.Length);
+            Assert.Equal(1, ((ArrayTypeSymbol)other.ReturnType).ElementTypeWithAnnotations.CustomModifiers.Length);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -161,8 +161,8 @@ public class Test : C107
             {
                 var refs = assembly.Modules[0].ReferencedAssemblies.OrderBy(r => r.Name).ToArray();
                 Assert.Equal(2, refs.Length);
-                Assert.Equal(refs[0].Name, "MDTestLib1", StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(refs[1].Name, "mscorlib", StringComparer.OrdinalIgnoreCase);
+                Assert.Equal("MDTestLib1", refs[0].Name, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal("mscorlib", refs[1].Name, StringComparer.OrdinalIgnoreCase);
             });
         }
 
@@ -743,11 +743,11 @@ class Derived<T, U> : Base<T, U>
             Action<ModuleSymbol> validator = module =>
             {
                 var derivedType = module.GlobalNamespace.GetTypeMembers("Derived").Single();
-                Assert.Equal(derivedType.Arity, 2);
+                Assert.Equal(2, derivedType.Arity);
 
                 var baseType = derivedType.BaseType();
-                Assert.Equal(baseType.Name, "Base");
-                Assert.Equal(baseType.Arity, 2);
+                Assert.Equal("Base", baseType.Name);
+                Assert.Equal(2, baseType.Arity);
 
                 Assert.Equal(derivedType.BaseType(), baseType);
                 Assert.Same(baseType.TypeArguments()[0], derivedType.TypeParameters[0]);
@@ -914,25 +914,25 @@ class C
                 var pBack = p.BackingField;
                 Assert.False(pBack.IsReadOnly);
                 Assert.False(pBack.IsStatic);
-                Assert.Equal(pBack.Type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, pBack.Type.SpecialType);
 
                 var q = type.GetMember<SourcePropertySymbol>("Q");
                 var qBack = q.BackingField;
                 Assert.False(qBack.IsReadOnly);
                 Assert.False(qBack.IsStatic);
-                Assert.Equal(qBack.Type.SpecialType, SpecialType.System_String);
+                Assert.Equal(SpecialType.System_String, qBack.Type.SpecialType);
 
                 var r = type.GetMember<SourcePropertySymbol>("R");
                 var rBack = r.BackingField;
                 Assert.True(rBack.IsReadOnly);
                 Assert.False(rBack.IsStatic);
-                Assert.Equal(rBack.Type.SpecialType, SpecialType.System_Decimal);
+                Assert.Equal(SpecialType.System_Decimal, rBack.Type.SpecialType);
 
                 var s = type.GetMember<SourcePropertySymbol>("S");
                 var sBack = s.BackingField;
                 Assert.True(sBack.IsReadOnly);
                 Assert.True(sBack.IsStatic);
-                Assert.Equal(sBack.Type.SpecialType, SpecialType.System_Char);
+                Assert.Equal(SpecialType.System_Char, sBack.Type.SpecialType);
             };
 
             CompileAndVerify(
@@ -985,25 +985,25 @@ struct S
                 Assert.False(p.HasInitializer);
                 Assert.True(p.IsReadOnly);
                 Assert.False(p.IsStatic);
-                Assert.Equal(p.Type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, p.Type.SpecialType);
 
                 var q = type.GetMember<SourcePropertySymbol>("Q");
                 var qBack = q.BackingField;
                 Assert.True(qBack.IsReadOnly);
                 Assert.False(qBack.IsStatic);
-                Assert.Equal(qBack.Type.SpecialType, SpecialType.System_String);
+                Assert.Equal(SpecialType.System_String, qBack.Type.SpecialType);
 
                 var r = type.GetMember<SourcePropertySymbol>("R");
                 var rBack = r.BackingField;
                 Assert.True(rBack.IsReadOnly);
                 Assert.False(rBack.IsStatic);
-                Assert.Equal(rBack.Type.SpecialType, SpecialType.System_Decimal);
+                Assert.Equal(SpecialType.System_Decimal, rBack.Type.SpecialType);
 
                 var s = type.GetMember<SourcePropertySymbol>("T");
                 var sBack = s.BackingField;
                 Assert.True(sBack.IsReadOnly);
                 Assert.True(sBack.IsStatic);
-                Assert.Equal(sBack.Type.SpecialType, SpecialType.System_Char);
+                Assert.Equal(SpecialType.System_Char, sBack.Type.SpecialType);
             };
 
             CompileAndVerify(
@@ -1132,7 +1132,7 @@ public class C : I
         private static void CheckPropertyAccessibility(PropertySymbol property, Accessibility propertyAccessibility, Accessibility getterAccessibility, Accessibility setterAccessibility)
         {
             var type = property.TypeWithAnnotations;
-            Assert.NotEqual(type.PrimitiveTypeCode, Microsoft.Cci.PrimitiveTypeCode.Void);
+            Assert.NotEqual(Microsoft.Cci.PrimitiveTypeCode.Void, type.PrimitiveTypeCode);
             Assert.Equal(propertyAccessibility, property.DeclaredAccessibility);
             CheckPropertyAccessorAccessibility(property, propertyAccessibility, property.GetMethod, getterAccessibility);
             CheckPropertyAccessorAccessibility(property, propertyAccessibility, property.SetMethod, setterAccessibility);
@@ -1142,7 +1142,7 @@ public class C : I
         {
             if (accessor == null)
             {
-                Assert.Equal(accessorAccessibility, Accessibility.NotApplicable);
+                Assert.Equal(Accessibility.NotApplicable, accessorAccessibility);
             }
             else
             {
@@ -1244,7 +1244,7 @@ class C : B<string>
                 var classC = module.GlobalNamespace.GetTypeMembers("C").Single();
                 p = classC.BaseType().GetProperty("P");
                 VerifyAutoProperty(p, isFromSource);
-                Assert.Equal(p.Type.SpecialType, SpecialType.System_String);
+                Assert.Equal(SpecialType.System_String, p.Type.SpecialType);
                 Assert.Equal(p.GetMethod.AssociatedSymbol, p);
             };
 
@@ -1355,7 +1355,7 @@ class C : B<string>
 
         private void CheckEnumType(NamedTypeSymbol type, Accessibility declaredAccessibility, SpecialType underlyingType)
         {
-            Assert.Equal(type.BaseType().SpecialType, SpecialType.System_Enum);
+            Assert.Equal(SpecialType.System_Enum, type.BaseType().SpecialType);
             Assert.Equal(type.EnumUnderlyingType.SpecialType, underlyingType);
             Assert.Equal(type.DeclaredAccessibility, declaredAccessibility);
             Assert.True(type.IsSealed);
@@ -1374,7 +1374,7 @@ class C : B<string>
                 Assert.False(field.IsStatic);
                 Assert.False(field.IsConst);
                 Assert.False(field.IsReadOnly);
-                Assert.Equal(field.DeclaredAccessibility, Accessibility.Public); // Dev10: value__ is public
+                Assert.Equal(Accessibility.Public, field.DeclaredAccessibility); // Dev10: value__ is public
                 Assert.Equal(field.Type, type.EnumUnderlyingType);
 
                 var module = new PEAssemblyBuilder((SourceAssemblySymbol)sourceType.ContainingAssembly, EmitOptions.Default, OutputKind.DynamicallyLinkedLibrary,

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -5701,7 +5701,7 @@ class B : IA
                 Assert.Equal(ParameterAttributes.HasDefault, p.Flags);
                 Assert.Equal((object)0x0000000C, p.ExplicitDefaultConstantValue.Value);
                 Assert.False(p.HasExplicitDefaultValue);
-                Assert.Throws(typeof(InvalidOperationException), delegate
+                Assert.Throws<InvalidOperationException>(delegate
                     {
                         var tmp = p.ExplicitDefaultValue;
                     });
@@ -5770,7 +5770,7 @@ class B : IA
                 Assert.Equal("System.Runtime.CompilerServices.DateTimeConstantAttribute(987654321)", p.GetAttributes().Single().ToString());
                 Assert.Null(p.ExplicitDefaultConstantValue);
                 Assert.False(p.HasExplicitDefaultValue);
-                Assert.Throws(typeof(InvalidOperationException), delegate
+                Assert.Throws<InvalidOperationException>(delegate
                 {
                     var tmp = p.ExplicitDefaultValue;
                 });

--- a/src/Compilers/CSharp/Test/Emit/Emit/OptionalArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/OptionalArgumentsTests.cs
@@ -214,11 +214,11 @@ partial class C
             var attributes = parameter.GetAttributes();
             if (expectedAttributeName == null)
             {
-                Assert.Equal(attributes.Length, 0);
+                Assert.Equal(0, attributes.Length);
             }
             else
             {
-                Assert.Equal(attributes.Length, 1);
+                Assert.Equal(1, attributes.Length);
                 var attribute = attributes[0];
                 var argument = attribute.ConstructorArguments.Last();
                 Assert.Equal(expectedAttributeName, attribute.AttributeClass.Name);

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBEmbeddedSourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBEmbeddedSourceTests.cs
@@ -122,7 +122,7 @@ class C
                              Text = pdbReader.GetEmbeddedSource(documentHandle)
                          }).Single();
 
-                    Assert.Equal(embeddedSource.FilePath, "f:/build/goo.cs");
+                    Assert.Equal("f:/build/goo.cs", embeddedSource.FilePath);
                     Assert.Equal(source, embeddedSource.Text.ToString());
                 }
             }

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IBranchOperation.Extensions.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IBranchOperation.Extensions.cs
@@ -36,7 +36,7 @@ class C
         }/*</bind>*/
     }
 }");
-            Assert.IsAssignableFrom(typeof(ILabeledOperation), result.outer);
+            Assert.IsAssignableFrom<ILabeledOperation>(result.outer);
             Assert.Null(result.corresponding);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -708,7 +708,7 @@ public class B
             var analyzer = new CSharpCompilerDiagnosticAnalyzer();
             foreach (var descriptor in analyzer.SupportedDiagnostics)
             {
-                Assert.Equal(descriptor.IsEnabledByDefault, true);
+                Assert.True(descriptor.IsEnabledByDefault);
 
                 if (descriptor.IsNotConfigurable())
                 {

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/IterationJumpYieldStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/IterationJumpYieldStatementTests.cs
@@ -910,8 +910,8 @@ public class Program
             var foreachNode = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ForEachStatementSyntax>().Single();
             var flow = semanticModel.AnalyzeDataFlow(foreachNode);
             Assert.Equal(2, flow.VariablesDeclared.Count());
-            Assert.Equal(true, flow.VariablesDeclared.Any((s) => s.Name == "b"));
-            Assert.Equal(true, flow.VariablesDeclared.Any((s) => s.Name == "s"));
+            Assert.True(flow.VariablesDeclared.Any((s) => s.Name == "b"));
+            Assert.True(flow.VariablesDeclared.Any((s) => s.Name == "s"));
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/IterationJumpYieldStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/IterationJumpYieldStatementTests.cs
@@ -41,12 +41,12 @@ class C {
             Assert.True(controlFlowAnalysisResults.StartPointIsReachable);
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -74,12 +74,12 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -103,13 +103,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -133,13 +133,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -163,13 +163,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -192,13 +192,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [WorkItem(3850, "DevDiv_Projects/Roslyn")]
@@ -222,13 +222,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -251,13 +251,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -297,13 +297,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -326,13 +326,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -355,13 +355,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -384,13 +384,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -413,13 +413,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -442,13 +442,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -566,14 +566,14 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [WorkItem(540183, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540183")]
@@ -648,7 +648,7 @@ class C
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
@@ -686,8 +686,8 @@ class C
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("k", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("k", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("i, j", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("k", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
@@ -738,7 +738,7 @@ class C {
 }");
             Assert.Equal("c", GetSymbolNamesJoined(analysis.VariablesDeclared));
             Assert.Equal("c", GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
         }
 
         [WorkItem(528498, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528498")]
@@ -786,12 +786,12 @@ class Test
 }
 ");
             Assert.Equal("v, x", GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("ary, a", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
             Assert.Equal("ary, a, v, x", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("v, x", GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("this, ary, a", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -820,7 +820,7 @@ class Test
             Assert.Equal("x", GetSymbolNamesJoined(analysis.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("a, v", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
             Assert.Equal("a, v, x", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("ary", GetSymbolNamesJoined(analysis.ReadOutside));
@@ -852,7 +852,7 @@ class Test
             Assert.Equal("x", GetSymbolNamesJoined(analysis.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("a, v", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
             Assert.Equal("a, v, x", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("ary", GetSymbolNamesJoined(analysis.ReadOutside));
@@ -880,13 +880,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("i, i100", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -971,12 +971,12 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x, y, z", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -999,12 +999,12 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -1027,11 +1027,11 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -1055,13 +1055,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [WorkItem(528583, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528583")]
@@ -1098,13 +1098,13 @@ class C {
             Assert.Empty(controlFlowAnalysisResults.EntryPoints);
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("i1, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("i1, i2, i3, i4, i5, f1, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/PatternsVsRegions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/PatternsVsRegions.cs
@@ -30,16 +30,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }");
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("o", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("o, i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("args, o", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -57,15 +57,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("o", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("o", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("args, o", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -80,18 +80,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         if (o is int i && /*<bind>*/i > 10/*</bind>*/) {}
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, o", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("args, o, i", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -114,10 +114,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("args, o", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.UnsafeAddressTaken));
         }
 
     }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -2697,8 +2697,8 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
-            Assert.Equal(true, controlFlowAnalysisResults.StartPointIsReachable);
-            Assert.Equal(true, controlFlowAnalysisResults.EndPointIsReachable);
+            Assert.True(controlFlowAnalysisResults.StartPointIsReachable);
+            Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i, j, s", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -49,19 +49,19 @@ struct S
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("args, i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("args, i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
         }
 
         [Fact]
@@ -85,19 +85,19 @@ struct S
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("args, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("args, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, s, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
         }
 
         [Fact]
@@ -125,19 +125,19 @@ struct S
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("args, i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("args, i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, i, s", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
         }
 
         [WorkItem(538238, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538238")]
@@ -220,19 +220,19 @@ enum E1
     V1
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("a, b, c, d, e, f", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
             Assert.Equal("a, b, c, d, e, f", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
         [WorkItem(538997, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538997")]
@@ -290,7 +290,7 @@ class C
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
@@ -423,15 +423,15 @@ x
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -452,13 +452,13 @@ x = 1
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
@@ -498,7 +498,7 @@ class C {
             ;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -540,7 +540,7 @@ class C {
           ? 1 : 2;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -603,7 +603,7 @@ class C {
           ? 1 : 2;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -666,7 +666,7 @@ class C {
         ;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -738,7 +738,7 @@ class C {
         bool c = B(out a) && B(out /*<bind>*/b/*</bind>*/);
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -772,7 +772,7 @@ class C {
         bool c = B(out a) || B(out /*<bind>*/b/*</bind>*/);
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -825,8 +825,8 @@ class C {
             ;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("args", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -846,7 +846,7 @@ class C {
             ;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("args", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -862,9 +862,9 @@ class C {
         /*<bind>*/x/*</bind>*/ = 3;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
@@ -882,8 +882,8 @@ class C {
     }
 }");
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
@@ -901,9 +901,9 @@ class C {
         M(out /*<bind>*/x/*</bind>*/);
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
@@ -922,7 +922,7 @@ class C {
     }
 }");
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("args, x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
@@ -944,13 +944,13 @@ x = 1
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
@@ -972,15 +972,15 @@ x
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -1000,7 +1000,7 @@ class C {
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -1031,15 +1031,15 @@ x
     static void Goo(ref int x) { }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -1055,9 +1055,9 @@ class C
         /*<bind>*/Main(ref 1)/*</bind>*/;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
         }
 
         [Fact]
@@ -1072,7 +1072,7 @@ class C {
         object c = B(out a) ?? B(out /*<bind>*/b/*</bind>*/);
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("args, a", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
         }
@@ -1092,7 +1092,7 @@ struct STest {
         return ret;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Equal("ss", GetSymbolNamesJoined(dataFlows.AlwaysAssigned));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlows.DataFlowsIn));
             Assert.Equal("ss", GetSymbolNamesJoined(dataFlows.DataFlowsOut));
@@ -1116,9 +1116,9 @@ class Test {
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("s, ss", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("s, ss", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
@@ -1137,9 +1137,9 @@ class Test<T> {
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
@@ -1162,9 +1162,9 @@ class Test<T>
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("this, t", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("this, t", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
@@ -1187,9 +1187,9 @@ struct Test<T>
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Equal("t", GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("this, t", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("this, t", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
@@ -1213,9 +1213,9 @@ struct Test<T>
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Equal("t", GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("this, t, ret", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("this, t, ret", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
@@ -1237,15 +1237,15 @@ y
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("y, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -1267,15 +1267,15 @@ y
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("z, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("z, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("z", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("z, y, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -1297,15 +1297,15 @@ y
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("z, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("z, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("z", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("z, y, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -1408,10 +1408,8 @@ class C {
                 GetSymbolNamesJoined(results2.DataFlowsIn));
             Assert.Equal(GetSymbolNamesJoined(results1.DataFlowsOut),
                 GetSymbolNamesJoined(results2.DataFlowsOut));
-            Assert.Equal(null,
-                GetSymbolNamesJoined(results2.DefinitelyAssignedOnEntry));
-            Assert.Equal(null,
-                GetSymbolNamesJoined(results2.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(results2.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results2.DefinitelyAssignedOnExit));
             Assert.Equal(GetSymbolNamesJoined(results1.ReadInside),
                 GetSymbolNamesJoined(results2.ReadInside));
             Assert.Equal(GetSymbolNamesJoined(results1.ReadOutside),
@@ -1434,9 +1432,9 @@ public class Aa
 }
 ");
 
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
 
         [WorkItem(541968, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541968")]
@@ -1451,7 +1449,7 @@ public class Aa
     const bool myLength = true || ((Func<int, int>)(x => { int y = x; return /*<bind>*/y/*</bind>*/; }))(1) == 2;
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("System.Int32 y", dataFlows.DataFlowsIn.Single().ToTestDisplayString());
@@ -1469,7 +1467,7 @@ public class Aa
     bool myLength = true || ((Func<int, int>)(x => { int y = x; return /*<bind>*/y/*</bind>*/; }))(1) == 2;
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("System.Int32 y", dataFlows.DataFlowsIn.Single().ToTestDisplayString());
@@ -1490,9 +1488,9 @@ class myClass
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
         }
 
         [WorkItem(542463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542463")]
@@ -1583,20 +1581,20 @@ class Program
 }
 ");
             Assert.Equal("x", GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("px", GetSymbolNamesJoined(analysis.WrittenOutside));
@@ -1617,20 +1615,20 @@ class Program
 }
 ");
             Assert.Equal("x", GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, px", GetSymbolNamesJoined(analysis.WrittenOutside));
@@ -1656,21 +1654,21 @@ class Program
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("s", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("px", GetSymbolNamesJoined(analysis.WrittenOutside));
@@ -1697,21 +1695,21 @@ class Program
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("s", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.DataFlowsIn));
             Assert.Equal("s", GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("s, px", GetSymbolNamesJoined(analysis.WrittenOutside));
@@ -1739,20 +1737,20 @@ class Program
             // Really ???
             Assert.Equal("s", GetSymbolNamesJoined(analysis.AlwaysAssigned));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("s", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("s", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("s, px", GetSymbolNamesJoined(analysis.WrittenOutside));
@@ -1778,20 +1776,20 @@ class Program
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
             Assert.Equal("s", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.WrittenOutside));
@@ -1817,7 +1815,7 @@ unsafe public class Test
             Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("p", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("p", GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("i", GetSymbolNamesJoined(analysis.UnsafeAddressTaken));
             Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
@@ -1849,22 +1847,22 @@ public class MemberInitializerTest
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("i", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -1884,22 +1882,22 @@ public class MemberInitializerTest
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, y, i", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -1919,22 +1917,22 @@ public class MemberInitializerTest
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("i, x, y", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -1954,22 +1952,22 @@ public class MemberInitializerTest
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x, y", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, y, i", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -1993,14 +1991,14 @@ public class MemberInitializerTest
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("z", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
@@ -2008,7 +2006,7 @@ public class MemberInitializerTest
             Assert.Equal("z", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, z, i", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -2033,22 +2031,22 @@ public class MemberInitializerTest
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("z", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("z", GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, z, i", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -2069,22 +2067,22 @@ class Test
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("list", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -2106,22 +2104,22 @@ class Test
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, list", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -2166,22 +2164,22 @@ class Test
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
 
             Assert.Equal("x", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
 
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("x, list", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -2206,8 +2204,8 @@ public class Test
             Assert.Null(GetSymbolNamesJoined(dataFlows.CapturedOutside));
             Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsIn));
             Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.WrittenInside));
             Assert.Null(GetSymbolNamesJoined(dataFlows.ReadOutside));
@@ -2235,8 +2233,8 @@ public class Test
             Assert.Null(GetSymbolNamesJoined(dataFlows.CapturedOutside));
             Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsIn));
             Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.WrittenInside));
             Assert.Null(GetSymbolNamesJoined(dataFlows.ReadOutside));
@@ -2263,13 +2261,13 @@ class Test
 ");
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.VariablesDeclared));
             Assert.Null(GetSymbolNamesJoined(dataFlows.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.CapturedOutside));
             Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsIn));
             Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlows.WrittenInside));
             Assert.Null(GetSymbolNamesJoined(dataFlows.ReadOutside));
@@ -2414,19 +2412,19 @@ class Main
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("a", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("a", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("a", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("a", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("a", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
         }
 
         [Fact]
@@ -2466,17 +2464,17 @@ public class C
 
             void assertAllInfo(DataFlowAnalysis dataFlowAnalysis, string currentX, string currentY, string otherX, string otherY)
             {
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysis.VariablesDeclared));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.VariablesDeclared));
                 Assert.Equal(currentX, GetSymbolNamesJoined(dataFlowAnalysis.AlwaysAssigned));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysis.DataFlowsIn));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.DataFlowsIn));
                 Assert.Equal($"{currentX}, {currentY}", GetSymbolNamesJoined(dataFlowAnalysis.DataFlowsOut));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysis.ReadInside));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.ReadInside));
                 Assert.Equal("c, x1, y1, x2, y2", GetSymbolNamesJoined(dataFlowAnalysis.ReadOutside));
                 Assert.Equal($"{currentX}, {currentY}", GetSymbolNamesJoined(dataFlowAnalysis.WrittenInside));
                 Assert.Equal($"c, {otherX}, {otherY}", GetSymbolNamesJoined(dataFlowAnalysis.WrittenOutside));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysis.Captured));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysis.CapturedInside));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysis.CapturedOutside));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.Captured));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.CapturedInside));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysis.CapturedOutside));
             }
         }
 
@@ -2506,7 +2504,7 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.StartPointIsReachable);
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -2565,8 +2563,8 @@ class C {
         int j = i;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
         }
 
         [WorkItem(542231, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542231")]
@@ -2615,8 +2613,8 @@ l2:
         return false && /*<bind>*/((i = i + 1) == 2 || (j = i) == 3)/*</bind>*/;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
         }
 
         [Fact]
@@ -2640,12 +2638,12 @@ class C {
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -2669,12 +2667,12 @@ class C {
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("x, z, y", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("z", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -2703,15 +2701,15 @@ class C {
             Assert.Equal(true, controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i, j, s", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("i, j", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("i, j", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("i, j, s", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
         }
 
 
@@ -2759,7 +2757,7 @@ public class Test
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
 
             // Case 2
             analysis = CompileAndAnalyzeDataFlowStatements(@"
@@ -2896,8 +2894,8 @@ class C {
     }
 }");
             Assert.Equal("x, y, z", GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
             Assert.Equal("x, z", GetSymbolNamesJoined(analysis.AlwaysAssigned));
         }
 
@@ -3085,7 +3083,7 @@ class Program
         return builder.ToString();
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact]
@@ -3203,7 +3201,7 @@ class Program
         s = args[0] + i.ToString();/*</bind>*/
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact]
@@ -3456,12 +3454,12 @@ class C {
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -3486,7 +3484,7 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -3518,7 +3516,7 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -3550,8 +3548,8 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
@@ -3584,12 +3582,12 @@ class C {
         //            Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
         //            Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
         //            Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.VariablesDeclared));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsIn));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsOut));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadInside));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadOutside));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenInside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.VariablesDeclared));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsIn));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsOut));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadInside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadOutside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenInside));
         //            Assert.Equal("x", GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenOutside));
         //        }
 
@@ -3615,13 +3613,13 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -3648,7 +3646,7 @@ class C {
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -3673,8 +3671,8 @@ public class MyClass
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
         }
 
         [Fact, WorkItem(538979, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538979")]
@@ -3774,12 +3772,12 @@ class Program
 }
 ");
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -3835,12 +3833,12 @@ public class Test
             Assert.Empty(controlFlowAnalysisResults.EntryPoints);
             Assert.Equal(2, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("p", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("p", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("p", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, p", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -3872,14 +3870,14 @@ public class Test
         //            Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
         //            Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
         //            Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.VariablesDeclared));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.AlwaysAssigned));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsIn));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsOut));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadInside));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadOutside));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenInside));
-        //            Assert.Equal(null, GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenOutside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.VariablesDeclared));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.AlwaysAssigned));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsIn));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.DataFlowsOut));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadInside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.ReadOutside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenInside));
+        //            Assert.Null(GetSymbolNamesSortedAndJoined(dataFlowAnalysisResults.WrittenOutside));
         //        }
 
         [WorkItem(541331, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541331")]
@@ -3929,13 +3927,13 @@ struct S
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -3958,14 +3956,14 @@ public class Test
     }    
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("p, v", GetSymbolNamesJoined(analysis.DataFlowsIn));
             // By Design
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
             Assert.Equal("p, v", GetSymbolNamesJoined(analysis.ReadInside));
             // By Design
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("p, v", GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("this, p, v", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
@@ -3989,7 +3987,7 @@ public class A
             var dataFlows = results.Item2;
 
             Assert.False(ctrlFlows.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
         }
 
         [WorkItem(8926, "DevDiv_Projects/Roslyn")]
@@ -4015,7 +4013,7 @@ public class A
             var dataFlows = results.Item2;
 
             Assert.True(ctrlFlows.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.VariablesDeclared));
         }
 
         [WorkItem(541980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541980")]
@@ -4124,7 +4122,7 @@ struct S
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
         }
 
         #endregion
@@ -4286,14 +4284,14 @@ class Program
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("args, i", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("args, i", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, i, lambda", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4395,14 +4393,14 @@ class A
         System.Func<int, int> a = x => /*<bind>*/x * x/*</bind>*/;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, a, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4425,7 +4423,7 @@ class C
 }");
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(analysis.DataFlowsIn));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, a, y, lambda", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
@@ -4511,12 +4509,12 @@ class Program
 
             Assert.Equal("testDel, x, y", GetSymbolNamesJoined(results1.VariablesDeclared));
             Assert.Equal("testDel", GetSymbolNamesJoined(results1.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(results1.Captured));
+            Assert.Null(GetSymbolNamesJoined(results1.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results1.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results1.DataFlowsIn));
             Assert.Equal("testDel", GetSymbolNamesJoined(results1.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results1.DefinitelyAssignedOnEntry));
             Assert.Equal("testDel", GetSymbolNamesJoined(results1.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(results1.ReadInside));
             Assert.Equal("testDel, p", GetSymbolNamesJoined(results1.ReadOutside));
@@ -4544,15 +4542,15 @@ class C {
 ");
 
             Assert.Equal("x", GetSymbolNamesJoined(results1.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results1.Captured));
+            Assert.Null(GetSymbolNamesJoined(results1.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results1.CapturedOutside));
             Assert.Equal("p, y", GetSymbolNamesJoined(results1.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results1.DataFlowsOut));
             Assert.Equal("p, x, y", GetSymbolNamesJoined(results1.DefinitelyAssignedOnEntry));
             Assert.Equal("p, x, y", GetSymbolNamesJoined(results1.DefinitelyAssignedOnExit));
             Assert.Equal("p, y", GetSymbolNamesJoined(results1.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results1.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results1.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(results1.WrittenInside));
             Assert.Equal("f, p, x, y", GetSymbolNamesJoined(results1.WrittenOutside));
         }
@@ -4575,15 +4573,15 @@ internal class Test
 }
 ");
 
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.Captured));
             Assert.Equal("ary", GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("this, ary", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("this, ary", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("ary, x", GetSymbolNamesJoined(dataFlows.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlows.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.ReadOutside));
             Assert.Equal("this, ary", GetSymbolNamesJoined(dataFlows.WrittenOutside));
         }
 
@@ -4615,14 +4613,14 @@ public class A
             Assert.Equal("d", GetSymbolNamesJoined(dataFlows.AlwaysAssigned));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlows.Captured));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlows.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.CapturedOutside));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlows.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.DataFlowsOut));
             Assert.Equal("this, i", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnEntry));
             Assert.Equal("this, i, d", GetSymbolNamesJoined(dataFlows.DefinitelyAssignedOnExit));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlows.ReadInside));
             Assert.Equal("i, d", GetSymbolNamesJoined(dataFlows.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlows.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlows.ReadOutside));
             Assert.Equal("this, i", GetSymbolNamesJoined(dataFlows.WrittenOutside));
         }
 
@@ -4644,18 +4642,18 @@ class Program
         }
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("num", GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
             Assert.Equal("num", GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("num, f, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, num, f, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4741,11 +4739,11 @@ class Program
             Assert.Equal("q2, x", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("q2", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums, q2", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("nums, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("q2, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -4768,15 +4766,15 @@ class Program
                 select /*<bind>*/ x+1 /*</bind>*/;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("nums, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, q2, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4796,15 +4794,15 @@ class Program
                  group x.Value + 1 by /*<bind>*/ x.Value % 2 /*</bind>*/;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("nums, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, q2, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4823,15 +4821,15 @@ class Program
         var q2 = from int x in nums where x < 3 select /*<bind>*/ x /*</bind>*/;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("nums, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, q2, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4850,15 +4848,15 @@ class Program
         var q2 = from int x in nums where x < 3 group /*<bind>*/ x /*</bind>*/ by x%2;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("nums, x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, q2, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4882,18 +4880,18 @@ class Program
         }
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("num", GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
             Assert.Equal("num", GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums, num", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums, num", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("nums, num", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, num, q, n", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4917,16 +4915,16 @@ class Program
         }
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("num", GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("nums, num", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("nums, num", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("nums", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("num", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("nums, num, q, n", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -4951,15 +4949,15 @@ class C
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.Equal("temp, x, z, w", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("temp", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("args", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("args, temp", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x, z, w", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("temp, x, z, w", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -4981,18 +4979,18 @@ class Program
                  select x;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("args", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("args", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("args, q1, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -5014,7 +5012,7 @@ public class Test
     }
 }");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
         }
 
         [WorkItem(1291, "https://github.com/dotnet/roslyn/issues/1291")]
@@ -5096,16 +5094,16 @@ class C
 ");
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("i, f1", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -5138,10 +5136,10 @@ class Program
             Assert.Empty(dataFlowAnalysisResults.AlwaysAssigned);
             Assert.Empty(dataFlowAnalysisResults.DataFlowsIn);
             Assert.Empty(dataFlowAnalysisResults.DataFlowsOut);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Empty(dataFlowAnalysisResults.ReadInside);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Empty(dataFlowAnalysisResults.WrittenInside);
             Assert.Equal("i100", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -5175,12 +5173,12 @@ class Program
             Assert.Empty(dataFlowAnalysisResults.AlwaysAssigned);
             Assert.Empty(dataFlowAnalysisResults.DataFlowsIn);
             Assert.Empty(dataFlowAnalysisResults.DataFlowsOut);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Empty(dataFlowAnalysisResults.ReadInside);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Empty(dataFlowAnalysisResults.WrittenInside);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -5217,7 +5215,7 @@ class C
             Assert.Equal("this, p", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, p", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("p", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Empty(dataFlowAnalysisResults.WrittenInside);
             Assert.Equal("this, p", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -5256,7 +5254,7 @@ class Test
             Assert.Equal("this, node", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, node", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("node", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Empty(dataFlowAnalysisResults.WrittenInside);
             Assert.Equal("this, node", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -5330,18 +5328,18 @@ class A
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -5399,18 +5397,18 @@ class C
             var analysis = model.AnalyzeDataFlow(statement);
             Assert.True(analysis.Succeeded);
             Assert.Equal("o", GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.Captured));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
         [WorkItem(545372, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545372")]
@@ -5438,7 +5436,7 @@ class Program
             Assert.Equal("if (args == null) {}", statement.ToFullString());
             var analysis = model.AnalyzeDataFlow(statement);
             Assert.True(analysis.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("args, f3", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
 
@@ -5557,7 +5555,7 @@ public class ExportedSymbol
             var expression = GetLastNode<ExpressionSyntax>(tree, root.ToFullString().IndexOf("value ", StringComparison.Ordinal));
             var analysis = model.AnalyzeDataFlow(expression);
             Assert.True(analysis.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact, WorkItem(14110, "https://github.com/dotnet/roslyn/issues/14110")]
@@ -5636,17 +5634,17 @@ class C
     }
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(results.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenOutside));
         }
 
         [Fact]
@@ -5667,17 +5665,17 @@ class C
     }
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(results.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenOutside));
         }
 
         [Fact]
@@ -5697,17 +5695,17 @@ class C
     }
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("a", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("a", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("a", GetSymbolNamesJoined(results.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenOutside));
         }
 
         [Fact]
@@ -5727,17 +5725,17 @@ class C
     }
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("a", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("a", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("a", GetSymbolNamesJoined(results.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenOutside));
         }
 
         [Fact]
@@ -5762,17 +5760,17 @@ class C
     int M(int i) => i;
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenOutside));
         }
 
         [Fact]
@@ -5800,12 +5798,12 @@ class C
     int M(int i) => i;
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.WrittenInside));
@@ -5830,15 +5828,15 @@ class C
     }
 }");
             Assert.True(results.Succeeded);
-            Assert.Equal(null, GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.Captured));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("a", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("a", GetSymbolNamesJoined(results.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.WrittenOutside));
         }
 
         [Fact]
@@ -5863,10 +5861,10 @@ class C
 }");
             Assert.True(results.Succeeded);
             Assert.Equal("x", GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("x", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadInside));
@@ -5890,17 +5888,17 @@ public static class SomeClass
 }");
             Assert.True(results.Succeeded);
             Assert.Equal("arg", GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
             Assert.Equal("arg", GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("arg", GetSymbolNamesJoined(results.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
             Assert.Equal("arg", GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("arg, localValue", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("localValue", GetSymbolNamesJoined(results.AlwaysAssigned));
             Assert.Equal("arg", GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("arg", GetSymbolNamesJoined(results.ReadOutside));
             Assert.Equal("localValue", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(results.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -5920,17 +5918,17 @@ class C
 }");
             Assert.True(results.Succeeded);
             Assert.Equal("x", GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(results.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
             Assert.Equal("this, x", GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(results.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(results.ReadOutside));
             Assert.Equal("y", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(results.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -5950,17 +5948,17 @@ class C
 }");
             Assert.True(results.Succeeded);
             Assert.Equal("x", GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("x", GetSymbolNamesJoined(results.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
             Assert.Equal("this", GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("this, y", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(results.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadOutside));
             Assert.Equal("y", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(results.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -5980,7 +5978,7 @@ class C
 }");
             Assert.True(results.Succeeded);
             Assert.Equal("x", GetSymbolNamesJoined(results.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedInside));
             Assert.Equal("x", GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("y", GetSymbolNamesJoined(results.DataFlowsIn));
             Assert.Equal("x", GetSymbolNamesJoined(results.DataFlowsOut));
@@ -5991,8 +5989,8 @@ class C
             Assert.Equal("x", GetSymbolNamesJoined(results.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(results.WrittenInside));
             Assert.Equal("this, y", GetSymbolNamesJoined(results.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.UnsafeAddressTaken));
+            Assert.Null(GetSymbolNamesJoined(results.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(results.UnsafeAddressTaken));
         }
 
         [Fact]
@@ -6013,9 +6011,9 @@ class C
 }");
             Assert.Equal("this", GetSymbolNamesJoined(results.Captured));
             Assert.Equal("this", GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("a", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
             Assert.Equal("this", GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("this", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("this", GetSymbolNamesJoined(results.ReadInside));
@@ -6047,12 +6045,12 @@ class C
 }");
             Assert.Equal("x, y", GetSymbolNamesJoined(results.Captured));
             Assert.Equal("x, y", GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.VariablesDeclared));
             // TODO(https://github.com/dotnet/roslyn/issues/14214): This is wrong.
             // Both x and y should flow out.
             Assert.Equal("y", GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("x, y", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("x, y", GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(results.WrittenInside));
@@ -6083,10 +6081,10 @@ class C
 }");
             Assert.Equal("x", GetSymbolNamesJoined(results.Captured));
             Assert.Equal("x", GetSymbolNamesJoined(results.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(results.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(results.CapturedOutside));
             Assert.Equal("y", GetSymbolNamesJoined(results.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(results.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(results.DefinitelyAssignedOnEntry));
             Assert.Equal("x, y", GetSymbolNamesJoined(results.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(results.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(results.WrittenInside));
@@ -6111,17 +6109,17 @@ class C
         /*</bind>*/
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("y", GetSymbolNamesJoined(analysis.CapturedInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
@@ -6143,17 +6141,17 @@ class C
         /*</bind>*/
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(analysis.Captured));
             Assert.Equal("y", GetSymbolNamesJoined(analysis.CapturedInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("this, x, a, y", GetSymbolNamesJoined(analysis.WrittenOutside));
         }
@@ -6217,17 +6215,17 @@ class A
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -6247,17 +6245,17 @@ class A
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -6277,17 +6275,17 @@ class A
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -6307,18 +6305,18 @@ class MyClass
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -6337,18 +6335,18 @@ class MyClass
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -6367,18 +6365,18 @@ struct MyStruct
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -6397,11 +6395,11 @@ struct MyStruct
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("value", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
@@ -6427,18 +6425,18 @@ class MyClass
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -6457,18 +6455,18 @@ class MyClass
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -6487,11 +6485,11 @@ struct MyStruct
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
@@ -6517,11 +6515,11 @@ struct MyStruct
 }
 ");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, value", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
@@ -6547,18 +6545,18 @@ class C
 ");
             var dataFlowAnalysisResults = analysisResults;
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -6576,18 +6574,18 @@ class C
 ");
             var dataFlowAnalysisResults = analysisResults;
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -6600,19 +6598,19 @@ class C {
     int Y = /*<bind>*/X/*</bind>*/;
 }");
             var dataFlowAnalysisResults = analysisResults;
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -6636,18 +6634,18 @@ class C {
             Assert.Equal(0, stmt.Span.Length);
 
             var dataFlowAnalysisResults = model.AnalyzeDataFlow(stmt);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnExit));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -6686,11 +6684,11 @@ namespace ConsoleApp39
 
             var dataFlowAnalysisResults = analysisResults.Item2;
 
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
             Assert.Equal("test, a", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("test", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, test, a", GetSymbolNamesJoined(dataFlowAnalysisResults.DefinitelyAssignedOnEntry));
@@ -6747,9 +6745,9 @@ class A
                 Assert.True(dataFlowAnalysisResults.Succeeded);
                 Assert.Equal("k", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
                 Assert.Equal("j", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
-                Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedInside));
+                Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.CapturedOutside));
                 Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
                 Assert.Equal("j", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
                 Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/TryLockUsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/TryLockUsingStatementTests.cs
@@ -45,14 +45,14 @@ class C
             Assert.Empty(controlFlowAnalysisResults.ExitPoints);
             Assert.Empty(controlFlowAnalysisResults.ReturnStatements);
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -82,14 +82,14 @@ class C
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(1, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
         [Fact]
@@ -139,13 +139,13 @@ public class TryCatchFinally
             Assert.Equal(3, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, para, by", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -196,13 +196,13 @@ public class TryCatchFinally
             Assert.Equal(0, controlFlowAnalysisResults.EntryPoints.Count());
             Assert.Equal(5, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("para, by", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("para, by", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, para, by", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -255,7 +255,7 @@ public class TryCatchFinally
             Assert.Equal(2, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("by", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -293,13 +293,13 @@ public class TryCatchFinally
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, para", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
 
@@ -338,7 +338,7 @@ public class TryCatchFinally
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -399,12 +399,12 @@ public class TryCatchFinally
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("sb", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("sb", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -444,11 +444,11 @@ public class TryCatchFinally
             Assert.Equal(0, controlFlowAnalysisResults.ExitPoints.Count());
             Assert.Equal(0, controlFlowAnalysisResults.ReturnStatements.Count());
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("para, local", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("para, local", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
@@ -483,10 +483,10 @@ public class TryCatchFinally
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("para, local", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("para, local", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
@@ -527,7 +527,7 @@ public class TryCatchFinally
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("ax", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("para", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -570,8 +570,8 @@ public class TryCatchFinally
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("p, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("z", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("p, x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
@@ -610,7 +610,7 @@ public class TryCatchFinally
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("z", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("p, x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
@@ -704,10 +704,10 @@ public class TryCatchFinally
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("s, ax, s, s", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("s, ax, s, s", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -813,9 +813,9 @@ public class TryCatchFinally
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             // unreachable is ALWAYS assigned
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("ax", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("y, ax", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("s", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
@@ -896,12 +896,12 @@ public class TryCatchFinally
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable); // possible if while (false)...
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -940,12 +940,12 @@ public class TryCatchFinally
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -992,9 +992,9 @@ public class TryCatchFinally
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("i", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("this, p", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("this, p, i", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
             Assert.Equal("y, i", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("this, p", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenOutside));
         }
@@ -1179,10 +1179,10 @@ public class TryCatchFinally
             Assert.False(controlFlowAnalysisResults.EndPointIsReachable);
 
             Assert.Equal("e, d, ap", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("p, local, e", GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
             Assert.Equal("p, local", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("p, local, e, d, ap", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("e, d, ap", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("p", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
@@ -1229,7 +1229,7 @@ public class TryCatchFinally
             Assert.Equal("d", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Equal("p, local, e", GetSymbolNamesJoined(dataFlowAnalysisResults.Captured));
             Assert.Equal("p, local, e", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Equal("p, local, e, d, ap", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("d, ap", GetSymbolNamesJoined(dataFlowAnalysisResults.WrittenInside));
             Assert.Equal("p, local", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
@@ -1268,7 +1268,7 @@ public class Program
             var controlFlowAnalysisResults = analysisResults.Item1;
             var dataFlowAnalysisResults = analysisResults.Item2;
             Assert.True(controlFlowAnalysisResults.EndPointIsReachable);
-            Assert.Equal(null, GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
         }
 
         [Fact]
@@ -1439,10 +1439,10 @@ class C {
             Assert.Equal("c", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("c", GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact]
@@ -1462,14 +1462,14 @@ class C {
         int b;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("c", GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact]
@@ -1501,10 +1501,10 @@ class C : System.IAsyncDisposable
             Assert.Equal("c", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
             Assert.Equal("c", GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
 
             Assert.Empty(analysisControlFlow.EntryPoints);
             Assert.Empty(analysisControlFlow.ExitPoints);
@@ -1532,14 +1532,14 @@ class C {
         int b;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact]
@@ -1560,14 +1560,14 @@ class C {
         int b;
     }
 }");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this, x, c", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.ReadInside));
             Assert.Equal("c", GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("this, x", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact()]
@@ -1590,14 +1590,14 @@ class Test
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("this", GetSymbolNamesJoined(analysis.WrittenOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact()]
@@ -1621,14 +1621,14 @@ class Test
     { return 1; }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.WrittenInside));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("name, obj", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("name, obj", GetSymbolNamesJoined(analysis.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.ReadOutside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.AlwaysAssigned));
+            Assert.Null(GetSymbolNamesJoined(analysis.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysis.AlwaysAssigned));
             Assert.Equal("name, obj", GetSymbolNamesJoined(analysis.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
         [Fact()]
@@ -1651,7 +1651,7 @@ class Test
     }
 }
 ");
-            Assert.Equal(null, GetSymbolNamesJoined(analysis.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysis.VariablesDeclared));
             Assert.Equal("obj", GetSymbolNamesJoined(analysis.WrittenInside));
             Assert.Equal("str", GetSymbolNamesJoined(analysis.WrittenOutside));
             Assert.Equal("str", GetSymbolNamesJoined(analysis.ReadInside));
@@ -1685,14 +1685,14 @@ class Test
 ");
             var analysisControlFlow = analysis.Item1;
             var analysisDataflow = analysis.Item2;
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.VariablesDeclared));
             Assert.Equal("obj", GetSymbolNamesJoined(analysisDataflow.WrittenInside));
             Assert.Equal("str", GetSymbolNamesJoined(analysisDataflow.WrittenOutside));
             Assert.Equal("str", GetSymbolNamesJoined(analysisDataflow.ReadInside));
             Assert.Equal("obj", GetSymbolNamesJoined(analysisDataflow.ReadOutside));
             Assert.Equal("obj", GetSymbolNamesJoined(analysisDataflow.AlwaysAssigned));
             Assert.Equal("str", GetSymbolNamesJoined(analysisDataflow.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.DataFlowsOut));
 
             Assert.Equal(1, analysisControlFlow.ExitPoints.Count());
             Assert.Equal(0, analysisControlFlow.EntryPoints.Count());
@@ -1724,14 +1724,14 @@ class Test
 ");
             var analysisControlFlow = analysis.Item1;
             var analysisDataflow = analysis.Item2;
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.VariablesDeclared));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.VariablesDeclared));
             Assert.Equal("obj", GetSymbolNamesJoined(analysisDataflow.WrittenInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.WrittenOutside));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.WrittenOutside));
             Assert.Equal("obj", GetSymbolNamesJoined(analysisDataflow.ReadInside));
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.ReadOutside));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.ReadOutside));
             Assert.Equal("obj", GetSymbolNamesJoined(analysisDataflow.AlwaysAssigned));
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.DataFlowsIn));
-            Assert.Equal(null, GetSymbolNamesJoined(analysisDataflow.DataFlowsOut));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.DataFlowsIn));
+            Assert.Null(GetSymbolNamesJoined(analysisDataflow.DataFlowsOut));
 
             Assert.Equal(0, analysisControlFlow.ExitPoints.Count());
             Assert.Equal(0, analysisControlFlow.EntryPoints.Count());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AccessibilityTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AccessibilityTests.cs
@@ -35,17 +35,17 @@ class C1
         [Fact]
         public void IsAccessibleNullArguments()
         {
-            Assert.Throws(typeof(ArgumentNullException), () =>
+            Assert.Throws<ArgumentNullException>(() =>
                 s_testModel.IsAccessible(s_testPosition, null));
         }
 
         [Fact]
         public void IsAccessibleLocationNotInSource()
         {
-            Assert.Throws(typeof(ArgumentOutOfRangeException), () =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
                 s_testModel.IsAccessible(-1, s_testSymbol));
 
-            Assert.Throws(typeof(ArgumentOutOfRangeException), () =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
                 s_testModel.IsAccessible(s_testModel.SyntaxTree.GetCompilationUnitRoot().FullSpan.End + 1, s_testSymbol));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -1893,7 +1893,7 @@ class C
             var verifier = CompileAndVerify(compilation);
             var actualIL = verifier.VisualizeIL("C.<F>d__0<T1, T2, T3, T4, T5, T6>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()");
             var calls = actualIL.Split(new[] { '\n', '\r' }, System.StringSplitOptions.RemoveEmptyEntries).Where(s => s.Contains("OnCompleted")).ToArray();
-            Assert.Equal(calls.Length, 6);
+            Assert.Equal(6, calls.Length);
             Assert.Equal("    IL_0056:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted<T1, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T1, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[0]);
             Assert.Equal("    IL_00b9:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T2, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T2, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[1]);
             Assert.Equal("    IL_011c:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T3, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T3, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[2]);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2884,7 +2884,7 @@ class c1
             var comp = CreateCompilation(tree);
             var constantValue = comp.GetSemanticModel(tree).GetConstantValue(expr);
             Assert.True(constantValue.HasValue);
-            Assert.Equal(constantValue.Value, 6);
+            Assert.Equal(6, constantValue.Value);
         }
 
         [WorkItem(544620, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544620")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -1277,7 +1277,7 @@ class Program
             var comp = CreateCompilationWithMscorlib40(new[] { tree });
             var model = comp.GetSemanticModel(tree);
             var eof = tree.GetCompilationUnitRoot().FullSpan.End;
-            Assert.NotEqual(eof, 0);
+            Assert.NotEqual(0, eof);
             var symbols = model.LookupSymbols(eof);
             CompilationUtils.CheckSymbols(symbols, "System", "Microsoft");
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -51,10 +51,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.NotEqual(insideEnumDefinition, insideMethodBody);
 
-            Assert.Equal("System.Int32 System.Int32.op_BitwiseOr(System.Int32 left, System.Int32 right)",
-insideEnumDefinition.Symbol.ToTestDisplayString());
-            Assert.Equal("TestEnum TestEnum.op_BitwiseOr(TestEnum left, TestEnum right)",
-insideMethodBody.Symbol.ToTestDisplayString());
+            Assert.Equal("System.Int32 System.Int32.op_BitwiseOr(System.Int32 left, System.Int32 right)", insideEnumDefinition.Symbol.ToTestDisplayString());
+            Assert.Equal("TestEnum TestEnum.op_BitwiseOr(TestEnum left, TestEnum right)", insideMethodBody.Symbol.ToTestDisplayString());
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -51,9 +51,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.NotEqual(insideEnumDefinition, insideMethodBody);
 
-            Assert.Equal(                "System.Int32 System.Int32.op_BitwiseOr(System.Int32 left, System.Int32 right)",
+            Assert.Equal("System.Int32 System.Int32.op_BitwiseOr(System.Int32 left, System.Int32 right)",
 insideEnumDefinition.Symbol.ToTestDisplayString());
-            Assert.Equal(                "TestEnum TestEnum.op_BitwiseOr(TestEnum left, TestEnum right)",
+            Assert.Equal("TestEnum TestEnum.op_BitwiseOr(TestEnum left, TestEnum right)",
 insideMethodBody.Symbol.ToTestDisplayString());
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var semanticModel = compilation.GetSemanticModel(tree);
 
             var orNodes = tree.GetRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().ToArray();
-            Assert.Equal(orNodes.Length, 2);
+            Assert.Equal(2, orNodes.Length);
 
             var insideEnumDefinition = semanticModel.GetSymbolInfo(orNodes[0]);
             var insideMethodBody = semanticModel.GetSymbolInfo(orNodes[1]);
@@ -51,10 +51,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.NotEqual(insideEnumDefinition, insideMethodBody);
 
-            Assert.Equal(insideEnumDefinition.Symbol.ToTestDisplayString(),
-                "System.Int32 System.Int32.op_BitwiseOr(System.Int32 left, System.Int32 right)");
-            Assert.Equal(insideMethodBody.Symbol.ToTestDisplayString(),
-                "TestEnum TestEnum.op_BitwiseOr(TestEnum left, TestEnum right)");
+            Assert.Equal(                "System.Int32 System.Int32.op_BitwiseOr(System.Int32 left, System.Int32 right)",
+insideEnumDefinition.Symbol.ToTestDisplayString());
+            Assert.Equal(                "TestEnum TestEnum.op_BitwiseOr(TestEnum left, TestEnum right)",
+insideMethodBody.Symbol.ToTestDisplayString());
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -2898,7 +2898,7 @@ class C
             var x = model.GetDeclaredSymbol(q.FromClause);
             Assert.Equal(SymbolKind.RangeVariable, x.Kind);
             Assert.Equal("x", x.Name);
-            Assert.Equal(null, info0.CastInfo.Symbol);
+            Assert.Null(info0.CastInfo.Symbol);
             Assert.Null(info0.OperationInfo.Symbol);
             var infoSelect = model.GetSemanticInfoSummary(q.Body.SelectOrGroup);
             Assert.Equal("Select", infoSelect.Symbol.Name);
@@ -2931,7 +2931,7 @@ class C
             var x = model.GetDeclaredSymbol(q.FromClause);
             Assert.Equal(SymbolKind.RangeVariable, x.Kind);
             Assert.Equal("x", x.Name);
-            Assert.Equal(null, info0.CastInfo.Symbol);
+            Assert.Null(info0.CastInfo.Symbol);
             Assert.Null(info0.OperationInfo.Symbol);
             var infoSelect = model.GetSemanticInfoSummary(q.Body.SelectOrGroup);
             Assert.Equal("Select", infoSelect.Symbol.Name);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -401,7 +401,7 @@ G();
 
             Assert.Equal(1, members.Length);
             Assert.Equal("Goo", members[0].Name);
-            Assert.IsAssignableFrom(typeof(NamespaceSymbol), members[0]);
+            Assert.IsAssignableFrom<NamespaceSymbol>(members[0]);
             var ns = (NamespaceSymbol)members[0];
             members = ns.GetMembers();
 
@@ -595,7 +595,7 @@ this[1]
                     var type = (NamedTypeSymbol)symbol;
                     Assert.False(type.IsScriptClass);
                     Assert.False(type.IsSubmissionClass);
-                    Assert.NotEqual(type.TypeKind, TypeKind.Submission);
+                    Assert.NotEqual(TypeKind.Submission, type.TypeKind);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SyntaxTreeRootTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SyntaxTreeRootTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
         public void SyntaxTreeHasCompilationUnitRootReturnsTrueForFullDocument()
         {
             var tree = SyntaxFactory.ParseSyntaxTree(@"class Program { static void Main() { System.Console.WriteLine(""Wah""); } }");
-            Assert.Equal(true, tree.HasCompilationUnitRoot);
+            Assert.True(tree.HasCompilationUnitRoot);
             Assert.Equal(typeof(CompilationUnitSyntax), tree.GetRoot().GetType());
         }
 
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
         {
             var tree = SyntaxFactory.SyntaxTree(SyntaxFactory.FromClause("Nay", SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(823))));
             SyntaxNode root;
-            Assert.Equal(true, tree.TryGetRoot(out root));
-            Assert.Equal(false, tree.HasCompilationUnitRoot);
+            Assert.True(tree.TryGetRoot(out root));
+            Assert.False(tree.HasCompilationUnitRoot);
             Assert.NotEqual(typeof(CompilationUnitSyntax), root.GetType());
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SyntaxTreeRootTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SyntaxTreeRootTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
         {
             var node = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(3));
             var syntaxTreeField = typeof(CSharpSyntaxNode).GetFields(BindingFlags.NonPublic | BindingFlags.Instance).Single(f => f.FieldType == typeof(SyntaxTree));
-            Assert.Equal(null, syntaxTreeField.GetValue(node));
+            Assert.Null(syntaxTreeField.GetValue(node));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void WithModuleName()
         {
             // ModuleName
-            Assert.Equal(null, TestOptions.ReleaseDll.WithModuleName(null).ModuleName);
+            Assert.Null(TestOptions.ReleaseDll.WithModuleName(null).ModuleName);
             TestOptions.ReleaseDll.WithModuleName("").VerifyErrors(
                 // error CS7087: Invalid module name: Name cannot be empty.
                 Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name cannot be empty.").WithLocation(1, 1)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -2271,7 +2271,7 @@ public class C { public static FrameworkName Goo() { return null; }}";
             var assemblyName = GetUniqueName();
             var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
             CSharpCompilation.Create(assemblyName, new[] { tree1, tree2 }, new[] { MscorlibRef }, compilationOptions);
-            Assert.Throws(typeof(ArgumentException), () =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 CSharpCompilation.Create(assemblyName, new[] { tree1, tree3 }, new[] { MscorlibRef }, compilationOptions);
             });

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -1142,7 +1142,7 @@ var a = new C2();
             Assert.True(comp.References.Contains(compRef1));
             Assert.True(comp.References.Contains(compRef2));
             var smb = comp.GetReferencedAssemblySymbol(compRef1);
-            Assert.Equal(smb.Kind, SymbolKind.Assembly);
+            Assert.Equal(SymbolKind.Assembly, smb.Kind);
             Assert.Equal("Test1", smb.Identity.Name, StringComparer.OrdinalIgnoreCase);
 
             // Mixed reference type

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -331,7 +331,7 @@ class C
             var symbol1 = model1.GetSymbolInfo(statement.Expression).Symbol;
             var symbol2 = model2.GetSymbolInfo(statement.Expression).Symbol;
 
-            Assert.Equal(false, ReferenceEquals(symbol1, symbol2));
+            Assert.False(ReferenceEquals(symbol1, symbol2));
             Assert.Equal(symbol1, symbol2);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4165,7 +4165,7 @@ class C {
 
             var symbolInfo = model.GetSpeculativeSymbolInfo(position, attr1);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4173,7 +4173,7 @@ class C {
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr2);
             Assert.Null(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.OverloadResolutionFailure);
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, symbolInfo.CandidateReason);
             Assert.Equal(3, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor()", symbolInfo.CandidateSymbols[0].ToTestDisplayString());
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.CandidateSymbols[1].ToTestDisplayString());
@@ -4183,7 +4183,7 @@ class C {
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr3);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4191,14 +4191,14 @@ class C {
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr4);
             Assert.Null(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
 
             var attr5 = ParseAttributeSyntax("[D]");
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr5);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("C.DAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4207,7 +4207,7 @@ class C {
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position2, attr6);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4216,7 +4216,7 @@ class C {
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position3, attr7);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
         }
@@ -4249,7 +4249,7 @@ class C {
 
             var symbolInfo = speculativeModel.GetSymbolInfo(attr1);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4260,7 +4260,7 @@ class C {
 
             symbolInfo = speculativeModel.GetSymbolInfo(attr2);
             Assert.Null(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.OverloadResolutionFailure);
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, symbolInfo.CandidateReason);
             Assert.Equal(3, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor()", symbolInfo.CandidateSymbols[0].ToTestDisplayString());
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.CandidateSymbols[1].ToTestDisplayString());
@@ -4277,7 +4277,7 @@ class C {
             Assert.NotNull(speculativeModel);
             symbolInfo = speculativeModel.GetSymbolInfo(attr3);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4299,7 +4299,7 @@ class C {
 
             symbolInfo = speculativeModel.GetSymbolInfo(attr4);
             Assert.Null(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
 
             var attr5 = ParseAttributeSyntax("[D]");
@@ -4310,7 +4310,7 @@ class C {
 
             symbolInfo = speculativeModel.GetSymbolInfo(attr5);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("C.DAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4323,7 +4323,7 @@ class C {
 
             symbolInfo = speculativeModel.GetSymbolInfo(attr6);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4346,7 +4346,7 @@ class C {
 
             symbolInfo = speculativeModel.GetSymbolInfo(attr7);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4368,7 +4368,7 @@ class C {
 
             symbolInfo = speculativeModel.GetSymbolInfo(attr8);
             Assert.NotNull(symbolInfo.Symbol);
-            Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
@@ -4686,7 +4686,7 @@ class C : A<object>.B<> { }";
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
             type = type.BaseType();
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "A<object>.B<?>");
+            Assert.Equal("A<object>.B<?>", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
         }
 
         [Fact]
@@ -4701,7 +4701,7 @@ class C : A<,,>.B<object> { }";
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
             type = type.BaseType();
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "A<?, ?, ?>.B<object>");
+            Assert.Equal("A<?, ?, ?>.B<object>", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
         }
 
         [Fact]
@@ -4716,7 +4716,7 @@ class C : A<>.B<> { }";
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
             type = type.BaseType();
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "A<?>.B<?>");
+            Assert.Equal("A<?>.B<?>", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
         }
 
         [WorkItem(563572, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/563572")]
@@ -4798,9 +4798,9 @@ class C
             var decl = (TupleExpressionSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.TupleExpression));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(int, int)");
-            Assert.Equal(type.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "(1, 2)");
-            Assert.Equal(type.Locations.Single().IsInSource, true);
+            Assert.Equal("(int, int)", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("(1, 2)", type.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(type.Locations.Single().IsInSource);
 
         }
 
@@ -4827,9 +4827,9 @@ class C
             var decl = (TupleExpressionSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.TupleExpression));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(int Alice, int Bob)");
-            Assert.Equal(type.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "(Alice: 1, Bob: 2)");
-            Assert.Equal(type.Locations.Single().IsInSource, true);
+            Assert.Equal("(int Alice, int Bob)", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("(Alice: 1, Bob: 2)", type.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(type.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -4855,9 +4855,9 @@ class C
             var decl = (TupleExpressionSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.TupleExpression));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short, int)");
-            Assert.Equal(type.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "(1, 1)");
-            Assert.Equal(type.Locations.Single().IsInSource, true);
+            Assert.Equal("(short, int)", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("(1, 1)", type.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(type.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -4883,9 +4883,9 @@ class C
             var decl = (TupleExpressionSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.TupleExpression));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short, string)");
-            Assert.Equal(type.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "(1, null)");
-            Assert.Equal(type.Locations.Single().IsInSource, true);
+            Assert.Equal("(short, string)", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("(1, null)", type.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(type.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -4911,9 +4911,9 @@ class C
             var decl = (TupleExpressionSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.TupleExpression));
             var model = compilation.GetSemanticModel(tree);
             var type = (NamedTypeSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short Alice, string Bob)");
-            Assert.Equal(type.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "(Alice:1, Bob:null)");
-            Assert.Equal(type.Locations.Single().IsInSource, true);
+            Assert.Equal("(short Alice, string Bob)", type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("(Alice:1, Bob:null)", type.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(type.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -4939,9 +4939,9 @@ class C
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(int Alice, int Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(int Alice, int Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -4967,9 +4967,9 @@ class C
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(int Alice, short Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(int Alice, short Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -4995,9 +4995,9 @@ class C
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short Alice, string Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(short Alice, string Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -5030,9 +5030,9 @@ class C
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short Alice, string Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(short Alice, string Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -5076,9 +5076,9 @@ namespace System
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short Alice, string Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(short Alice, string Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -5125,9 +5125,9 @@ namespace System
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short Alice, string Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(short Alice, string Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]
@@ -5153,9 +5153,9 @@ class C
             var decl = (ArgumentSyntax)tree.GetCompilationUnitRoot().DescendantNodes().Last(n => n.IsKind(SyntaxKind.Argument));
             var model = compilation.GetSemanticModel(tree);
             var element = (FieldSymbol)model.GetDeclaredSymbol(decl);
-            Assert.Equal(element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat), "(short, string Bob).Bob");
-            Assert.Equal(element.DeclaringSyntaxReferences.Single().GetSyntax().ToString(), "Bob");
-            Assert.Equal(element.Locations.Single().IsInSource, true);
+            Assert.Equal("(short, string Bob).Bob", element.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat));
+            Assert.Equal("Bob", element.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(element.Locations.Single().IsInSource);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -11600,7 +11600,7 @@ class Test
             Assert.Equal("global", aliasInfo.Name);
             Assert.Equal("<global namespace>", aliasInfo.Target.ToTestDisplayString());
             Assert.True(((NamespaceSymbol)(aliasInfo.Target)).IsGlobalNamespace);
-            Assert.Equal(false, aliasInfo.IsExtern);
+            Assert.False(aliasInfo.IsExtern);
 
             Assert.False(semanticInfo.IsCompileTimeConstant);
         }
@@ -11634,7 +11634,7 @@ class Test
             Assert.Equal("global", aliasInfo.Name);
             Assert.Equal("<global namespace>", aliasInfo.Target.ToTestDisplayString());
             Assert.True(((NamespaceSymbol)(aliasInfo.Target)).IsGlobalNamespace);
-            Assert.Equal(false, aliasInfo.IsExtern);
+            Assert.False(aliasInfo.IsExtern);
 
             Assert.False(semanticInfo.IsCompileTimeConstant);
         }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -1752,7 +1752,7 @@ class Test
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 
             Assert.True(semanticInfo.IsCompileTimeConstant);
-            Assert.Equal(null, semanticInfo.ConstantValue.Value);
+            Assert.Null(semanticInfo.ConstantValue.Value);
         }
 
         [WorkItem(3019, "DevDiv_Projects/Roslyn")]
@@ -3942,7 +3942,7 @@ public class Test
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 
             Assert.True(semanticInfo.IsCompileTimeConstant);
-            Assert.Equal(null, semanticInfo.ConstantValue.Value);
+            Assert.Null(semanticInfo.ConstantValue.Value);
         }
 
         [WorkItem(538215, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538215")]
@@ -8512,7 +8512,7 @@ public class Test
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 
             Assert.True(semanticInfo.IsCompileTimeConstant);
-            Assert.Equal(null, semanticInfo.ConstantValue.Value);
+            Assert.Null(semanticInfo.ConstantValue.Value);
         }
 
         [Fact]
@@ -8717,7 +8717,7 @@ public class Test
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 
             Assert.True(semanticInfo.IsCompileTimeConstant);
-            Assert.Equal(null, semanticInfo.ConstantValue.Value);
+            Assert.Null(semanticInfo.ConstantValue.Value);
         }
 
         [Fact]
@@ -11454,7 +11454,7 @@ class Program
             Assert.Equal(0, semanticInfo.MethodGroup.Length);
 
             Assert.True(semanticInfo.IsCompileTimeConstant);
-            Assert.Equal(null, semanticInfo.ConstantValue.Value);
+            Assert.Null(semanticInfo.ConstantValue.Value);
         }
 
         [WorkItem(542850, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542850")]

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/CrefTests.cs
@@ -1808,7 +1808,7 @@ class C
             Assert.Equal(SymbolKind.Method, actualSymbol.Kind);
             var model = compilation.GetSemanticModel(compilation.SyntaxTrees.Single());
             var info = model.GetSymbolInfo(crefSyntax);
-            Assert.Equal(info.CandidateReason, CandidateReason.None);
+            Assert.Equal(CandidateReason.None, info.CandidateReason);
             Assert.Equal(info.Symbol, actualSymbol);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -4300,7 +4300,7 @@ End Class
             Assert.Equal("1.5", SymbolDisplay.FormatPrimitive((decimal)1.5, quoteStrings: false, useHexadecimalNumbers: false));
             Assert.Equal("null", SymbolDisplay.FormatPrimitive(null, quoteStrings: false, useHexadecimalNumbers: false));
             Assert.Equal("abc", SymbolDisplay.FormatPrimitive("abc", quoteStrings: false, useHexadecimalNumbers: false));
-            Assert.Equal(null, SymbolDisplay.FormatPrimitive(SymbolDisplayFormat.TestFormat, quoteStrings: false, useHexadecimalNumbers: false));
+            Assert.Null(SymbolDisplay.FormatPrimitive(SymbolDisplayFormat.TestFormat, quoteStrings: false, useHexadecimalNumbers: false));
         }
 
         [WorkItem(879984, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/879984")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -35,19 +35,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
                 var method = type.GetMember<MethodSymbol>("M1");
                 Assert.False(method.IsExtensionMethod);
                 var parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Object);
+                Assert.Equal(SpecialType.System_Object, parameter.Type.SpecialType);
 
                 // Extension method.
                 method = type.GetMember<MethodSymbol>("M2");
                 Assert.True(method.IsExtensionMethod);
                 parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Object);
+                Assert.Equal(SpecialType.System_Object, parameter.Type.SpecialType);
 
                 // Extension method with type parameters.
                 method = type.GetMember<MethodSymbol>("M3");
                 Assert.True(method.IsExtensionMethod);
                 parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.TypeKind, TypeKind.TypeParameter);
+                Assert.Equal(TypeKind.TypeParameter, parameter.Type.TypeKind);
             };
             CompileAndVerify(source, validator: validator, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.Internal));
         }
@@ -2581,7 +2581,7 @@ internal static class C
             {
                 var method = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<PEMethodSymbol>("M1");
                 Assert.True(method.IsExtensionMethod);
-                Assert.Equal(method.Parameters.Single().Type.SpecialType, SpecialType.System_Object);
+                Assert.Equal(SpecialType.System_Object, method.Parameters.Single().Type.SpecialType);
 
                 var attr = ((PEModuleSymbol)module).GetCustomAttributesForToken(method.Handle).Single();
                 Assert.Equal("System.Runtime.CompilerServices.ExtensionAttribute", attr.AttributeClass.ToTestDisplayString());
@@ -4019,13 +4019,13 @@ public static class C
                 var method = type.GetMember<MethodSymbol>("M1");
                 Assert.True(method.IsExtensionMethod);
                 var parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, parameter.Type.SpecialType);
                 Assert.Equal(RefKind.In, parameter.RefKind);
 
                 method = type.GetMember<MethodSymbol>("M2");
                 Assert.True(method.IsExtensionMethod);
                 parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, parameter.Type.SpecialType);
                 Assert.Equal(RefKind.In, parameter.RefKind);
             }
 
@@ -4049,13 +4049,13 @@ public static class C
                 var method = type.GetMember<MethodSymbol>("M1");
                 Assert.True(method.IsExtensionMethod);
                 var parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, parameter.Type.SpecialType);
                 Assert.Equal(RefKind.Ref, parameter.RefKind);
 
                 method = type.GetMember<MethodSymbol>("M2");
                 Assert.True(method.IsExtensionMethod);
                 parameter = method.Parameters[0];
-                Assert.Equal(parameter.Type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, parameter.Type.SpecialType);
                 Assert.Equal(RefKind.Ref, parameter.RefKind);
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -5691,7 +5691,7 @@ End Module",
             Assert.Equal(typeParameter.IsValueType, isValueType);
             Assert.Equal(typeParameter.IsReferenceType, isReferenceType);
             Assert.Null(typeParameter.BaseType());
-            Assert.Equal(typeParameter.Interfaces().Length, 0);
+            Assert.Equal(0, typeParameter.Interfaces().Length);
             Utils.CheckSymbol(typeParameter.EffectiveBaseClassNoUseSiteDiagnostics, effectiveBaseClassDescription);
             Utils.CheckSymbol(typeParameter.DeducedBaseTypeNoUseSiteDiagnostics, deducedBaseTypeDescription);
             Utils.CheckSymbols(typeParameter.ConstraintTypes(), constraintTypeDescriptions);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingNamespacesAndTypes.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingNamespacesAndTypes.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var extent = globalNS.Extent;
 
-            Assert.Equal(extent.Kind, NamespaceKind.Module);
+            Assert.Equal(NamespaceKind.Module, extent.Kind);
             Assert.Same(extent.Module, module0);
             Assert.Equal(1, globalNS.ConstituentNamespaces.Length);
             Assert.Same(globalNS, globalNS.ConstituentNamespaces[0]);
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             extent = systemNS.Extent;
 
-            Assert.Equal(extent.Kind, NamespaceKind.Module);
+            Assert.Equal(NamespaceKind.Module, extent.Kind);
             Assert.Same(extent.Module, module0);
             Assert.Equal(1, systemNS.ConstituentNamespaces.Length);
             Assert.Same(systemNS, systemNS.ConstituentNamespaces[0]);
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             extent = collectionsNS.Extent;
 
-            Assert.Equal(extent.Kind, NamespaceKind.Module);
+            Assert.Equal(NamespaceKind.Module, extent.Kind);
             Assert.Same(extent.Module, module0);
             Assert.Equal(1, collectionsNS.ConstituentNamespaces.Length);
             Assert.Same(collectionsNS, collectionsNS.ConstituentNamespaces[0]);
@@ -172,14 +172,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         private void TypeAndNamespaceDifferByCase(ModuleSymbol module0)
         {
             var someName = module0.GlobalNamespace.GetMembers("SomenamE");
-            Assert.Equal(someName.Length, 0);
+            Assert.Equal(0, someName.Length);
 
             someName = module0.GlobalNamespace.GetMembers("somEnamE");
-            Assert.Equal(someName.Length, 1);
+            Assert.Equal(1, someName.Length);
             Assert.NotNull((someName[0] as NamedTypeSymbol));
 
             someName = module0.GlobalNamespace.GetMembers("SomeName");
-            Assert.Equal(someName.Length, 1);
+            Assert.Equal(1, someName.Length);
             Assert.NotNull((someName[0] as NamespaceSymbol));
 
             var someName1_1 = module0.GlobalNamespace.GetTypeMembers("somEnamE1").OrderBy((t) => t.Name).ToArray();
@@ -219,35 +219,35 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
         private void TestGetMembersOfName(ModuleSymbol module0)
         {
             var sys = module0.GlobalNamespace.GetMembers("SYSTEM");
-            Assert.Equal(sys.Length, 0);
+            Assert.Equal(0, sys.Length);
 
             sys = module0.GlobalNamespace.GetMembers("System");
-            Assert.Equal(sys.Length, 1);
+            Assert.Equal(1, sys.Length);
 
             var system = sys[0] as NamespaceSymbol;
             Assert.NotNull(system);
 
-            Assert.Equal(system.GetMembers("Action").Length, 9);
-            Assert.Equal(system.GetMembers("ActionThatDoesntExist").Length, 0);
+            Assert.Equal(9, system.GetMembers("Action").Length);
+            Assert.Equal(0, system.GetMembers("ActionThatDoesntExist").Length);
 
-            Assert.Equal(system.GetTypeMembers("Action").Length, 9);
-            Assert.Equal(system.GetTypeMembers("ActionThatDoesntExist").Length, 0);
+            Assert.Equal(9, system.GetTypeMembers("Action").Length);
+            Assert.Equal(0, system.GetTypeMembers("ActionThatDoesntExist").Length);
 
-            Assert.Equal(system.GetTypeMembers("Action", 20).Length, 0);
+            Assert.Equal(0, system.GetTypeMembers("Action", 20).Length);
             var actionOf0 = system.GetTypeMembers("Action", 0).Single();
             var actionOf4 = system.GetTypeMembers("Action", 4).Single();
             Assert.Equal("Action", actionOf0.Name);
             Assert.Equal("Action", actionOf4.Name);
-            Assert.Equal(actionOf0.Arity, 0);
-            Assert.Equal(actionOf4.Arity, 4);
+            Assert.Equal(0, actionOf0.Arity);
+            Assert.Equal(4, actionOf4.Arity);
 
-            Assert.Equal(system.GetTypeMembers("ActionThatDoesntExist", 1).Length, 0);
+            Assert.Equal(0, system.GetTypeMembers("ActionThatDoesntExist", 1).Length);
 
             var collectionsArray = ((NamespaceSymbol)sys[0]).GetMembers("CollectionS");
-            Assert.Equal(collectionsArray.Length, 0);
+            Assert.Equal(0, collectionsArray.Length);
 
             collectionsArray = ((NamespaceSymbol)sys[0]).GetMembers("Collections");
-            Assert.Equal(collectionsArray.Length, 1);
+            Assert.Equal(1, collectionsArray.Length);
 
             var collections = collectionsArray[0] as NamespaceSymbol;
             Assert.NotNull(collections);
@@ -255,34 +255,34 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             Assert.Equal(0, collections.GetAttributes().Length);
 
             var enumerable = collections.GetMembers("IEnumerable");
-            Assert.Equal(enumerable.Length, 1);
+            Assert.Equal(1, enumerable.Length);
             Assert.Equal("System.Collections.IEnumerable", ((NamedTypeSymbol)enumerable[0]).ToTestDisplayString());
 
             var generic = collections.GetMembers("Generic");
-            Assert.Equal(generic.Length, 1);
+            Assert.Equal(1, generic.Length);
             Assert.NotNull((generic[0] as NamespaceSymbol));
 
             var dictionaryArray = ((NamespaceSymbol)generic[0]).GetMembers("Dictionary");
-            Assert.Equal(dictionaryArray.Length, 1);
+            Assert.Equal(1, dictionaryArray.Length);
 
             var dictionary = (NamedTypeSymbol)dictionaryArray[0];
-            Assert.Equal(dictionary.Arity, 2);
+            Assert.Equal(2, dictionary.Arity);
             Assert.Same(dictionary.ConstructedFrom, dictionary);
             Assert.Equal("Dictionary", dictionary.Name);
 
             Assert.Equal(0, collections.GetAttributes(dictionary).Count());
 
-            Assert.Equal(dictionary.GetTypeMembers("ValueCollectionThatDoesntExist").Length, 0);
-            Assert.Equal(dictionary.GetTypeMembers("ValueCollectioN").Length, 0);
+            Assert.Equal(0, dictionary.GetTypeMembers("ValueCollectionThatDoesntExist").Length);
+            Assert.Equal(0, dictionary.GetTypeMembers("ValueCollectioN").Length);
 
             var valueCollection = dictionary.GetTypeMembers("ValueCollection");
-            Assert.Equal(valueCollection.Length, 1);
+            Assert.Equal(1, valueCollection.Length);
             Assert.Equal("ValueCollection", ((NamedTypeSymbol)valueCollection[0]).Name);
-            Assert.Equal(((NamedTypeSymbol)valueCollection[0]).Arity, 0);
+            Assert.Equal(0, ((NamedTypeSymbol)valueCollection[0]).Arity);
 
-            Assert.Equal(dictionary.GetTypeMembers("ValueCollectionThatDoesntExist", 1).Length, 0);
+            Assert.Equal(0, dictionary.GetTypeMembers("ValueCollectionThatDoesntExist", 1).Length);
             Assert.Equal(valueCollection[0], dictionary.GetTypeMembers("ValueCollection", 0).Single());
-            Assert.Equal(dictionary.GetTypeMembers("ValueCollection", 1).Length, 0);
+            Assert.Equal(0, dictionary.GetTypeMembers("ValueCollection", 1).Length);
         }
 
         [ClrOnlyFact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MethodEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MethodEqualityTests.cs
@@ -40,7 +40,7 @@ class Class2
 
             //null
             Assert.NotNull(class1Method1);
-            Assert.NotEqual(class1Method1, null);
+            Assert.NotNull(class1Method1);
 
             //different type
             Assert.NotEqual<Symbol>(class1, class1Method1);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MethodEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MethodEqualityTests.cs
@@ -39,7 +39,7 @@ class Class2
             Assert.Equal(class1Method1, class1Method1);
 
             //null
-            Assert.NotEqual(null, class1Method1);
+            Assert.NotNull(class1Method1);
             Assert.NotEqual(class1Method1, null);
 
             //different type

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MockSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MockSymbolTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             AssemblySymbol assem1 = new MockAssemblySymbol("goo");
 
             NamespaceExtent ne1 = new NamespaceExtent(assem1);
-            Assert.Equal(ne1.Kind, NamespaceKind.Assembly);
+            Assert.Equal(NamespaceKind.Assembly, ne1.Kind);
             Assert.Same(ne1.Assembly, assem1);
 
             CSharpCompilation compilation = CSharpCompilation.Create("Test");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
@@ -51,7 +51,7 @@ class A {
 
             var f = a.GetMember<MethodSymbol>("F");
             Assert.False(f.HasComplete(CompletionPart.StartMethodChecks));
-            Assert.Equal(false, f.ReturnsVoid);
+            Assert.False(f.ReturnsVoid);
             Assert.True(f.HasComplete(CompletionPart.StartMethodChecks));
             Assert.True(f.HasComplete(CompletionPart.FinishMethodChecks));
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -121,7 +121,7 @@ class A {
 
             var comp = CreateCompilation(text);
             var v = comp.GlobalNamespace.GetTypeMembers("MyDel", 0).Single();
-            Assert.NotEqual(null, v);
+            Assert.NotNull(v);
             Assert.Equal(SymbolKind.NamedType, v.Kind);
             Assert.Equal(TypeKind.Delegate, v.TypeKind);
             Assert.True(v.IsReferenceType);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -774,14 +774,14 @@ class C
 
             Assert.False(lambda.ReturnsByRef);
             Assert.True(lambda.ReturnsByRefReadonly);
-            Assert.Equal(lambda.Parameters[0].RefKind, RefKind.In);
+            Assert.Equal(RefKind.In, lambda.Parameters[0].RefKind);
 
             lambdaSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<AnonymousMethodExpressionSyntax>().Single();
             lambda = (LambdaSymbol)model.GetSymbolInfo(lambdaSyntax).Symbol;
 
             Assert.False(lambda.ReturnsByRef);
             Assert.True(lambda.ReturnsByRefReadonly);
-            Assert.Equal(lambda.Parameters[0].RefKind, RefKind.In);
+            Assert.Equal(RefKind.In, lambda.Parameters[0].RefKind);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EnumTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EnumTests.cs
@@ -965,13 +965,13 @@ class C<T> { enum E4 : T { } }
                 );
 
             var decls = tree.GetCompilationUnitRoot().DescendantNodes().OfType<EnumDeclarationSyntax>().ToArray();
-            Assert.Equal(decls.Length, 4);
+            Assert.Equal(4, decls.Length);
 
             foreach (var decl in decls)
             {
                 var symbol = model.GetDeclaredSymbol(decl);
                 var type = symbol.EnumUnderlyingType;
-                Assert.Equal(type.SpecialType, SpecialType.System_Int32);
+                Assert.Equal(SpecialType.System_Int32, type.SpecialType);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -260,7 +260,7 @@ class C
             Assert.Equal("x", mem.Name);
             Assert.True(mem.IsConst);
             Assert.False(mem.HasConstantValue);
-            Assert.Equal(null, mem.ConstantValue);
+            Assert.Null(mem.ConstantValue);
         }
 
         [WorkItem(543538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543538")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -31,7 +31,7 @@ class A {
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var m = a.GetMembers("M").Single() as MethodSymbol;
-            Assert.NotEqual(null, m);
+            Assert.NotNull(m);
             Assert.Equal(true, m.ReturnsVoid);
             var x = m.Parameters[0];
             Assert.Equal("x", x.Name);
@@ -105,7 +105,7 @@ class A {
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var m = a.InstanceConstructors.Single();
-            Assert.NotEqual(null, m);
+            Assert.NotNull(m);
             Assert.Equal(WellKnownMemberNames.InstanceConstructorName, m.Name);
             Assert.Equal(true, m.ReturnsVoid);
             Assert.Equal(MethodKind.Constructor, m.MethodKind);
@@ -130,7 +130,7 @@ class A {
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var m = a.GetMembers("M").Single() as MethodSymbol;
-            Assert.NotEqual(null, m);
+            Assert.NotNull(m);
             Assert.Equal(true, m.ReturnsVoid);
             Assert.Equal(MethodKind.Ordinary, m.MethodKind);
             var x = m.Parameters[0];

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -32,7 +32,7 @@ class A {
             var a = global.GetTypeMembers("A", 0).Single();
             var m = a.GetMembers("M").Single() as MethodSymbol;
             Assert.NotNull(m);
-            Assert.Equal(true, m.ReturnsVoid);
+            Assert.True(m.ReturnsVoid);
             var x = m.Parameters[0];
             Assert.Equal("x", x.Name);
             Assert.Equal(SymbolKind.NamedType, x.Type.Kind);
@@ -107,7 +107,7 @@ class A {
             var m = a.InstanceConstructors.Single();
             Assert.NotNull(m);
             Assert.Equal(WellKnownMemberNames.InstanceConstructorName, m.Name);
-            Assert.Equal(true, m.ReturnsVoid);
+            Assert.True(m.ReturnsVoid);
             Assert.Equal(MethodKind.Constructor, m.MethodKind);
             var x = m.Parameters[0];
             Assert.Equal("x", x.Name);
@@ -131,7 +131,7 @@ class A {
             var a = global.GetTypeMembers("A", 0).Single();
             var m = a.GetMembers("M").Single() as MethodSymbol;
             Assert.NotNull(m);
-            Assert.Equal(true, m.ReturnsVoid);
+            Assert.True(m.ReturnsVoid);
             Assert.Equal(MethodKind.Ordinary, m.MethodKind);
             var x = m.Parameters[0];
             Assert.Equal("x", x.Name);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -560,21 +560,21 @@ class C : B<string>
             {
                 // Non-generic type.
                 var type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("A");
-                Assert.Equal(type.TypeParameters.Length, 0);
+                Assert.Equal(0, type.TypeParameters.Length);
                 Assert.Same(type, type.ConstructedFrom);
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("P"));
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("Q"));
 
                 // Generic type.
                 type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("B");
-                Assert.Equal(type.TypeParameters.Length, 1);
+                Assert.Equal(1, type.TypeParameters.Length);
                 Assert.Same(type, type.ConstructedFrom);
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("P"));
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("Q"));
 
                 // Generic type with parameter substitution.
                 type = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C").BaseType();
-                Assert.Equal(type.TypeParameters.Length, 1);
+                Assert.Equal(1, type.TypeParameters.Length);
                 Assert.NotSame(type, type.ConstructedFrom);
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("P"));
                 VerifyMethodsAndAccessorsSame(type, type.GetMember<PropertySymbol>("Q"));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/TypeMapTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/TypeMapTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private TypeSymbol TypeArg(TypeSymbol t)
         {
             var nts = t as NamedTypeSymbol;
-            Assert.NotEqual(null, nts);
+            Assert.NotNull(nts);
             Assert.Equal(1, nts.Arity);
             return nts.TypeArguments()[0];
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/UsingAliasTests.cs
@@ -203,7 +203,7 @@ partial class A : Object {}
             var model = comp.GetSemanticModel(tree);
 
             var alias = model.GetDeclaredSymbol(usingAlias);
-            Assert.Equal(null, alias);
+            Assert.Null(alias);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
@@ -405,18 +405,18 @@ public class A
             var member1 = model.GetDeclaredSymbol(member1Syntax.Declaration.Variables[0]);
             var member2 = model.GetDeclaredSymbol(member2Syntax.Declaration.Variables[0]);
 
-            Assert.Equal(true, member1.Equals(member1));
-            Assert.Equal(true, member2.Equals(member2));
-            Assert.Equal(false, member1.Equals(member2));
-            Assert.Equal(false, member2.Equals(member1));
+            Assert.True(member1.Equals(member1));
+            Assert.True(member2.Equals(member2));
+            Assert.False(member1.Equals(member2));
+            Assert.False(member2.Equals(member1));
 
             var field1 = (FieldSymbol)member1;
             var field2 = (FieldSymbol)member2;
 
-            Assert.Equal(true, field1.Equals(field1));
-            Assert.Equal(true, field2.Equals(field2));
-            Assert.Equal(false, field1.Equals(field2));
-            Assert.Equal(false, field2.Equals(field1));
+            Assert.True(field1.Equals(field1));
+            Assert.True(field2.Equals(field2));
+            Assert.False(field1.Equals(field2));
+            Assert.False(field2.Equals(field1));
         }
 
         [Fact]
@@ -744,20 +744,20 @@ public class B
         private void VerifyEquality(ISymbol type1, ISymbol type2, bool expectedDefault, bool expectedIncludeNullability)
         {
             // Symbol.Equals
-            Assert.Equal(true, type1.Equals(type1));
-            Assert.Equal(true, type2.Equals(type2));
+            Assert.True(type1.Equals(type1));
+            Assert.True(type2.Equals(type2));
             Assert.Equal(expectedDefault, type1.Equals(type2));
             Assert.Equal(expectedDefault, type2.Equals(type1));
 
             // TypeSymbol.Equals - Default
-            Assert.Equal(true, type1.Equals(type1, SymbolEqualityComparer.Default));
-            Assert.Equal(true, type2.Equals(type2, SymbolEqualityComparer.Default));
+            Assert.True(type1.Equals(type1, SymbolEqualityComparer.Default));
+            Assert.True(type2.Equals(type2, SymbolEqualityComparer.Default));
             Assert.Equal(expectedDefault, type1.Equals(type2, SymbolEqualityComparer.Default));
             Assert.Equal(expectedDefault, type2.Equals(type1, SymbolEqualityComparer.Default));
 
             // TypeSymbol.Equals - IncludeNullability
-            Assert.Equal(true, type1.Equals(type1, SymbolEqualityComparer.IncludeNullability));
-            Assert.Equal(true, type2.Equals(type2, SymbolEqualityComparer.IncludeNullability));
+            Assert.True(type1.Equals(type1, SymbolEqualityComparer.IncludeNullability));
+            Assert.True(type2.Equals(type2, SymbolEqualityComparer.IncludeNullability));
             Assert.Equal(expectedIncludeNullability, type1.Equals(type2, SymbolEqualityComparer.IncludeNullability));
             Assert.Equal(expectedIncludeNullability, type2.Equals(type1, SymbolEqualityComparer.IncludeNullability));
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -661,7 +661,7 @@ public class A {
 ";
             var comp = CreateCompilation(text);
             var v = comp.GlobalNamespace.GetTypeMembers("MyEnum", 0).Single();
-            Assert.NotEqual(null, v);
+            Assert.NotNull(v);
             Assert.Equal(Accessibility.Public, v.DeclaredAccessibility);
 
             var fields = v.GetMembers().OfType<FieldSymbol>().ToList();

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/LocationsTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/LocationsTests.cs
@@ -454,7 +454,7 @@ class MainClass
             Assert.Equal(5, diagnostics[0].Location.SourceSpan.Start);
             Assert.Equal(0, diagnostics[0].Location.SourceSpan.Length);
 
-            Assert.Equal(true, treeSpan.Contains(diagnostics[0].Location.SourceSpan));
+            Assert.True(treeSpan.Contains(diagnostics[0].Location.SourceSpan));
 
             var lineSpan = diagnostics[0].Location.GetLineSpan();
             Assert.Equal(0, lineSpan.StartLinePosition.Line);
@@ -482,7 +482,7 @@ class MainClass
             Assert.Equal(0, diagnostics[0].Location.SourceSpan.Start);
             Assert.Equal(0, diagnostics[0].Location.SourceSpan.Length);
 
-            Assert.Equal(true, treeSpan.Contains(diagnostics[0].Location.SourceSpan));
+            Assert.True(treeSpan.Contains(diagnostics[0].Location.SourceSpan));
 
             var lineSpan = diagnostics[0].Location.GetLineSpan();
             Assert.Equal(0, lineSpan.StartLinePosition.Line);

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/BinaryExpression.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/BinaryExpression.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
             var block = method.Body;
             var statement = block.Statements[0] as LocalDeclarationStatementSyntax;
             var expression = statement.Declaration.Variables[0].Initializer.Value as BinaryExpressionSyntax;
-            Assert.Equal(expression.Kind(), SyntaxKind.MultiplyExpression);
+            Assert.Equal(SyntaxKind.MultiplyExpression, expression.Kind());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/NodeValidators.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/NodeValidators.cs
@@ -15,21 +15,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         #region Verifiers
         internal static void PointerNameVerification(ExpressionSyntax nameTree, string name)
         {
-            Assert.IsType(typeof(PointerTypeSyntax), nameTree);
+            Assert.IsType<PointerTypeSyntax>(nameTree);
             var pointerName = nameTree as PointerTypeSyntax;
             Assert.Equal(pointerName.ElementType.ToString(), name);
         }
 
         internal static void PredefinedNameVerification(ExpressionSyntax nameTree, string typeName)
         {
-            Assert.IsType(typeof(PredefinedTypeSyntax), nameTree);
+            Assert.IsType<PredefinedTypeSyntax>(nameTree);
             var predefName = nameTree as PredefinedTypeSyntax;
             Assert.Equal(predefName.ToString(), typeName);
         }
 
         internal static void ArrayNameVerification(ExpressionSyntax nameTree, string arrayName, int numRanks)
         {
-            Assert.IsType(typeof(ArrayTypeSyntax), nameTree);
+            Assert.IsType<ArrayTypeSyntax>(nameTree);
             var arrayType = nameTree as ArrayTypeSyntax;
             Assert.Equal(arrayType.ElementType.ToString(), arrayName);
             Assert.Equal(arrayType.RankSpecifiers.Count(), numRanks);
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal static void AliasedNameVerification(ExpressionSyntax nameTree, string alias, string name)
         {
             // Verification of the change
-            Assert.IsType(typeof(AliasQualifiedNameSyntax), nameTree);
+            Assert.IsType<AliasQualifiedNameSyntax>(nameTree);
             var aliasName = nameTree as AliasQualifiedNameSyntax;
             Assert.Equal(aliasName.Alias.ToString(), alias);
             Assert.Equal(aliasName.Name.ToString(), name);
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal static void DottedNameVerification(ExpressionSyntax nameTree, string left, string right)
         {
             // Verification of the change
-            Assert.IsType(typeof(QualifiedNameSyntax), nameTree);
+            Assert.IsType<QualifiedNameSyntax>(nameTree);
             var dottedName = nameTree as QualifiedNameSyntax;
             Assert.Equal(dottedName.Left.ToString(), left);
             Assert.Equal(dottedName.Right.ToString(), right);
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal static void GenericNameVerification(ExpressionSyntax nameTree, string name, params string[] typeNames)
         {
             // Verification of the change
-            Assert.IsType(typeof(GenericNameSyntax), nameTree);
+            Assert.IsType<GenericNameSyntax>(nameTree);
             var genericName = nameTree as GenericNameSyntax;
             Assert.Equal(genericName.Identifier.ToString(), name);
             Assert.Equal(genericName.TypeArgumentList.Arguments.Count, typeNames.Count());
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         internal static void BasicNameVerification(ExpressionSyntax nameTree, string name)
         {
             // Verification of the change
-            Assert.IsType(typeof(IdentifierNameSyntax), nameTree);
+            Assert.IsType<IdentifierNameSyntax>(nameTree);
             var genericName = nameTree as IdentifierNameSyntax;
             Assert.Equal(genericName.ToString(), name);
         }

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/TypeChanges.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/TypeChanges.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
                 var newTree = oldTree.WithReplace(16, "set", "get");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
                 var propertyType = classType.Members[0] as PropertyDeclarationSyntax;
-                Assert.Equal(propertyType.AccessorList.Accessors[0].Kind(), SyntaxKind.GetAccessorDeclaration);
+                Assert.Equal(SyntaxKind.GetAccessorDeclaration, propertyType.AccessorList.Accessors[0].Kind());
             });
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
                 var newTree = oldTree.WithReplace(16, "add", "remove");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
                 var propertyType = classType.Members[0] as EventDeclarationSyntax;
-                Assert.Equal(propertyType.AccessorList.Accessors[0].Kind(), SyntaxKind.RemoveAccessorDeclaration);
+                Assert.Equal(SyntaxKind.RemoveAccessorDeclaration, propertyType.AccessorList.Accessors[0].Kind());
             });
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
                 var newTree = oldTree.WithReplace(16, "remove", "add");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
                 var propertyType = classType.Members[0] as EventDeclarationSyntax;
-                Assert.Equal(propertyType.AccessorList.Accessors[0].Kind(), SyntaxKind.AddAccessorDeclaration);
+                Assert.Equal(SyntaxKind.AddAccessorDeclaration, propertyType.AccessorList.Accessors[0].Kind());
             });
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/TypeChanges.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/TypeChanges.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
             {
                 var newTree = oldTree.WithReplace(16, "construct", "~construct");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
-                Assert.IsType(typeof(DestructorDeclarationSyntax), classType.Members[0]);
+                Assert.IsType<DestructorDeclarationSyntax>(classType.Members[0]);
             });
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
             {
                 var newTree = oldTree.WithReplace(16, "M", "construct");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
-                Assert.IsType(typeof(ConstructorDeclarationSyntax), classType.Members[0]);
+                Assert.IsType<ConstructorDeclarationSyntax>(classType.Members[0]);
             });
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
             {
                 var newTree = oldTree.WithReplace(16, "construct", "M");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
-                Assert.IsType(typeof(ConstructorDeclarationSyntax), classType.Members[0]);
+                Assert.IsType<ConstructorDeclarationSyntax>(classType.Members[0]);
             });
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.IncrementalParsing
             {
                 var newTree = oldTree.WithReplace(16, "~construct", "construct");
                 var classType = newTree.GetCompilationUnitRoot().Members[0] as TypeDeclarationSyntax;
-                Assert.IsType(typeof(ConstructorDeclarationSyntax), classType.Members[0]);
+                Assert.IsType<ConstructorDeclarationSyntax>(classType.Members[0]);
             });
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3443,7 +3443,7 @@ class C
             Assert.True(token.HasLeadingTrivia);
             var trivia = token.LeadingTrivia.Single();
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia.Span.Length, 22);
+            Assert.Equal(22, trivia.Span.Length);
 
             Assert.True(trivia.ContainsDiagnostics);
             var errors = trivia.Errors();
@@ -3456,7 +3456,7 @@ class C
             Assert.Equal(3, token.LeadingTrivia.Count);
             trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia.Span.Length, 16);
+            Assert.Equal(16, trivia.Span.Length);
 
             Assert.True(trivia.ContainsDiagnostics);
             errors = trivia.Errors();
@@ -3465,13 +3465,13 @@ class C
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia.Span.Start, 16);
-            Assert.Equal(trivia.Span.Length, 2);
+            Assert.Equal(16, trivia.Span.Start);
+            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(trivia.Span.Start, 18);
-            Assert.Equal(trivia.Span.Length, 13);
+            Assert.Equal(18, trivia.Span.Start);
+            Assert.Equal(13, trivia.Span.Length);
 
             token = Lex("======= Trailing\r\ndisabled text\r\n>>>> still disabled").First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
@@ -3480,7 +3480,7 @@ class C
 
             trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia.Span.Length, 16);
+            Assert.Equal(16, trivia.Span.Length);
 
             Assert.True(trivia.ContainsDiagnostics);
             errors = trivia.Errors();
@@ -3489,19 +3489,19 @@ class C
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia.Span.Length, 2);
+            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(trivia.Span.Length, 34);
+            Assert.Equal(34, trivia.Span.Length);
 
             token = Lex("======= Trailing\r\ndisabled text\r\n>>>>>>> Actually the end").First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
-            Assert.Equal(token.LeadingTrivia.Count, 4);
+            Assert.Equal(4, token.LeadingTrivia.Count);
             var trivia1 = token.LeadingTrivia[0];
             Assert.True(trivia1.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia1.Span.Length, 16);
+            Assert.Equal(16, trivia1.Span.Length);
 
             Assert.True(trivia1.ContainsDiagnostics);
             errors = trivia1.Errors();
@@ -3510,18 +3510,18 @@ class C
 
             var trivia2 = token.LeadingTrivia[1];
             Assert.True(trivia2.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia2.Span.Start, 16);
-            Assert.Equal(trivia2.Span.Length, 2);
+            Assert.Equal(16, trivia2.Span.Start);
+            Assert.Equal(2, trivia2.Span.Length);
 
             var trivia3 = token.LeadingTrivia[2];
             Assert.True(trivia3.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(trivia3.Span.Start, 18);
-            Assert.Equal(trivia3.Span.Length, 15);
+            Assert.Equal(18, trivia3.Span.Start);
+            Assert.Equal(15, trivia3.Span.Length);
 
             var trivia4 = token.LeadingTrivia[3];
             Assert.True(trivia4.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia4.Span.Start, 33);
-            Assert.Equal(trivia4.Span.Length, 24);
+            Assert.Equal(33, trivia4.Span.Start);
+            Assert.Equal(24, trivia4.Span.Length);
 
             Assert.True(trivia4.ContainsDiagnostics);
             errors = trivia4.Errors();
@@ -3532,10 +3532,10 @@ class C
             token = Lex("======= Trailing\r\n>>>>>>> Actually the end").First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
-            Assert.Equal(token.LeadingTrivia.Count, 3);
+            Assert.Equal(3, token.LeadingTrivia.Count);
             trivia1 = token.LeadingTrivia[0];
             Assert.True(trivia1.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia1.Span.Length, 16);
+            Assert.Equal(16, trivia1.Span.Length);
 
             Assert.True(trivia1.ContainsDiagnostics);
             errors = trivia1.Errors();
@@ -3544,13 +3544,13 @@ class C
 
             trivia2 = token.LeadingTrivia[1];
             Assert.True(trivia2.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia2.Span.Start, 16);
-            Assert.Equal(trivia2.Span.Length, 2);
+            Assert.Equal(16, trivia2.Span.Start);
+            Assert.Equal(2, trivia2.Span.Length);
 
             trivia3 = token.LeadingTrivia[2];
             Assert.True(trivia3.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia3.Span.Start, 18);
-            Assert.Equal(trivia3.Span.Length, 24);
+            Assert.Equal(18, trivia3.Span.Start);
+            Assert.Equal(24, trivia3.Span.Length);
 
             Assert.True(trivia3.ContainsDiagnostics);
             errors = trivia3.Errors();
@@ -3583,7 +3583,7 @@ class C
             Assert.True(token.HasLeadingTrivia);
             var trivia = token.LeadingTrivia.Single();
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia.Span.Length, 22);
+            Assert.Equal(22, trivia.Span.Length);
 
             token = Lex("{\r\n======= Trailing\r\ndisabled text").Skip(1).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
@@ -3591,17 +3591,17 @@ class C
             Assert.Equal(3, token.LeadingTrivia.Count);
             trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia.Span.Length, 16);
+            Assert.Equal(16, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia.Span.Start, 19);
-            Assert.Equal(trivia.Span.Length, 2);
+            Assert.Equal(19, trivia.Span.Start);
+            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(trivia.Span.Start, 21);
-            Assert.Equal(trivia.Span.Length, 13);
+            Assert.Equal(21, trivia.Span.Start);
+            Assert.Equal(13, trivia.Span.Length);
 
             token = Lex("{\r\n======= Trailing\r\ndisabled text\r\n>>>> still disabled").Skip(1).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
@@ -3610,39 +3610,39 @@ class C
 
             trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia.Span.Length, 16);
+            Assert.Equal(16, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia.Span.Length, 2);
+            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(trivia.Span.Length, 34);
+            Assert.Equal(34, trivia.Span.Length);
 
 
             token = Lex("{\r\n======= Trailing\r\ndisabled text\r\n>>>>>>> Actually the end").Skip(1).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
-            Assert.Equal(token.LeadingTrivia.Count, 4);
+            Assert.Equal(4, token.LeadingTrivia.Count);
             var trivia1 = token.LeadingTrivia[0];
             Assert.True(trivia1.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia1.Span.Length, 16);
+            Assert.Equal(16, trivia1.Span.Length);
 
             var trivia2 = token.LeadingTrivia[1];
             Assert.True(trivia2.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(trivia2.Span.Start, 19);
-            Assert.Equal(trivia2.Span.Length, 2);
+            Assert.Equal(19, trivia2.Span.Start);
+            Assert.Equal(2, trivia2.Span.Length);
 
             var trivia3 = token.LeadingTrivia[2];
             Assert.True(trivia3.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(trivia3.Span.Start, 21);
-            Assert.Equal(trivia3.Span.Length, 15);
+            Assert.Equal(21, trivia3.Span.Start);
+            Assert.Equal(15, trivia3.Span.Length);
 
             var trivia4 = token.LeadingTrivia[3];
             Assert.True(trivia4.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(trivia4.Span.Start, 36);
-            Assert.Equal(trivia4.Span.Length, 24);
+            Assert.Equal(36, trivia4.Span.Start);
+            Assert.Equal(24, trivia4.Span.Length);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
 
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
 
@@ -425,7 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
 
@@ -442,7 +442,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
 
@@ -459,7 +459,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(3, ((string)token.ValueText).Length);
         }
 
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(4, ((string)token.ValueText).Length);
         }
 
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
             Assert.NotEqual(default, token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(1, ((string)token.ValueText).Length);
         }
 
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var errors = token.Errors();
             Assert.Equal(0, errors.Length);
             Assert.NotNull(token.ValueText);
-            Assert.IsType(typeof(string), token.ValueText);
+            Assert.IsType<string>(token.ValueText);
             Assert.Equal(3, ((string)token.ValueText).Length);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/XmlDocCommentTests.cs
@@ -2652,7 +2652,7 @@ class C{}";
             var doc = classKeyword.GetLeadingTrivia()[0].GetStructure() as DocumentationCommentTriviaSyntax;
 
             // we should still get an XmlElement
-            Assert.IsType(typeof(XmlElementSyntax), doc.Content[0]);
+            Assert.IsType<XmlElementSyntax>(doc.Content[0]);
         }
 
         [WorkItem(926873, "DevDiv/Personal")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -419,25 +419,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("a.b", e.Expression.ToString());
             var cons = e.WhenNotNull;
             Assert.Equal(".c.d?[1]?.e()?.f", cons.ToString());
-            Assert.Equal(cons.Kind(), SyntaxKind.ConditionalAccessExpression);
+            Assert.Equal(SyntaxKind.ConditionalAccessExpression, cons.Kind());
 
             e = e.WhenNotNull as ConditionalAccessExpressionSyntax;
             Assert.Equal(".c.d", e.Expression.ToString());
             cons = e.WhenNotNull;
             Assert.Equal("[1]?.e()?.f", cons.ToString());
-            Assert.Equal(cons.Kind(), SyntaxKind.ConditionalAccessExpression);
+            Assert.Equal(SyntaxKind.ConditionalAccessExpression, cons.Kind());
 
             e = e.WhenNotNull as ConditionalAccessExpressionSyntax;
             Assert.Equal("[1]", e.Expression.ToString());
             cons = e.WhenNotNull;
             Assert.Equal(".e()?.f", cons.ToString());
-            Assert.Equal(cons.Kind(), SyntaxKind.ConditionalAccessExpression);
+            Assert.Equal(SyntaxKind.ConditionalAccessExpression, cons.Kind());
 
             e = e.WhenNotNull as ConditionalAccessExpressionSyntax;
             Assert.Equal(".e()", e.Expression.ToString());
             cons = e.WhenNotNull;
             Assert.Equal(".f", cons.ToString());
-            Assert.Equal(cons.Kind(), SyntaxKind.MemberBindingExpression);
+            Assert.Equal(SyntaxKind.MemberBindingExpression, cons.Kind());
         }
 
         private void TestFunctionKeyword(SyntaxKind kind, SyntaxToken keyword)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -2180,7 +2180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var qs = (QueryExpressionSyntax)expr;
             Assert.NotNull(qs.Body.SelectOrGroup);
-            Assert.IsType(typeof(GroupClauseSyntax), qs.Body.SelectOrGroup);
+            Assert.IsType<GroupClauseSyntax>(qs.Body.SelectOrGroup);
 
             var gs = (GroupClauseSyntax)qs.Body.SelectOrGroup;
             Assert.NotNull(gs.GroupExpression);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/NameParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/NameParsingTests.cs
@@ -533,13 +533,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var gname = (GenericNameSyntax)tname;
             Assert.Equal("goo", gname.Identifier.ToString());
-            Assert.Equal(false, gname.IsUnboundGenericName);
+            Assert.False(gname.IsUnboundGenericName);
             Assert.Equal(1, gname.TypeArgumentList.Arguments.Count);
             Assert.NotNull(gname.TypeArgumentList.Arguments[0]);
 
             var arg = gname.TypeArgumentList.Arguments[0];
             Assert.Equal(SyntaxKind.IdentifierName, arg.Kind());
-            Assert.Equal(true, arg.ContainsDiagnostics);
+            Assert.True(arg.ContainsDiagnostics);
             Assert.Equal(1, arg.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_IllegalVarianceSyntax, arg.Errors()[0].Code);
 
@@ -558,13 +558,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var gname = (GenericNameSyntax)tname;
             Assert.Equal("goo", gname.Identifier.ToString());
-            Assert.Equal(false, gname.IsUnboundGenericName);
+            Assert.False(gname.IsUnboundGenericName);
             Assert.Equal(1, gname.TypeArgumentList.Arguments.Count);
             Assert.NotNull(gname.TypeArgumentList.Arguments[0]);
 
             var arg = gname.TypeArgumentList.Arguments[0];
             Assert.Equal(SyntaxKind.IdentifierName, arg.Kind());
-            Assert.Equal(true, arg.ContainsDiagnostics);
+            Assert.True(arg.ContainsDiagnostics);
             Assert.Equal(1, arg.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_TypeExpected, arg.Errors()[0].Code);
 
@@ -584,13 +584,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var gname = (GenericNameSyntax)tname;
             Assert.Equal("goo", gname.Identifier.ToString());
-            Assert.Equal(false, gname.IsUnboundGenericName);
+            Assert.False(gname.IsUnboundGenericName);
             Assert.Equal(1, gname.TypeArgumentList.Arguments.Count);
             Assert.NotNull(gname.TypeArgumentList.Arguments[0]);
 
             var arg = gname.TypeArgumentList.Arguments[0];
             Assert.Equal(SyntaxKind.IdentifierName, arg.Kind());
-            Assert.Equal(true, arg.ContainsDiagnostics);
+            Assert.True(arg.ContainsDiagnostics);
             Assert.Equal(1, arg.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_TypeExpected, arg.Errors()[0].Code);
 
@@ -610,20 +610,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var gname = (GenericNameSyntax)tname;
             Assert.Equal("goo", gname.Identifier.ToString());
-            Assert.Equal(false, gname.IsUnboundGenericName);
+            Assert.False(gname.IsUnboundGenericName);
             Assert.Equal(2, gname.TypeArgumentList.Arguments.Count);
             Assert.NotNull(gname.TypeArgumentList.Arguments[0]);
             Assert.NotNull(gname.TypeArgumentList.Arguments[1]);
 
             var arg = gname.TypeArgumentList.Arguments[0];
             Assert.Equal(SyntaxKind.IdentifierName, arg.Kind());
-            Assert.Equal(true, arg.ContainsDiagnostics);
+            Assert.True(arg.ContainsDiagnostics);
             Assert.Equal(1, arg.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_TypeExpected, arg.Errors()[0].Code);
 
             var arg2 = gname.TypeArgumentList.Arguments[1];
             Assert.Equal(SyntaxKind.PredefinedType, arg2.Kind());
-            Assert.Equal(false, arg2.ContainsDiagnostics);
+            Assert.False(arg2.ContainsDiagnostics);
             Assert.Equal(0, arg2.Errors().Length);
 
             Assert.Equal(text, tname.ToString());
@@ -642,13 +642,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var gname = (GenericNameSyntax)tname;
             Assert.Equal("goo", gname.Identifier.ToString());
-            Assert.Equal(false, gname.IsUnboundGenericName);
+            Assert.False(gname.IsUnboundGenericName);
             Assert.Equal(1, gname.TypeArgumentList.Arguments.Count);
             Assert.NotNull(gname.TypeArgumentList.Arguments[0]);
 
             var arg = gname.TypeArgumentList.Arguments[0];
             Assert.Equal(SyntaxKind.IdentifierName, arg.Kind());
-            Assert.Equal(true, arg.ContainsDiagnostics);
+            Assert.True(arg.ContainsDiagnostics);
             Assert.Equal(1, arg.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_TypeExpected, arg.Errors()[0].Code);
 
@@ -667,13 +667,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var gname = (GenericNameSyntax)tname;
             Assert.Equal("goo", gname.Identifier.ToString());
-            Assert.Equal(false, gname.IsUnboundGenericName);
+            Assert.False(gname.IsUnboundGenericName);
             Assert.Equal(1, gname.TypeArgumentList.Arguments.Count);
             Assert.NotNull(gname.TypeArgumentList.Arguments[0]);
 
             var arg = gname.TypeArgumentList.Arguments[0];
             Assert.Equal(SyntaxKind.IdentifierName, arg.Kind());
-            Assert.Equal(true, arg.ContainsDiagnostics);
+            Assert.True(arg.ContainsDiagnostics);
             Assert.Equal(2, arg.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_TypeExpected, arg.Errors()[0].Code);
             Assert.Equal((int)ErrorCode.ERR_IllegalVarianceSyntax, arg.Errors()[1].Code);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -6419,27 +6419,27 @@ class C
             Assert.Equal(text, file.ToFullString());
 
             var incompleteMemberDecl = file.ChildNodesAndTokens()[0];
-            Assert.Equal(incompleteMemberDecl.Kind(), SyntaxKind.IncompleteMember);
+            Assert.Equal(SyntaxKind.IncompleteMember, incompleteMemberDecl.Kind());
             Assert.False(incompleteMemberDecl.IsMissing);
 
             var attributeDecl = incompleteMemberDecl.ChildNodesAndTokens()[0];
-            Assert.Equal(attributeDecl.Kind(), SyntaxKind.AttributeList);
+            Assert.Equal(SyntaxKind.AttributeList, attributeDecl.Kind());
             Assert.False(attributeDecl.IsMissing);
 
             var openBracketToken = attributeDecl.ChildNodesAndTokens()[0];
-            Assert.Equal(openBracketToken.Kind(), SyntaxKind.OpenBracketToken);
+            Assert.Equal(SyntaxKind.OpenBracketToken, openBracketToken.Kind());
             Assert.False(openBracketToken.IsMissing);
 
             var attribute = attributeDecl.ChildNodesAndTokens()[1];
-            Assert.Equal(attribute.Kind(), SyntaxKind.Attribute);
+            Assert.Equal(SyntaxKind.Attribute, attribute.Kind());
             Assert.True(attribute.IsMissing);
 
             var identifierName = attribute.ChildNodesAndTokens()[0];
-            Assert.Equal(identifierName.Kind(), SyntaxKind.IdentifierName);
+            Assert.Equal(SyntaxKind.IdentifierName, identifierName.Kind());
             Assert.True(identifierName.IsMissing);
 
             var identifierToken = identifierName.ChildNodesAndTokens()[0];
-            Assert.Equal(identifierToken.Kind(), SyntaxKind.IdentifierToken);
+            Assert.Equal(SyntaxKind.IdentifierToken, identifierToken.Kind());
             Assert.True(identifierToken.IsMissing);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -1268,7 +1268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotEqual(default, ts.Catches[0].Declaration.OpenParenToken);
             Assert.NotNull(ts.Catches[0].Declaration.Type);
             Assert.Equal("T", ts.Catches[0].Declaration.Type.ToString());
-            Assert.Equal(ts.Catches[0].Declaration.Identifier.Kind(), SyntaxKind.None);
+            Assert.Equal(SyntaxKind.None, ts.Catches[0].Declaration.Identifier.Kind());
             Assert.NotEqual(default, ts.Catches[0].Declaration.CloseParenToken);
             Assert.NotNull(ts.Catches[0].Block);
 
@@ -1956,9 +1956,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotEqual(default, fs.ForEachKeyword);
             Assert.Equal(SyntaxKind.ForEachKeyword, fs.ForEachKeyword.Kind());
             Assert.True(fs.ForEachKeyword.IsMissing);
-            Assert.Equal(fs.ForEachKeyword.TrailingTrivia.Count, 1);
-            Assert.Equal(fs.ForEachKeyword.TrailingTrivia[0].Kind(), SyntaxKind.SkippedTokensTrivia);
-            Assert.Equal(fs.ForEachKeyword.TrailingTrivia[0].ToString(), "for");
+            Assert.Equal(1, fs.ForEachKeyword.TrailingTrivia.Count);
+            Assert.Equal(SyntaxKind.SkippedTokensTrivia, fs.ForEachKeyword.TrailingTrivia[0].Kind());
+            Assert.Equal("for", fs.ForEachKeyword.TrailingTrivia[0].ToString());
 
             Assert.NotEqual(default, fs.OpenParenToken);
             Assert.NotNull(fs.Type);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -3335,7 +3335,7 @@ class C
 
             var decl = (LocalDeclarationStatementSyntax)statement;
             Assert.Equal(keywordText, decl.Declaration.Type.ToString());
-            Assert.IsType(typeof(IdentifierNameSyntax), decl.Declaration.Type);
+            Assert.IsType<IdentifierNameSyntax>(decl.Declaration.Type);
             var name = (IdentifierNameSyntax)decl.Declaration.Type;
             Assert.Equal(kind, name.Identifier.ContextualKind());
             Assert.Equal(SyntaxKind.IdentifierToken, name.Identifier.Kind());

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SerializationTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SerializationTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var droot = CSharpSyntaxNode.DeserializeFrom(stream);
             var dtext = droot.ToFullString();
 
-            Assert.Equal(true, droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
+            Assert.True(droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(text, dtext);
             Assert.Equal(1, droot.Errors().Length);
-            Assert.Equal(true, droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
+            Assert.True(droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
             Assert.Equal(root.Errors()[0].GetMessage(), droot.Errors()[0].GetMessage());
         }
 
@@ -60,8 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var tree = SyntaxFactory.ParseSyntaxTree(text);
             var annotation = new SyntaxAnnotation();
             var root = tree.GetCompilationUnitRoot().WithAdditionalAnnotations(annotation);
-            Assert.Equal(true, root.ContainsAnnotations);
-            Assert.Equal(true, root.HasAnnotation(annotation));
+            Assert.True(root.ContainsAnnotations);
+            Assert.True(root.HasAnnotation(annotation));
 
             var stream = new MemoryStream();
             root.SerializeTo(stream);
@@ -72,9 +72,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var dtext = droot.ToFullString();
 
             Assert.Equal(text, dtext);
-            Assert.Equal(true, droot.ContainsAnnotations);
-            Assert.Equal(true, droot.HasAnnotation(annotation));
-            Assert.Equal(true, droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
+            Assert.True(droot.ContainsAnnotations);
+            Assert.True(droot.HasAnnotation(annotation));
+            Assert.True(droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
         }
 
         [Fact]
@@ -84,8 +84,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var tree = SyntaxFactory.ParseSyntaxTree(text);
             var annotation = new SyntaxAnnotation();
             var root = tree.GetCompilationUnitRoot().WithAdditionalAnnotations(annotation, annotation);
-            Assert.Equal(true, root.ContainsAnnotations);
-            Assert.Equal(true, root.HasAnnotation(annotation));
+            Assert.True(root.ContainsAnnotations);
+            Assert.True(root.HasAnnotation(annotation));
 
             var stream = new MemoryStream();
             root.SerializeTo(stream);
@@ -96,9 +96,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var dtext = droot.ToFullString();
 
             Assert.Equal(text, dtext);
-            Assert.Equal(true, droot.ContainsAnnotations);
-            Assert.Equal(true, droot.HasAnnotation(annotation));
-            Assert.Equal(true, droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
+            Assert.True(droot.ContainsAnnotations);
+            Assert.True(droot.HasAnnotation(annotation));
+            Assert.True(droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
         }
 
         [Fact]
@@ -108,8 +108,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var tree = SyntaxFactory.ParseSyntaxTree(text);
             var annotation = new SyntaxAnnotation("TestAnnotation", "this is a test");
             var root = tree.GetCompilationUnitRoot().WithAdditionalAnnotations(annotation);
-            Assert.Equal(true, root.ContainsAnnotations);
-            Assert.Equal(true, root.HasAnnotation(annotation));
+            Assert.True(root.ContainsAnnotations);
+            Assert.True(root.HasAnnotation(annotation));
 
             var stream = new MemoryStream();
             root.SerializeTo(stream);
@@ -120,9 +120,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var dtext = droot.ToFullString();
 
             Assert.Equal(text, dtext);
-            Assert.Equal(true, droot.ContainsAnnotations);
-            Assert.Equal(true, droot.HasAnnotation(annotation));
-            Assert.Equal(true, droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
+            Assert.True(droot.ContainsAnnotations);
+            Assert.True(droot.HasAnnotation(annotation));
+            Assert.True(droot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
 
             var dannotation = droot.GetAnnotations("TestAnnotation").SingleOrDefault();
             Assert.NotNull(dannotation);
@@ -137,11 +137,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var tree = SyntaxFactory.ParseSyntaxTree(text);
             var annotation1 = new SyntaxAnnotation("annotation1");
             var root = tree.GetCompilationUnitRoot().WithAdditionalAnnotations(annotation1);
-            Assert.Equal(true, root.ContainsAnnotations);
-            Assert.Equal(true, root.HasAnnotation(annotation1));
+            Assert.True(root.ContainsAnnotations);
+            Assert.True(root.HasAnnotation(annotation1));
             var removedRoot = root.WithoutAnnotations(annotation1);
-            Assert.Equal(false, removedRoot.ContainsAnnotations);
-            Assert.Equal(false, removedRoot.HasAnnotation(annotation1));
+            Assert.False(removedRoot.ContainsAnnotations);
+            Assert.False(removedRoot.HasAnnotation(annotation1));
 
             var stream = new MemoryStream();
             removedRoot.SerializeTo(stream);
@@ -150,19 +150,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var droot = CSharpSyntaxNode.DeserializeFrom(stream);
 
-            Assert.Equal(false, droot.ContainsAnnotations);
-            Assert.Equal(false, droot.HasAnnotation(annotation1));
+            Assert.False(droot.ContainsAnnotations);
+            Assert.False(droot.HasAnnotation(annotation1));
 
             var annotation2 = new SyntaxAnnotation("annotation2");
 
             var doubleAnnoRoot = droot.WithAdditionalAnnotations(annotation1, annotation2);
-            Assert.Equal(true, doubleAnnoRoot.ContainsAnnotations);
-            Assert.Equal(true, doubleAnnoRoot.HasAnnotation(annotation1));
-            Assert.Equal(true, doubleAnnoRoot.HasAnnotation(annotation2));
+            Assert.True(doubleAnnoRoot.ContainsAnnotations);
+            Assert.True(doubleAnnoRoot.HasAnnotation(annotation1));
+            Assert.True(doubleAnnoRoot.HasAnnotation(annotation2));
             var removedDoubleAnnoRoot = doubleAnnoRoot.WithoutAnnotations(annotation1, annotation2);
-            Assert.Equal(false, removedDoubleAnnoRoot.ContainsAnnotations);
-            Assert.Equal(false, removedDoubleAnnoRoot.HasAnnotation(annotation1));
-            Assert.Equal(false, removedDoubleAnnoRoot.HasAnnotation(annotation2));
+            Assert.False(removedDoubleAnnoRoot.ContainsAnnotations);
+            Assert.False(removedDoubleAnnoRoot.HasAnnotation(annotation1));
+            Assert.False(removedDoubleAnnoRoot.HasAnnotation(annotation2));
 
             stream = new MemoryStream();
             removedRoot.SerializeTo(stream);
@@ -171,9 +171,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             droot = CSharpSyntaxNode.DeserializeFrom(stream);
 
-            Assert.Equal(false, droot.ContainsAnnotations);
-            Assert.Equal(false, droot.HasAnnotation(annotation1));
-            Assert.Equal(false, droot.HasAnnotation(annotation2));
+            Assert.False(droot.ContainsAnnotations);
+            Assert.False(droot.HasAnnotation(annotation1));
+            Assert.False(droot.HasAnnotation(annotation2));
         }
 
         [Fact]
@@ -183,11 +183,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var tree = SyntaxFactory.ParseSyntaxTree(text);
             var annotation1 = new SyntaxAnnotation("MyAnnotationId", "SomeData");
             var root = tree.GetCompilationUnitRoot().WithAdditionalAnnotations(annotation1, annotation1);
-            Assert.Equal(true, root.ContainsAnnotations);
-            Assert.Equal(true, root.HasAnnotation(annotation1));
+            Assert.True(root.ContainsAnnotations);
+            Assert.True(root.HasAnnotation(annotation1));
             var removedRoot = root.WithoutAnnotations(annotation1);
-            Assert.Equal(false, removedRoot.ContainsAnnotations);
-            Assert.Equal(false, removedRoot.HasAnnotation(annotation1));
+            Assert.False(removedRoot.ContainsAnnotations);
+            Assert.False(removedRoot.HasAnnotation(annotation1));
 
             var stream = new MemoryStream();
             removedRoot.SerializeTo(stream);
@@ -196,8 +196,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var droot = CSharpSyntaxNode.DeserializeFrom(stream);
 
-            Assert.Equal(false, droot.ContainsAnnotations);
-            Assert.Equal(false, droot.HasAnnotation(annotation1));
+            Assert.False(droot.ContainsAnnotations);
+            Assert.False(droot.HasAnnotation(annotation1));
         }
 
         private static void RoundTrip(string text, bool expectRecursive = true)
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var newRoot = CSharpSyntaxNode.DeserializeFrom(stream);
             var newText = newRoot.ToFullString();
 
-            Assert.Equal(true, newRoot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
+            Assert.True(newRoot.IsEquivalentTo(tree.GetCompilationUnitRoot()));
             Assert.Equal(originalText, newText);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/StructuredTriviaTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/StructuredTriviaTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(" ", trResult.ToString());
 
             var foundDocComment = result.Parent.Parent.Parent.Parent;
-            Assert.Equal(null, foundDocComment.Parent);
+            Assert.Null(foundDocComment.Parent);
 
             var identTrivia = identExpr.GetLeadingTrivia()[0];
             var foundTrivia = ((DocumentationCommentTriviaSyntax)foundDocComment).ParentTrivia;

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -544,7 +544,7 @@ a + b";
             for (int i = 0; i < node.FullSpan.End; i++)
             {
                 var token = node.FindToken(i);
-                Assert.Equal(true, token.FullSpan.Contains(i));
+                Assert.True(token.FullSpan.Contains(i));
             }
         }
 
@@ -1517,8 +1517,8 @@ class A { }
 
             Assert.Equal(rootNode.FullSpan.Length, rootNode.ToFullString().Length);
             Assert.Equal(rootNode.Span.Length, rootNode.ToString().Length);
-            Assert.Equal(true, rootNode.ToString().Contains("/*END*/"));
-            Assert.Equal(false, rootNode.ToString().Contains("/*START*/"));
+            Assert.True(rootNode.ToString().Contains("/*END*/"));
+            Assert.False(rootNode.ToString().Contains("/*START*/"));
         }
 
         [WorkItem(536996, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536996")]
@@ -1535,8 +1535,8 @@ namespace Microsoft.CSharp.Test
 
             Assert.Equal(rootNode.FullSpan.Length, rootNode.ToFullString().Length);
             Assert.Equal(rootNode.Span.Length, rootNode.ToString().Length);
-            Assert.Equal(true, rootNode.ToString().Contains("/*END*/"));
-            Assert.Equal(false, rootNode.ToString().Contains("/*START*/"));
+            Assert.True(rootNode.ToString().Contains("/*END*/"));
+            Assert.False(rootNode.ToString().Contains("/*START*/"));
         }
 
         [Fact]
@@ -3454,101 +3454,101 @@ namespace HelloWorld
         {
             // token constructed using factory w/o specifying trivia (should have zero-width elastic trivia)
             var idToken = SyntaxFactory.Identifier("goo");
-            Assert.Equal(true, idToken.HasLeadingTrivia);
+            Assert.True(idToken.HasLeadingTrivia);
             Assert.Equal(1, idToken.LeadingTrivia.Count);
             Assert.Equal(0, idToken.LeadingTrivia.Span.Length); // zero-width elastic trivia
-            Assert.Equal(true, idToken.HasTrailingTrivia);
+            Assert.True(idToken.HasTrailingTrivia);
             Assert.Equal(1, idToken.TrailingTrivia.Count);
             Assert.Equal(0, idToken.TrailingTrivia.Span.Length); // zero-width elastic trivia
 
             // token constructed by parser w/o trivia
             idToken = SyntaxFactory.ParseToken("x");
-            Assert.Equal(false, idToken.HasLeadingTrivia);
+            Assert.False(idToken.HasLeadingTrivia);
             Assert.Equal(0, idToken.LeadingTrivia.Count);
-            Assert.Equal(false, idToken.HasTrailingTrivia);
+            Assert.False(idToken.HasTrailingTrivia);
             Assert.Equal(0, idToken.TrailingTrivia.Count);
 
             // token constructed by parser with trivia
             idToken = SyntaxFactory.ParseToken(" x  ");
-            Assert.Equal(true, idToken.HasLeadingTrivia);
+            Assert.True(idToken.HasLeadingTrivia);
             Assert.Equal(1, idToken.LeadingTrivia.Count);
             Assert.Equal(1, idToken.LeadingTrivia.Span.Length);
-            Assert.Equal(true, idToken.HasTrailingTrivia);
+            Assert.True(idToken.HasTrailingTrivia);
             Assert.Equal(1, idToken.TrailingTrivia.Count);
             Assert.Equal(2, idToken.TrailingTrivia.Span.Length);
 
             // node constructed using factory w/o specifying trivia
             SyntaxNode namedNode = SyntaxFactory.IdentifierName("goo");
-            Assert.Equal(true, namedNode.HasLeadingTrivia);
+            Assert.True(namedNode.HasLeadingTrivia);
             Assert.Equal(1, namedNode.GetLeadingTrivia().Count);
             Assert.Equal(0, namedNode.GetLeadingTrivia().Span.Length);  // zero-width elastic trivia
-            Assert.Equal(true, namedNode.HasTrailingTrivia);
+            Assert.True(namedNode.HasTrailingTrivia);
             Assert.Equal(1, namedNode.GetTrailingTrivia().Count);
             Assert.Equal(0, namedNode.GetTrailingTrivia().Span.Length);  // zero-width elastic trivia
 
             // node constructed by parse w/o trivia
             namedNode = SyntaxFactory.ParseExpression("goo");
-            Assert.Equal(false, namedNode.HasLeadingTrivia);
+            Assert.False(namedNode.HasLeadingTrivia);
             Assert.Equal(0, namedNode.GetLeadingTrivia().Count);
-            Assert.Equal(false, namedNode.HasTrailingTrivia);
+            Assert.False(namedNode.HasTrailingTrivia);
             Assert.Equal(0, namedNode.GetTrailingTrivia().Count);
 
             // node constructed by parse with trivia
             namedNode = SyntaxFactory.ParseExpression(" goo  ");
-            Assert.Equal(true, namedNode.HasLeadingTrivia);
+            Assert.True(namedNode.HasLeadingTrivia);
             Assert.Equal(1, namedNode.GetLeadingTrivia().Count);
             Assert.Equal(1, namedNode.GetLeadingTrivia().Span.Length);
-            Assert.Equal(true, namedNode.HasTrailingTrivia);
+            Assert.True(namedNode.HasTrailingTrivia);
             Assert.Equal(1, namedNode.GetTrailingTrivia().Count);
             Assert.Equal(2, namedNode.GetTrailingTrivia().Span.Length);
 
             // nodeOrToken with token constructed from factory w/o specifying trivia
             SyntaxNodeOrToken nodeOrToken = SyntaxFactory.Identifier("goo");
-            Assert.Equal(true, nodeOrToken.HasLeadingTrivia);
+            Assert.True(nodeOrToken.HasLeadingTrivia);
             Assert.Equal(1, nodeOrToken.GetLeadingTrivia().Count);
             Assert.Equal(0, nodeOrToken.GetLeadingTrivia().Span.Length); // zero-width elastic trivia
-            Assert.Equal(true, nodeOrToken.HasTrailingTrivia);
+            Assert.True(nodeOrToken.HasTrailingTrivia);
             Assert.Equal(1, nodeOrToken.GetTrailingTrivia().Count);
             Assert.Equal(0, nodeOrToken.GetTrailingTrivia().Span.Length); // zero-width elastic trivia
 
             // nodeOrToken with node constructed from factory w/o specifying trivia
             nodeOrToken = SyntaxFactory.IdentifierName("goo");
-            Assert.Equal(true, nodeOrToken.HasLeadingTrivia);
+            Assert.True(nodeOrToken.HasLeadingTrivia);
             Assert.Equal(1, nodeOrToken.GetLeadingTrivia().Count);
             Assert.Equal(0, nodeOrToken.GetLeadingTrivia().Span.Length); // zero-width elastic trivia
-            Assert.Equal(true, nodeOrToken.HasTrailingTrivia);
+            Assert.True(nodeOrToken.HasTrailingTrivia);
             Assert.Equal(1, nodeOrToken.GetTrailingTrivia().Count);
             Assert.Equal(0, nodeOrToken.GetTrailingTrivia().Span.Length); // zero-width elastic trivia
 
             // nodeOrToken with token parsed from factory w/o trivia
             nodeOrToken = SyntaxFactory.ParseToken("goo");
-            Assert.Equal(false, nodeOrToken.HasLeadingTrivia);
+            Assert.False(nodeOrToken.HasLeadingTrivia);
             Assert.Equal(0, nodeOrToken.GetLeadingTrivia().Count);
-            Assert.Equal(false, nodeOrToken.HasTrailingTrivia);
+            Assert.False(nodeOrToken.HasTrailingTrivia);
             Assert.Equal(0, nodeOrToken.GetTrailingTrivia().Count);
 
             // nodeOrToken with node parsed from factory w/o trivia
             nodeOrToken = SyntaxFactory.ParseExpression("goo");
-            Assert.Equal(false, nodeOrToken.HasLeadingTrivia);
+            Assert.False(nodeOrToken.HasLeadingTrivia);
             Assert.Equal(0, nodeOrToken.GetLeadingTrivia().Count);
-            Assert.Equal(false, nodeOrToken.HasTrailingTrivia);
+            Assert.False(nodeOrToken.HasTrailingTrivia);
             Assert.Equal(0, nodeOrToken.GetTrailingTrivia().Count);
 
             // nodeOrToken with token parsed from factory with trivia
             nodeOrToken = SyntaxFactory.ParseToken(" goo  ");
-            Assert.Equal(true, nodeOrToken.HasLeadingTrivia);
+            Assert.True(nodeOrToken.HasLeadingTrivia);
             Assert.Equal(1, nodeOrToken.GetLeadingTrivia().Count);
             Assert.Equal(1, nodeOrToken.GetLeadingTrivia().Span.Length); // zero-width elastic trivia
-            Assert.Equal(true, nodeOrToken.HasTrailingTrivia);
+            Assert.True(nodeOrToken.HasTrailingTrivia);
             Assert.Equal(1, nodeOrToken.GetTrailingTrivia().Count);
             Assert.Equal(2, nodeOrToken.GetTrailingTrivia().Span.Length); // zero-width elastic trivia
 
             // nodeOrToken with node parsed from factory with trivia
             nodeOrToken = SyntaxFactory.ParseExpression(" goo  ");
-            Assert.Equal(true, nodeOrToken.HasLeadingTrivia);
+            Assert.True(nodeOrToken.HasLeadingTrivia);
             Assert.Equal(1, nodeOrToken.GetLeadingTrivia().Count);
             Assert.Equal(1, nodeOrToken.GetLeadingTrivia().Span.Length); // zero-width elastic trivia
-            Assert.Equal(true, nodeOrToken.HasTrailingTrivia);
+            Assert.True(nodeOrToken.HasTrailingTrivia);
             Assert.Equal(1, nodeOrToken.GetTrailingTrivia().Count);
             Assert.Equal(2, nodeOrToken.GetTrailingTrivia().Span.Length); // zero-width elastic trivia
         }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -494,7 +494,7 @@ a + b";
 
             // var node = t1.GetCompilationUnitRoot().Usings[0].GetTokens(new TextSpan(6, 3)).First();
             var node = t1.GetCompilationUnitRoot().DescendantTokens(new TextSpan(6, 3)).First();
-            Assert.Equal(node.ToString(), "Goo");
+            Assert.Equal("Goo", node.ToString());
         }
 
         [Fact]
@@ -3024,8 +3024,8 @@ class A { } #endregion";
 
             var list = (SeparatedSyntaxList<ParameterSyntax>)method.ParameterList.Parameters;
 
-            Assert.Equal(((SyntaxToken)list.GetSeparator(0)).Kind(), SyntaxKind.CommaToken);
-            Assert.Equal(((SyntaxToken)list.GetSeparator(1)).Kind(), SyntaxKind.CommaToken);
+            Assert.Equal(SyntaxKind.CommaToken, ((SyntaxToken)list.GetSeparator(0)).Kind());
+            Assert.Equal(SyntaxKind.CommaToken, ((SyntaxToken)list.GetSeparator(1)).Kind());
 
             foreach (var index in new int[] { -1, 2 })
             {
@@ -3044,21 +3044,21 @@ class A { } #endregion";
             var internalParameterList = (InternalSyntax.ParameterListSyntax)method.ParameterList.Green;
             var internalParameters = internalParameterList.Parameters;
 
-            Assert.Equal(internalParameters.SeparatorCount, 2);
-            Assert.Equal((new SyntaxToken(internalParameters.GetSeparator(0))).Kind(), SyntaxKind.CommaToken);
-            Assert.Equal((new SyntaxToken(internalParameters.GetSeparator(1))).Kind(), SyntaxKind.CommaToken);
+            Assert.Equal(2, internalParameters.SeparatorCount);
+            Assert.Equal(SyntaxKind.CommaToken, (new SyntaxToken(internalParameters.GetSeparator(0))).Kind());
+            Assert.Equal(SyntaxKind.CommaToken, (new SyntaxToken(internalParameters.GetSeparator(1))).Kind());
 
-            Assert.Equal(internalParameters.Count, 3);
-            Assert.Equal(internalParameters[0].Identifier.ValueText, "a");
-            Assert.Equal(internalParameters[1].Identifier.ValueText, "b");
-            Assert.Equal(internalParameters[2].Identifier.ValueText, "c");
+            Assert.Equal(3, internalParameters.Count);
+            Assert.Equal("a", internalParameters[0].Identifier.ValueText);
+            Assert.Equal("b", internalParameters[1].Identifier.ValueText);
+            Assert.Equal("c", internalParameters[2].Identifier.ValueText);
         }
 
         [Fact]
         public void ThrowIfUnderlyingNodeIsNullForList()
         {
             var list = new SyntaxNodeOrTokenList();
-            Assert.Equal(list.Count, 0);
+            Assert.Equal(0, list.Count);
 
             foreach (var index in new int[] { -1, 0, 23 })
             {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxRewriterTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxRewriterTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
 
             Assert.NotNull(caught);
-            Assert.Equal(true, caught is InvalidOperationException);
+            Assert.True(caught is InvalidOperationException);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
 
             Assert.NotNull(caught);
-            Assert.Equal(true, caught is InvalidOperationException);
+            Assert.True(caught is InvalidOperationException);
         }
 
         #endregion Red Tree / SeparatedSyntaxList
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
 
             Assert.NotNull(caught);
-            Assert.Equal(true, caught is InvalidOperationException);
+            Assert.True(caught is InvalidOperationException);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTreeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTreeTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var newTree = oldTree.WithFilePath("new.cs");
             var newText = newTree.GetText();
 
-            Assert.Equal(newTree.FilePath, "new.cs");
+            Assert.Equal("new.cs", newTree.FilePath);
             Assert.Equal(oldTree.ToString(), newTree.ToString());
 
             Assert.Null(newText.Encoding);
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var newTree = oldTree.WithFilePath("new.cs");
             var newText = newTree.GetText();
 
-            Assert.Equal(newTree.FilePath, "new.cs");
+            Assert.Equal("new.cs", newTree.FilePath);
             Assert.Equal(oldTree.ToString(), newTree.ToString());
 
             Assert.Same(Encoding.UTF7, newText.Encoding);
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var oldTree = new CSharpSyntaxTree.DummySyntaxTree();
             var newTree = oldTree.WithFilePath("new.cs");
 
-            Assert.Equal(newTree.FilePath, "new.cs");
+            Assert.Equal("new.cs", newTree.FilePath);
             Assert.Equal(oldTree.ToString(), newTree.ToString());
         }
 

--- a/src/Compilers/CSharp/Test/WinRT/CodeGen/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/CodeGen/WinMdEventTests.cs
@@ -665,7 +665,7 @@ B");
             var model = comp.GetSemanticModel(tree);
             var syntax = tree.GetRoot().DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
             var type = model.GetTypeInfo(syntax);
-            Assert.Equal(type.Type.SpecialType, SpecialType.System_Void);
+            Assert.Equal(SpecialType.System_Void, type.Type.SpecialType);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
@@ -131,9 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var blk = clas.GetMembers("Black").Single();
             //The windows.winmd module points to a Windows.UI.Color which should be modified to belong
             //to System.Runtime.WindowsRuntime
-            Assert.Equal(                   "System.Runtime.WindowsRuntime.dll",
-((Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol)
-                ((((Microsoft.CodeAnalysis.CSharp.Symbols.PropertySymbol)(blk)).GetMethod).ReturnType)).ContainingModule.ToString());
+            Assert.Equal("System.Runtime.WindowsRuntime.dll", ((PENamedTypeSymbol)((((PropertySymbol)(blk)).GetMethod).ReturnType)).ContainingModule.ToString());
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdMetadataTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var itextrange = wns1.GetMember<PENamedTypeSymbol>("ITextRange");
             var func = itextrange.GetMember<PEMethodSymbol>("SetPoint");
             var pt = ((PEParameterSymbol)(func.Parameters[0])).Type as PENamedTypeSymbol;
-            Assert.Equal(pt.ContainingAssembly.Name, "System.Runtime.WindowsRuntime");
+            Assert.Equal("System.Runtime.WindowsRuntime", pt.ContainingAssembly.Name);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             wns1 = wns1.GetMember<NamespaceSymbol>("Xaml");
             var itextrange = wns1.GetMember<PENamedTypeSymbol>("SuspendingEventHandler");
             var func = itextrange.GetMember<PEMethodSymbol>(".ctor");
-            Assert.Equal(func.DeclaredAccessibility, Accessibility.Public);
+            Assert.Equal(Accessibility.Public, func.DeclaredAccessibility);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var iref = wns1.GetMember<PENamedTypeSymbol>("IUriRuntimeClass");
             var func = iref.GetMember<PEMethodSymbol>("CombineUri");
             var ret = func.ReturnTypeWithAnnotations;
-            Assert.Equal(func.ReturnType.ToTestDisplayString(), "System.Uri");
+            Assert.Equal("System.Uri", func.ReturnType.ToTestDisplayString());
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var wns2 = wns1.GetMember<NamespaceSymbol>("Foundation");
             var clas = wns2.GetMember<PENamedTypeSymbol>("Point");
-            Assert.Equal(clas.DeclaredAccessibility, Accessibility.Internal);
+            Assert.Equal(Accessibility.Internal, clas.DeclaredAccessibility);
         }
 
         /// <summary>
@@ -131,9 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var blk = clas.GetMembers("Black").Single();
             //The windows.winmd module points to a Windows.UI.Color which should be modified to belong
             //to System.Runtime.WindowsRuntime
-            Assert.Equal(((Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol)
-                ((((Microsoft.CodeAnalysis.CSharp.Symbols.PropertySymbol)(blk)).GetMethod).ReturnType)).ContainingModule.ToString(),
-                   "System.Runtime.WindowsRuntime.dll");
+            Assert.Equal(                   "System.Runtime.WindowsRuntime.dll",
+((Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PENamedTypeSymbol)
+                ((((Microsoft.CodeAnalysis.CSharp.Symbols.PropertySymbol)(blk)).GetMethod).ReturnType)).ContainingModule.ToString());
         }
 
         /// <summary>

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -97,7 +97,7 @@ my_PROP = my_VAL");
             var properties = config.GlobalSection.Properties;
 
             Assert.True(properties.TryGetValue("my_PrOp", out var val));
-            Assert.Equal(val, "my_VAL");
+            Assert.Equal("my_VAL", val);
             Assert.Equal("my_prop", properties.Keys.Single());
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/AsyncQueueTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AsyncQueueTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var queue = new AsyncQueue<int>();
             queue.Complete();
-            Assert.Throws(typeof(InvalidOperationException), () => queue.Enqueue(42));
+            Assert.Throws<InvalidOperationException>(() => queue.Enqueue(42));
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var queue = new AsyncQueue<int>();
             Assert.True(queue.TryEnqueue(42));
             queue.PromiseNotToEnqueue();
-            Assert.Throws(typeof(InvalidOperationException), () =>
+            Assert.Throws<InvalidOperationException>(() =>
             {
                 queue.TryEnqueue(42);
             });

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/CachingFactoryTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/CachingFactoryTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
                 (k, v) => k.Value == v.Value);
 
             var key = new CacheKey(0);
-            Assert.Equal(CacheKey.GetHashCode(key), 0);
+            Assert.Equal(0, CacheKey.GetHashCode(key));
 
             CacheValue value;
             bool found = cache.TryGetValue(key, out value);

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/IdentifierCollectionTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/IdentifierCollectionTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             var idcol = new IdentifierCollection(strings).AsCaseSensitiveCollection();
 
             Assert.Equal(strings.Length, idcol.Count);
-            Assert.Equal(true, Enumerable.SequenceEqual(strings.OrderBy(x => x), idcol.OrderBy(x => x)));
+            Assert.True(Enumerable.SequenceEqual(strings.OrderBy(x => x), idcol.OrderBy(x => x)));
             Assert.Equal(idcol.GetEnumerator().GetType(), ((System.Collections.IEnumerable)idcol).GetEnumerator().GetType());
 
             AssertContains(idcol, strings);
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             var copy = new string[strings.Length];
             idcol.CopyTo(copy, 0);
-            Assert.Equal(true, Enumerable.SequenceEqual(strings.OrderBy(x => x), copy.OrderBy(x => x)));
+            Assert.True(Enumerable.SequenceEqual(strings.OrderBy(x => x), copy.OrderBy(x => x)));
         }
 
         private void TestCaseInsensitive(params string[] strings)
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             var idcol = new IdentifierCollection(strings).AsCaseInsensitiveCollection();
 
             Assert.Equal(strings.Length, idcol.Count);
-            Assert.Equal(true, Enumerable.SequenceEqual(strings.OrderBy(x => x), idcol.OrderBy(x => x)));
+            Assert.True(Enumerable.SequenceEqual(strings.OrderBy(x => x), idcol.OrderBy(x => x)));
             Assert.Equal(idcol.GetEnumerator().GetType(), ((System.Collections.IEnumerable)idcol).GetEnumerator().GetType());
 
             AssertContains(idcol, strings);
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
             var copy = new string[strings.Length];
             idcol.CopyTo(copy, 0);
-            Assert.Equal(true, Enumerable.SequenceEqual(strings.OrderBy(x => x), copy.OrderBy(x => x)));
+            Assert.True(Enumerable.SequenceEqual(strings.OrderBy(x => x), copy.OrderBy(x => x)));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
 
         private void TestReadOnly(ICollection<string> collection)
         {
-            Assert.Equal(true, collection.IsReadOnly);
+            Assert.True(collection.IsReadOnly);
             Assert.Throws<NotSupportedException>(() => collection.Add("x"));
             Assert.Throws<NotSupportedException>(() => collection.Remove("x"));
             Assert.Throws<NotSupportedException>(() => collection.Clear());
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         {
             foreach (var str in strings)
             {
-                Assert.Equal(true, collection.Contains(str));
+                Assert.True(collection.Contains(str));
             }
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         {
             foreach (var str in strings)
             {
-                Assert.Equal(false, collection.Contains(str));
+                Assert.False(collection.Contains(str));
             }
         }
     }

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.Equal(1, a.Length);
             Assert.Equal(2, a[0]);
 
-            Assert.Throws(typeof(ArgumentNullException), () => ImmutableArray.CreateRange<int>((IEnumerable<int>)null));
+            Assert.Throws<ArgumentNullException>(() => ImmutableArray.CreateRange<int>((IEnumerable<int>)null));
 
             a = ImmutableArray.CreateRange<int>(Enumerable.Range(1, 2));
             Assert.Equal(2, a.Length);
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             ImmutableArray<int> nullOrEmpty = default(ImmutableArray<int>);
             Assert.True(nullOrEmpty.IsDefault);
             Assert.True(nullOrEmpty.IsDefaultOrEmpty);
-            Assert.Throws(typeof(NullReferenceException), () => nullOrEmpty.IsEmpty);
+            Assert.Throws<NullReferenceException>(() => nullOrEmpty.IsEmpty);
 
             nullOrEmpty = ImmutableArray.Create<int>();
             Assert.True(nullOrEmpty.IsEmpty);
@@ -213,9 +213,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         public void Last()
         {
             var roa = new int?[] { }.AsImmutableOrNull();
-            Assert.Throws(typeof(InvalidOperationException), () => roa.Last());
+            Assert.Throws<InvalidOperationException>(() => roa.Last());
             roa = new int?[] { 1, 2, 3 }.AsImmutableOrNull();
-            Assert.Throws(typeof(InvalidOperationException), () => roa.Last(i => i < 1));
+            Assert.Throws<InvalidOperationException>(() => roa.Last(i => i < 1));
             Assert.Equal(3, roa.Last(i => i > 1));
         }
 
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             roa = new int?[] { 1 }.AsImmutableOrNull();
             Assert.Equal(1, roa.SingleOrDefault());
             roa = new int?[] { 1, 2, 3 }.AsImmutableOrNull();
-            Assert.Throws(typeof(InvalidOperationException), () => roa.SingleOrDefault());
+            Assert.Throws<InvalidOperationException>(() => roa.SingleOrDefault());
             roa = new int?[] { 1, 2, 3 }.AsImmutableOrNull();
             Assert.Equal(2, roa.SingleOrDefault(i => i == 2));
         }
@@ -294,25 +294,25 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             Assert.Equal("one:1", dict["one"]);
             Assert.Equal("two:2", dict["two"]);
             Assert.Equal("three:3", dict["three"]);
-            Assert.Throws(typeof(KeyNotFoundException), () => dict["One"]);
+            Assert.Throws<KeyNotFoundException>(() => dict["One"]);
 
             dict = System.Linq.ImmutableArrayExtensions.ToDictionary(roa, s => s.Split(':').First(), StringComparer.OrdinalIgnoreCase);
             Assert.Equal("one:1", dict["one"]);
             Assert.Equal("two:2", dict["Two"]);
             Assert.Equal("three:3", dict["THREE"]);
-            Assert.Throws(typeof(KeyNotFoundException), () => dict[""]);
+            Assert.Throws<KeyNotFoundException>(() => dict[""]);
 
             dict = System.Linq.ImmutableArrayExtensions.ToDictionary(roa, s => s.Split(':').First(), s => s.Split(':').Last());
             Assert.Equal("1", dict["one"]);
             Assert.Equal("2", dict["two"]);
             Assert.Equal("3", dict["three"]);
-            Assert.Throws(typeof(KeyNotFoundException), () => dict["THREE"]);
+            Assert.Throws<KeyNotFoundException>(() => dict["THREE"]);
 
             dict = System.Linq.ImmutableArrayExtensions.ToDictionary(roa, s => s.Split(':').First(), s => s.Split(':').Last(), StringComparer.OrdinalIgnoreCase);
             Assert.Equal("1", dict["onE"]);
             Assert.Equal("2", dict["Two"]);
             Assert.Equal("3", dict["three"]);
-            Assert.Throws(typeof(KeyNotFoundException), () => dict["four"]);
+            Assert.Throws<KeyNotFoundException>(() => dict["four"]);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
@@ -161,20 +161,20 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         public void CompareToNull()
         {
             var roaNull = default(ImmutableArray<int>);
-            Assert.Equal(true, roaNull == null);
-            Assert.Equal(false, roaNull != null);
-            Assert.Equal(true, null == roaNull);
-            Assert.Equal(false, null != roaNull);
+            Assert.True(roaNull == null);
+            Assert.False(roaNull != null);
+            Assert.True(null == roaNull);
+            Assert.False(null != roaNull);
 
             var copy = roaNull;
-            Assert.Equal(true, copy == roaNull);
-            Assert.Equal(false, copy != roaNull);
+            Assert.True(copy == roaNull);
+            Assert.False(copy != roaNull);
 
             var notnull = ImmutableArray.Create<int>();
-            Assert.Equal(false, notnull == null);
-            Assert.Equal(true, notnull != null);
-            Assert.Equal(false, null == notnull);
-            Assert.Equal(true, null != notnull);
+            Assert.False(notnull == null);
+            Assert.True(notnull != null);
+            Assert.False(null == notnull);
+            Assert.True(null != notnull);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
@@ -67,12 +67,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
             builder.Insert(1, "banana");
             builder.Insert(0, "$$$");
 
-            Assert.Equal(builder[0], "$$$");
-            Assert.Equal(builder[1], "apple");
-            Assert.Equal(builder[2], "banana");
-            Assert.Equal(builder[3], "candy");
-            Assert.Equal(builder[4], "drum");
-            Assert.Equal(builder[5], "elephant");
+            Assert.Equal("$$$", builder[0]);
+            Assert.Equal("apple", builder[1]);
+            Assert.Equal("banana", builder[2]);
+            Assert.Equal("candy", builder[3]);
+            Assert.Equal("drum", builder[4]);
+            Assert.Equal("elephant", builder[5]);
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/CommonCommandLineParserTests.cs
@@ -402,15 +402,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
 ";
             var ruleSet = ParseRuleSet(source);
             Assert.Contains("CA1012", ruleSet.SpecificDiagnosticOptions.Keys);
-            Assert.Equal(ruleSet.SpecificDiagnosticOptions["CA1012"], ReportDiagnostic.Error);
+            Assert.Equal(ReportDiagnostic.Error, ruleSet.SpecificDiagnosticOptions["CA1012"]);
             Assert.Contains("CA1013", ruleSet.SpecificDiagnosticOptions.Keys);
-            Assert.Equal(ruleSet.SpecificDiagnosticOptions["CA1013"], ReportDiagnostic.Warn);
+            Assert.Equal(ReportDiagnostic.Warn, ruleSet.SpecificDiagnosticOptions["CA1013"]);
             Assert.Contains("CA1014", ruleSet.SpecificDiagnosticOptions.Keys);
-            Assert.Equal(ruleSet.SpecificDiagnosticOptions["CA1014"], ReportDiagnostic.Suppress);
+            Assert.Equal(ReportDiagnostic.Suppress, ruleSet.SpecificDiagnosticOptions["CA1014"]);
             Assert.Contains("CA1015", ruleSet.SpecificDiagnosticOptions.Keys);
-            Assert.Equal(ruleSet.SpecificDiagnosticOptions["CA1015"], ReportDiagnostic.Info);
+            Assert.Equal(ReportDiagnostic.Info, ruleSet.SpecificDiagnosticOptions["CA1015"]);
             Assert.Contains("CA1016", ruleSet.SpecificDiagnosticOptions.Keys);
-            Assert.Equal(ruleSet.SpecificDiagnosticOptions["CA1016"], ReportDiagnostic.Hidden);
+            Assert.Equal(ReportDiagnostic.Hidden, ruleSet.SpecificDiagnosticOptions["CA1016"]);
         }
 
         [Fact]
@@ -443,8 +443,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 ";
             var ruleSet = ParseRuleSet(source);
             Assert.True(ruleSet.Includes.Count() == 1);
-            Assert.Equal(ruleSet.Includes.First().Action, ReportDiagnostic.Default);
-            Assert.Equal(ruleSet.Includes.First().IncludePath, "goo.ruleset");
+            Assert.Equal(ReportDiagnostic.Default, ruleSet.Includes.First().Action);
+            Assert.Equal("goo.ruleset", ruleSet.Includes.First().IncludePath);
         }
 
 #pragma warning disable CA2243 // Attribute string literals should parse correctly

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTests.cs
@@ -33,15 +33,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             argumentNames = default;
             argumentRefKinds = default;
             dynamicExpression = createDynamicExpression(arguments, argumentNames, argumentRefKinds);
-            Assert.Equal(null, dynamicExpression.GetArgumentName(0));
-            Assert.Equal(null, dynamicExpression.GetArgumentRefKind(0));
+            Assert.Null(dynamicExpression.GetArgumentName(0));
+            Assert.Null(dynamicExpression.GetArgumentRefKind(0));
 
             // Non-empty arguments and empty argument names/refkinds
             arguments = ImmutableArray.Create((IOperation)null);
             argumentNames = ImmutableArray<string>.Empty;
             argumentRefKinds = ImmutableArray<RefKind>.Empty;
             dynamicExpression = createDynamicExpression(arguments, argumentNames, argumentRefKinds);
-            Assert.Equal(null, dynamicExpression.GetArgumentName(0));
+            Assert.Null(dynamicExpression.GetArgumentName(0));
             Assert.Equal(RefKind.None, dynamicExpression.GetArgumentRefKind(0));
 
             // Non-empty arguments and non-empty argument names/refkinds

--- a/src/Compilers/Core/CodeAnalysisTest/DiffUtilTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DiffUtilTests.cs
@@ -10,16 +10,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestDiffTester()
         {
-            // Make sure the diff tester is working!
-            Assert.Equal(@"    A
-++> 1
-    B
-    C
---> D
-    E
-++> 2
---> F",
-DiffUtil.DiffReport(
+            var expected = DiffUtil.DiffReport(
 @"A
 B
 C
@@ -31,7 +22,16 @@ F",
 B
 C
 E
-2"));
+2");
+            // Make sure the diff tester is working!
+            Assert.Equal(@"    A
+++> 1
+    B
+    C
+--> D
+    E
+++> 2
+--> F", expected);
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/DiffUtilTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DiffUtilTests.cs
@@ -11,7 +11,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void TestDiffTester()
         {
             // Make sure the diff tester is working!
-            Assert.Equal(DiffUtil.DiffReport(
+            Assert.Equal(@"    A
+++> 1
+    B
+    C
+--> D
+    E
+++> 2
+--> F",
+DiffUtil.DiffReport(
 @"A
 B
 C
@@ -23,15 +31,7 @@ F",
 B
 C
 E
-2"),
-@"    A
-++> 1
-    B
-    C
---> D
-    E
-++> 2
---> F");
+2"));
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/EmbeddedTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EmbeddedTextTests.cs
@@ -78,7 +78,7 @@ class Program
         {
             var text = EmbeddedText.FromBytes("pathToEmpty", new ArraySegment<byte>(new byte[0], 0, 0), SourceHashAlgorithm.Sha1);
             Assert.Equal("pathToEmpty", text.FilePath);
-            Assert.Equal(text.ChecksumAlgorithm, SourceHashAlgorithm.Sha1);
+            Assert.Equal(SourceHashAlgorithm.Sha1, text.ChecksumAlgorithm);
             AssertEx.Equal(SourceText.CalculateChecksum(new byte[0], 0, 0, SourceHashAlgorithm.Sha1), text.Checksum);
             AssertEx.Equal(new byte[] { 0, 0, 0, 0 }, text.Blob);
         }
@@ -90,7 +90,7 @@ class Program
             var checksum = SourceText.CalculateChecksum(new byte[0], 0, 0, SourceHashAlgorithm.Sha1);
 
             Assert.Equal("pathToEmpty", text.FilePath);
-            Assert.Equal(text.ChecksumAlgorithm, SourceHashAlgorithm.Sha1);
+            Assert.Equal(SourceHashAlgorithm.Sha1, text.ChecksumAlgorithm);
             AssertEx.Equal(checksum, text.Checksum);
             AssertEx.Equal(new byte[] { 0, 0, 0, 0 }, text.Blob);
         }
@@ -116,7 +116,7 @@ class Program
             var text = EmbeddedText.FromBytes("pathToSmall", new ArraySegment<byte>(bytes, 0, bytes.Length));
 
             Assert.Equal("pathToSmall", text.FilePath);
-            Assert.Equal(text.ChecksumAlgorithm, SourceHashAlgorithm.Sha1);
+            Assert.Equal(SourceHashAlgorithm.Sha1, text.ChecksumAlgorithm);
             AssertEx.Equal(checksum, text.Checksum);
             AssertEx.Equal(new byte[] { 0, 0, 0, 0 }, text.Blob.Take(4));
             AssertEx.Equal(bytes, text.Blob.Skip(4));

--- a/src/Compilers/Core/CodeAnalysisTest/FileLinePositionSpanTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileLinePositionSpanTests.cs
@@ -28,22 +28,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void Ctor1()
         {
-            Assert.Throws(
-                typeof(ArgumentNullException),
+            Assert.Throws<ArgumentNullException>(
                 () =>
             {
                 var notUsed = new FileLinePositionSpan(null, new LinePosition(1, 2), new LinePosition(3, 5));
             });
 
-            Assert.Throws(
-                typeof(ArgumentException),
+            Assert.Throws<ArgumentException>(
                 () =>
             {
                 var notUsed = new FileLinePositionSpan("C:\\goo.cs", new LinePosition(3, 2), new LinePosition(2, 4));
             });
 
-            Assert.Throws(
-                typeof(ArgumentException),
+            Assert.Throws<ArgumentException>(
                 () =>
             {
                 var notUsed = new FileLinePositionSpan("C:\\goo.cs", new LinePosition(1, 2), new LinePosition(1, 1));

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
             TestGetDirectoryNameAndCompareToDotnet(null, @"C:");
 
             // dotnet throws on empty argument.  But not on null... go figure.
-            Assert.Equal(
-                null,
-                PathUtilities.TestAccessor.GetDirectoryName(@"", isUnixLike: false));
+            Assert.Null(PathUtilities.TestAccessor.GetDirectoryName(@"", isUnixLike: false));
 
             TestGetDirectoryNameAndCompareToDotnet(null, null);
         }
@@ -69,16 +67,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
                 @"/",
                 PathUtilities.TestAccessor.GetDirectoryName(@"/temp", isUnixLike: true));
 
-            Assert.Equal(
-                null,
+            Assert.Null(
                 PathUtilities.TestAccessor.GetDirectoryName(@"/", isUnixLike: true));
 
-            Assert.Equal(
-                null,
+            Assert.Null(
                 PathUtilities.TestAccessor.GetDirectoryName(@"", isUnixLike: true));
 
-            Assert.Equal(
-                null,
+            Assert.Null(
                 PathUtilities.TestAccessor.GetDirectoryName(null, isUnixLike: true));
         }
 
@@ -109,12 +104,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
                 "",
                 PathUtilities.TestAccessor.GetDirectoryName(@"goo", isUnixLike: true));
 
-            Assert.Equal(
-                null,
+            Assert.Null(
                 PathUtilities.TestAccessor.GetDirectoryName(@"", isUnixLike: true));
 
-            Assert.Equal(
-                null,
+            Assert.Null(
                 PathUtilities.TestAccessor.GetDirectoryName(null, isUnixLike: true));
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -256,38 +256,38 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
         [ConditionalFact(typeof(WindowsOnly))]
         public void IsSameDirectoryOrChildOfHandlesDifferentSlashes()
         {
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:\"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:", @"C:"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:", @"C:\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:", @"C:"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:", @"C:\"));
 
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\"));
 
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\"));
 
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\"));
 
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\"));
 
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\EFGH"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\EFGH\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\EFGH"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\EFGH\"));
 
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\EFGH"));
-            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\EFGH\"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\EFGH"));
+            Assert.True(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\EFGH\"));
         }
 
         [Fact]
         public void IsSameDirectoryOrChildOfNegativeTests()
         {
-            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:\ABCD"));
-            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABC", @"C:\ABCD"));
-            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCDE", @"C:\ABCD"));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:\ABCD"));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABC", @"C:\ABCD"));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCDE", @"C:\ABCD"));
 
-            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\B\C", @"C:\A\B\C\D"));
+            Assert.False(PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\B\C", @"C:\A\B\C\D"));
         }
 
         [Fact]

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/RelativePathResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/RelativePathResolverTests.cs
@@ -43,13 +43,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(filePath, path);
 
             path = resolver.ResolvePath(@"\" + fileName, baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             path = resolver.ResolvePath(@"/" + fileName, baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             path = resolver.ResolvePath(@".", baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             path = resolver.ResolvePath(@".\" + fileName, baseFilePath: null);
             Assert.Equal(subFilePath, path);
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(dotted, path);
 
             path = resolver.ResolvePath(@"..", baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             path = resolver.ResolvePath(@"..\" + fileName, baseFilePath: null);
             Assert.Equal(filePath, path);
@@ -70,17 +70,17 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(filePath, path);
 
             path = resolver.ResolvePath(@"C:\" + fileName, baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             path = resolver.ResolvePath(@"C:/" + fileName, baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             path = resolver.ResolvePath(filePath, baseFilePath: null);
             Assert.Equal(filePath, path);
 
             // drive-relative paths not supported:
             path = resolver.ResolvePath(drive + ":" + fileName, baseFilePath: null);
-            Assert.Equal(null, path);
+            Assert.Null(path);
 
             // \abc\def
             string rooted = filePath.Substring(2);

--- a/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [ConditionalFact(typeof(WindowsOnly))]
         public void GetPathRoot()
         {
-            Assert.Equal(null, PathUtilities.GetPathRoot(null));
+            Assert.Null(PathUtilities.GetPathRoot(null));
             Assert.Equal("", PathUtilities.GetPathRoot(""));
             Assert.Equal("", PathUtilities.GetPathRoot("C"));
             Assert.Equal("", PathUtilities.GetPathRoot("abc.txt"));
@@ -93,9 +93,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(@"C:\x/y", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x/y", null));
             Assert.Equal(@"C:\x/y", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x/y", null));
 
-            Assert.Equal(null, PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\", @"C:\goo"));
-            Assert.Equal(null, PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\", @"C:goo"));
-            Assert.Equal(null, PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\", @"\goo"));
+            Assert.Null(PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\", @"C:\goo"));
+            Assert.Null(PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\", @"C:goo"));
+            Assert.Null(PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\", @"\goo"));
 
             Assert.Equal(@"C:\x\y\goo", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x\y", @"goo"));
             Assert.Equal(@"C:\x/y\goo", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x/y", @"goo"));

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/WeakListTests.cs
@@ -77,11 +77,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.InternalUtilities
             e.AssertReleased();
 
             Assert.Equal(5, list.WeakCount);
-            Assert.Same(null, list.GetWeakReference(0).GetTarget());
+            Assert.Null(list.GetWeakReference(0).GetTarget());
             Assert.Same(b.GetReference(), list.GetWeakReference(1).GetTarget());
-            Assert.Same(null, list.GetWeakReference(2).GetTarget());
-            Assert.Same(null, list.GetWeakReference(3).GetTarget());
-            Assert.Same(null, list.GetWeakReference(4).GetTarget());
+            Assert.Null(list.GetWeakReference(2).GetTarget());
+            Assert.Null(list.GetWeakReference(3).GetTarget());
+            Assert.Null(list.GetWeakReference(4).GetTarget());
 
             var array = list.ToArray();
 

--- a/src/Compilers/Core/CodeAnalysisTest/LinePositionTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/LinePositionTests.cs
@@ -24,16 +24,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void Ctor1()
         {
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () => { var notUsed = new LinePosition(-1, 42); });
         }
 
         [Fact]
         public void Ctor2()
         {
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () => { var notUsed = new LinePosition(42, -1); });
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -138,8 +138,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(0, 0, 0, 0), id.Version);
             Assert.Equal(AssemblyNameFlags.None, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(false, id.HasPublicKey);
-            Assert.Equal(false, id.IsRetargetable);
+            Assert.False(id.HasPublicKey);
+            Assert.False(id.IsRetargetable);
             Assert.Equal(0, id.PublicKey.Length);
             Assert.Equal(0, id.PublicKeyToken.Length);
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
@@ -149,8 +149,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(0, 0, 0, 0), id.Version);
             Assert.Equal(AssemblyNameFlags.PublicKey, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(true, id.HasPublicKey);
-            Assert.Equal(false, id.IsRetargetable);
+            Assert.True(id.HasPublicKey);
+            Assert.False(id.IsRetargetable);
             AssertEx.Equal(PublicKey1, id.PublicKey);
             AssertEx.Equal(PublicKeyToken1, id.PublicKeyToken);
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
@@ -160,8 +160,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(0, 0, 0, 0), id.Version);
             Assert.Equal(AssemblyNameFlags.Retargetable, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(false, id.HasPublicKey);
-            Assert.Equal(true, id.IsRetargetable);
+            Assert.False(id.HasPublicKey);
+            Assert.True(id.IsRetargetable);
             Assert.Equal(0, id.PublicKey.Length);
             AssertEx.Equal(PublicKeyToken1, id.PublicKeyToken);
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
@@ -171,8 +171,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(0, 0, 0, 0), id.Version);
             Assert.Equal(AssemblyNameFlags.PublicKey | AssemblyNameFlags.Retargetable, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(true, id.HasPublicKey);
-            Assert.Equal(true, id.IsRetargetable);
+            Assert.True(id.HasPublicKey);
+            Assert.True(id.IsRetargetable);
             AssertEx.Equal(PublicKey1, id.PublicKey);
             AssertEx.Equal(PublicKeyToken1, id.PublicKeyToken);
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
@@ -182,8 +182,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(0, 0, 0, 0), id.Version);
             Assert.Equal(AssemblyNameFlags.PublicKey, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(true, id.HasPublicKey);
-            Assert.Equal(false, id.IsRetargetable);
+            Assert.True(id.HasPublicKey);
+            Assert.False(id.IsRetargetable);
             AssertEx.Equal(PublicKey1, id.PublicKey);
             AssertEx.Equal(PublicKeyToken1, id.PublicKeyToken);
             Assert.Equal(AssemblyContentType.WindowsRuntime, id.ContentType);
@@ -253,8 +253,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(1, 2, 3, 4), id.Version);
             Assert.Equal(AssemblyNameFlags.PublicKey | AssemblyNameFlags.Retargetable, id.Flags);
             Assert.Equal("en-US", id.CultureName);
-            Assert.Equal(true, id.HasPublicKey);
-            Assert.Equal(true, id.IsRetargetable);
+            Assert.True(id.HasPublicKey);
+            Assert.True(id.IsRetargetable);
             AssertEx.Equal(PublicKey1, id.PublicKey);
             AssertEx.Equal(PublicKeyToken1, id.PublicKeyToken);
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 hasPublicKey: false, isRetargetable: false, contentType: (AssemblyContentType)2);
             Assert.Equal(AssemblyNameFlags.None, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(false, id.HasPublicKey);
+            Assert.False(id.HasPublicKey);
             Assert.Equal(0, id.PublicKey.Length);
             Assert.Equal(0, id.PublicKeyToken.Length);
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
@@ -276,8 +276,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(1, 2, 3, 4), id.Version);
             Assert.Equal(AssemblyNameFlags.None, id.Flags);
             Assert.Equal("", id.CultureName);
-            Assert.Equal(false, id.HasPublicKey);
-            Assert.Equal(false, id.IsRetargetable);
+            Assert.False(id.HasPublicKey);
+            Assert.False(id.IsRetargetable);
             Assert.Equal(AssemblyContentType.WindowsRuntime, id.ContentType);
 
             // invalid culture:

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertEx.Equal(new byte[0], an.GetPublicKeyToken());
             AssertEx.Equal(null, an.GetPublicKey());
             Assert.Equal(AssemblyNameFlags.None, an.Flags);
-            Assert.Equal(null, an.CodeBase);
+            Assert.Null(an.CodeBase);
 
             ai = new AssemblyIdentity("goo", new Version(1, 2, 3, 4), "en-US", RoPublicKey1,
                 hasPublicKey: true,
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             AssertEx.Equal(PublicKeyToken1, an.GetPublicKeyToken());
             AssertEx.Equal(PublicKey1, an.GetPublicKey());
             Assert.Equal(AssemblyNameFlags.PublicKey | AssemblyNameFlags.Retargetable, an.Flags);
-            Assert.Equal(null, an.CodeBase);
+            Assert.Null(an.CodeBase);
 
             // invalid characters are ok in the name, the FullName can't be built though:
             foreach (char c in ClrInvalidCharacters)

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataReferenceTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Same(doc, r.DocumentationProvider);
             Assert.Same(doc, r.DocumentationProvider);
             Assert.NotNull(r.GetMetadataNoCopy());
-            Assert.Equal(false, r.Properties.EmbedInteropTypes);
+            Assert.False(r.Properties.EmbedInteropTypes);
             Assert.Equal(MetadataImageKind.Module, r.Properties.Kind);
             Assert.True(r.Properties.Aliases.IsEmpty);
             Assert.Equal(@"c:\temp", r.FilePath);
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Same(doc, r.DocumentationProvider);
             Assert.Same(doc, r.DocumentationProvider);
             Assert.NotNull(r.GetMetadataNoCopy());
-            Assert.Equal(true, r.Properties.EmbedInteropTypes);
+            Assert.True(r.Properties.EmbedInteropTypes);
             Assert.Equal(MetadataImageKind.Assembly, r.Properties.Kind);
             AssertEx.Equal(new[] { "a" }, r.Properties.Aliases);
             Assert.Equal(@"c:\temp", r.FilePath);
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var r4 = r.WithEmbedInteropTypes(false);
             Assert.Same(r.DocumentationProvider, r4.DocumentationProvider);
             Assert.Same(r.GetMetadataNoCopy(), r4.GetMetadataNoCopy());
-            Assert.Equal(false, r4.Properties.EmbedInteropTypes);
+            Assert.False(r4.Properties.EmbedInteropTypes);
             Assert.Equal(r.Properties.Kind, r4.Properties.Kind);
             AssertEx.Equal(r.Properties.Aliases, r4.Properties.Aliases);
             Assert.Equal(r.FilePath, r4.FilePath);

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -970,8 +970,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("\uD800\uDC00", (String)reader.ReadValue()); // valid surrogate pair
             Assert.Equal("\uDC00\uD800", (String)reader.ReadValue()); // invalid surrogate pair
             Assert.Equal("\uD800", (String)reader.ReadValue()); // incomplete surrogate pair
-            Assert.Equal(null, reader.ReadValue());
-            Assert.Equal(null, reader.ReadValue());
+            Assert.Null(reader.ReadValue());
+            Assert.Null(reader.ReadValue());
 
             unchecked
             {

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -851,8 +851,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         private static void TestReadingPrimitiveAPIs(ObjectReader reader)
         {
-            Assert.Equal(true, reader.ReadBoolean());
-            Assert.Equal(false, reader.ReadBoolean());
+            Assert.True(reader.ReadBoolean());
+            Assert.False(reader.ReadBoolean());
             Assert.Equal(Byte.MaxValue, reader.ReadByte());
             Assert.Equal(SByte.MaxValue, reader.ReadSByte());
             Assert.Equal(Int16.MaxValue, reader.ReadInt16());
@@ -950,8 +950,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         private static void TestReadingPrimitiveValues(ObjectReader reader)
         {
-            Assert.Equal(true, (bool)reader.ReadValue());
-            Assert.Equal(false, (bool)reader.ReadValue());
+            Assert.True((bool)reader.ReadValue());
+            Assert.False((bool)reader.ReadValue());
             Assert.Equal(Byte.MaxValue, (Byte)reader.ReadValue());
             Assert.Equal(SByte.MaxValue, (SByte)reader.ReadValue());
             Assert.Equal(Int16.MaxValue, (Int16)reader.ReadValue());

--- a/src/Compilers/Core/CodeAnalysisTest/Text/LargeTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/LargeTextTests.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void IndexerTest()
         {
             var text = CreateSourceText(HelloWorld);
-            Assert.Throws(typeof(IndexOutOfRangeException), () => text[-1]);
-            Assert.Throws(typeof(IndexOutOfRangeException), () => text[HelloWorld.Length]);
+            Assert.Throws<IndexOutOfRangeException>(() => text[-1]);
+            Assert.Throws<IndexOutOfRangeException>(() => text[HelloWorld.Length]);
             for (int i = HelloWorld.Length - 1; i >= 0; i--)
             {
                 Assert.Equal(HelloWorld[i], text[i]);

--- a/src/Compilers/Core/CodeAnalysisTest/Text/LargeTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/LargeTextTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             using (MemoryStream stream = new MemoryStream())
             {
                 var text = CreateSourceText(stream);
-                Assert.Equal(text.Length, 0);
+                Assert.Equal(0, text.Length);
             }
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Text/LargeTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/LargeTextTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 }
 
                 var text = SourceText.From(stream);
-                Assert.IsType(typeof(LargeText), text);
+                Assert.IsType<LargeText>(text);
 
                 char[] buffer = new char[HelloWorld.Length];
                 for (int start = 0; start < text.Length; start += HelloWorld.Length)

--- a/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextStreamTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/SourceTextStreamTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Text
                 for (int i = 0; i < max; i++)
                 {
                     var local = i;
-                    Assert.Throws(typeof(ArgumentException), () => stream.Read(buffer, 0, local));
+                    Assert.Throws<ArgumentException>(() => stream.Read(buffer, 0, local));
                 }
             }
         }

--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // bytes should not decode to UTF-8
             using (var stream = new MemoryStream(bytes))
             {
-                Assert.Throws(typeof(DecoderFallbackException), () =>
+                Assert.Throws<DecoderFallbackException>(() =>
                 {
                     EncodedStringText.TestAccessor.Decode(stream, utf8, SourceHashAlgorithm.Sha1, throwIfBinaryDetected: false, canBeEmbedded: false);
                 });

--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTest.cs
@@ -77,8 +77,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void Indexer1()
         {
             var data = SourceText.From(string.Empty, Encoding.UTF8);
-            Assert.Throws(
-                typeof(IndexOutOfRangeException),
+            Assert.Throws<IndexOutOfRangeException>(
                 () => { var value = data[-1]; });
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTests_Default.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/StringTextTests_Default.cs
@@ -43,8 +43,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void Indexer1()
         {
             var data = Create(String.Empty);
-            Assert.Throws(
-                typeof(IndexOutOfRangeException),
+            Assert.Throws<IndexOutOfRangeException>(
                 () => { var value = data[-1]; });
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeRangeTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeRangeTest.cs
@@ -12,8 +12,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void Ctor1()
         {
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () => { var notUsed = new TextChangeRange(new TextSpan(), -1); });
         }
 

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextSpanTest.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextSpanTest.cs
@@ -83,9 +83,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void TextSpan00()
         {
             TextSpan span = new TextSpan(0, 0);
-            Assert.Equal(span.Start, 0);
-            Assert.Equal(span.End, 0);
-            Assert.Equal(span.Length, 0);
+            Assert.Equal(0, span.Start);
+            Assert.Equal(0, span.End);
+            Assert.Equal(0, span.Length);
             Assert.Equal("[0..0)", span.ToString());
             Assert.True(span.IsEmpty);
         }
@@ -94,9 +94,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void TextSpan01()
         {
             TextSpan span = new TextSpan(0, 1);
-            Assert.Equal(span.Start, 0);
-            Assert.Equal(span.End, 1);
-            Assert.Equal(span.Length, 1);
+            Assert.Equal(0, span.Start);
+            Assert.Equal(1, span.End);
+            Assert.Equal(1, span.Length);
             Assert.Equal("[0..1)", span.ToString());
             Assert.False(span.IsEmpty);
             span.GetHashCode();
@@ -106,9 +106,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void TextSpan02()
         {
             TextSpan span = new TextSpan(15, 1485);
-            Assert.Equal(span.Start, 15);
-            Assert.Equal(span.End, 1500);
-            Assert.Equal(span.Length, 1485);
+            Assert.Equal(15, span.Start);
+            Assert.Equal(1500, span.End);
+            Assert.Equal(1485, span.Length);
             Assert.Equal("[15..1500)", span.ToString());
         }
 
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void TextSpan03()
         {
             TextSpan span = new TextSpan(0, int.MaxValue - 1);
-            Assert.Equal(span.Start, 0);
+            Assert.Equal(0, span.Start);
             Assert.Equal(span.End, int.MaxValue - 1);
             Assert.Equal(span.Length, int.MaxValue - 1);
         }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -291,7 +291,7 @@ End Module")
                 var files = new Dictionary<string, string> { { "hello.cs", "♕" } };
 
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, files, redirectEncoding: Encoding.ASCII, shouldRunOnServer: false);
-                Assert.Equal(result.ExitCode, 1);
+                Assert.Equal(1, result.ExitCode);
                 Assert.Equal("hello.cs(1,1): error CS1056: Unexpected character '?'", result.Output.Trim());
                 await serverData.Verify(connections: 1, completed: 1).ConfigureAwait(true);
             }
@@ -332,7 +332,7 @@ End Module")
                     redirectEncoding: Encoding.ASCII,
                     shouldRunOnServer: false);
 
-                Assert.Equal(result.ExitCode, 1);
+                Assert.Equal(1, result.ExitCode);
                 Assert.Equal(@"test.vb(1) : error BC30037: Character is not valid.
 
 ?

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2396,7 +2396,7 @@ struct Type<T>
             Assert.Empty(tags);
             Assert.NotEmpty(allTags);
 
-            Assert.Equal(allTags.Count(), 1);
+            Assert.Equal(1, allTags.Count());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -27,7 +27,7 @@ using System.Diagnostics;
             var edits = GetTopEdits(src1, src2);
             edits.VerifyEdits("Delete [using System.Diagnostics;]@2");
             Assert.IsType<UsingDirectiveSyntax>(edits.Edits.First().OldNode);
-            Assert.Equal(edits.Edits.First().NewNode, null);
+            Assert.Null(edits.Edits.First().NewNode);
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3493,7 +3493,7 @@ class Program{
             var tokenRange = FormattingRangeHelper.FindAppropriateRange(endToken);
             if (tokenRange == null)
             {
-                Assert.Equal(startTokenKind, SyntaxKind.None);
+                Assert.Equal(SyntaxKind.None, startTokenKind);
                 return;
             }
 

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -149,7 +149,7 @@ partial class Goo
 Class Program { FileStyleUriParser f; }", async w =>
             {
                 var items = await _aggregator.GetItemsAsync("FileStyleUriParser");
-                Assert.Equal(items.Count(), 0);
+                Assert.Equal(0, items.Count());
             });
         }
 

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -171,7 +171,7 @@ partial class Goo
 Class Program { FileStyleUriParser f; }", async w =>
             {
                 var items = await _aggregator.GetItemsAsync("FileStyleUriParser");
-                Assert.Equal(items.Count(), 0);
+                Assert.Equal(0, items.Count());
             });
         }
 

--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyCompilationsTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyCompilationsTests.cs
@@ -95,8 +95,8 @@ public void Method()
             Assert.NotNull(symbol01);
             Assert.NotNull(symbol02);
 
-            Assert.NotEqual(symbol01.Kind, SymbolKind.ErrorType);
-            Assert.NotEqual(symbol02.Kind, SymbolKind.ErrorType);
+            Assert.NotEqual(SymbolKind.ErrorType, symbol01.Kind);
+            Assert.NotEqual(SymbolKind.ErrorType, symbol02.Kind);
 
             var originalSymbols = GetSourceSymbols(comp1, SymbolCategory.DeclaredType | SymbolCategory.DeclaredNamespace).OrderBy(s => s.Name);
             var newSymbols = GetSourceSymbols(comp2, SymbolCategory.DeclaredType | SymbolCategory.DeclaredNamespace).OrderBy(s => s.Name);

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForMethodsAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForMethodsAnalyzerTests.cs
@@ -52,13 +52,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
             var serialized = option.ToXElement();
             var deserialized = CodeStyleOption<bool>.FromXElement(serialized);
 
-            Assert.Equal(false, deserialized.Value);
+            Assert.False(deserialized.Value);
 
             option = new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.Silent);
             serialized = option.ToXElement();
             deserialized = CodeStyleOption<bool>.FromXElement(serialized);
 
-            Assert.Equal(true, deserialized.Value);
+            Assert.True(deserialized.Value);
 
             // This new values can't actually translate back to a bool.  So we'll just get the default
             // value for this option.

--- a/src/EditorFeatures/Test/Collections/Immutable/Maps/BidirectionalMapTests.cs
+++ b/src/EditorFeatures/Test/Collections/Immutable/Maps/BidirectionalMapTests.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Collections.Immutable.Maps
         {
             var map = BidirectionalMap<string, int>.Empty;
 
-            Assert.Equal(map.Keys.Count(), 0);
-            Assert.Equal(map.Values.Count(), 0);
+            Assert.Equal(0, map.Keys.Count());
+            Assert.Equal(0, map.Values.Count());
             Assert.False(map.TryGetKey(0, out var key));
             Assert.False(map.TryGetValue("0", out var value));
 
@@ -32,20 +32,20 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Collections.Immutable.Maps
                 .Add("1", 1)
                 .Add("2", 2);
 
-            Assert.Equal(map.Keys.Count(), 3);
-            Assert.Equal(map.Values.Count(), 3);
+            Assert.Equal(3, map.Keys.Count());
+            Assert.Equal(3, map.Values.Count());
             Assert.True(map.TryGetKey(0, out var key));
-            Assert.Equal(key, "0");
+            Assert.Equal("0", key);
             Assert.True(map.TryGetKey(1, out key));
-            Assert.Equal(key, "1");
+            Assert.Equal("1", key);
             Assert.True(map.TryGetKey(2, out key));
-            Assert.Equal(key, "2");
+            Assert.Equal("2", key);
             Assert.True(map.TryGetValue("0", out var value));
-            Assert.Equal(value, 0);
+            Assert.Equal(0, value);
             Assert.True(map.TryGetValue("1", out value));
-            Assert.Equal(value, 1);
+            Assert.Equal(1, value);
             Assert.True(map.TryGetValue("2", out value));
-            Assert.Equal(value, 2);
+            Assert.Equal(2, value);
 
             Assert.True(map.ContainsKey("0"));
             Assert.True(map.ContainsKey("1"));

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -276,13 +276,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var incrementalAnalyzer = (DiagnosticIncrementalAnalyzer)service.CreateIncrementalAnalyzer(workspace);
             var analyzers = incrementalAnalyzer.GetAnalyzersTestOnly(project).ToArray();
 
-            Assert.Equal(analyzers[0].GetType(), typeof(CSharpCompilerDiagnosticAnalyzer));
-            Assert.Equal(analyzers[1].GetType(), typeof(Analyzer));
-            Assert.Equal(analyzers[2].GetType(), typeof(Priority0Analyzer));
-            Assert.Equal(analyzers[3].GetType(), typeof(Priority1Analyzer));
-            Assert.Equal(analyzers[4].GetType(), typeof(Priority10Analyzer));
-            Assert.Equal(analyzers[5].GetType(), typeof(Priority15Analyzer));
-            Assert.Equal(analyzers[6].GetType(), typeof(Priority20Analyzer));
+            Assert.Equal(typeof(CSharpCompilerDiagnosticAnalyzer), analyzers[0].GetType());
+            Assert.Equal(typeof(Analyzer), analyzers[1].GetType());
+            Assert.Equal(typeof(Priority0Analyzer), analyzers[2].GetType());
+            Assert.Equal(typeof(Priority1Analyzer), analyzers[3].GetType());
+            Assert.Equal(typeof(Priority10Analyzer), analyzers[4].GetType());
+            Assert.Equal(typeof(Priority15Analyzer), analyzers[5].GetType());
+            Assert.Equal(typeof(Priority20Analyzer), analyzers[6].GetType());
         }
 
         [Fact]

--- a/src/EditorFeatures/Test/Extensions/IProjectionBufferFactoryServiceExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/IProjectionBufferFactoryServiceExtensionsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                 exposedSpans: textBuffer.CurrentSnapshot.GetFullSpan());
 
             var elisionSnapshot = elisionBuffer.CurrentSnapshot;
-            Assert.Equal(elisionSnapshot.LineCount, 3);
+            Assert.Equal(3, elisionSnapshot.LineCount);
 
             foreach (var line in elisionSnapshot.Lines)
             {
@@ -62,13 +62,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                 LineSpan.FromBounds(1, 2), LineSpan.FromBounds(3, 4));
 
             var projectionSnapshot = projectionBuffer.CurrentSnapshot;
-            Assert.Equal(projectionSnapshot.LineCount, 4);
+            Assert.Equal(4, projectionSnapshot.LineCount);
 
             var lines = projectionSnapshot.Lines.ToList();
-            Assert.Equal(lines[0].GetText(), "...");
-            Assert.Equal(lines[1].GetText(), "  line 2");
-            Assert.Equal(lines[2].GetText(), "...");
-            Assert.Equal(lines[3].GetText(), "  line 4");
+            Assert.Equal("...", lines[0].GetText());
+            Assert.Equal("  line 2", lines[1].GetText());
+            Assert.Equal("...", lines[2].GetText());
+            Assert.Equal("  line 4", lines[3].GetText());
         }
 
         [Fact]
@@ -91,13 +91,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                 LineSpan.FromBounds(0, 1), LineSpan.FromBounds(2, 4));
 
             var projectionSnapshot = projectionBuffer.CurrentSnapshot;
-            Assert.Equal(projectionSnapshot.LineCount, 4);
+            Assert.Equal(4, projectionSnapshot.LineCount);
 
             var lines = projectionSnapshot.Lines.ToList();
-            Assert.Equal(lines[0].GetText(), "line 1");
-            Assert.Equal(lines[1].GetText(), "...");
-            Assert.Equal(lines[2].GetText(), "line 3");
-            Assert.Equal(lines[3].GetText(), "  line 4");
+            Assert.Equal("line 1", lines[0].GetText());
+            Assert.Equal("...", lines[1].GetText());
+            Assert.Equal("line 3", lines[2].GetText());
+            Assert.Equal("  line 4", lines[3].GetText());
         }
     }
 }

--- a/src/EditorFeatures/Test/Extensions/ITextSnapshotExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/ITextSnapshotExtensionsTests.cs
@@ -132,10 +132,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
             var span = snapshot.GetSpan(0, 2, 1, 1);
 
             // column 0, index 2 = (0 * 5) + 2 = 2
-            Assert.Equal(span.Start, 2);
+            Assert.Equal(2, span.Start);
 
             // column 1, index 1 = (1 * 5) + 1 = 6
-            Assert.Equal(span.End, 6);
+            Assert.Equal(6, span.End);
         }
 
         [Fact]

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -659,8 +659,8 @@ End Class");
             var result = await context.GenerateSourceAsync(compilation.ObjectType);
             var openedDocument = context.GetDocument(result);
 
-            Assert.Equal(openedDocument.Project.AssemblyName, "mscorlib");
-            Assert.Equal(openedDocument.Project.Name, "mscorlib");
+            Assert.Equal("mscorlib", openedDocument.Project.AssemblyName);
+            Assert.Equal("mscorlib", openedDocument.Project.Name);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.MetadataAsSource)]

--- a/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
+++ b/src/EditorFeatures/Test/Threading/ForegroundNotificationServiceTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Threading
 
             await PumpWait().ConfigureAwait(false);
             Assert.True(_done);
-            Assert.Equal(count, 9000000);
+            Assert.Equal(9000000, count);
             Assert.True(Service.IsEmpty_TestOnly);
         }
 

--- a/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
+++ b/src/EditorFeatures/Test/Utilities/SymbolEquivalenceComparerTests.cs
@@ -1435,10 +1435,10 @@ End Class
             var method2 = GetInvokedSymbol<TInvocation>(comp2, typeName, methodName);
 
             Assert.NotNull(method1);
-            Assert.Equal(method1.MethodKind, MethodKind.ReducedExtension);
+            Assert.Equal(MethodKind.ReducedExtension, method1.MethodKind);
 
             Assert.NotNull(method2);
-            Assert.Equal(method2.MethodKind, MethodKind.ReducedExtension);
+            Assert.Equal(MethodKind.ReducedExtension, method2.MethodKind);
 
             Assert.True(SymbolEquivalenceComparer.Instance.Equals(method1, method2));
 

--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             Assert.NotSame(text, text2);
             Assert.Equal(text.ToString(), text2.ToString());
-            Assert.Equal(text2.Encoding, null);
+            Assert.Null(text2.Encoding);
         }
 
         [Fact]

--- a/src/EditorFeatures/TestUtilities/Semantics/SpeculationAnalyzerTestsBase.cs
+++ b/src/EditorFeatures/TestUtilities/Semantics/SpeculationAnalyzerTestsBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Semantics
         protected void Test(string code, string replacementExpression, bool semanticChanges, string expressionToAnalyze = null, bool isBrokenCode = false)
         {
             var initialMatch = UnderTestRegex.Match(code);
-            Assert.Equal(true, initialMatch.Success);
+            Assert.True(initialMatch.Success);
             var initialExpression = initialMatch.Groups["content"].Value;
 
             var initialTree = Parse(UnderTestRegex.Replace(code, m => m.Groups["content"].Value));
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Semantics
         {
             using (var temporaryStream = new MemoryStream())
             {
-                Assert.Equal(true, CompilationSucceeded(compilation, temporaryStream));
+                Assert.True(CompilationSucceeded(compilation, temporaryStream));
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/AccessibilityTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 expr: "this.get_P()",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0571: 'C.P.get': cannot explicitly call operator or accessor");
+            Assert.Equal("error CS0571: 'C.P.get': cannot explicitly call operator or accessor", error);
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DebuggerDisplayAttributeTests.cs
@@ -264,10 +264,10 @@ namespace N
                 context = CreateTypeContext(runtime, "N.C");
                 testData = new CompilationTestData();
                 result = context.CompileExpression("typeof(A.C) ?? typeof(B) ?? typeof(C)", out error, testData);
-                Assert.Equal(error, "error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)");
+                Assert.Equal("error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)", error);
                 testData = new CompilationTestData();
                 result = context.CompileExpression("typeof(B) ?? typeof(C)", out error, testData);
-                Assert.Equal(error, "error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)");
+                Assert.Equal("error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)", error);
             });
         }
 
@@ -287,7 +287,7 @@ class C
                 string error;
                 var testData = new CompilationTestData();
                 var result = context.CompileExpression("$ReturnValue", out error, testData);
-                Assert.Equal(error, "error CS0103: The name '$ReturnValue' does not exist in the current context");
+                Assert.Equal("error CS0103: The name '$ReturnValue' does not exist in the current context", error);
             });
         }
 
@@ -346,9 +346,9 @@ class C
                 // Format specifiers.
                 result = context.CompileExpression("F, nq,ac", out error);
                 Assert.NotNull(result.Assembly);
-                Assert.Equal(result.FormatSpecifiers.Count, 2);
-                Assert.Equal(result.FormatSpecifiers[0], "nq");
-                Assert.Equal(result.FormatSpecifiers[1], "ac");
+                Assert.Equal(2, result.FormatSpecifiers.Count);
+                Assert.Equal("nq", result.FormatSpecifiers[0]);
+                Assert.Equal("ac", result.FormatSpecifiers[1]);
             });
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -505,7 +505,7 @@ class C
                     out error,
                     testData);
 
-                Assert.Equal(testData.GetExplicitlyDeclaredMethods().Length, 1);
+                Assert.Equal(1, testData.GetExplicitlyDeclaredMethods().Length);
                 testData.GetMethodData("<>x.<>m0<T>").VerifyIL(
 @"{
   // Code size       78 (0x4e)
@@ -616,7 +616,7 @@ class C
 
                 // Expression with format specifiers with ';' as statement.
                 result = context.CompileExpression("string.Empty, nq;", DkmEvaluationFlags.None, NoAliases, out error);
-                Assert.Equal(error, "error CS1073: Unexpected token ','");
+                Assert.Equal("error CS1073: Unexpected token ','", error);
                 Assert.Null(result);
 
                 // Assignment without ';' as statement.
@@ -629,23 +629,23 @@ class C
 
                 // Statement without ';' as statement.
                 result = context.CompileExpression("int o", DkmEvaluationFlags.None, NoAliases, out error);
-                Assert.Equal(error, "error CS1525: Invalid expression term 'int'");
+                Assert.Equal("error CS1525: Invalid expression term 'int'", error);
 
                 // Neither statement nor expression as statement.
                 result = context.CompileExpression("M(;", DkmEvaluationFlags.None, NoAliases, out error);
-                Assert.Equal(error, "error CS1026: ) expected");
+                Assert.Equal("error CS1026: ) expected", error);
 
                 // Statement without ';' as expression.
                 result = context.CompileExpression("int o", DkmEvaluationFlags.TreatAsExpression, NoAliases, out error);
-                Assert.Equal(error, "error CS1525: Invalid expression term 'int'");
+                Assert.Equal("error CS1525: Invalid expression term 'int'", error);
 
                 // Statement with ';' as expression.
                 result = context.CompileExpression("int o;", DkmEvaluationFlags.TreatAsExpression, NoAliases, out error);
-                Assert.Equal(error, "error CS1525: Invalid expression term 'int'");
+                Assert.Equal("error CS1525: Invalid expression term 'int'", error);
 
                 // Neither statement nor expression as expression.
                 result = context.CompileExpression("M(;", DkmEvaluationFlags.TreatAsExpression, NoAliases, out error);
-                Assert.Equal(error, "error CS1026: ) expected");
+                Assert.Equal("error CS1026: ) expected", error);
             });
         }
 
@@ -812,7 +812,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS0103: The name 'F' does not exist in the current context");
+                Assert.Equal("error CS0103: The name 'F' does not exist in the current context", error);
             });
         }
 
@@ -837,7 +837,7 @@ class C
                     NoAliases,
                     out error);
 
-                Assert.Equal(error, "error CS0818: Implicitly-typed variables must be initialized");
+                Assert.Equal("error CS0818: Implicitly-typed variables must be initialized", error);
             });
         }
 
@@ -862,7 +862,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS0815: Cannot assign <null> to an implicitly-typed variable");
+                Assert.Equal("error CS0815: Cannot assign <null> to an implicitly-typed variable", error);
             });
         }
 
@@ -887,7 +887,7 @@ class C
                     NoAliases,
                     out error);
 
-                Assert.Equal(error, "error CS0815: Cannot assign void to an implicitly-typed variable");
+                Assert.Equal("error CS0815: Cannot assign void to an implicitly-typed variable", error);
             });
         }
 
@@ -1058,7 +1058,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS0841: Cannot use local variable 'y' before it is declared");
+                Assert.Equal("error CS0841: Cannot use local variable 'y' before it is declared", error);
             });
         }
 
@@ -1083,7 +1083,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "...");
+                Assert.Equal("...", error);
             });
         }
 
@@ -1109,7 +1109,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "...");
+                Assert.Equal("...", error);
             });
         }
 
@@ -1134,7 +1134,7 @@ class C
                     DkmEvaluationFlags.None,
                     ImmutableArray.Create(VariableAlias("z", typeof(int))),
                     out error);
-                Assert.Equal(error, "...");
+                Assert.Equal("...", error);
             });
         }
 
@@ -1159,7 +1159,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS1525: Invalid expression term 'int'");
+                Assert.Equal("error CS1525: Invalid expression term 'int'", error);
             });
         }
 
@@ -1333,7 +1333,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS1056: Unexpected character '$'");
+                Assert.Equal("error CS1056: Unexpected character '$'", error);
 
                 // $exception
                 context.CompileExpression(
@@ -1341,7 +1341,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS1056: Unexpected character '$'");
+                Assert.Equal("error CS1056: Unexpected character '$'", error);
 
                 // $ReturnValue
                 context.CompileExpression(
@@ -1349,7 +1349,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS1056: Unexpected character '$'");
+                Assert.Equal("error CS1056: Unexpected character '$'", error);
 
                 // $x
                 context.CompileExpression(
@@ -1357,7 +1357,7 @@ class C
                     DkmEvaluationFlags.None,
                     NoAliases,
                     out error);
-                Assert.Equal(error, "error CS1056: Unexpected character '$'");
+                Assert.Equal("error CS1056: Unexpected character '$'", error);
             });
         }
 
@@ -1435,10 +1435,10 @@ class C
                 string error;
                 var testData = new CompilationTestData();
                 context.CompileExpression("while(false) ;", DkmEvaluationFlags.None, NoAliases, out error);
-                Assert.Equal(error, "error CS8092: Expression or declaration statement expected.");
+                Assert.Equal("error CS8092: Expression or declaration statement expected.", error);
                 testData = new CompilationTestData();
                 context.CompileExpression("try { } catch (System.Exception) { }", DkmEvaluationFlags.None, NoAliases, out error);
-                Assert.Equal(error, "error CS8092: Expression or declaration statement expected.");
+                Assert.Equal("error CS8092: Expression or declaration statement expected.", error);
             });
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -887,7 +887,7 @@ public class Outer<T, U>
                     typeName: out typeName,
                     testData: testData);
                 diagnostics.Free();
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
 
                 VerifyCustomTypeInfo(locals[0], "d1", 0x01);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "d1", expectedILOpt:

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 string error;
                 var result = context.CompileExpression("M(", out error);
                 Assert.Null(result);
-                Assert.Equal(error, "error CS1026: ) expected");
+                Assert.Equal("error CS1026: ) expected", error);
             });
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                         preferredUICulture: null,
                         testData: null);
                     Assert.Null(result);
-                    Assert.Equal(error, "LCID=1031, Code=1026");
+                    Assert.Equal("LCID=1031, Code=1026", error);
                     Assert.Empty(missingAssemblyIdentities);
                 });
             }
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 expr: "y ?? x",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0103: The name 'x' does not exist in the current context");
+            Assert.Equal("error CS0103: The name 'x' does not exist in the current context", error);
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             string error;
             var testData = new CompilationTestData();
             var result = context.CompileExpression("F(y)", out error, testData);
-            Assert.Equal(error, "error CS0103: The name 'y' does not exist in the current context");
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
             // No local reference.
             testData = new CompilationTestData();
             result = context.CompileExpression("F(x)", out error, testData);
@@ -461,10 +461,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 Assert.Null(error);
                 // Multiple semicolons: not supported.
                 result = context.CompileExpression("x;;", out error);
-                Assert.Equal(error, "error CS1073: Unexpected token ';'");
+                Assert.Equal("error CS1073: Unexpected token ';'", error);
                 // // comments.
                 result = context.CompileExpression("x;//", out error);
-                Assert.Equal(error, "error CS0726: ';//' is not a valid format specifier");
+                Assert.Equal("error CS0726: ';//' is not a valid format specifier", error);
                 result = context.CompileExpression("x//;", out error);
                 Assert.Null(error);
                 // /*...*/ comments.
@@ -473,12 +473,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 result = context.CompileExpression("x/*;*/", out error);
                 Assert.Null(error);
                 result = context.CompileExpression("x;/*...*/", out error);
-                Assert.Equal(error, "error CS0726: ';/*...*/' is not a valid format specifier");
+                Assert.Equal("error CS0726: ';/*...*/' is not a valid format specifier", error);
                 result = context.CompileExpression("x/*...*/;", out error);
                 Assert.Null(error);
                 // Trailing semicolon, no expression.
                 result = context.CompileExpression(" ; ", out error);
-                Assert.Equal(error, "error CS1733: Expected expression");
+                Assert.Equal("error CS1733: Expected expression", error);
             });
         }
 
@@ -503,27 +503,27 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 CheckFormatSpecifiers(result);
                 // Format specifiers on expression.
                 result = context.CompileExpression("x,", out error);
-                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                Assert.Equal("error CS0726: ',' is not a valid format specifier", error);
                 result = context.CompileExpression("x,,", out error);
-                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                Assert.Equal("error CS0726: ',' is not a valid format specifier", error);
                 result = context.CompileExpression("x y", out error);
-                Assert.Equal(error, "error CS0726: 'y' is not a valid format specifier");
+                Assert.Equal("error CS0726: 'y' is not a valid format specifier", error);
                 result = context.CompileExpression("x yy zz", out error);
-                Assert.Equal(error, "error CS0726: 'yy' is not a valid format specifier");
+                Assert.Equal("error CS0726: 'yy' is not a valid format specifier", error);
                 result = context.CompileExpression("x,,y", out error);
-                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                Assert.Equal("error CS0726: ',' is not a valid format specifier", error);
                 result = context.CompileExpression("x,yy,zz,ww", out error);
                 CheckFormatSpecifiers(result, "yy", "zz", "ww");
                 result = context.CompileExpression("x, y z", out error);
-                Assert.Equal(error, "error CS0726: 'z' is not a valid format specifier");
+                Assert.Equal("error CS0726: 'z' is not a valid format specifier", error);
                 result = context.CompileExpression("x, y  ,  z  ", out error);
                 CheckFormatSpecifiers(result, "y", "z");
                 result = context.CompileExpression("x, y, z,", out error);
-                Assert.Equal(error, "error CS0726: ',' is not a valid format specifier");
+                Assert.Equal("error CS0726: ',' is not a valid format specifier", error);
                 result = context.CompileExpression("x,y,z;w", out error);
-                Assert.Equal(error, "error CS0726: 'z;w' is not a valid format specifier");
+                Assert.Equal("error CS0726: 'z;w' is not a valid format specifier", error);
                 result = context.CompileExpression("x, y;, z", out error);
-                Assert.Equal(error, "error CS0726: 'y;' is not a valid format specifier");
+                Assert.Equal("error CS0726: 'y;' is not a valid format specifier", error);
                 // Format specifiers after // comment: ignored.
                 result = context.CompileExpression("x // ,f", out error);
                 CheckFormatSpecifiers(result);
@@ -533,21 +533,21 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 // Format specifiers on assignment value.
                 result = context.CompileAssignment("x", "null, y", out error);
                 Assert.Null(result);
-                Assert.Equal(error, "error CS1073: Unexpected token ','");
+                Assert.Equal("error CS1073: Unexpected token ','", error);
                 // Trailing semicolon, no format specifiers.
                 result = context.CompileExpression("x; ", out error);
                 CheckFormatSpecifiers(result);
                 // Format specifiers, no expression.
                 result = context.CompileExpression(",f", out error);
-                Assert.Equal(error, "error CS1525: Invalid expression term ','");
+                Assert.Equal("error CS1525: Invalid expression term ','", error);
                 // Format specifiers before semicolon: not supported.
                 result = context.CompileExpression("x,f;\t", out error);
-                Assert.Equal(error, "error CS1073: Unexpected token ','");
+                Assert.Equal("error CS1073: Unexpected token ','", error);
                 // Format specifiers after semicolon: not supported.
                 result = context.CompileExpression("x;,f", out error);
-                Assert.Equal(error, "error CS0726: ';' is not a valid format specifier");
+                Assert.Equal("error CS0726: ';' is not a valid format specifier", error);
                 result = context.CompileExpression("x; f, g", out error);
-                Assert.Equal(error, "error CS0726: ';' is not a valid format specifier");
+                Assert.Equal("error CS0726: ';' is not a valid format specifier", error);
             });
         }
 
@@ -783,7 +783,7 @@ class B : A
                 expr: "F(this, this.x)");
             var methodData = testData.GetMethodData("<>x.<>m0(ref S)");
             var parameter = ((MethodSymbol)methodData.Method).Parameters[0];
-            Assert.Equal(parameter.RefKind, RefKind.Ref);
+            Assert.Equal(RefKind.Ref, parameter.RefKind);
             methodData.VerifyIL(
 @"{
   // Code size       23 (0x17)
@@ -1031,7 +1031,7 @@ class B : A
                 expr: "M(out y)");
             var methodData = testData.GetMethodData("<>x.<>m0(out object)");
             var parameter = ((MethodSymbol)methodData.Method).Parameters[0];
-            Assert.Equal(parameter.RefKind, RefKind.Out);
+            Assert.Equal(RefKind.Out, parameter.RefKind);
             methodData.VerifyIL(
 @"{
   // Code size        8 (0x8)
@@ -1118,8 +1118,8 @@ class B : A
             var methodData = testData.GetMethodData("<>x.<>m0");
             var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
             var local = locals[0];
-            Assert.Equal(local.Type.ToString(), "C");
-            Assert.Equal(local.CustomModifiers.Length, 0); // Custom modifiers are not copied.
+            Assert.Equal("C", local.Type.ToString());
+            Assert.Equal(0, local.CustomModifiers.Length); // Custom modifiers are not copied.
             methodData.VerifyIL(
 @"{
   // Code size        7 (0x7)
@@ -1399,10 +1399,10 @@ class B : A
                 expr: "null",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.ReadOnlyResult);
+            Assert.Equal(DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
             var methodData = testData.GetMethodData("<>x.<>m0");
             var method = (MethodSymbol)methodData.Method;
-            Assert.Equal(method.ReturnType.SpecialType, SpecialType.System_Object);
+            Assert.Equal(SpecialType.System_Object, method.ReturnType.SpecialType);
             Assert.False(method.ReturnsVoid);
             methodData.VerifyIL(
 @"{
@@ -1600,13 +1600,13 @@ class C
                 ResultProperties resultProperties;
                 string error;
                 context.CompileExpression("x", out resultProperties, out error);
-                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult);
+                Assert.Equal(DkmClrCompilationResultFlags.BoolResult, resultProperties.Flags);
                 context.CompileExpression("y", out resultProperties, out error);
-                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.None);
+                Assert.Equal(DkmClrCompilationResultFlags.None, resultProperties.Flags);
                 context.CompileExpression("(bool)y", out resultProperties, out error);
                 Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult);
                 context.CompileExpression("!y", out resultProperties, out error);
-                Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.ReadOnlyResult);
+                Assert.Equal(DkmClrCompilationResultFlags.ReadOnlyResult, resultProperties.Flags);
                 context.CompileExpression("false", out resultProperties, out error);
                 Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.BoolResult | DkmClrCompilationResultFlags.ReadOnlyResult);
                 context.CompileExpression("F()", out resultProperties, out error);
@@ -1637,7 +1637,7 @@ class C
                 expr: "P",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor");
+            Assert.Equal("error CS0154: The property or indexer 'C.P' cannot be used in this context because it lacks the get accessor", error);
         }
 
         /// <summary>
@@ -1665,7 +1665,7 @@ class C
             Assert.Equal(resultProperties.Flags, DkmClrCompilationResultFlags.PotentialSideEffect | DkmClrCompilationResultFlags.ReadOnlyResult);
             var methodData = testData.GetMethodData("<>x.<>m0");
             var method = (MethodSymbol)methodData.Method;
-            Assert.Equal(method.ReturnType.SpecialType, SpecialType.System_Void);
+            Assert.Equal(SpecialType.System_Void, method.ReturnType.SpecialType);
             Assert.True(method.ReturnsVoid);
 
             methodData.VerifyIL(
@@ -1697,7 +1697,7 @@ class C
                 expr: "this.M",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
+            Assert.Equal("error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?", error);
         }
 
         [Fact]
@@ -1724,7 +1724,7 @@ class C
                     expr: "M",
                     error: out error,
                     testData: testData);
-                Assert.Equal(error, "error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?");
+                Assert.Equal("error CS0428: Cannot convert method group 'M' to non-delegate type 'object'. Did you intend to invoke the method?", error);
             });
         }
 
@@ -1783,7 +1783,7 @@ class C
                     expr: "2",
                     error: out error,
                     testData: testData);
-                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", error);
             });
         }
 
@@ -1849,7 +1849,7 @@ class C
                     expr: "F(() => y)",
                     error: out error,
                     testData: testData);
-                Assert.Equal(error, "error CS1628: Cannot use ref, out, or in parameter 'y' inside an anonymous method, lambda expression, query expression, or local function");
+                Assert.Equal("error CS1628: Cannot use ref, out, or in parameter 'y' inside an anonymous method, lambda expression, query expression, or local function", error);
             });
         }
 
@@ -1876,7 +1876,7 @@ class C
                 resultProperties: out resultProperties,
                 error: out error);
             // Note: The native EE reports "CS0119: 'N' is a namespace, which is not valid in the given context"
-            Assert.Equal(error, "error CS0118: 'N' is a namespace but is used like a variable");
+            Assert.Equal("error CS0118: 'N' is a namespace but is used like a variable", error);
         }
 
         [Fact]
@@ -1902,7 +1902,7 @@ class C
             // that the user can expand to see the base type. To enable similar
             // behavior, the expression compiler would probably return something
             // other than IL. Instead, we disallow this scenario.
-            Assert.Equal(error, "error CS0119: 'C' is a type, which is not valid in the given context");
+            Assert.Equal("error CS0119: 'C' is a type, which is not valid in the given context", error);
         }
 
         [Fact]
@@ -1928,7 +1928,7 @@ class C
                     out error,
                     testData);
                 Assert.Null(error);
-                Assert.Equal(testData.GetExplicitlyDeclaredMethods().Length, 1);
+                Assert.Equal(1, testData.GetExplicitlyDeclaredMethods().Length);
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
     @"{
   // Code size       61 (0x3d)
@@ -1961,7 +1961,7 @@ class C
                 context.CompileExpression(
                     "@0xffff0000ffff0000ffff0000",
                     out error, testData);
-                Assert.Equal(error, "error CS1021: Integral constant is too large");
+                Assert.Equal("error CS1021: Integral constant is too large", error);
             });
         }
 
@@ -2079,12 +2079,12 @@ class C<T>
                 var methodData = testData.GetMethodData("<>x.<>m0<T>()");
                 var method = (MethodSymbol)methodData.Method;
                 var returnType = method.ReturnTypeWithAnnotations;
-                Assert.Equal(returnType.TypeKind, TypeKind.TypeParameter);
+                Assert.Equal(TypeKind.TypeParameter, returnType.TypeKind);
                 Assert.Equal(returnType.Type.ContainingSymbol, method);
 
                 var locals = methodData.ILBuilder.LocalSlotManager.LocalsInOrder();
                 // The original local of type T from <>m0<T>.
-                Assert.Equal(locals.Length, 1);
+                Assert.Equal(1, locals.Length);
                 foreach (var local in locals)
                 {
                     var localType = (TypeSymbol)local.Type;
@@ -2203,7 +2203,7 @@ class C
                     expr: "M()",
                     error: out error,
                     testData: testData);
-                Assert.Equal(error, "error CS0029: Cannot implicitly convert type 'void' to 'object'");
+                Assert.Equal("error CS0029: Cannot implicitly convert type 'void' to 'object'", error);
             });
         }
 
@@ -2355,7 +2355,7 @@ class C
 }))()",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0165: Use of unassigned local variable 'o'");
+            Assert.Equal("error CS0165: Use of unassigned local variable 'o'", error);
         }
 
         /// <summary>
@@ -2475,7 +2475,7 @@ class C
   IL_002c:  ret
 }");
                 // Verify generated type and method are generic.
-                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Generic);
+                Assert.Equal(Cci.CallingConvention.Generic, ((Cci.IMethodDefinition)methodData.Method).CallingConvention);
                 var metadata = ModuleMetadata.CreateFromImage(ImmutableArray.CreateRange(result.Assembly));
                 var reader = metadata.MetadataReader;
                 var typeDef = reader.GetTypeDef(result.TypeName);
@@ -2489,7 +2489,7 @@ class C
                 testData = new CompilationTestData();
                 context.CompileExpression("(object)t ?? typeof(T) ?? typeof(U)", out error, testData);
                 methodData = testData.GetMethodData("<>x<T, U, V>.<>m0");
-                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Default);
+                Assert.Equal(Cci.CallingConvention.Default, ((Cci.IMethodDefinition)methodData.Method).CallingConvention);
             });
         }
 
@@ -2534,7 +2534,7 @@ class C<T>
   IL_001e:  call       ""U C<T>.F<U>(System.Func<U>)""
   IL_0023:  ret
 }");
-                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.Generic);
+                Assert.Equal(Cci.CallingConvention.Generic, ((Cci.IMethodDefinition)methodData.Method).CallingConvention);
             });
         }
 
@@ -2565,7 +2565,7 @@ class C<T>
   IL_0002:  newobj     ""System.ArgIterator..ctor(System.RuntimeArgumentHandle)""
   IL_0007:  ret
 }");
-                Assert.Equal(((Cci.IMethodDefinition)methodData.Method).CallingConvention, Cci.CallingConvention.ExtraArguments);
+                Assert.Equal(Cci.CallingConvention.ExtraArguments, ((Cci.IMethodDefinition)methodData.Method).CallingConvention);
             });
         }
 
@@ -3438,7 +3438,7 @@ class B : A
                 var testData = new CompilationTestData();
                 context.CompileExpression("new [] { 1, 2, 3, 4, 5 }", out error, testData);
                 var methodData = testData.GetMethodData("<>x.<>m0");
-                Assert.Equal(methodData.Method.ReturnType.ToDisplayString(), "int[]");
+                Assert.Equal("int[]", methodData.Method.ReturnType.ToDisplayString());
                 methodData.VerifyIL(
     @"{
   // Code size       18 (0x12)
@@ -3597,7 +3597,7 @@ class C
                 string error;
                 var testData = new CompilationTestData();
                 context.CompileExpression("F(() => null ?? new object())", out error, testData);
-                Assert.Equal(error, "error CS0845: An expression tree lambda may not contain a coalescing operator with a null or default literal left-hand side");
+                Assert.Equal("error CS0845: An expression tree lambda may not contain a coalescing operator with a null or default literal left-hand side", error);
             });
         }
 
@@ -3669,7 +3669,7 @@ class C
                     out missingAssemblyIdentities,
                     EnsureEnglishUICulture.PreferredOrNull,
                     testData: null);
-                Assert.Equal(error, "error CS1061: 'object[]' does not contain a definition for 'First' and no accessible extension method 'First' accepting a first argument of type 'object[]' could be found (are you missing a using directive or an assembly reference?)");
+                Assert.Equal("error CS1061: 'object[]' does not contain a definition for 'First' and no accessible extension method 'First' accepting a first argument of type 'object[]' could be found (are you missing a using directive or an assembly reference?)", error);
                 AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
             });
         }
@@ -3913,7 +3913,7 @@ class C
                 expr: "sizeof(C)",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('C')");
+            Assert.Equal("error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('C')", error);
         }
 
         [Fact]
@@ -4102,7 +4102,7 @@ class C
                 resultProperties: out resultProperties,
                 error: out error);
             // Should delegates to [Conditional] methods be supported?
-            Assert.Equal(error, "error CS1618: Cannot create delegate with 'C.F()' because it or a method it overrides has a Conditional attribute");
+            Assert.Equal("error CS1618: Cannot create delegate with 'C.F()' because it or a method it overrides has a Conditional attribute", error);
         }
 
         [Fact]
@@ -4745,7 +4745,7 @@ struct S
                 var testData = new CompilationTestData();
                 var result = context.CompileExpression("this?.F()", out error, testData);
                 var methodData = testData.GetMethodData("<>x.<>m0");
-                Assert.Equal(((MethodSymbol)methodData.Method).ReturnTypeWithAnnotations.ToDisplayString(), "int?");
+                Assert.Equal("int?", ((MethodSymbol)methodData.Method).ReturnTypeWithAnnotations.ToDisplayString());
                 methodData.VerifyIL(
     @"{
   // Code size       25 (0x19)
@@ -4766,7 +4766,7 @@ struct S
                 testData = new CompilationTestData();
                 result = context.CompileExpression("(new C())?.G()?.F()", out error, testData);
                 methodData = testData.GetMethodData("<>x.<>m0");
-                Assert.Equal(((MethodSymbol)methodData.Method).ReturnTypeWithAnnotations.ToDisplayString(), "int?");
+                Assert.Equal("int?", ((MethodSymbol)methodData.Method).ReturnTypeWithAnnotations.ToDisplayString());
 
                 testData = new CompilationTestData();
                 result = context.CompileExpression("G()?.M()", out error, testData);
@@ -5284,7 +5284,7 @@ class C
                     EnsureEnglishUICulture.PreferredOrNull,
                     testData);
                 Assert.Equal(new AssemblyIdentity("System.Core"), missingAssemblyIdentities.Single());
-                Assert.Equal(error, "error CS1935: Could not find an implementation of the query pattern for source type 'string'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?");
+                Assert.Equal("error CS1935: Could not find an implementation of the query pattern for source type 'string'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?", error);
             });
         }
 
@@ -5321,7 +5321,7 @@ class C
 }");
                 testData = new CompilationTestData();
                 context.CompileExpression("y", out error, testData);
-                Assert.Equal(error, "error CS0103: The name 'y' does not exist in the current context");
+                Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
             });
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/HoistedThisTests.cs
@@ -972,7 +972,7 @@ class C
             var testData = new CompilationTestData();
             var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
             Assert.NotNull(assembly);
-            Assert.NotEqual(assembly.Count, 0);
+            Assert.NotEqual(0, assembly.Count);
             var methods = testData.GetMethodsByName();
             var localAndMethod = locals.Single(l => l.LocalName == "this");
             if (expectedIL != null)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalFunctionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalFunctionTests.cs
@@ -37,8 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.Equal(assembly.Count, 0);
-                Assert.Equal(locals.Count, 0);
+                Assert.Equal(0, assembly.Count);
+                Assert.Equal(0, locals.Count);
                 locals.Free();
             });
         }
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "y", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 locals.Free();
                 string error;
                 context.CompileExpression("this.F(1)", out error, testData);
-                Assert.Equal(error, "error CS0027: Keyword 'this' is not available in the current context");
+                Assert.Equal("error CS0027: Keyword 'this' is not available in the current context", error);
             });
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "value", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -292,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 var testData = new CompilationTestData();
                 string error;
                 context.CompileExpression("value", out error, testData);
-                Assert.Equal(error, "error CS0103: The name 'value' does not exist in the current context");
+                Assert.Equal("error CS0103: The name 'value' does not exist in the current context", error);
             });
         }
     }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.Equal(assembly.Count, 0);
-                Assert.Equal(locals.Count, 0);
+                Assert.Equal(0, assembly.Count);
+                Assert.Equal(0, locals.Count);
                 locals.Free();
             });
         }
@@ -74,9 +74,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
     @"{
   // Code size        2 (0x2)
@@ -158,9 +158,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -217,9 +217,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -313,9 +313,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 3);
+                Assert.Equal(3, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -377,9 +377,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 3);
+                Assert.Equal(3, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -441,9 +441,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 // We should be able to evaluate "s" within this context, https://github.com/dotnet/roslyn/issues/16594.
                 //                VerifyLocal(testData, typeName, locals[0], "<>m0", "s", expectedILOpt:
                 //@"{
@@ -469,9 +469,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 // We should be able to evaluate "s" within this context, https://github.com/dotnet/roslyn/issues/16594.
                 //                VerifyLocal(testData, typeName, locals[0], "<>m0", "s", expectedILOpt:
                 //@"{
@@ -538,9 +538,9 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -609,9 +609,9 @@ class C
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -713,7 +713,7 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
     @"{
   // Code size        2 (0x2)
@@ -733,7 +733,7 @@ class C
                 string error;
                 testData = new CompilationTestData();
                 context.CompileExpression("b", out error, testData);
-                Assert.Equal(error, "error CS0103: The name 'b' does not exist in the current context");
+                Assert.Equal("error CS0103: The name 'b' does not exist in the current context", error);
 
                 testData = new CompilationTestData();
                 context.CompileExpression("a[1]", out error, testData);
@@ -783,7 +783,7 @@ class C
                     diagnostics: diagnostics,
                     typeName: out typeName,
                     testData: testData);
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "o");
                 locals.Clear();
 
@@ -796,7 +796,7 @@ class C
                     typeName: out typeName,
                     testData: testData);
                 diagnostics.Free();
-                Assert.Equal(locals.Count, 6);
+                Assert.Equal(6, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "$exception", "Error", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
     @"{
   // Code size       11 (0xb)
@@ -875,7 +875,7 @@ class C
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
     @"{
   // Code size        2 (0x2)
@@ -914,7 +914,7 @@ class C
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: true, typeName: out typeName, testData: testData);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0<T>", "x", expectedILOpt:
     @"{
   // Code size        2 (0x2)
@@ -960,7 +960,7 @@ class C
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "args", expectedILOpt:
     @"{
   // Code size        7 (0x7)
@@ -1055,7 +1055,7 @@ IL_0001:  ret
                 testData = new CompilationTestData();
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 5);
+                Assert.Equal(5, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "w");
                 VerifyLocal(testData, typeName, locals[1], "<>m1", "u");
                 VerifyLocal(testData, typeName, locals[2], "<>m2", "y", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
@@ -1099,7 +1099,7 @@ class C
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
 
                 var method = (MethodSymbol)testData.GetMethodData("<>x.<>m0").Method;
                 Assert.Equal(method.Parameters[0].Type, method.ReturnType);
@@ -1155,7 +1155,7 @@ class P
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 3);
+                Assert.Equal(3, locals.Count);
 
                 VerifyLocal(testData, "<>x<T>", locals[0], "<>m0<U>", "t", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult, expectedILOpt:
     @"{
@@ -1290,7 +1290,7 @@ class P
   IL_0001:  ldfld      ""int C.<>c__DisplayClass1_1.w""
   IL_0006:  ret
 }");
-                Assert.Equal(locals.Count, 5);
+                Assert.Equal(5, locals.Count);
                 locals.Free();
             });
         }
@@ -1364,7 +1364,7 @@ class P
   IL_0001:  ldfld      ""object C.<>c__DisplayClass1_1.y""
   IL_0006:  ret
 }");
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 locals.Free();
             });
         }
@@ -1547,7 +1547,7 @@ class C
                 VerifyLocal(testData, typeName, locals[2], "<>m2", "x3");
                 VerifyLocal(testData, typeName, locals[3], "<>m3", "x4");
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
 
                 locals.Free();
 
@@ -1585,7 +1585,7 @@ class C
   IL_0006:  ret
 }");
                 VerifyLocal(testData, typeName, locals[5], "<>m5", "x4");
-                Assert.Equal(locals.Count, 6);
+                Assert.Equal(6, locals.Count);
                 locals.Free();
 
                 context = CreateMethodContext(
@@ -1624,7 +1624,7 @@ class C
   IL_000b:  ret
 }");
                 VerifyLocal(testData, typeName, locals[6], "<>m6", "x4");
-                Assert.Equal(locals.Count, 7);
+                Assert.Equal(7, locals.Count);
                 locals.Free();
 
                 context = CreateMethodContext(
@@ -1662,7 +1662,7 @@ class C
   IL_000b:  ldfld      ""object C.<>c__DisplayClass0_0.x4""
   IL_0010:  ret
 }");
-                Assert.Equal(locals.Count, 7);
+                Assert.Equal(7, locals.Count);
                 locals.Free();
             });
         }
@@ -1711,7 +1711,7 @@ class C
                 testData = new CompilationTestData();
                 locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 VerifyLocal(testData, "<>x<T>", locals[0], "<>m0", "z");
                 VerifyLocal(testData, "<>x<T>", locals[1], "<>m1", "y");
                 VerifyLocal(testData, "<>x<T>", locals[2], "<>m2", "x");
@@ -1745,7 +1745,7 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                Assert.Equal(locals.Count, 6);
+                Assert.Equal(6, locals.Count);
                 VerifyLocal(testData, "<>x<T, U, V>", locals[0], "<>m0<W>", "this", expectedILOpt:
     @"{
   // Code size        7 (0x7)
@@ -1878,7 +1878,7 @@ class C
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
 
-                Assert.Equal(locals.Count, 3);
+                Assert.Equal(3, locals.Count);
                 VerifyLocal(testData, "<>x<T, U>", locals[0], "<>m0", "t");
                 VerifyLocal(testData, "<>x<T, U>", locals[1], "<>m1", "u", expectedILOpt:
     @"{
@@ -1929,7 +1929,7 @@ class C
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, "<>x", locals[0], "<>m0", "this", expectedILOpt:
     @"{
   // Code size        7 (0x7)
@@ -2018,7 +2018,7 @@ class C
   IL_0006:  ret
 }");
                 VerifyLocal(testData, "<>x<T>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 locals.Free();
             });
         }
@@ -2086,7 +2086,7 @@ struct S<T> where T : class
 }");
                 VerifyLocal(testData, "<>x<T, U>", locals[3], "<>m3", "<>TypeVariables", expectedFlags: DkmClrCompilationResultFlags.ReadOnlyResult);
 
-                Assert.Equal(locals.Count, 4);
+                Assert.Equal(4, locals.Count);
                 locals.Free();
             });
         }
@@ -2148,7 +2148,7 @@ class C
   IL_0001:  ldfld      ""object C.<M>d__1.<y>5__1""
   IL_0006:  ret
 }");
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 locals.Free();
             });
         }
@@ -2222,7 +2222,7 @@ class C
   IL_0001:  ldfld      ""int C.<M>d__1.<y>5__1""
   IL_0006:  ret
 }");
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 locals.Free();
 
                 context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 2000);
@@ -2262,7 +2262,7 @@ class C
   IL_0001:  ldfld      ""long C.<M>d__1.<y>5__3""
   IL_0006:  ret
 }");
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 locals.Free();
             });
         }
@@ -2305,7 +2305,7 @@ class C
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
     @"{
   // Code size       12 (0xc)
@@ -2363,7 +2363,7 @@ class C
                 string typeName;
                 var testData = new CompilationTestData();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
     @"{
   // Code size        7 (0x7)
@@ -2430,7 +2430,7 @@ public struct B
                 Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("A", "Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
             });
 
-                Assert.Equal(locals.Count, 0);
+                Assert.Equal(0, locals.Count);
                 locals.Free();
             });
         }
@@ -2475,7 +2475,7 @@ public struct B
                 Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("I", "Comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
             });
 
-                Assert.Equal(locals.Count, 0);
+                Assert.Equal(0, locals.Count);
                 locals.Free();
             });
         }
@@ -2676,9 +2676,9 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 5);
+                Assert.Equal(5, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt: @"
 {
   // Code size        2 (0x2)
@@ -2765,9 +2765,9 @@ static class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: expectedIL);
                 Assert.Equal(SpecialType.System_Int32, testData.GetMethodData(typeName + ".<>m0").Method.ReturnType.SpecialType);
                 locals.Free();
@@ -3449,7 +3449,7 @@ class C
                 string typeName;
                 var testData = new CompilationTestData();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, "<>x", locals[0], "<>m0", "this", expectedILOpt:
     @"{
   // Code size        7 (0x7)
@@ -3502,7 +3502,7 @@ class C
                 string typeName;
                 var testData = new CompilationTestData();
                 context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, "<>x", locals[0], "<>m0", "this");
                 VerifyLocal(testData, "<>x", locals[1], "<>m1", "s");
                 locals.Free();
@@ -3871,7 +3871,7 @@ class C
                     testData: testData);
                 diagnostics.Verify();
                 diagnostics.Free();
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x");
                 VerifyLocal(testData, typeName, locals[1], "<>m1", "y");
                 locals.Free();
@@ -3905,9 +3905,9 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -3966,9 +3966,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4002,9 +4002,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4039,9 +4039,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4098,9 +4098,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4131,9 +4131,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x1", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -4177,9 +4177,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4212,9 +4212,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x1", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -4236,9 +4236,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4271,9 +4271,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x2", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -4314,9 +4314,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4369,9 +4369,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4402,9 +4402,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x1", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -4451,9 +4451,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4511,9 +4511,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4569,9 +4569,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4630,9 +4630,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 3);
+                Assert.Equal(3, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4699,9 +4699,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 3);
+                Assert.Equal(3, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4772,9 +4772,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4806,9 +4806,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x1", expectedILOpt:
 @"{
   // Code size        7 (0x7)
@@ -4852,9 +4852,9 @@ class Base
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4912,9 +4912,9 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "a", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -4976,9 +4976,9 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 2);
+                Assert.Equal(2, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "a", expectedILOpt:
 @"{
   // Code size        2 (0x2)
@@ -5010,9 +5010,9 @@ class C
                 string typeName;
                 var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
                 Assert.NotNull(assembly);
-                Assert.NotEqual(assembly.Count, 0);
+                Assert.NotEqual(0, assembly.Count);
 
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 VerifyLocal(testData, typeName, locals[0], "<>m0", "x1", expectedILOpt:
 @"{
   // Code size        7 (0x7)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/NoPIATests.cs
@@ -181,7 +181,7 @@ public interface I
                 EnsureEnglishUICulture.PreferredOrNull,
                 testData: null);
             AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
-            Assert.Equal(error, "error CS1061: 'I' does not contain a definition for 'F' and no accessible extension method 'F' accepting a first argument of type 'I' could be found (are you missing a using directive or an assembly reference?)");
+            Assert.Equal("error CS1061: 'I' does not contain a definition for 'F' and no accessible extension method 'F' accepting a first argument of type 'I' could be found (are you missing a using directive or an assembly reference?)", error);
 
             // Binding to method on original PIA should succeed
             // in assembly referencing PIA.dll.

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/PseudoVariableTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             {
                 string error;
                 Evaluate(runtime, "C.M", "$v", out error);
-                Assert.Equal(error, "error CS0103: The name '$v' does not exist in the current context");
+                Assert.Equal("error CS0103: The name '$v' does not exist in the current context", error);
             });
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 expr: "global::$exception",
                 resultProperties: out resultProperties,
                 error: out error);
-            Assert.Equal(error, "error CS0400: The type or namespace name '$exception' could not be found in the global namespace (are you missing an assembly reference?)");
+            Assert.Equal("error CS0400: The type or namespace name '$exception' could not be found in the global namespace (are you missing an assembly reference?)", error);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     EnsureEnglishUICulture.PreferredOrNull,
                     testData: null);
                 AssertEx.SetEqual(missingAssemblyIdentities, EvaluationContextBase.SystemCoreIdentity);
-                Assert.Equal(error, "error CS1061: 'C' does not contain a definition for '$exception' and no accessible extension method '$exception' accepting a first argument of type 'C' could be found (are you missing a using directive or an assembly reference?)");
+                Assert.Equal("error CS1061: 'C' does not contain a definition for '$exception' and no accessible extension method '$exception' accepting a first argument of type 'C' could be found (are you missing a using directive or an assembly reference?)", error);
             });
         }
 
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     out error,
                     testData);
                 Assert.Null(error);
-                Assert.Equal(testData.GetExplicitlyDeclaredMethods().Length, 1);
+                Assert.Equal(1, testData.GetExplicitlyDeclaredMethods().Length);
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       25 (0x19)
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     aliases,
                     out error,
                     testData);
-                Assert.Equal(testData.GetExplicitlyDeclaredMethods().Length, 1);
+                Assert.Equal(1, testData.GetExplicitlyDeclaredMethods().Length);
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       22 (0x16)
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                 context.CompileExpression(
                     "23#",
                     out error);
-                Assert.Equal(error, "error CS2043: 'id#' syntax is no longer supported. Use '$id' instead.");
+                Assert.Equal("error CS2043: 'id#' syntax is no longer supported. Use '$id' instead.", error);
             });
         }
 
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
                     aliases,
                     out error,
                     testData);
-                Assert.Equal(testData.GetExplicitlyDeclaredMethods().Length, 1);
+                Assert.Equal(1, testData.GetExplicitlyDeclaredMethods().Length);
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
   // Code size       40 (0x28)
@@ -460,7 +460,7 @@ class C
                     aliases,
                     out error,
                     testData);
-                Assert.Equal(error, "error CS0648: '' is a type not supported by the language");
+                Assert.Equal("error CS0648: '' is a type not supported by the language", error);
 
                 // Unrecognized array element type.
                 aliases = ImmutableArray.Create(
@@ -471,7 +471,7 @@ class C
                     aliases,
                     out error,
                     testData);
-                Assert.Equal(error, "error CS0648: '' is a type not supported by the language");
+                Assert.Equal("error CS0648: '' is a type not supported by the language", error);
 
                 // Unrecognized generic type argument.
                 aliases = ImmutableArray.Create(
@@ -482,7 +482,7 @@ class C
                     aliases,
                     out error,
                     testData);
-                Assert.Equal(error, "error CS0648: '' is a type not supported by the language");
+                Assert.Equal("error CS0648: '' is a type not supported by the language", error);
             });
         }
 
@@ -555,7 +555,7 @@ class C
                     out error,
                     ReturnValueAlias(1));
 
-                Assert.Equal(error, "error CS0307: The variable '$ReturnValue1' cannot be used with type arguments");
+                Assert.Equal("error CS0307: The variable '$ReturnValue1' cannot be used with type arguments", error);
 
                 testData = Evaluate(
                     runtime,
@@ -564,7 +564,7 @@ class C
                     out error,
                     ReturnValueAlias(2));
 
-                Assert.Equal(error, "error CS0149: Method name expected");
+                Assert.Equal("error CS0149: Method name expected", error);
             });
         }
 
@@ -672,7 +672,7 @@ class C
             {
                 string error;
                 Evaluate(runtime, "C.M", "$exception = null", out error, ExceptionAlias());
-                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", error);
             });
         }
 
@@ -706,13 +706,13 @@ class C
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", error);
                 context.CompileExpression(
                     "F(ref $exception)",
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS1510: A ref or out value must be an assignable variable");
+                Assert.Equal("error CS1510: A ref or out value must be an assignable variable", error);
 
                 // Object at address
                 context.CompileExpression(
@@ -720,13 +720,13 @@ class C
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", error);
                 context.CompileExpression(
                     "F(ref @0x123)",
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS1510: A ref or out value must be an assignable variable");
+                Assert.Equal("error CS1510: A ref or out value must be an assignable variable", error);
 
                 // $ReturnValue
                 context.CompileExpression(
@@ -734,13 +734,13 @@ class C
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", error);
                 context.CompileExpression(
                     "F(ref $ReturnValue)",
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS1510: A ref or out value must be an assignable variable");
+                Assert.Equal("error CS1510: A ref or out value must be an assignable variable", error);
 
                 // Object id
                 context.CompileExpression(
@@ -748,13 +748,13 @@ class C
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS0131: The left-hand side of an assignment must be a variable, property or indexer");
+                Assert.Equal("error CS0131: The left-hand side of an assignment must be a variable, property or indexer", error);
                 context.CompileExpression(
                     "F(ref $1)",
                     DkmEvaluationFlags.TreatAsExpression,
                     aliases,
                     out error);
-                Assert.Equal(error, "error CS1510: A ref or out value must be an assignable variable");
+                Assert.Equal("error CS1510: A ref or out value must be an assignable variable", error);
 
                 // Declared variable
                 var testData = new CompilationTestData();

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ReferencedModulesTests.cs
@@ -676,7 +676,7 @@ class B : A
                 // A is unrecognized since there were no direct references to AS1 or AS2.
                 testData = new CompilationTestData();
                 context.CompileExpression("new A()", out error, testData);
-                Assert.Equal(error, "error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)");
+                Assert.Equal("error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)", error);
                 testData = new CompilationTestData();
                 // B should be resolved to BS2.
                 context.CompileExpression("new B()", out error, testData);
@@ -743,7 +743,7 @@ IL_0005:  ret
                 // A is unrecognized since there were no direct references to AS1 or AS2.
                 testData = new CompilationTestData();
                 context.CompileExpression("new A()", out error, testData);
-                Assert.Equal(error, "error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)");
+                Assert.Equal("error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)", error);
                 testData = new CompilationTestData();
                 // B should be resolved to BS2.
                 context.CompileExpression("new B()", out error, testData);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/TupleTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/TupleTests.cs
@@ -458,7 +458,7 @@ class C
                     testData: testData);
                 diagnostics.Verify();
                 diagnostics.Free();
-                Assert.Equal(locals.Count, 1);
+                Assert.Equal(1, locals.Count);
                 ReadOnlyCollection<byte> customTypeInfo;
                 var customTypeInfoId = locals[0].GetCustomTypeInfo(out customTypeInfo);
                 ReadOnlyCollection<byte> dynamicFlags;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/UsingDebugInfoTests.cs
@@ -1141,7 +1141,7 @@ namespace N
                 resultProperties: out resultProperties,
                 error: out error,
                 includeSymbols: false);
-            Assert.Equal(error, "error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)");
+            Assert.Equal("error CS0246: The type or namespace name 'B' could not be found (are you missing a using directive or an assembly reference?)", error);
 
             // With symbols, type reference inside namespace.
             testData = Evaluate(

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/WinMdTests.cs
@@ -227,9 +227,9 @@ class C
                     SignatureHeader signatureHeader;
                     BadImageFormatException metadataException;
                     var parameters = metadataDecoder.GetSignatureForMethod(methodHandle, out signatureHeader, out metadataException);
-                    Assert.Equal(parameters.Length, 5);
+                    Assert.Equal(5, parameters.Length);
                     var actualReturnType = parameters[0].Type;
-                    Assert.Equal(actualReturnType.TypeKind, TypeKind.Class); // not error
+                    Assert.Equal(TypeKind.Class, actualReturnType.TypeKind); // not error
                     var expectedReturnType = compilation.GetMember("Windows.Storage.StorageFolder");
                     Assert.Equal(expectedReturnType, actualReturnType);
                     Assert.Equal(storageAssemblyName, actualReturnType.ContainingAssembly.Name);

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var evalResult = FormatResult("o", value);
             DkmEvaluationResultEnumContext enumContext;
             var children = GetChildren(evalResult, 100, null, out enumContext);
-            Assert.Equal(enumContext.Count, 4);
+            Assert.Equal(4, enumContext.Count);
             Verify(children,
                 EvalResult("F1", "null", "object", "o.F1"),
                 EvalResult("F2", "null", "object", "o.F2"),
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var evalResult = FormatResult("o", value);
             DkmEvaluationResultEnumContext enumContext;
             var children = GetChildren(evalResult, 0, null, out enumContext);
-            Assert.Equal(enumContext.Count, 4);
+            Assert.Equal(4, enumContext.Count);
             Verify(children);
             children = GetItems(enumContext, 2, 4);
             Verify(children,
@@ -2408,13 +2408,13 @@ class D : C
             // GetChildren
             var getChildrenResult = default(DkmGetChildrenAsyncResult);
             resultProvider.GetChildren(evalResult, workList, n, DefaultInspectionContext, r => getChildrenResult = r);
-            Assert.Equal(workList.Length, 0);
+            Assert.Equal(0, workList.Length);
             Assert.Equal(getChildrenResult.InitialChildren.Length, n);
 
             // GetItems
             var getItemsResult = default(DkmEvaluationEnumAsyncResult);
             resultProvider.GetItems(getChildrenResult.EnumContext, workList, 0, n, r => getItemsResult = r);
-            Assert.Equal(workList.Length, 0);
+            Assert.Equal(0, workList.Length);
             Assert.Equal(getItemsResult.Items.Length, n);
         }
 
@@ -2446,14 +2446,14 @@ class C
                 // GetChildren
                 var getChildrenResult = default(DkmGetChildrenAsyncResult);
                 resultProvider.GetChildren(evalResult, workList, n, DefaultInspectionContext, r => getChildrenResult = r);
-                Assert.Equal(workList.Length, 1);
+                Assert.Equal(1, workList.Length);
                 workList.Execute();
                 Assert.Equal(getChildrenResult.InitialChildren.Length, n);
 
                 // GetItems
                 var getItemsResult = default(DkmEvaluationEnumAsyncResult);
                 resultProvider.GetItems(getChildrenResult.EnumContext, workList, 0, n, r => getItemsResult = r);
-                Assert.Equal(workList.Length, 1);
+                Assert.Equal(1, workList.Length);
                 workList.Execute();
                 Assert.Equal(getItemsResult.Items.Length, n);
             }
@@ -2493,7 +2493,7 @@ class C
                 // GetChildren
                 var getChildrenResult = default(DkmGetChildrenAsyncResult);
                 resultProvider.GetChildren(evalResult, workList, n, DefaultInspectionContext, r => getChildrenResult = r);
-                Assert.Equal(workList.Length, 1);
+                Assert.Equal(1, workList.Length);
                 workList.Execute();
                 var items = getChildrenResult.InitialChildren;
                 Assert.Equal(items.Length, n);
@@ -2502,7 +2502,7 @@ class C
                 // GetItems
                 var getItemsResult = default(DkmEvaluationEnumAsyncResult);
                 resultProvider.GetItems(getChildrenResult.EnumContext, workList, 0, n, r => getItemsResult = r);
-                Assert.Equal(workList.Length, 1);
+                Assert.Equal(1, workList.Length);
                 workList.Execute();
                 items = getItemsResult.Items;
                 Assert.Equal(items.Length, n);

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ResultsViewTests.cs
@@ -1294,7 +1294,7 @@ class C : IEnumerable
                     EvalResult("e", "{int[2]}", "System.Collections.IEnumerable {int[]}", "o.e", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
                 // Verify the module was found but ResolveTypeName failed.
                 var module = runtime.Modules.Single(m => m.Assembly == assembly0);
-                Assert.Equal(module.ResolveTypeNameFailures, 1);
+                Assert.Equal(1, module.ResolveTypeNameFailures);
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ValueFormattingTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             string multiByte = "\ud83c\udfc8"; // unicode surrogates properly paired representing a printable Unicode codepoint
             Assert.Equal(string.Format(format, "🏈"), FormatValue(multiByte));
             Assert.Equal(string.Format(format, "🏈"), FormatValue(multiByte, useHexadecimal: true));
-            Assert.Equal(multiByte, "🏈");
+            Assert.Equal("🏈", multiByte);
 
             multiByte = "\udbff\udfff"; // unicode surrogates representing an unprintable Unicode codepoint
             Assert.Equal(string.Format(format, "\\U0010ffff"), FormatValue(multiByte));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Initialize/InitializeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Initialize/InitializeTests.cs
@@ -24,19 +24,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Initialize
 
         private static void AssertServerCapabilities(LSP.ServerCapabilities actual)
         {
-            Assert.Equal(true, actual.DefinitionProvider);
-            Assert.Equal(true, actual.ReferencesProvider);
-            Assert.Equal(true, actual.ImplementationProvider);
-            Assert.Equal(true, actual.HoverProvider);
-            Assert.Equal(true, actual.CodeActionProvider);
-            Assert.Equal(true, actual.DocumentSymbolProvider);
-            Assert.Equal(true, actual.WorkspaceSymbolProvider);
-            Assert.Equal(true, actual.DocumentFormattingProvider);
-            Assert.Equal(true, actual.DocumentRangeFormattingProvider);
-            Assert.Equal(true, actual.DocumentHighlightProvider);
-            Assert.Equal(true, actual.RenameProvider);
+            Assert.True(actual.DefinitionProvider);
+            Assert.True(actual.ReferencesProvider);
+            Assert.True(actual.ImplementationProvider);
+            Assert.True(actual.HoverProvider);
+            Assert.True(actual.CodeActionProvider);
+            Assert.True(actual.DocumentSymbolProvider);
+            Assert.True(actual.WorkspaceSymbolProvider);
+            Assert.True(actual.DocumentFormattingProvider);
+            Assert.True(actual.DocumentRangeFormattingProvider);
+            Assert.True(actual.DocumentHighlightProvider);
+            Assert.True(actual.RenameProvider);
 
-            Assert.Equal(true, actual.CompletionProvider.ResolveProvider);
+            Assert.True(actual.CompletionProvider.ResolveProvider);
             Assert.Equal(new[] { "." }, actual.CompletionProvider.TriggerCharacters);
 
             Assert.Equal(new[] { "(", "," }, actual.SignatureHelpProvider.TriggerCharacters);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Symbols/DocumentSymbolsTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Symbols
 }";
             var (solution, _) = CreateTestSolution(markup);
             var results = await RunGetDocumentSymbolsAsync(solution, false).ConfigureAwait(false);
-            Assert.Equal(results.Length, 3);
+            Assert.Equal(3, results.Length);
         }
 
         [Fact]

--- a/src/Scripting/CSharpTest/InteractiveSessionReferencesTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionReferencesTests.cs
@@ -149,7 +149,7 @@ F(new C())
             var m = s1.GetCompilation().Assembly.Modules.Single();
             Assert.False(m.ReferencedAssemblies.Any(a => a.Name == "libB"));
             var missingB = m.ReferencedAssemblySymbols.Single(a => a.Name == "libA").Modules.Single().ReferencedAssemblySymbols.Single(a => a.Name == "libB");
-            Assert.IsType(typeof(MissingAssemblySymbol), missingB);
+            Assert.IsType<MissingAssemblySymbol>(missingB);
         }
     }
 }

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1082,7 +1082,7 @@ new object[] { x, y, z }
         public void AwaitVoid()
         {
             var task = CSharpScript.EvaluateAsync<object>("await System.Threading.Tasks.Task.Run(() => { })");
-            Assert.Equal(null, task.Result);
+            Assert.Null(task.Result);
             Assert.Equal(TaskStatus.RanToCompletion, task.Status);
         }
 
@@ -1385,7 +1385,7 @@ d
         {
             Assert.Equal(2, CSharpScript.EvaluateAsync<int>("1+1").Result);
 
-            Assert.Equal(null, CSharpScript.EvaluateAsync<string>("null").Result);
+            Assert.Null(CSharpScript.EvaluateAsync<string>("null").Result);
 
             try
             {
@@ -1402,9 +1402,9 @@ d
             var options = ScriptOptions.Default.AddReferences(HostAssembly);
 
             var cint = CSharpScript.EvaluateAsync<C<int>>("null", options).Result;
-            Assert.Equal(null, cint);
+            Assert.Null(cint);
 
-            Assert.Equal(null, CSharpScript.EvaluateAsync<int?>("null", options).Result);
+            Assert.Null(CSharpScript.EvaluateAsync<int?>("null", options).Result);
 
             try
             {
@@ -1442,7 +1442,7 @@ using System.Collections.Generic;
 new List<ArgumentException>()
 ").Result;
 
-            Assert.Equal(null, value.FirstOrDefault());
+            Assert.Null(value.FirstOrDefault());
         }
 
         public class B
@@ -1499,7 +1499,7 @@ new List<ArgumentException>()
         {
             var m = new M<string>();
             var result = CSharpScript.EvaluateAsync<string>("G()", globals: m);
-            Assert.Equal(null, result.Result);
+            Assert.Null(result.Result);
         }
 
         [Fact]

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
             );
 
             str = s_formatter.FormatObject(obj, SingleLineOptions);
-            Assert.Equal(str, "object[5] { 1, { ... }, ListNode { data={ ... }, next=ListNode { data=object[4] { 7, ListNode { ... }, 8, { ... } }, next=ListNode { ... } } }, object[5] { 4, 5, { ... }, 6, ListNode { data=null, next=null } }, 3 }");
+            Assert.Equal("object[5] { 1, { ... }, ListNode { data={ ... }, next=ListNode { data=object[4] { 7, ListNode { ... }, 8, { ... } }, next=ListNode { ... } } }, object[5] { 4, 5, { ... }, 6, ListNode { data=null, next=null } }, 3 }", str);
         }
 
         [Fact]

--- a/src/Scripting/CSharpTest/ScriptTests.cs
+++ b/src/Scripting/CSharpTest/ScriptTests.cs
@@ -407,7 +407,7 @@ throw e;", globals: new ScriptTests());
             Assert.Equal(5m, state.GetVariable("x").Value);
             Assert.Equal(20, state.GetVariable("X").Value);
 
-            Assert.Equal(null, state.GetVariable("A"));
+            Assert.Null(state.GetVariable("A"));
             Assert.Same(state.GetVariable("X"), state.GetVariable("X"));
         }
 

--- a/src/Scripting/CoreTest/ScriptOptionsTests.cs
+++ b/src/Scripting/CoreTest/ScriptOptionsTests.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         public void WithOptimizationLevel_SetsOptimizationLevel(OptimizationLevel optimizationLevel)
         {
             Assert.Equal(ScriptOptions.Default.WithOptimizationLevel(optimizationLevel).OptimizationLevel, optimizationLevel);
-            Assert.Equal(ScriptOptions.Default.OptimizationLevel, OptimizationLevel.Debug);
+            Assert.Equal(OptimizationLevel.Debug, ScriptOptions.Default.OptimizationLevel);
         }
 
         [Theory]
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         public void WithWarningLevel_SetsWarningLevel(int warningLevel)
         {
             Assert.Equal(ScriptOptions.Default.WithWarningLevel(warningLevel).WarningLevel, warningLevel);
-            Assert.Equal(ScriptOptions.Default.WarningLevel, 4);
+            Assert.Equal(4, ScriptOptions.Default.WarningLevel);
         }
 
         [Theory]

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeClassTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeClassTests.cs
@@ -58,14 +58,14 @@ public class Bar
 
             var bases = cc.Bases;
 
-            Assert.Equal(bases.Count, 1);
-            Assert.Equal(bases.Cast<CodeElement>().Count(), 1);
+            Assert.Equal(1, bases.Count);
+            Assert.Equal(1, bases.Cast<CodeElement>().Count());
 
             Assert.NotNull(bases.Parent);
 
             var parentClass = bases.Parent as CodeClass;
             Assert.NotNull(parentClass);
-            Assert.Equal(parentClass.FullName, "Goo");
+            Assert.Equal("Goo", parentClass.FullName);
 
             Assert.True(bases.Item("object") is CodeClass);
         }
@@ -78,14 +78,14 @@ public class Bar
 
             var interfaces = cc.ImplementedInterfaces;
 
-            Assert.Equal(interfaces.Count, 2);
-            Assert.Equal(interfaces.Cast<CodeElement>().Count(), 2);
+            Assert.Equal(2, interfaces.Count);
+            Assert.Equal(2, interfaces.Cast<CodeElement>().Count());
 
             Assert.NotNull(interfaces.Parent);
 
             var parentClass = interfaces.Parent as CodeClass;
             Assert.NotNull(parentClass);
-            Assert.Equal(parentClass.FullName, "Goo");
+            Assert.Equal("Goo", parentClass.FullName);
 
             Assert.True(interfaces.Item("System.IDisposable") is CodeInterface);
             Assert.True(interfaces.Item("ICloneable") is CodeInterface);

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeFunctionTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeFunctionTests.cs
@@ -508,10 +508,10 @@ public class Ref<T> where T : Entity
             var testObject = (CodeVariable)GetCodeElement("C", "DynamicField");
 
             var returnType = testObject.Type;
-            Assert.Equal(returnType.AsFullName, "dynamic");
-            Assert.Equal(returnType.AsString, "dynamic");
-            Assert.Equal(returnType.CodeType.FullName, "System.Object");
-            Assert.Equal(returnType.TypeKind, vsCMTypeRef.vsCMTypeRefOther);
+            Assert.Equal("dynamic", returnType.AsFullName);
+            Assert.Equal("dynamic", returnType.AsString);
+            Assert.Equal("System.Object", returnType.CodeType.FullName);
+            Assert.Equal(vsCMTypeRef.vsCMTypeRefOther, returnType.TypeKind);
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -521,10 +521,10 @@ public class Ref<T> where T : Entity
             var testObject = GetCodeFunction("C", "DynamicMethod");
 
             var returnType = ((CodeParameter)testObject.Parameters.Item(1)).Type;
-            Assert.Equal(returnType.AsFullName, "dynamic");
-            Assert.Equal(returnType.AsString, "dynamic");
-            Assert.Equal(returnType.CodeType.FullName, "System.Object");
-            Assert.Equal(returnType.TypeKind, vsCMTypeRef.vsCMTypeRefOther);
+            Assert.Equal("dynamic", returnType.AsFullName);
+            Assert.Equal("dynamic", returnType.AsString);
+            Assert.Equal("System.Object", returnType.CodeType.FullName);
+            Assert.Equal(vsCMTypeRef.vsCMTypeRefOther, returnType.TypeKind);
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeVariableTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeVariableTests.cs
@@ -114,7 +114,7 @@ unsafe public struct DevDivBugs70194
         {
             var testObject = GetCodeVariable("A", "intB");
 
-            Assert.Equal(null, testObject.InitExpression);
+            Assert.Null(testObject.InitExpression);
         }
 
         [ConditionalWpfFact(typeof(x86))]
@@ -132,7 +132,7 @@ unsafe public struct DevDivBugs70194
         {
             var testObject = GetCodeVariable("DevDivBugs70194", "buffer");
 
-            Assert.Equal(null, testObject.InitExpression);
+            Assert.Null(testObject.InitExpression);
         }
 
         [ConditionalWpfFact(typeof(x86))]

--- a/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
+++ b/src/VisualStudio/CSharp/Test/Interactive/Commands/ResetInteractiveTests.cs
@@ -100,7 +100,7 @@ namespace ResetInteractiveTestsDocument
 
             if (buildSucceeds)
             {
-                Assert.Equal(true, testHost.Evaluator.ResetOptions.Is64Bit);
+                Assert.True(testHost.Evaluator.ResetOptions.Is64Bit);
             }
             else
             {

--- a/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/AbstractPersistentStorageTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var streamName1 = "TestReadChecksumReturnsNullWhenNeverWritten";
 
             using var storage = GetStorage(solution);
-            Assert.Equal(null, await storage.ReadChecksumAsync(streamName1));
+            Assert.Null(await storage.ReadChecksumAsync(streamName1));
         }
 
         [Fact]
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(null, await storage.ReadStreamAsync(streamName1, s_checksum2));
+                Assert.Null(await storage.ReadStreamAsync(streamName1, s_checksum2));
             }
         }
 
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(null, await storage.ReadChecksumAsync(streamName1));
+                Assert.Null(await storage.ReadChecksumAsync(streamName1));
             }
         }
 
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
             using (var storage = GetStorage(solution))
             {
-                Assert.Equal(null, await storage.ReadChecksumAsync(streamName1));
+                Assert.Null(await storage.ReadChecksumAsync(streamName1));
             }
         }
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -101,7 +101,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             using var environment = new TestEnvironment();
             using var project1 = CSharpHelpers.CreateCSharpCPSProject(environment, "Test", binOutputPath: null);
             // Null output path is allowed.
-            Assert.Equal(null, project1.BinOutputPath);
+            Assert.Null(project1.BinOutputPath);
         }
 
         [WpfFact, WorkItem(14520, "https://github.com/dotnet/roslyn/issues/14520")]
@@ -111,7 +111,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
             using var environment = new TestEnvironment();
             using var project2 = CSharpHelpers.CreateCSharpCPSProject(environment, "Test2", binOutputPath: String.Empty);
             // Empty output path is not allowed, it gets reset to null.
-            Assert.Equal(null, project2.BinOutputPath);
+            Assert.Null(project2.BinOutputPath);
         }
 
         [WpfFact, WorkItem(14520, "https://github.com/dotnet/roslyn/issues/14520")]

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -63,7 +63,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
 
         public static unsafe void SetOption(this CSharpProjectShim csharpProject, CompilerOptions optionID, object value)
         {
-            Assert.Equal(8 + 2 * IntPtr.Size, sizeof(HACK_VariantStructure));
+            Assert.Equal(sizeof(HACK_VariantStructure), 8 + 2 * IntPtr.Size);
             Assert.Equal(8, (int)Marshal.OffsetOf<HACK_VariantStructure>("_booleanValue"));
 
             HACK_VariantStructure variant = default;

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpCompilerOptionsTests.cs
@@ -144,13 +144,13 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
             var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
 
             var outputs = (CompilationOutputFilesWithImplicitPdbPath)environment.Workspace.GetCompilationOutputs(project.Test_VisualStudioProject.Id);
-            Assert.Equal(null, outputs.AssemblyFilePath);
+            Assert.Null(outputs.AssemblyFilePath);
 
             Assert.Equal(0, ((ICompilerOptionsHostObject)project).SetCompilerOptions(@"/pdb:C:\a\1.pdb /debug+", out _));
 
             // Compilation doesn't have output file, so we don't expect any build outputs either.
             outputs = (CompilationOutputFilesWithImplicitPdbPath)environment.Workspace.GetCompilationOutputs(project.Test_VisualStudioProject.Id);
-            Assert.Equal(null, outputs.AssemblyFilePath);
+            Assert.Null(outputs.AssemblyFilePath);
 
             Assert.Equal(0, ((ICompilerOptionsHostObject)project).SetCompilerOptions(@"/out:C:\a\2.dll /debug+", out _));
 

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -132,7 +132,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                     new object[] { solution.Projects.First().DocumentIds.First(), ImmutableArray.Create(new TodoCommentDescriptor("TODO", 0)) },
                     CancellationToken.None);
 
-                Assert.Equal(comments.Count, 1);
+                Assert.Equal(1, comments.Count);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                     solution.Projects.First().DocumentIds.First(),
                     CancellationToken.None);
 
-                Assert.Equal(result.DesignerAttributeArgument, "Form");
+                Assert.Equal("Form", result.DesignerAttributeArgument);
             }
         }
 

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -122,7 +122,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var array = new string[] { };
             Assert.Equal(Hash.CombineValues(array, StringComparer.Ordinal), compilationOptions.StrongNameProvider.GetHashCode());
-            Assert.Equal(((XmlFileResolver)compilationOptions.XmlReferenceResolver).BaseDirectory, null);
+            Assert.Null(((XmlFileResolver)compilationOptions.XmlReferenceResolver).BaseDirectory);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
@@ -364,10 +364,10 @@ public class Program
             SetUpEditor(@"$$");
 
             VisualStudio.Editor.SendKeys(Ctrl(VirtualKey.Space));
-            Assert.Equal(true, VisualStudio.Editor.IsCompletionActive());
+            Assert.True(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.Editor.SendKeys(Ctrl(VirtualKey.A));
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicIntelliSense.cs
@@ -146,10 +146,10 @@ End Module");
             VisualStudio.Editor.Verify.CompletionItemsExist("Dim", "ReDim");
 
             VisualStudio.SendKeys.Send(' ');
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send('i');
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send(' ');
             VisualStudio.Editor.Verify.CompletionItemsExist("As");
@@ -159,30 +159,30 @@ End Module");
             VisualStudio.Editor.Verify.CompletionItemsExist("Integer", "UInteger");
 
             VisualStudio.SendKeys.Send(' ');
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send('=');
-            Assert.Equal(true, VisualStudio.Editor.IsCompletionActive());
+            Assert.True(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send(' ');
-            Assert.Equal(true, VisualStudio.Editor.IsCompletionActive());
+            Assert.True(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send("fooo");
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send(' ');
-            Assert.Equal(true, VisualStudio.Editor.IsCompletionActive());
+            Assert.True(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send(VirtualKey.Backspace);
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send(VirtualKey.Backspace);
-            Assert.Equal(true, VisualStudio.Editor.IsCompletionActive());
+            Assert.True(VisualStudio.Editor.IsCompletionActive());
 
             VisualStudio.SendKeys.Send(
                 VirtualKey.Left,
                 VirtualKey.Delete);
-            Assert.Equal(true, VisualStudio.Editor.IsCompletionActive());
+            Assert.True(VisualStudio.Editor.IsCompletionActive());
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -201,7 +201,7 @@ End Module");
             VisualStudio.Editor.Verify.CompletionItemsExist("_AppDomain");
 
             VisualStudio.SendKeys.Send("'");
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
             var actualText = VisualStudio.Editor.GetText();
             Assert.Contains(@"Module Module1
     Sub Main()
@@ -222,7 +222,7 @@ Imports$$");
             VisualStudio.Editor.Verify.CompletionItemsExist("Microsoft", "System");
 
             VisualStudio.SendKeys.Send('<');
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -304,7 +304,7 @@ End Class");
             VisualStudio.Editor.Verify.CompletionItemsExist("UFoo");
 
             VisualStudio.SendKeys.Send(VirtualKey.Enter);
-            Assert.Equal(false, VisualStudio.Editor.IsCompletionActive());
+            Assert.False(VisualStudio.Editor.IsCompletionActive());
             var actualText = VisualStudio.Editor.GetText();
             Assert.Contains(@"
 Interface UFoo

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -562,8 +562,7 @@ class C
     public void M1([global::N.M.A] String p1) { }
 
     public void M2([A] String p2) { }
-}",
-actualText);
+}", actualText);
         }
 
         private static MetadataReference GetInMemoryAssemblyReferenceForCode(string code)

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -554,8 +554,7 @@ class C
             var formatted = await Formatter.FormatAsync(imported, options);
             var actualText = (await formatted.GetTextAsync()).ToString();
 
-            Assert.Equal(actualText,
-@"using System;
+            Assert.Equal(@"using System;
 using N.M;
 
 class C
@@ -563,7 +562,8 @@ class C
     public void M1([global::N.M.A] String p1) { }
 
     public void M2([A] String p2) { }
-}");
+}",
+actualText);
         }
 
         private static MetadataReference GetInMemoryAssemblyReferenceForCode(string code)

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -44,14 +44,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
 
         private void VerifySyntax<TSyntax>(SyntaxNode node, string expectedText) where TSyntax : SyntaxNode
         {
-            Assert.IsAssignableFrom(typeof(TSyntax), node);
+            Assert.IsAssignableFrom<TSyntax>(node);
             var normalized = node.NormalizeWhitespace().ToFullString();
             Assert.Equal(expectedText, normalized);
         }
 
         private void VerifySyntaxRaw<TSyntax>(SyntaxNode node, string expectedText) where TSyntax : SyntaxNode
         {
-            Assert.IsAssignableFrom(typeof(TSyntax), node);
+            Assert.IsAssignableFrom<TSyntax>(node);
             var normalized = node.ToFullString();
             Assert.Equal(expectedText, normalized);
         }

--- a/src/Workspaces/CoreTest/Editting/SyntaxEditorTests.cs
+++ b/src/Workspaces/CoreTest/Editting/SyntaxEditorTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
 
         private void VerifySyntax<TSyntax>(SyntaxNode node, string expectedText) where TSyntax : SyntaxNode
         {
-            Assert.IsAssignableFrom(typeof(TSyntax), node);
+            Assert.IsAssignableFrom<TSyntax>(node);
             var formatted = Formatter.Format(node, EmptyWorkspace);
             var actualText = formatted.ToFullString();
             Assert.Equal(expectedText, actualText);

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var projectsSyncObject = snapshot.GetRemotableData(solutionObject.Projects.Checksum, CancellationToken.None);
             VerifySynchronizationObjectInService(snapshotService, projectsSyncObject);
 
-            Assert.Equal(solutionObject.Projects.Count, 0);
+            Assert.Equal(0, solutionObject.Projects.Count);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var projectSyncObject = snapshot.GetRemotableData(solutionObject.Projects.Checksum, CancellationToken.None);
             VerifySynchronizationObjectInService(snapshotService, projectSyncObject);
 
-            Assert.Equal(solutionObject.Projects.Count, 1);
+            Assert.Equal(1, solutionObject.Projects.Count);
             VerifySnapshotInService(snapshotService, solutionObject.Projects.ToProjectObjects(snapshotService)[0], 0, 0, 0, 0, 0);
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes);
             VerifyChecksumInService(snapshotService, solutionObject.Projects.Checksum, WellKnownSynchronizationKind.Projects);
 
-            Assert.Equal(solutionObject.Projects.Count, 1);
+            Assert.Equal(1, solutionObject.Projects.Count);
             VerifySnapshotInService(snapshotService, solutionObject.Projects.ToProjectObjects(snapshotService)[0], 1, 0, 0, 0, 0);
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes);
             VerifyChecksumInService(snapshotService, solutionObject.Projects.Checksum, WellKnownSynchronizationKind.Projects);
 
-            Assert.Equal(solutionObject.Projects.Count, 2);
+            Assert.Equal(2, solutionObject.Projects.Count);
 
             var projects = solutionObject.Projects.ToProjectObjects(snapshotService);
             VerifySnapshotInService(snapshotService, projects.Where(p => p.Checksum == firstProjectChecksum).First(), 1, 1, 1, 1, 1);

--- a/src/Workspaces/CoreTest/SerializationTests.cs
+++ b/src/Workspaces/CoreTest/SerializationTests.cs
@@ -60,16 +60,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var root = (CS.Syntax.CompilationUnitSyntax)model.SyntaxTree.GetRoot();
             var annotation = SymbolAnnotation.Create(symbol);
             var rootWithAnnotation = root.WithAdditionalAnnotations(annotation);
-            Assert.Equal(true, rootWithAnnotation.ContainsAnnotations);
-            Assert.Equal(true, rootWithAnnotation.HasAnnotation(annotation));
+            Assert.True(rootWithAnnotation.ContainsAnnotations);
+            Assert.True(rootWithAnnotation.HasAnnotation(annotation));
 
             var stream = new MemoryStream();
             rootWithAnnotation.SerializeTo(stream);
 
             stream.Position = 0;
             var droot = CS.CSharpSyntaxNode.DeserializeFrom(stream);
-            Assert.Equal(true, droot.ContainsAnnotations);
-            Assert.Equal(true, droot.HasAnnotation(annotation));
+            Assert.True(droot.ContainsAnnotations);
+            Assert.True(droot.HasAnnotation(annotation));
 
             var dannotation = droot.GetAnnotations(SymbolAnnotation.Kind).SingleOrDefault();
             Assert.NotNull(dannotation);
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var id = SymbolAnnotation.GetSymbol(annotation, model.Compilation);
             var did = SymbolAnnotation.GetSymbol(dannotation, model.Compilation);
 
-            Assert.Equal(true, id.Equals(did));
+            Assert.True(id.Equals(did));
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -1211,7 +1211,7 @@ End Class";
             Assert.NotEqual(oldVersion, solutionInfo.Version);
             Assert.Equal(newVersion, solutionInfo.Version);
 
-            Assert.Equal(null, solutionInfo.FilePath);
+            Assert.Null(solutionInfo.FilePath);
             var newFilePath = @"C:\test\fake.sln";
             solutionInfo = solutionInfo.WithFilePath(newFilePath);
             Assert.Equal(newFilePath, solutionInfo.FilePath);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -576,13 +576,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 .AddDocument(did, "goo.cs", text);
 
             var document = sol.GetDocument(did);
-            Assert.Equal(false, document.TryGetSyntaxRoot(out var root));
+            Assert.False(document.TryGetSyntaxRoot(out var root));
 
             root = await document.GetSyntaxRootAsync();
             Assert.NotNull(root);
             Assert.Equal(text, root.ToString());
 
-            Assert.Equal(true, document.TryGetSyntaxRoot(out root));
+            Assert.True(document.TryGetSyntaxRoot(out root));
             Assert.NotNull(root);
         }
 
@@ -631,7 +631,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var root2 = tree2.GetRoot();
             // text should not be available yet (it should be defer created from the node)
             // and getting the document or root should not cause it to be created.
-            Assert.Equal(false, tree2.TryGetText(out var text2));
+            Assert.False(tree2.TryGetText(out var text2));
 
             text2 = tree2.GetText();
             Assert.NotNull(text2);
@@ -639,8 +639,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.NotSame(tree, tree2);
             Assert.NotSame(annotatedRoot, root2);
 
-            Assert.Equal(true, annotatedRoot.IsEquivalentTo(root2));
-            Assert.Equal(true, root2.HasAnnotation(annotation));
+            Assert.True(annotatedRoot.IsEquivalentTo(root2));
+            Assert.True(root2.HasAnnotation(annotation));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]

--- a/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
@@ -32,8 +32,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             where TSymbol : ISymbol
         {
             var symbol = DocumentationCommentId.GetFirstSymbolForDeclarationId(expectedId, compilation);
-            Assert.Equal(true, symbol is TSymbol);
-            Assert.Equal(true, test((TSymbol)symbol));
+            Assert.True(symbol is TSymbol);
+            Assert.True(test((TSymbol)symbol));
 
             return (TSymbol)symbol;
         }

--- a/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentTests.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var document = DocumentationComment.FromXmlFragment("");
 
-            Assert.Equal(null, document.ExampleText);
-            Assert.Equal(null, document.ReturnsText);
-            Assert.Equal(null, document.SummaryText);
+            Assert.Null(document.ExampleText);
+            Assert.Null(document.ReturnsText);
+            Assert.Null(document.SummaryText);
         }
 
         [Fact]

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             });
 
             var optionvalid = new PerLanguageOption<bool>("Test Feature", "Test Name", false);
-            Assert.Equal(false, optionSet.GetOption(optionvalid, "CS"));
+            Assert.False(optionSet.GetOption(optionvalid, "CS"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var optionService = TestOptionService.GetService();
             var optionSet = optionService.GetOptions();
             var option = new Option<bool>("Test Feature", "Test Name", false);
-            Assert.Equal(false, optionSet.GetOption(option));
+            Assert.False(optionSet.GetOption(option));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -166,7 +166,7 @@ language: LanguageNames.CSharp);
             Assert.Equal(0, ws.CurrentSolution.Projects.Count());
 
             var result = ws.TryApplyChanges(newSolution);
-            Assert.Equal(result, true);
+            Assert.True(result);
 
             Assert.Equal(1, ws.CurrentSolution.Projects.Count());
             var proj = ws.CurrentSolution.Projects.First();
@@ -484,7 +484,7 @@ language: LanguageNames.CSharp);
             using var ws = new AdhocWorkspace();
             var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).Id;
             var originalDoc = ws.AddDocument(projectId, "TestDocument", SourceText.From(""));
-            Assert.Equal(originalDoc.Name, "TestDocument");
+            Assert.Equal("TestDocument", originalDoc.Name);
 
             var newName = "ChangedName";
             var changedDoc = originalDoc.WithName(newName);
@@ -614,7 +614,7 @@ language: LanguageNames.CSharp);
             var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).Id;
 
             var originalDoc = ws.AddDocument(projectId, "TestDocument", SourceText.From(""));
-            Assert.Equal(originalDoc.Name, "TestDocument");
+            Assert.Equal("TestDocument", originalDoc.Name);
             Assert.Equal(0, originalDoc.Folders.Count);
             Assert.Null(originalDoc.FilePath);
 
@@ -644,7 +644,7 @@ language: LanguageNames.CSharp);
             using var ws = new AdhocWorkspace();
             var service = ws.Services.GetService<IDocumentTextDifferencingService>();
             Assert.NotNull(service);
-            Assert.Equal(service.GetType(), typeof(DefaultDocumentTextDifferencingService));
+            Assert.Equal(typeof(DefaultDocumentTextDifferencingService), service.GetType());
         }
     }
 }

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -200,7 +200,7 @@ language: LanguageNames.CSharp);
             Assert.Equal(0, newSolution.Projects.Count());
 
             var result = ws.TryApplyChanges(newSolution);
-            Assert.Equal(true, result);
+            Assert.True(result);
 
             Assert.Equal(0, ws.CurrentSolution.Projects.Count());
         }
@@ -223,20 +223,20 @@ language: LanguageNames.CSharp);
             using var ws = new AdhocWorkspace();
             ws.AddProject(projInfo);
             var doc = ws.CurrentSolution.GetDocument(docInfo.Id);
-            Assert.Equal(false, doc.TryGetText(out var currentText));
+            Assert.False(doc.TryGetText(out var currentText));
 
             ws.OpenDocument(docInfo.Id);
 
             doc = ws.CurrentSolution.GetDocument(docInfo.Id);
-            Assert.Equal(true, doc.TryGetText(out currentText));
-            Assert.Equal(true, doc.TryGetTextVersion(out var currentVersion));
+            Assert.True(doc.TryGetText(out currentText));
+            Assert.True(doc.TryGetTextVersion(out var currentVersion));
             Assert.Same(text, currentText);
             Assert.Equal(version, currentVersion);
 
             ws.CloseDocument(docInfo.Id);
 
             doc = ws.CurrentSolution.GetDocument(docInfo.Id);
-            Assert.Equal(false, doc.TryGetText(out currentText));
+            Assert.False(doc.TryGetText(out currentText));
         }
 
         [Fact]
@@ -257,20 +257,20 @@ language: LanguageNames.CSharp);
             using var ws = new AdhocWorkspace();
             ws.AddProject(projInfo);
             var doc = ws.CurrentSolution.GetAdditionalDocument(docInfo.Id);
-            Assert.Equal(false, doc.TryGetText(out var currentText));
+            Assert.False(doc.TryGetText(out var currentText));
 
             ws.OpenAdditionalDocument(docInfo.Id);
 
             doc = ws.CurrentSolution.GetAdditionalDocument(docInfo.Id);
-            Assert.Equal(true, doc.TryGetText(out currentText));
-            Assert.Equal(true, doc.TryGetTextVersion(out var currentVersion));
+            Assert.True(doc.TryGetText(out currentText));
+            Assert.True(doc.TryGetTextVersion(out var currentVersion));
             Assert.Same(text, currentText);
             Assert.Equal(version, currentVersion);
 
             ws.CloseAdditionalDocument(docInfo.Id);
 
             doc = ws.CurrentSolution.GetAdditionalDocument(docInfo.Id);
-            Assert.Equal(false, doc.TryGetText(out currentText));
+            Assert.False(doc.TryGetText(out currentText));
         }
 
         [Fact]
@@ -297,20 +297,20 @@ language: LanguageNames.CSharp);
             {
                 ws.AddProject(projInfo);
                 var doc = ws.CurrentSolution.GetAnalyzerConfigDocument(docInfo.Id);
-                Assert.Equal(false, doc.TryGetText(out var currentText));
+                Assert.False(doc.TryGetText(out var currentText));
 
                 ws.OpenAnalyzerConfigDocument(docInfo.Id);
 
                 doc = ws.CurrentSolution.GetAnalyzerConfigDocument(docInfo.Id);
-                Assert.Equal(true, doc.TryGetText(out currentText));
-                Assert.Equal(true, doc.TryGetTextVersion(out var currentVersion));
+                Assert.True(doc.TryGetText(out currentText));
+                Assert.True(doc.TryGetTextVersion(out var currentVersion));
                 Assert.Same(text, currentText);
                 Assert.Equal(version, currentVersion);
 
                 ws.CloseAnalyzerConfigDocument(docInfo.Id);
 
                 doc = ws.CurrentSolution.GetAnalyzerConfigDocument(docInfo.Id);
-                Assert.Equal(false, doc.TryGetText(out currentText));
+                Assert.False(doc.TryGetText(out currentText));
             }
         }
 
@@ -351,13 +351,13 @@ language: LanguageNames.CSharp);
             using var ws = new AdhocWorkspace();
             ws.AddProject(projInfo);
             var doc = ws.CurrentSolution.GetDocument(docInfo.Id);
-            Assert.Equal(false, doc.TryGetText(out var currentText));
-            Assert.Equal(false, doc.TryGetTextVersion(out var currentVersion));
+            Assert.False(doc.TryGetText(out var currentText));
+            Assert.False(doc.TryGetTextVersion(out var currentVersion));
 
             // cause text to load and show that TryGet now works for text and version
             currentText = await doc.GetTextAsync();
-            Assert.Equal(true, doc.TryGetText(out currentText));
-            Assert.Equal(true, doc.TryGetTextVersion(out currentVersion));
+            Assert.True(doc.TryGetText(out currentText));
+            Assert.True(doc.TryGetTextVersion(out currentVersion));
             Assert.Equal(version, currentVersion);
 
             // change document
@@ -368,10 +368,10 @@ language: LanguageNames.CSharp);
             Assert.NotSame(doc, newDoc);
 
             // text is now unavailable since it must be constructed from tree
-            Assert.Equal(false, newDoc.TryGetText(out currentText));
+            Assert.False(newDoc.TryGetText(out currentText));
 
             // version is available because it is cached
-            Assert.Equal(true, newDoc.TryGetTextVersion(out currentVersion));
+            Assert.True(newDoc.TryGetTextVersion(out currentVersion));
 
             // access it the hard way
             var actualVersion = await newDoc.GetTextVersionAsync();
@@ -380,7 +380,7 @@ language: LanguageNames.CSharp);
             Assert.Equal(currentVersion, actualVersion);
 
             // accessing text version did not cause text to be constructed.
-            Assert.Equal(false, newDoc.TryGetText(out currentText));
+            Assert.False(newDoc.TryGetText(out currentText));
 
             // now access text directly (force it to be constructed)
             var actualText = await newDoc.GetTextAsync();

--- a/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/GeneralWorkspaceTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             using var ws = new NoChangesAllowedWorkspace();
             var projectId = ws.AddProject("TestProject", LanguageNames.CSharp).Id;
             var originalDoc = ws.AddDocument(projectId, "TestDocument", SourceText.From(""));
-            Assert.Equal(originalDoc.Name, "TestDocument");
+            Assert.Equal("TestDocument", originalDoc.Name);
 
             var newName = "ChangedName";
             var changedDoc = originalDoc.WithName(newName);

--- a/src/Workspaces/DesktopTest/CommandLineProjectWorkspaceTests.cs
+++ b/src/Workspaces/DesktopTest/CommandLineProjectWorkspaceTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(tempFile.ReadAllText(), text);
 
             var tree = await gooDoc.GetSyntaxRootAsync();
-            Assert.Equal(false, tree.ContainsDiagnostics);
+            Assert.False(tree.ContainsDiagnostics);
 
             var compilation = await project.GetCompilationAsync();
         }

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTestBase.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTestBase.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
                 {
                     var c1 = await p1.GetCompilationAsync();
                     var result = c1.Emit(p1.OutputFilePath);
-                    Assert.Equal(true, result.Success);
+                    Assert.True(result.Success);
                 }
             }
         }

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -2045,7 +2045,7 @@ class C1
                 var sol = await workspace.OpenSolutionAsync(solutionFilePath);
                 var project = sol.GetProjectsByName("VisualBasicProject").FirstOrDefault();
                 var options = (VB.VisualBasicParseOptions)project.ParseOptions;
-                Assert.Equal(true, options.PreprocessorSymbolNames.Contains("EnableMyAttribute"));
+                Assert.True(options.PreprocessorSymbolNames.Contains("EnableMyAttribute"));
 
                 var compilation = await project.GetCompilationAsync();
                 var metadataBytes = compilation.EmitToArray();
@@ -2070,7 +2070,7 @@ class C1
                 var sol = await workspace.OpenSolutionAsync(solutionFilePath);
                 var project = sol.GetProjectsByName("VisualBasicProject").FirstOrDefault();
                 var options = (VB.VisualBasicParseOptions)project.ParseOptions;
-                Assert.Equal(false, options.PreprocessorSymbolNames.Contains("EnableMyAttribute"));
+                Assert.False(options.PreprocessorSymbolNames.Contains("EnableMyAttribute"));
 
                 var compilation = await project.GetCompilationAsync();
                 var metadataBytes = compilation.EmitToArray();
@@ -3247,7 +3247,7 @@ class C { }";
 
             var projFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var projFileText = File.ReadAllText(projFile);
-            Assert.Equal(false, projFileText.Contains(@"System.Xaml"));
+            Assert.False(projFileText.Contains(@"System.Xaml"));
 
             using (var workspace = CreateMSBuildWorkspace())
             {
@@ -3278,11 +3278,11 @@ class C { }";
 
             var csProjFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var csProjFileText = File.ReadAllText(csProjFile);
-            Assert.Equal(true, csProjFileText.Contains(@"<Reference Include=""System.Numerics"""));
+            Assert.True(csProjFileText.Contains(@"<Reference Include=""System.Numerics"""));
 
             var vbProjFile = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
             var vbProjFileText = File.ReadAllText(vbProjFile);
-            Assert.Equal(false, vbProjFileText.Contains(@"System.Numerics"));
+            Assert.False(vbProjFileText.Contains(@"System.Numerics"));
 
             using (var workspace = CreateMSBuildWorkspace())
             {
@@ -3312,7 +3312,7 @@ class C { }";
 
             var projFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var projFileText = File.ReadAllText(projFile);
-            Assert.Equal(false, projFileText.Contains(@"MyAssembly"));
+            Assert.False(projFileText.Contains(@"MyAssembly"));
 
             using (var workspace = CreateMSBuildWorkspace())
             {
@@ -3345,7 +3345,7 @@ class C { }";
 
             var projFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var projFileText = File.ReadAllText(projFile);
-            Assert.Equal(false, projFileText.Contains(@"<Analyzer Include=""..\Analyzers\MyAnalyzer.dll"));
+            Assert.False(projFileText.Contains(@"<Analyzer Include=""..\Analyzers\MyAnalyzer.dll"));
 
             using (var workspace = CreateMSBuildWorkspace())
             {
@@ -3375,7 +3375,7 @@ class C { }";
 
             var projFile = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
             var projFileText = File.ReadAllText(projFile);
-            Assert.Equal(true, projFileText.Contains(@"<ProjectReference Include=""..\CSharpProject\CSharpProject.csproj"">"));
+            Assert.True(projFileText.Contains(@"<ProjectReference Include=""..\CSharpProject\CSharpProject.csproj"">"));
 
             using (var workspace = CreateMSBuildWorkspace())
             {

--- a/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/MSBuildWorkspaceTests.cs
@@ -3072,7 +3072,7 @@ class C1
                 // The smart quote (“) in class1.cs shows up as "â€œ" in codepage 1254. Do a sanity
                 // check here to make sure this file hasn't been corrupted in a way that would
                 // impact subsequent asserts.
-                Assert.Equal("//\u00E2\u20AC\u0153".Length, 5);
+                Assert.Equal(5, "//\u00E2\u20AC\u0153".Length);
                 Assert.Equal("//\u00E2\u20AC\u0153".Length, text.Length);
             }
         }


### PR DESCRIPTION
This enables the following xUnit analyzer rules:

- xUnit2000 - literal or constant value should be first in Assert.Equal" is a valid assert, but very noisy. Will do the refactoring later
- xUnit2003 - do not use Assert.Equal for null value" is a valid assert, but very noisy right now 
- xUnit2004 - do not use Assert.Equal for boolean conditions" is a valid assert, but very noisy right now
- xUnit2007 - do not use Assert.IsType(typeof...)" is a valid assert, but very noisy right now 
- xUnit2015 - do not use typeof() expression to check the exception type. " is a valid assert, but very noisy right now 
