### PR TITLE
Fix an accidental reverse caused by a bad merge

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -239,22 +239,7 @@ namespace Microsoft.CodeAnalysis.Completion
         // If they both seemed just as good, but they differ on preselection, then
         // item1 is better if it is preselected, otherwise it is worse.
         private int ComparePreselection(CompletionItem item1, CompletionItem item2)
-        {
-            // If they both seemed just as good, but they differ on preselection, then
-            // item1 is better if it is preselected, otherwise it is worse.
-            if (item1.Rules.MatchPriority == MatchPriority.Preselect &&
-                item2.Rules.MatchPriority != MatchPriority.Preselect)
-            {
-                return -1;
-            }
-            else if (item1.Rules.MatchPriority != MatchPriority.Preselect &&
-                     item2.Rules.MatchPriority == MatchPriority.Preselect)
-            {
-                return 1;
-            }
-
-            return 0;
-        }
+            => (item1.Rules.MatchPriority != MatchPriority.Preselect).CompareTo(item2.Rules.MatchPriority != MatchPriority.Preselect);
 
         private static int CompareExpandedItem(CompletionItem item1, PatternMatch match1, CompletionItem item2, PatternMatch match2)
         {


### PR DESCRIPTION
The change was originally made in PR #37894. However, it was later overwritten by auto-merge when flowing changes from 16.3 to 16.4p1 in this commit https://github.com/dotnet/roslyn/commit/7b852992edd8fddf1fce2854cedb764741c3087d

This PR restore the code to the correct state which matches what we shipped in 16.4p1

Thanks @RikkiGibson for noticing this issue!

FYI @ivanbasov @dotnet/roslyn-infrastructure 