### PR TITLE
Allow disabled by default analyzers to be enabled with editorconfig e…

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/CommandLine/Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.csproj
@@ -24,6 +24,9 @@
     <EmbeddedResource Include="..\..\csc\csc.rsp" LogicalName="csc.rsp" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Xunit.Combinatorial" Version="$(XunitCombinatorialVersion)" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -313,6 +313,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     isSuppressed = severity == ReportDiagnostic.Suppress;
                 }
+                else if (isEnabledWithAnalyzerConfigOptions(diag.Id, analyzerExecutor.Compilation))
+                {
+                    isSuppressed = false;
+                }
 
                 if (!isSuppressed)
                 {
@@ -332,6 +336,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             return true;
+
+            static bool isEnabledWithAnalyzerConfigOptions(string diagnosticId, Compilation compilation)
+            {
+                if (compilation != null)
+                {
+                    foreach (var tree in compilation.SyntaxTrees)
+                    {
+                        if (tree.DiagnosticOptions.TryGetValue(diagnosticId, out var configuredValue) &&
+                            configuredValue != ReportDiagnostic.Suppress)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
         }
 
         internal static bool HasNotConfigurableTag(IEnumerable<string> customTags)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -308,12 +308,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Is this diagnostic suppressed by default (as written by the rule author)
                 var isSuppressed = !diag.IsEnabledByDefault;
 
-                // If the user said something about it, that overrides the author.
+                // Compilation wide user settings from ruleset/nowarn/warnaserror overrides the analyzer author.
                 if (diagnosticOptions.TryGetValue(diag.Id, out var severity))
                 {
                     isSuppressed = severity == ReportDiagnostic.Suppress;
                 }
-                else if (isEnabledWithAnalyzerConfigOptions(diag.Id, analyzerExecutor.Compilation))
+
+                // Editorconfig user settings override compilation wide settings.
+                if (isSuppressed &&
+                    isEnabledWithAnalyzerConfigOptions(diag.Id, analyzerExecutor.Compilation))
                 {
                     isSuppressed = false;
                 }

--- a/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -1828,5 +1828,54 @@ namespace Microsoft.CodeAnalysis
                 context.ReportSuppression(Suppression.Create(_descriptor2, nonReportedDiagnostic));
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class AnalyzerWithNoLocationDiagnostics : DiagnosticAnalyzer
+        {
+            public AnalyzerWithNoLocationDiagnostics(bool isEnabledByDefault)
+            {
+                Descriptor = new DiagnosticDescriptor(
+                    "ID0001",
+                    "Title1",
+                    "Message1",
+                    "Category1",
+                    defaultSeverity: DiagnosticSeverity.Warning,
+                    isEnabledByDefault);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationAction(compilationContext =>
+                    compilationContext.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.None)));
+            }
+        }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public sealed class NamedTypeAnalyzerWithConfigurableEnabledByDefault : DiagnosticAnalyzer
+        {
+            public NamedTypeAnalyzerWithConfigurableEnabledByDefault(bool isEnabledByDefault)
+            {
+                Descriptor = new DiagnosticDescriptor(
+                    "ID0001",
+                    "Title1",
+                    "Message1",
+                    "Category1",
+                    defaultSeverity: DiagnosticSeverity.Warning,
+                    isEnabledByDefault);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterSymbolAction(
+                    context => context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Symbol.Locations[0])),
+                    SymbolKind.NamedType);
+            }
+        }
     }
 }

--- a/src/Test/Utilities/Portable/Diagnostics/ReportDiagnosticExtensions.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/ReportDiagnosticExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class ReportDiagnosticExtensions
+    {
+        public static string ToAnalyzerConfigString(this ReportDiagnostic reportDiagnostic)
+        {
+            return reportDiagnostic switch
+            {
+                ReportDiagnostic.Error => "error",
+                ReportDiagnostic.Warn => "warning",
+                ReportDiagnostic.Info => "suggestion",
+                ReportDiagnostic.Hidden => "silent",
+                ReportDiagnostic.Suppress => "none",
+                _ => throw ExceptionUtilities.Unreachable,
+            };
+        }
+    }
+}


### PR DESCRIPTION
…ntries.

We now mark analyzer as not suppressed if at least one syntax tree in compilation has DiagnosticOptions that has non-suppress severity.