### PR TITLE
Fix crash in flow analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.VariableIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.VariableIdentifier.cs
@@ -12,10 +12,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal readonly struct VariableIdentifier : IEquatable<VariableIdentifier>
         {
             public readonly Symbol Symbol;
+            /// <summary>
+            /// Indicates whether this variable is nested inside another tracked variable.
+            /// For instance, if a field `x` of a struct is tracked a symbol is not sufficient
+            /// to uniquely determine which field is being tracked. The containing slot(s) would
+            /// identify which tracked variable the field `x` is part of.
+            /// </summary>
             public readonly int ContainingSlot;
 
             public VariableIdentifier(Symbol symbol, int containingSlot = 0)
             {
+                Debug.Assert(containingSlot >= 0);
                 Debug.Assert(symbol.Kind switch
                 {
                     SymbolKind.Local => true,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.VariableIdentifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.VariableIdentifier.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public readonly Symbol Symbol;
             /// <summary>
             /// Indicates whether this variable is nested inside another tracked variable.
-            /// For instance, if a field `x` of a struct is tracked a symbol is not sufficient
+            /// For instance, if a field `x` of a struct is a tracked variable, the symbol is not sufficient
             /// to uniquely determine which field is being tracked. The containing slot(s) would
             /// identify which tracked variable the field `x` is part of.
             /// </summary>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -23,6 +23,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// A mapping from the local variable slot to the symbol for the local variable itself.  This
         /// is used in the implementation of region analysis (support for extract method) to compute
         /// the set of variables "always assigned" in a region of code.
+        ///
+        /// The first slot, slot 0, is reserved for indicating reachability, so the first tracked variable will
+        /// be given slot 1. When referring to <see cref="VariableIdentifier.ContainingSlot"/>, slot 0 indicates
+        /// that the variable in <see cref="VariableIdentifier.Symbol"/> is a root, i.e. not nested within another
+        /// tracked variable. Slots &lt; 0 are illegal.
         /// </summary>
         protected VariableIdentifier[] variableBySlot = new VariableIdentifier[1];
 
@@ -101,6 +106,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         protected int GetOrCreateSlot(Symbol symbol, int containingSlot = 0, bool forceSlotEvenIfEmpty = false)
         {
+            Debug.Assert(containingSlot >= 0);
+
             if (symbol.Kind == SymbolKind.RangeVariable) return -1;
 
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: true);
@@ -253,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected int MakeMemberSlot(BoundExpression receiverOpt, Symbol member)
         {
-            int containingSlot = -1;
+            int containingSlot;
             if (member.RequiresInstanceReceiver())
             {
                 if (receiverOpt is null)
@@ -265,6 +272,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return -1;
                 }
+            }
+            else
+            {
+                containingSlot = 0;
             }
             return GetOrCreateSlot(member, containingSlot);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -112,6 +112,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             containingSlot = DescendThroughTupleRestFields(ref symbol, containingSlot, forceContainingSlotsToExist: true);
 
+            if (containingSlot < 0)
+            {
+                // Error case. Diagnostics should already have been produced.
+                return -1;
+            }
+
             VariableIdentifier identifier = new VariableIdentifier(symbol, containingSlot);
             int slot;
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -713,11 +713,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private NullableFlowState GetDefaultState(ref LocalState state, int slot)
         {
+            Debug.Assert(slot > 0);
+
             if (!state.Reachable)
                 return NullableFlowState.NotNull;
-
-            if (slot == 0)
-                return NullableFlowState.MaybeNull;
 
             var variable = variableBySlot[slot];
             var symbol = variable.Symbol;
@@ -1324,7 +1323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override LocalState TopState()
         {
             var state = LocalState.ReachableState(capacity: nextVariableSlot);
-            Populate(ref state, start: 0);
+            Populate(ref state, start: 1);
             return state;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var method = (MethodSymbol)_symbol;
-            bool isStatic = method.IsStatic;
+            bool isStatic = !method.RequiresInstanceReceiver();
 
             int thisSlot = -1;
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/UnassignedFieldsWalker.cs
@@ -88,10 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 method.TryGetThisParameter(out var thisParameter);
                 thisSlot = VariableSlot(thisParameter);
-                if (thisSlot == -1)
-                {
-                    return;
-                }
+                Debug.Assert(thisSlot > 0);
             }
 
             var containingType = method.ContainingType;
@@ -113,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return true;
             }
-            int slot = VariableSlot(symbol, thisSlot);
+            int slot = VariableSlot(symbol, symbol.IsStatic ? 0 : thisSlot);
             return slot > 0 && this.State.IsAssigned(slot);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -98,6 +98,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypesWithAnnotations, syntax, compilation, diagnostics);
 
+            if (numElements >= RestPosition && diagnostics != null && !underlyingType.IsErrorType())
+            {
+                WellKnownMember wellKnownTupleRest = GetTupleTypeMember(RestPosition, RestPosition);
+                _ = (FieldSymbol)GetWellKnownMemberInType(underlyingType.OriginalDefinition, wellKnownTupleRest, diagnostics, syntax);
+            }
+
             if (diagnostics != null && ((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked)
             {
                 // Complain about unembeddable types from linked assemblies.

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (numElements >= RestPosition && diagnostics != null && !underlyingType.IsErrorType())
             {
                 WellKnownMember wellKnownTupleRest = GetTupleTypeMember(RestPosition, RestPosition);
-                _ = (FieldSymbol)GetWellKnownMemberInType(underlyingType.OriginalDefinition, wellKnownTupleRest, diagnostics, syntax);
+                _ = GetWellKnownMemberInType(underlyingType.OriginalDefinition, wellKnownTupleRest, diagnostics, syntax);
             }
 
             if (diagnostics != null && ((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -4466,6 +4466,7 @@ namespace System
 
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
     {
+        public TRest Rest;
     }
 }
 ";
@@ -20696,9 +20697,40 @@ namespace System
 " + TestResources.NetFX.ValueTuple.tupleattributes_cs;
 
             var comp = CreateCompilation(source,
+                assemblyName: "comp",
                 parseOptions: TestOptions.Regular);
 
             comp.VerifyDiagnostics(
+                // (8,13): error CS8128: Member 'Rest' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //             (string I1, 
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, @"(string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8)").WithArguments("Rest", "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(8, 13),
+                // (30,13): error CS8128: Member 'Rest' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //             (string I1, 
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, @"(string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8)").WithArguments("Rest", "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(30, 13),
+                // (52,13): error CS8128: Member 'Rest' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //             (string I1, 
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, @"(string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8)").WithArguments("Rest", "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(52, 13),
                 // (70,38): error CS0165: Use of unassigned local variable 'ss'
                 //             System.Console.WriteLine(ss); // should fail
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "ss").WithArguments("ss").WithLocation(70, 38)
@@ -21187,6 +21219,8 @@ namespace System
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
     {
         public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { }
+
+        public TRest Rest;
     }
 }
 public class D
@@ -21267,7 +21301,9 @@ namespace System
     }
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
     {
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { }
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest) { Rest = rest; }
+
+        public TRest Rest;
     }
 }
 ";

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -677,7 +677,7 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
 ";
             var compilation = CreateCompilationWithMscorlib45(source, assemblyName: "comp");
             compilation.VerifyDiagnostics(
-                // (10,12): error CS8128: Member 'Rest' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>' from assembly '0d0471f0-7d25-49f3-97e3-a96a48c4ef56, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                // (10,12): error CS8128: Member 'Rest' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>' from assembly comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //     static (MyTask, char, byte, short, ushort, int, uint, long, ulong, char, byte, short, ushort, int, uint, long, MyTask<T>) F3;
                 Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(MyTask, char, byte, short, ushort, int, uint, long, ulong, char, byte, short, ushort, int, uint, long, MyTask<T>)").WithArguments("Rest", "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(10, 12));
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -675,8 +675,11 @@ namespace System.Runtime.CompilerServices
 
 namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : System.Attribute { public AsyncMethodBuilderAttribute(System.Type t) { } } }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source);
-            compilation.VerifyDiagnostics();
+            var compilation = CreateCompilationWithMscorlib45(source, assemblyName: "comp");
+            compilation.VerifyDiagnostics(
+                // (10,12): error CS8128: Member 'Rest' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>' from assembly '0d0471f0-7d25-49f3-97e3-a96a48c4ef56, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //     static (MyTask, char, byte, short, ushort, int, uint, long, ulong, char, byte, short, ushort, int, uint, long, MyTask<T>) F3;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(MyTask, char, byte, short, ushort, int, uint, long, ulong, char, byte, short, ushort, int, uint, long, MyTask<T>)").WithArguments("Rest", "System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(10, 12));
 
             var type = compilation.GetMember<FieldSymbol>("C.F0").Type;
             var normalized = type.NormalizeTaskTypes(compilation);

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TupleTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TupleTests.cs
@@ -326,27 +326,6 @@ class C
         {
         }
     }
-    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>
-    {
-        public T1 Item1;
-        public T2 Item2;
-        public T3 Item3;
-        public T4 Item4;
-        public T5 Item5;
-        public T6 Item6;
-        public T7 Item7;
-        // No Rest.
-        public ValueTuple(T1 _1, T2 _2, T3 _3, T4 _4, T5 _5, T6 _6, T7 _7, T8 _8)
-        {
-            Item1 = _1;
-            Item2 = _2;
-            Item3 = _3;
-            Item4 = _4;
-            Item5 = _5;
-            Item6 = _6;
-            Item7 = _7;
-        }
-    }
 }
 namespace System.Runtime.CompilerServices
 {
@@ -361,7 +340,6 @@ class C
 {
     (int A, int B) F = (1, 2);
     (int, int, int C) G = (1, 2, 3);
-    (int, int B, int, int D, int, int F, int, int H, int) H = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 }";
             var runtime = new DkmClrRuntimeInstance(ReflectionUtilities.GetMscorlib(GetAssembly(source)));
             using (runtime.Load())
@@ -374,24 +352,13 @@ class C
                 var children = GetChildren(evalResult);
                 Verify(children,
                     EvalResult("F", "{(int, int)}", "(int A, int B)", "o.F", DkmEvaluationResultFlags.Expandable),
-                    EvalResult("G", "{(int, int, int)}", "(int, int, int C)", "o.G", DkmEvaluationResultFlags.Expandable), // expandable, but with no children
-                    EvalResult("H", "{(int, int, int, int, int, int, int, int, int)}", "(int, int B, int, int D, int, int F, int, int H, int)", "o.H", DkmEvaluationResultFlags.Expandable));
+                    EvalResult("G", "{(int, int, int)}", "(int, int, int C)", "o.G", DkmEvaluationResultFlags.Expandable)); // expandable, but with no children
                 var moreChildren = GetChildren(children[0]);
                 Verify(moreChildren,
                     EvalResult("A", "1", "int", "o.F.Item1"),
                     EvalResult("Raw View", "{(int, int)}", "(int A, int B)", "o.F, raw", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
                 moreChildren = GetChildren(children[1]);
                 Verify(moreChildren);
-                moreChildren = GetChildren(children[2]);
-                Verify(moreChildren,
-                    EvalResult("Item1", "1", "int", "o.H.Item1"),
-                    EvalResult("B", "2", "int", "o.H.Item2"),
-                    EvalResult("Item3", "3", "int", "o.H.Item3"),
-                    EvalResult("D", "4", "int", "o.H.Item4"),
-                    EvalResult("Item5", "5", "int", "o.H.Item5"),
-                    EvalResult("F", "6", "int", "o.H.Item6"),
-                    EvalResult("Item7", "7", "int", "o.H.Item7"),
-                    EvalResult("Raw View", "{(int, int, int, int, int, int, int, int, int)}", "(int, int B, int, int D, int, int F, int, int H, int)", "o.H, raw", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TupleTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/TupleTests.cs
@@ -326,6 +326,27 @@ class C
         {
         }
     }
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>
+    {
+        // No Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+        public T8 Rest;
+        public ValueTuple(T1 _1, T2 _2, T3 _3, T4 _4, T5 _5, T6 _6, T7 _7, T8 _8)
+        {
+            Item2 = _2;
+            Item3 = _3;
+            Item4 = _4;
+            Item5 = _5;
+            Item6 = _6;
+            Item7 = _7;
+            Rest = _8;
+        }
+    }
 }
 namespace System.Runtime.CompilerServices
 {
@@ -340,6 +361,7 @@ class C
 {
     (int A, int B) F = (1, 2);
     (int, int, int C) G = (1, 2, 3);
+    (int, int B, int, int D, int, int F, int, int H, int) H = (1, 2, 3, 4, 5, 6, 7, 8, 9);
 }";
             var runtime = new DkmClrRuntimeInstance(ReflectionUtilities.GetMscorlib(GetAssembly(source)));
             using (runtime.Load())
@@ -352,13 +374,24 @@ class C
                 var children = GetChildren(evalResult);
                 Verify(children,
                     EvalResult("F", "{(int, int)}", "(int A, int B)", "o.F", DkmEvaluationResultFlags.Expandable),
-                    EvalResult("G", "{(int, int, int)}", "(int, int, int C)", "o.G", DkmEvaluationResultFlags.Expandable)); // expandable, but with no children
+                    EvalResult("G", "{(int, int, int)}", "(int, int, int C)", "o.G", DkmEvaluationResultFlags.Expandable), // expandable, but with no children
+                    EvalResult("H", "{(int, int, int, int, int, int, int, int, int)}", "(int, int B, int, int D, int, int F, int, int H, int)", "o.H", DkmEvaluationResultFlags.Expandable));
                 var moreChildren = GetChildren(children[0]);
                 Verify(moreChildren,
                     EvalResult("A", "1", "int", "o.F.Item1"),
                     EvalResult("Raw View", "{(int, int)}", "(int A, int B)", "o.F, raw", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
                 moreChildren = GetChildren(children[1]);
                 Verify(moreChildren);
+                moreChildren = GetChildren(children[2]);
+                Verify(moreChildren,
+                    EvalResult("B", "2", "int", "o.H.Item2"),
+                    EvalResult("Item3", "3", "int", "o.H.Item3"),
+                    EvalResult("D", "4", "int", "o.H.Item4"),
+                    EvalResult("Item5", "5", "int", "o.H.Item5"),
+                    EvalResult("F", "6", "int", "o.H.Item6"),
+                    EvalResult("Item7", "7", "int", "o.H.Item7"),
+                    EvalResult("H", "8", "int", "o.H.Rest.Item1"),
+                    EvalResult("Raw View", "{(int, int, int, int, int, int, int, int, int)}", "(int, int B, int, int D, int, int F, int, int H, int)", "o.H, raw", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly));
             }
         }
 


### PR DESCRIPTION
When we added support for tracking static fields as part of nullable
analysis, we used -1 for their containing slot. Negative numbers are
not meant to be used as actual slots and flowed through the flow analysis
code, they are only used as sentinels from slot-returning methods to indicate
that the variable in question is not tracked. The appropriate root
slot for a static variable is the same as the root slot for a top-level tracked
variable (like a local), which is 0.

Fixes #38725