### PR TITLE
Fix crash that would happen when renaming in mixed f#/c# project.

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1965,46 +1965,5 @@ End Class
                 Assert.Equal(InlineRenameFileRenameInfo.NotAllowed, session.FileRenameInfo)
             End Using
         End Sub
-
-        <WpfFact>
-        <WorkItem(28474, "https://github.com/dotnet/roslyn/issues/28474")>
-        <Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Async Function HandleProjectsWithoutCompilations() As Task
-            Using workspace = CreateWorkspaceWithWaiter(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName="CSharpProject" CommonReferences="true">
-                            <Document>
-                                public interface IGoo
-                                {
-                                    void [|$$Goo|]();
-                                }
-                                public class C : IGoo
-                                {
-                                    public void [|Goo|]() {}
-                                }
-                            </Document>
-                        </Project>
-                        <Project Language="NoCompilation" CommonReferences="false">
-                            <ProjectReference>CSharpProject</ProjectReference>
-                            <Document>
-                                // a no-compilation document
-                            </Document>
-                        </Project>
-                    </Workspace>)
-
-                Dim session = StartSession(workspace)
-
-                ' Type a bit in the file
-                Dim caretDoc = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
-                Dim caretPosition = caretDoc.CursorPosition.Value
-                Dim textBuffer = caretDoc.TextBuffer
-
-                textBuffer.Insert(caretPosition, "Bar")
-
-                session.Commit()
-
-                Await VerifyTagsAreCorrect(workspace, "BarGoo")
-            End Using
-        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -7108,5 +7108,32 @@ class C
         End Sub
 #End Region
 
+        <WpfFact>
+        <WorkItem(28474, "https://github.com/dotnet/roslyn/issues/28474")>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub HandleProjectsWithoutCompilations()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSharpProject" CommonReferences="true">
+                        <Document>
+                            public interface IGoo
+                            {
+                                void [|$$Goo|]();
+                            }
+                            public class C : IGoo
+                            {
+                                public void [|Goo|]() {}
+                            }
+                        </Document>
+                    </Project>
+                    <Project Language="NoCompilation" CommonReferences="false">
+                        <ProjectReference>CSharpProject</ProjectReference>
+                        <Document>
+                            // a no-compilation document
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="Cat")
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -331,6 +331,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // cache churn we could cause creating all those compilations.
             foreach (var project in orderedProjectsToExamine)
             {
+                Debug.Assert(project.SupportsCompilation);
                 await FindTypesInProjectAsync(
                     searchInMetadata, result,
                     currentMetadataTypes, currentSourceAndMetadataTypes,
@@ -364,6 +365,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             bool transitive,
             CancellationToken cancellationToken)
         {
+            Debug.Assert(project.SupportsCompilation);
+
             // First see what derived metadata types we might find in this project.
             // This is only necessary if we started with a metadata type.
             if (searchInMetadata)
@@ -522,7 +525,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             //          /
             //         └
             //        E
-            // and we're passed in 'B, C, E' as hte project to search, then this set 
+            // and we're passed in 'B, C, E' as the project to search, then this set 
             // will be A, B, C, E.
             var allProjectsThatTheseProjectsDependOn = projects
                 .SelectMany(p => dependencyGraph.GetProjectsThatThisProjectTransitivelyDependsOn(p.Id))
@@ -537,8 +540,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // any information that would affect the result in the projects we are asked to search
             // within.
 
+            // Finally, because we're searching metadata and source symbols, this needs to be a project
+            // that actually supports compilations.
             return projectsThatCouldReferenceType.Intersect(allProjectsThatTheseProjectsDependOn)
                                                  .Select(solution.GetProject)
+                                                 .Where(p => p.SupportsCompilation)
                                                  .ToList();
         }
 
@@ -549,12 +555,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             SymbolAndProjectIdSet result,
             CancellationToken cancellationToken)
         {
-            if (metadataTypes.Count == 0)
-            {
-                return;
-            }
+            Debug.Assert(project.SupportsCompilation);
 
-            if (!project.SupportsCompilation)
+            if (metadataTypes.Count == 0)
             {
                 return;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/28474