### PR TITLE
Avoid a newline after type parameter attributes

### DIFF
--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 // Compare exact texts and verify that the location returned is exactly that
                 // indicated by expected
                 MarkupTestFile.GetSpan(expected, out expected, out var expectedSpan);
-                Assert.Equal(expected, actual);
+                AssertEx.EqualOrDiff(expected, actual);
                 Assert.Equal(expectedSpan.Start, actualSpan.Start);
                 Assert.Equal(expectedSpan.End, actualSpan.End);
             }

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -553,8 +553,7 @@ internal class MyAttribute : System.Attribute { }
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
-public class [|C|]<[MyAttribute]
-T>
+public class [|C|]<[MyAttribute] T>
 {{
     public C();
 
@@ -593,8 +592,7 @@ internal class AllowNullAttribute : System.Attribute { }
 using System.Runtime.CompilerServices;
 
 [NullableContextAttribute(1)]
-public interface [|C|]<[NullableAttribute(2)]
-T>
+public interface [|C|]<[NullableAttribute(2)] T>
 {{
     bool Equals([AllowNullAttribute] T other);
 }}");
@@ -2273,8 +2271,7 @@ class C
 
 using System.Runtime.CompilerServices;
 
-public class [|TestType|]<[NullableAttribute(1)]
-T> where T : notnull
+public class [|TestType|]<[NullableAttribute(1)] T> where T : notnull
 {{
     public TestType();
 }}";
@@ -2355,8 +2352,7 @@ class C
 
 using System.Runtime.CompilerServices;
 
-public delegate void [|D|]<[NullableAttribute(1)]
-T>() where T : notnull;";
+public delegate void [|D|]<[NullableAttribute(1)] T>() where T : notnull;";
 
             using var context = TestContext.Create(
                 LanguageNames.CSharp,

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -290,7 +290,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                             }
                         }
 
-                        if (previousToken.GetAncestor<ParameterSyntax>() == null)
+                        if (previousToken.GetAncestor<ParameterSyntax>() == null
+                            && previousToken.GetAncestor<TypeParameterSyntax>() == null)
                         {
                             return 1;
                         }


### PR DESCRIPTION
Fixes #38916
