### PR TITLE
x == default is valid object equality for reference types

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -25,10 +25,9 @@ Each entry should include a short description of the break, followed by either a
 
     Such code will produce an error in version 16.4.
 
-3. https://github.com/dotnet/roslyn/issues/35684 In C# `7.1` the resolution of a binary operator with a `default` literal could result in using an object equality and giving the literal a type `object`.
+3. https://github.com/dotnet/roslyn/issues/35684 In C# `7.1` the resolution of a binary operator with a `default` literal and unconstrained type parameter could result in using an object equality and giving the literal a type `object`.
     For example, given a variable `t` of an unconstrained type `T`, `t == default` would be improperly allowed and emitted as `t == default(object)`.
-    Similarly, for a reference type without a custom `==` operator, `x == default` would be improperly allowed and emitted as `x == default(object)`.
-    In *Visual Studio 2019 version 16.4* these scenarios will now produce an error.
+    In *Visual Studio 2019 version 16.4* this scenario will now produce an error.
 
 4. In C# `7.1`, `default as TClass` and `using (default)` were allowed. In *Visual Studio 2019 version 16.4* those scenarios will now produce errors.
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                     bool leftDefault = left.IsLiteralDefault();
                     bool rightDefault = right.IsLiteralDefault();
-                    foundOperator = !isObjectEquality || BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, rightType, rightNull, ref useSiteDiagnostics);
+                    foundOperator = !isObjectEquality || BuiltInOperators.IsValidObjectEquality(Conversions, leftType, leftNull, leftDefault, rightType, rightNull, rightDefault, ref useSiteDiagnostics);
                     diagnostics.Add(node, useSiteDiagnostics);
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -666,7 +666,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             kind = kind.OperatorWithLogical();
             var operators = ArrayBuilder<BinaryOperatorSignature>.GetInstance();
             bool isEquality = kind == BinaryOperatorKind.Equal || kind == BinaryOperatorKind.NotEqual;
-            if (isEquality && UseOnlyReferenceEquality(left, right, ref useSiteDiagnostics))
+            if (isEquality && useOnlyReferenceEquality(Conversions, left, right, ref useSiteDiagnostics))
             {
                 // As a special case, if the reference equality operator is applicable (and it
                 // is not a string or delegate) we do not check any other operators.  This patches
@@ -689,15 +689,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             CandidateOperators(operators, left, right, results, ref useSiteDiagnostics);
             operators.Free();
-        }
 
-        private bool UseOnlyReferenceEquality(BoundExpression left, BoundExpression right, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
-        {
-            // We consider the `null` literal, but not the `default` literal, since the latter does not require a reference equality
-            return
-                BuiltInOperators.IsValidObjectEquality(Conversions, left.Type, left.IsLiteralNull(), right.Type, right.IsLiteralNull(), ref useSiteDiagnostics) &&
-                ((object)left.Type == null || (!left.Type.IsDelegateType() && left.Type.SpecialType != SpecialType.System_String && left.Type.SpecialType != SpecialType.System_Delegate)) &&
-                ((object)right.Type == null || (!right.Type.IsDelegateType() && right.Type.SpecialType != SpecialType.System_String && right.Type.SpecialType != SpecialType.System_Delegate));
+            static bool useOnlyReferenceEquality(Conversions conversions, BoundExpression left, BoundExpression right, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+            {
+                // We consider the `null` literal, but not the `default` literal, since the latter does not require a reference equality
+                return
+                    BuiltInOperators.IsValidObjectEquality(conversions, left.Type, left.IsLiteralNull(), leftIsDefault: false, right.Type, right.IsLiteralNull(), rightIsDefault: false, ref useSiteDiagnostics) &&
+                    ((object)left.Type == null || (!left.Type.IsDelegateType() && left.Type.SpecialType != SpecialType.System_String && left.Type.SpecialType != SpecialType.System_Delegate)) &&
+                    ((object)right.Type == null || (!right.Type.IsDelegateType() && right.Type.SpecialType != SpecialType.System_String && right.Type.SpecialType != SpecialType.System_Delegate));
+            }
         }
 
         private void GetReferenceEquality(BinaryOperatorKind kind, ArrayBuilder<BinaryOperatorSignature> operators)

--- a/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
@@ -758,6 +758,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            if (leftIsDefault && rightIsNull)
+            {
+                return false;
+            }
+
+            if (leftIsNull && rightIsDefault)
+            {
+                return false;
+            }
+
             // If at least one side is null or default then clearly a conversion exists.
             if (leftIsNull || rightIsNull || leftIsDefault || rightIsDefault)
             {

--- a/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/BuiltInOperators.cs
@@ -696,15 +696,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal static bool IsValidObjectEquality(Conversions Conversions, TypeSymbol leftType, bool leftIsNull, TypeSymbol rightType, bool rightIsNull, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        internal static bool IsValidObjectEquality(Conversions Conversions, TypeSymbol leftType, bool leftIsNull, bool leftIsDefault, TypeSymbol rightType, bool rightIsNull, bool rightIsDefault, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // SPEC: The predefined reference type equality operators require one of the following:
 
-            // SPEC: (1) Both operands are a value of a type known to be a reference-type or the literal null. 
-            // SPEC:     Furthermore, an explicit reference conversion exists from the type of either 
+            // SPEC: (1) Both operands are a value of a type known to be a reference-type or the literal null.
+            // SPEC:     Furthermore, an explicit reference conversion exists from the type of either
             // SPEC:     operand to the type of the other operand. Or:
             // SPEC: (2) One operand is a value of type T where T is a type-parameter and the other operand is 
             // SPEC:     the literal null. Furthermore T does not have the value type constraint.
+            // SPEC: (3) One operand is the literal default and the other operand is a reference-type.
 
             // SPEC ERROR: Notice that the spec calls out that an explicit reference conversion must exist;
             // SPEC ERROR: in fact it should say that an explicit reference conversion, implicit reference
@@ -741,19 +742,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var leftIsReferenceType = ((object)leftType != null) && leftType.IsReferenceType;
-            if (!leftIsReferenceType && !leftIsNull)
+            if (!leftIsReferenceType && !leftIsNull && !leftIsDefault)
             {
                 return false;
             }
 
             var rightIsReferenceType = ((object)rightType != null) && rightType.IsReferenceType;
-            if (!rightIsReferenceType && !rightIsNull)
+            if (!rightIsReferenceType && !rightIsNull && !rightIsDefault)
             {
                 return false;
             }
 
-            // If at least one side is null then clearly a conversion exists.
-            if (leftIsNull || rightIsNull)
+            if (leftIsDefault && rightIsDefault)
+            {
+                return false;
+            }
+
+            // If at least one side is null or default then clearly a conversion exists.
+            if (leftIsNull || rightIsNull || leftIsDefault || rightIsDefault)
             {
                 return true;
             }


### PR DESCRIPTION
Since we've received significant feedback on part of the compat break we took in 16.4p1, we're making a refinement to reduce the negative impact.
`t == default` for unconstrained types will remain an error (introduced in 16.4p1), but `x == default` will be re-allowed for reference types (could bind as object equality).

Fixes https://github.com/dotnet/roslyn/issues/38643
Relates to https://github.com/dotnet/roslyn/pull/37596 (16.4p1 breaking changes)