### PR TITLE
Fix smart indent with hard tabs (16.3 servicing)

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
@@ -98,12 +98,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             string code,
             int indentationLine,
             char ch,
+            bool useTabs,
             int? baseIndentation = null,
             TextSpan span = default)
         {
             // create tree service
             using (var workspace = TestWorkspace.CreateCSharp(code))
             {
+                workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+
                 if (baseIndentation.HasValue)
                 {
                     var factory = workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>()

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1350,9 +1350,22 @@ class C
             int indentationLine,
             int? expectedIndentation)
         {
+            await AssertIndentUsingSmartTokenFormatterAsync(code, ch, indentationLine, expectedIndentation, useTabs: false).ConfigureAwait(false);
+            await AssertIndentUsingSmartTokenFormatterAsync(code.Replace("    ", "\t"), ch, indentationLine, expectedIndentation, useTabs: true).ConfigureAwait(false);
+        }
+
+        private async Task AssertIndentUsingSmartTokenFormatterAsync(
+            string code,
+            char ch,
+            int indentationLine,
+            int? expectedIndentation,
+            bool useTabs)
+        {
             // create tree service
             using (var workspace = TestWorkspace.CreateCSharp(code))
             {
+                workspace.Options = workspace.Options.WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+
                 var hostdoc = workspace.Documents.First();
 
                 var buffer = hostdoc.GetTextBuffer();
@@ -1380,10 +1393,23 @@ class C
             int? expectedIndentation,
             IndentStyle indentStyle = IndentStyle.Smart)
         {
+            await AssertIndentNotUsingSmartTokenFormatterButUsingIndenterAsync(code, indentationLine, expectedIndentation, useTabs: false, indentStyle).ConfigureAwait(false);
+            await AssertIndentNotUsingSmartTokenFormatterButUsingIndenterAsync(code.Replace("    ", "\t"), indentationLine, expectedIndentation, useTabs: true, indentStyle).ConfigureAwait(false);
+        }
+
+        private async Task AssertIndentNotUsingSmartTokenFormatterButUsingIndenterAsync(
+            string code,
+            int indentationLine,
+            int? expectedIndentation,
+            bool useTabs,
+            IndentStyle indentStyle)
+        {
             // create tree service
             using (var workspace = TestWorkspace.CreateCSharp(code))
             {
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle);
+                workspace.Options = workspace.Options
+                    .WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
                 var hostdoc = workspace.Documents.First();
                 var buffer = hostdoc.GetTextBuffer();
                 var snapshot = buffer.CurrentSnapshot;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2793,6 +2793,31 @@ class C
                 expectedIndentation: 12);
         }
 
+        [WorkItem(38819, "https://github.com/dotnet/roslyn/issues/38819")]
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public void IndentationOfReturnInFileWithTabs1()
+        {
+            var code = @"
+public class Example
+{
+	public void Test(object session)
+	{
+		if (session == null)
+return;
+	}
+}";
+            // Ensure the test code doesn't get switched to spaces
+            Assert.Contains("\t\tif (session == null)", code);
+            AssertSmartIndent(
+                code,
+                indentationLine: 6,
+                expectedIndentation: 12,
+                useTabs: true,
+                options: null,
+                indentStyle: IndentStyle.Smart);
+        }
+
         private void AssertSmartIndentInProjection(
             string markup,
             int expectedIndentation,

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2794,9 +2794,21 @@ class C
         }
 
         private void AssertSmartIndentInProjection(
-            string markup, int expectedIndentation,
+            string markup,
+            int expectedIndentation,
             CSharpParseOptions options = null,
             IndentStyle indentStyle = IndentStyle.Smart)
+        {
+            AssertSmartIndentInProjection(markup, expectedIndentation, useTabs: false, options, indentStyle);
+            AssertSmartIndentInProjection(markup.Replace("    ", "\t"), expectedIndentation, useTabs: true, options, indentStyle);
+        }
+
+        private void AssertSmartIndentInProjection(
+            string markup,
+            int expectedIndentation,
+            bool useTabs,
+            CSharpParseOptions options,
+            IndentStyle indentStyle)
         {
             var optionsSet = options != null
                     ? new[] { options }
@@ -2806,7 +2818,8 @@ class C
             {
                 using var workspace = TestWorkspace.CreateCSharp(markup, parseOptions: option);
 
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle);
+                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
                 var subjectDocument = workspace.Documents.Single();
 
                 var projectedDocument =
@@ -2834,6 +2847,18 @@ class C
             CSharpParseOptions options = null,
             IndentStyle indentStyle = IndentStyle.Smart)
         {
+            AssertSmartIndent(code, indentationLine, expectedIndentation, useTabs: false, options, indentStyle);
+            AssertSmartIndent(code.Replace("    ", "\t"), indentationLine, expectedIndentation, useTabs: true, options, indentStyle);
+        }
+
+        private void AssertSmartIndent(
+            string code,
+            int indentationLine,
+            int? expectedIndentation,
+            bool useTabs,
+            CSharpParseOptions options,
+            IndentStyle indentStyle)
+        {
             var optionsSet = options != null
                 ? new[] { options }
                 : new[] { Options.Regular, Options.Script };
@@ -2842,7 +2867,8 @@ class C
             {
                 using var workspace = TestWorkspace.CreateCSharp(code, parseOptions: option);
 
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle);
+                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
                 TestIndentation(workspace, indentationLine, expectedIndentation);
             }
         }
@@ -2853,6 +2879,17 @@ class C
             CSharpParseOptions options = null,
             IndentStyle indentStyle = IndentStyle.Smart)
         {
+            AssertSmartIndent(code, expectedIndentation, useTabs: false, options, indentStyle);
+            AssertSmartIndent(code.Replace("    ", "\t"), expectedIndentation, useTabs: true, options, indentStyle);
+        }
+
+        private void AssertSmartIndent(
+            string code,
+            int? expectedIndentation,
+            bool useTabs,
+            CSharpParseOptions options,
+            IndentStyle indentStyle)
+        {
             var optionsSet = options != null
                 ? new[] { options }
                 : new[] { Options.Regular, Options.Script };
@@ -2861,7 +2898,8 @@ class C
             {
                 using var workspace = TestWorkspace.CreateCSharp(code, parseOptions: option);
 
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle);
+                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
                 var wpfTextView = workspace.Documents.First().GetTextView();
                 var line = wpfTextView.TextBuffer.CurrentSnapshot.GetLineFromPosition(wpfTextView.Caret.Position.BufferPosition).LineNumber;
                 TestIndentation(workspace, line, expectedIndentation);

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3436,8 +3436,16 @@ class Program{
 
         internal static void AutoFormatToken(string markup, string expected)
         {
+            AutoFormatToken(markup, expected, useTabs: false);
+            AutoFormatToken(markup.Replace("    ", "\t"), expected.Replace("    ", "\t"), useTabs: true);
+        }
+
+        internal static void AutoFormatToken(string markup, string expected, bool useTabs)
+        {
             using (var workspace = TestWorkspace.CreateCSharp(markup))
             {
+                workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+
                 var subjectDocument = workspace.Documents.Single();
 
                 var commandHandler = workspace.GetService<FormatCommandHandler>();
@@ -3474,8 +3482,16 @@ class Program{
 
         private async Task AutoFormatOnMarkerAsync(string initialMarkup, string expected, SyntaxKind tokenKind, SyntaxKind startTokenKind)
         {
+            await AutoFormatOnMarkerAsync(initialMarkup, expected, useTabs: false, tokenKind, startTokenKind).ConfigureAwait(false);
+            await AutoFormatOnMarkerAsync(initialMarkup.Replace("    ", "\t"), expected.Replace("    ", "\t"), useTabs: true, tokenKind, startTokenKind).ConfigureAwait(false);
+        }
+
+        private async Task AutoFormatOnMarkerAsync(string initialMarkup, string expected, bool useTabs, SyntaxKind tokenKind, SyntaxKind startTokenKind)
+        {
             using (var workspace = TestWorkspace.CreateCSharp(initialMarkup))
             {
+                workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+
                 var tuple = GetService(workspace);
                 var testDocument = workspace.Documents.Single();
                 var buffer = testDocument.GetTextBuffer();

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2582,7 +2582,6 @@ End Namespace
                 code,
                 indentationLine:=3,
                 expectedIndentation:=0,
-                expectedBlankLineIndentation:=0,
                 indentStyle:=FormattingOptions.IndentStyle.None)
         End Sub
 
@@ -2970,6 +2969,27 @@ End Class
                 expectedIndentation:=12)
         End Sub
 
+        <WorkItem(38819, "https://github.com/dotnet/roslyn/issues/38819")>
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.SmartIndent)>
+        Public Sub IndentationOfReturnInFileWithTabs1()
+            dim code = "
+public class Example
+	public sub Test(session as object)
+		if (session is nothing)
+return
+	end sub
+end class"
+            ' Ensure the test code doesn't get switched to spaces
+            Assert.Contains(vbTab & vbTab & "if (session is nothing)", code)
+            AssertSmartIndent(
+                code,
+                indentationLine:=4,
+                expectedIndentation:=12,
+                useTabs:=True,
+                indentStyle:=FormattingOptions.IndentStyle.Smart)
+        End sub
+
         Private Sub AssertSmartIndentIndentationInProjection(
                 markup As String,
                 expectedIndentation As Integer)
@@ -2996,10 +3016,21 @@ End Class
         Private Sub AssertSmartIndent(
                 code As String, indentationLine As Integer,
                 expectedIndentation As Integer?,
-                Optional expectedBlankLineIndentation As Integer? = Nothing,
                 Optional indentStyle As FormattingOptions.IndentStyle = FormattingOptions.IndentStyle.Smart)
+            AssertSmartIndent(code, indentationLine, expectedIndentation, useTabs:=False, indentStyle)
+            AssertSmartIndent(code.Replace("    ", vbTab), indentationLine, expectedIndentation, useTabs:=True, indentStyle)
+        End Sub
+
+        ''' <param name="indentationLine">0-based. The line number in code to get indentation for.</param>
+        Private Sub AssertSmartIndent(
+                code As String, indentationLine As Integer,
+                expectedIndentation As Integer?,
+                useTabs As Boolean,
+                indentStyle As FormattingOptions.IndentStyle)
             Using workspace = TestWorkspace.CreateVisualBasic(code)
-                workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle)
+                workspace.Options = workspace.Options _
+                    .WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle) _
+                    .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.VisualBasic, useTabs)
 
                 TestIndentation(workspace, indentationLine, expectedIndentation)
             End Using

--- a/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
+++ b/src/Workspaces/Core/Portable/Indentation/AbstractIndentationService.Indenter.cs
@@ -126,12 +126,23 @@ namespace Microsoft.CodeAnalysis.Indentation
                     if (LineToBeIndented.LineNumber < updatedSourceText.Lines.Count)
                     {
                         var updatedLine = updatedSourceText.Lines[LineToBeIndented.LineNumber];
-                        var offset = updatedLine.GetFirstNonWhitespaceOffset();
-                        if (offset != null)
+                        var nonWhitespaceOffset = updatedLine.GetFirstNonWhitespaceOffset();
+                        if (nonWhitespaceOffset != null)
                         {
-                            indentationResult = new IndentationResult(
-                                basePosition: LineToBeIndented.Start,
-                                offset: offset.Value);
+                            // 'nonWhitespaceOffset' is simply an int indicating how many
+                            // *characters* of indentation to include.  For example, an indentation
+                            // string of \t\t\t would just count for nonWhitespaceOffset of '3' (one
+                            // for each tab char).
+                            //
+                            // However, what we want is the true columnar offset for the line.
+                            // That's what our caller (normally the editor) needs to determine where
+                            // to actually put the caret and what whitespace needs to proceed it.
+                            //
+                            // This can be computed with GetColumnFromLineOffset which again looks
+                            // at the contents of the line, but this time evaluates how \t characters 
+                            // should translate to column chars.
+                            var offset = updatedLine.GetColumnFromLineOffset(nonWhitespaceOffset.Value, _tabSize);
+                            indentationResult = new IndentationResult(basePosition: LineToBeIndented.Start, offset: offset);
                             return true;
                         }
                     }


### PR DESCRIPTION
Fixes #38798
Fixes #38819

### Customer scenario

When a user with indentation set to hard tabs is editing code, the code will not be correctly indented in some cases. These cases include:

* The caret is placed to the left of the first non-whitespace character, but not all the way left to column 1. For example, the caret is typically in an affected location if the user presses <kbd>Home</kbd>.
* The caret is placed between two parts of a compound statement, such as the situation described by https://github.com/dotnet/roslyn/issues/38819#issuecomment-534728599.

### Bugs this fixes

#38798 
#38819 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/987951 ([Public link](https://developercommunity.visualstudio.com/content/problem/745432/c-smart-indenting-is-broken-in-1630.html))

### Workarounds, if any

None.

### Risk

Low.

### Performance impact

Negligible. No significant changes to existing code paths.

### Is this a regression from a previous update?

Yes, regression from previous minor version.

### Root cause analysis

Hard tabs was an untested configuration for indentation. The existing test suite was updated to also test hard tabs for indentation in all scenarios previously covered by spaces only.

### How was the bug found?

Customer reported.

### Test documentation updated?

No.