### PR TITLE
support local functions inside static in signature help

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -2394,5 +2394,45 @@ class Program
 
             await TestAsync(markup, expectedOrderedItems);
         }
+
+        [WorkItem(38074, "https://github.com/dotnet/roslyn/issues/38074")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [CompilerTrait(CompilerFeature.LocalFunctions)]
+        public async Task TestLocalFunction()
+        {
+            var markup = @"
+class C
+{
+    void M()
+    {
+        void Local() { }
+        Local($$);
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem> { new SignatureHelpTestItem("void Local()") };
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
+        [WorkItem(38074, "https://github.com/dotnet/roslyn/issues/38074")]
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [CompilerTrait(CompilerFeature.LocalFunctions)]
+        public async Task TestLocalFunctionInStaticMethod()
+        {
+            var markup = @"
+class C
+{
+    static void M()
+    {
+        void Local() { }
+        Local($$);
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem> { new SignatureHelpTestItem("void Local()") };
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
@@ -56,8 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             else if (invocationExpression.Expression is SimpleNameSyntax &&
                 invocationExpression.IsInStaticContext())
             {
-                // Local functions even inside static methods can have IsStatic == false by the compiler update for C# 8.0.
-                // Therefore, here is a workaround to support these functions in the signature help.
+                // We always need to include local functions regardless of whether they are static.
                 methodGroup = methodGroup.Where(m => m.IsStatic || m is IMethodSymbol { MethodKind: MethodKind.LocalFunction });
             }
 

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider_MethodGroup.cs
@@ -56,7 +56,9 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             else if (invocationExpression.Expression is SimpleNameSyntax &&
                 invocationExpression.IsInStaticContext())
             {
-                methodGroup = methodGroup.Where(m => m.IsStatic);
+                // Local functions even inside static methods can have IsStatic == false by the compiler update for C# 8.0.
+                // Therefore, here is a workaround to support these functions in the signature help.
+                methodGroup = methodGroup.Where(m => m.IsStatic || m is IMethodSymbol { MethodKind: MethodKind.LocalFunction });
             }
 
             var accessibleMethods = methodGroup.Where(m => m.IsAccessibleWithin(within, throughType: throughType)).ToImmutableArrayOrEmpty();


### PR DESCRIPTION
Fixes signature help part of https://github.com/dotnet/roslyn/issues/38074

Thank you for discussions, @svick , @CyrusNajmabadi , @miloush and @333fred !

Tests were copied from https://github.com/dotnet/roslyn/commit/62918fc39895da53eb4ce76b4a83a949746220e8
It is weird but I could not cherry-pick it.