### PR TITLE
Fix refout internal attribute constructor fatal exception

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -281,6 +281,34 @@ public class C
             }
         }
 
+        [Fact]
+        public void EmitRefAssembly_InternalAttributeConstructor()
+        {
+            CSharpCompilation comp = CreateCompilation(@"
+using System;
+
+public class A : Attribute
+{
+    internal A(int arg)
+    {
+    }
+}
+
+[A(42)]
+public class C
+{
+}
+");
+            using (var output = new MemoryStream())
+            using (var metadataOutput = new MemoryStream())
+            {
+                EmitResult emitResult = comp.Emit(output, metadataPEStream: metadataOutput,
+                    options: new EmitOptions(includePrivateMembers: false));
+                Assert.True(emitResult.Success);
+                emitResult.Diagnostics.Verify();
+            }
+        }
+
         private class TestResourceSectionBuilder : ResourceSectionBuilder
         {
             public TestResourceSectionBuilder()

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2109,8 +2109,9 @@ namespace Microsoft.Cci
         private void AddCustomAttributeToTable(EntityHandle parentHandle, ICustomAttribute customAttribute)
         {
             IMethodReference constructor = customAttribute.Constructor(Context, reportDiagnostics: true);
+            IMethodDefinition methodDef = constructor.GetResolvedMethod(Context);
 
-            if (constructor != null)
+            if (constructor != null && (methodDef == null || methodDef.ShouldInclude(Context)))
             {
                 metadata.AddCustomAttribute(
                     parent: parentHandle,


### PR DESCRIPTION
Fix issue with "FATAL UNHANDLED EXCEPTION" being thrown by Roslyn when using /refout and compiling C# code that uses a custom attribute with an `internal` constructor. The issue below contains more details.

Fixes issue https://github.com/dotnet/roslyn/issues/38444