### PR TITLE
Update required version of VS in Building doc

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -15,9 +15,9 @@ The minimal required version of .NET Framework is 4.7.2.
 
 ## Developing with Visual Studio 2019
 
-1. [Visual Studio 2019 16.2](https://visualstudio.microsoft.com/downloads/)
+1. [Visual Studio 2019 16.3](https://visualstudio.microsoft.com/downloads/)
     - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
-    - Ensure Visual Studio is on Version "16.2" or greater
+    - Ensure Visual Studio is on Version "16.3" or greater
     - Ensure "Use Previews" is checked in Tools -> Options -> Projects and Solutions -> .NET Core
 1. [.NET Core SDK 3.0 Preview 6](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview6-012264/dotnet-sdk-3.0.100-preview6-012264-win-x64.exe )
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on earlier versions of Windows. The download link is under the ["Upgrading existing Windows PowerShell"](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-windows-powershell?view=powershell-6#upgrading-existing-windows-powershell) heading.


### PR DESCRIPTION
Now that we've merged 16.3-vs-deps back, we should update the required version of VS.