### PR TITLE
Generate direct GetHashCode calls for value types when they would be non-boxing

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -947,6 +947,264 @@ parameters: CSharp6);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task StructWithoutGetHashCodeOverride_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo
+{
+    [|Bar bar;|]
+}
+
+struct Bar
+{
+}",
+@"using System.Collections.Generic;
+
+class Foo
+{
+    Bar bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo;
+        return foo != null &&
+               EqualityComparer<Bar>.Default.Equals(bar, foo.bar);
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}
+
+struct Bar
+{
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task StructWithGetHashCodeOverride_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo
+{
+    [|Bar bar;|]
+}
+
+struct Bar
+{
+    public override int GetHashCode() => 0;
+}",
+@"using System.Collections.Generic;
+
+class Foo
+{
+    Bar bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo;
+        return foo != null &&
+               EqualityComparer<Bar>.Default.Equals(bar, foo.bar);
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}
+
+struct Bar
+{
+    public override int GetHashCode() => 0;
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task NullableStructWithoutGetHashCodeOverride_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo
+{
+    [|Bar? bar;|]
+}
+
+struct Bar
+{
+}",
+@"using System.Collections.Generic;
+
+class Foo
+{
+    Bar? bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo;
+        return foo != null &&
+               EqualityComparer<Bar?>.Default.Equals(bar, foo.bar);
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}
+
+struct Bar
+{
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task StructTypeParameter_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo<TBar> where TBar : struct
+{
+    [|TBar bar;|]
+}",
+@"using System.Collections.Generic;
+
+class Foo<TBar> where TBar : struct
+{
+    TBar bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo<TBar>;
+        return foo != null &&
+               EqualityComparer<TBar>.Default.Equals(bar, foo.bar);
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task NullableStructTypeParameter_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo<TBar> where TBar : struct
+{
+    [|TBar? bar;|]
+}",
+@"using System.Collections.Generic;
+
+class Foo<TBar> where TBar : struct
+{
+    TBar? bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo<TBar>;
+        return foo != null &&
+               EqualityComparer<TBar?>.Default.Equals(bar, foo.bar);
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task Enum_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo
+{
+    [|Bar bar;|]
+}
+
+enum Bar
+{
+}",
+@"using System.Collections.Generic;
+
+class Foo
+{
+    Bar bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo;
+        return foo != null &&
+               bar == foo.bar;
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}
+
+enum Bar
+{
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task PrimitiveValueType_ShouldCallGetHashCodeDirectly()
+        {
+            await TestInRegularAndScript1Async(
+@"using System.Collections.Generic;
+
+class Foo
+{
+    [|ulong bar;|]
+}",
+@"using System.Collections.Generic;
+
+class Foo
+{
+    ulong bar;
+
+    public override bool Equals(object obj)
+    {
+        var foo = obj as Foo;
+        return foo != null &&
+               bar == foo.bar;
+    }
+
+    public override int GetHashCode()
+    {
+        return 999205674 + bar.GetHashCode();
+    }
+}",
+index: 1,
+parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public async Task TestWithDialog1()
         {
             await TestWithPickMembersDialogAsync(

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateGetHashCodeMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateGetHashCodeMethod.cs
@@ -179,11 +179,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return thisSymbol;
             }
 
-            var memberType = member.GetSymbolType();
-            var primitiveValue = IsPrimitiveValueType(memberType) && memberType.SpecialType != SpecialType.System_String;
-            var isTupleType = memberType?.IsTupleType == true;
-            if (primitiveValue || isTupleType)
+            if (member.GetSymbolType()?.IsValueType ?? false)
             {
+                // There is no reason to generate the bulkier syntax of EqualityComparer<>.Default.GetHashCode for value
+                // types. No null check is necessary, and there's no performance advantage on .NET Core for using
+                // EqualityComparer.GetHashCode instead of calling GetHashCode directly. On .NET Framework, using
+                // EqualityComparer.GetHashCode on value types actually performs more poorly.
+
                 return factory.InvocationExpression(
                     factory.MemberAccessExpression(thisSymbol, nameof(object.GetHashCode)));
             }


### PR DESCRIPTION
Closes #31984.

⚠ I updated the PR to reflect my discovery at https://github.com/dotnet/roslyn/issues/31984#issuecomment-535310922.