### PR TITLE
Avoid crash on concat on structs with ToString member

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
@@ -414,8 +414,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var typeToStringMembers = type.GetMembers(objectToStringMethod.Name);
                 foreach (var member in typeToStringMembers)
                 {
-                    var toStringMethod = (MethodSymbol)member;
-                    if (toStringMethod.GetLeastOverriddenMethod(type) == (object)objectToStringMethod)
+                    if (member is MethodSymbol toStringMethod &&
+                        toStringMethod.GetLeastOverriddenMethod(type) == (object)objectToStringMethod)
                     {
                         structToStringMethod = toStringMethod;
                         break;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
@@ -75,6 +75,45 @@ B
 ");
         }
 
+        [Fact, WorkItem(38858, "https://github.com/dotnet/roslyn/issues/38858")]
+        public void ConcatEnumWithToString()
+        {
+            var source = @"
+public class C
+{
+    public static void Main()
+    {
+        System.Console.Write(M(Enum.A));
+    }
+    public static string M(Enum e)
+    {
+        return e + """";
+    }
+}
+public enum Enum { A = 0, ToString = 1 }
+";
+            var comp = CompileAndVerify(source, expectedOutput: "A");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(38858, "https://github.com/dotnet/roslyn/issues/38858")]
+        public void ConcatStructWithToString()
+        {
+            var source = @"
+public struct Bad
+{
+    public new int ToString;
+
+    string Crash()
+    {
+        return """" + this;
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
         [Fact]
         public void ConcatDefaults()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStringConcat.cs
@@ -110,7 +110,7 @@ public struct Bad
     }
 }
 ";
-            var comp = CreateCompilation(source);
+            var comp = CompileAndVerify(source);
             comp.VerifyDiagnostics();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38858