### PR TITLE
Share name for semantic classification view tagger provider and buffe…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.Tagger.cs
@@ -106,16 +106,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
 
             public IEnumerable<ITagSpan<IClassificationTag>> GetTags(NormalizedSnapshotSpanCollection spans)
-            {
-                this.AssertIsForeground();
-
-                // we never return any tags for GetTags.  This tagger is only for 'Accurate' scenarios.
-                return Array.Empty<ITagSpan<IClassificationTag>>();
-            }
+                => GetTagsWorker(spans, CancellationToken.None);
 
             public IEnumerable<ITagSpan<IClassificationTag>> GetAllTags(NormalizedSnapshotSpanCollection spans, CancellationToken cancellationToken)
+                => GetTagsWorker(spans, cancellationToken);
+
+            private IEnumerable<ITagSpan<IClassificationTag>> GetTagsWorker(NormalizedSnapshotSpanCollection spans, CancellationToken cancellationToken)
             {
                 this.AssertIsForeground();
+
                 if (spans.Count == 0)
                 {
                     return Array.Empty<ITagSpan<IClassificationTag>>();

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationBufferTaggerProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
     [TagType(typeof(IClassificationTag))]
     [ContentType(ContentTypeNames.CSharpContentType)]
     [ContentType(ContentTypeNames.VisualBasicContentType)]
+    [Name(SemanticClassificationUtilities.SemanticClassificationTaggerProviderName)]
     internal partial class SemanticClassificationBufferTaggerProvider : ForegroundThreadAffinitizedObject, ITaggerProvider
     {
         private readonly IAsynchronousOperationListener _asyncListener;

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
@@ -20,6 +20,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
     internal static class SemanticClassificationUtilities
     {
+        /// <summary>
+        /// Name shared by the semantic classification view tagger provider and buffer tagger provider
+        /// to allow the editor layer to avoid creating both the view tagger and buffer tagger where possible.
+        /// </summary>
+        public const string SemanticClassificationTaggerProviderName = nameof(SemanticClassificationTaggerProviderName);
+
         public static async Task ProduceTagsAsync(
             TaggerContext<IClassificationTag> context,
             DocumentSnapshotSpan spanToTag,

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
     [Export(typeof(IViewTaggerProvider))]
     [TagType(typeof(IClassificationTag))]
     [ContentType(ContentTypeNames.RoslynContentType)]
+    [Name(SemanticClassificationUtilities.SemanticClassificationTaggerProviderName)]
     internal partial class SemanticClassificationViewTaggerProvider : AsynchronousViewTaggerProvider<IClassificationTag>
     {
         private readonly ISemanticChangeNotificationService _semanticChangeNotificationService;


### PR DESCRIPTION
…r tagger provider

Editor team has requested that we share the name on our semantic classification view tagger and bugger tagger providers. This allows them to implement the following strategy to avoid creating both taggers where possible:

1. Create the view taggers first.
2. Keep track of the names of the view tagger providers that created a tagger for a particular buffer.
3. Don’t call buffer tagger providers for a buffer if it has the same name as a view tagger provider that provided a tagger for that buffer.

This also requires that the returned tagger returns tags when either GetTags() or GetAllTags() is called.