### PR TITLE
Pass the actual code action span to the server when calculating code …

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynCodeActionProvider.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynCodeActionProvider.cs
@@ -39,13 +39,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.CodeActions
             }
 
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var diagnostics = await _diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(document, span, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            var diagnostic = diagnostics?.FirstOrDefault();
-            if (diagnostic != null)
-            {
-                span = diagnostic.TextSpan;
-            }
 
             var codeActionParams = new LSP.CodeActionParams
             {


### PR DESCRIPTION
…actions.

Previously, liveshare was computing the diagnostics on the code action location and passing the diagnostic's span to the server.  This caused code actions that expect a caret position to never work if there was another diagnostic at the same location (e.g. move type to file, I've fixed that in https://github.com/dotnet/roslyn/pull/38787).

Either way, we shouldn't be modifying the user specified span.