### PR TITLE
Add API Review notes

### DIFF
--- a/docs/compilers/API Notes/9-30-19.md
+++ b/docs/compilers/API Notes/9-30-19.md
@@ -1,0 +1,38 @@
+## API Review Notes for September 30th, 2019
+
+### Changes reviewed
+Starting commit: `12b125030c34e340086b7fa192fb9426aaddf054`
+
+Ending Commit: `38c90f8401f9e3ee5fb7c82aac36f6b85fdda979`
+
+### Notes
+
+For the AnalyzerConfig removals, we've said that we're fine with this change because the API was just published, and wasn't intended to be.
+We don't want to maintain the API shape in the future, and we're willing to accept the risk of breaks in order to remove it now, before many people can take a hard dependency on the API surface.
+
+ErrorLogPath removed from CommandLineArguments, moved to ErrorLogOptions.Path
+ - We should maintain this API.
+ - Just forward to the old implementation.
+ - @333fred will send a PR.
+
+TextDocument
+ - Should we not remove the constructor? This is a binary breaking change
+ - This empty constructor cannot be used.
+ - We'll keep the change.
+
+Workspace
+ - CanApplyParseOptionChange going from virtual protected to virtual public is a source and binary breaking change
+ - We should look at having a new non-virtual public method on Workspace and forward to this API.
+ - @jasonmalinowski will look at this fix.
+
+SyntaxFactory.AnonymousMethodExpression
+ - Added overload with multiple parameters.
+ - Part of https://github.com/dotnet/roslyn/pull/37674, which brings the API in line with MethodBodySyntax.
+   This change is fine.
+
+Formatter.OrganizeUsings
+ - Should make cancellationtoken optional?
+ - Need to followup with framework on what the current guidelines are
+ - Make this default for now
+ - @jasonmalinowski to follow up.
+

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -130,6 +130,12 @@ namespace Microsoft.CodeAnalysis
 #nullable restore
 
         /// <summary>
+        /// Options controlling the generation of a SARIF log file containing compilation or
+        /// analysis diagnostics, or null if no log file is desired.
+        /// </summary>
+        public string ErrorLogPath => ErrorLogOptions?.Path;
+
+        /// <summary>
         /// An absolute path of the app.config file or null if not specified.
         /// </summary>
         public string AppConfigPath { get; internal set; }

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -127,13 +127,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
 #nullable enable
         public ErrorLogOptions? ErrorLogOptions { get; internal set; }
-#nullable restore
 
         /// <summary>
         /// Options controlling the generation of a SARIF log file containing compilation or
         /// analysis diagnostics, or null if no log file is desired.
         /// </summary>
-        public string ErrorLogPath => ErrorLogOptions?.Path;
+        public string? ErrorLogPath => ErrorLogOptions?.Path;
+#nullable restore
 
         /// <summary>
         /// An absolute path of the app.config file or null if not specified.


### PR DESCRIPTION
Added the notes from today's compiler API review. Also addressed the CommandLineArguments part of the notes, restoring a previously removed API to prevent breaking changes. @agocke for review of this API, as you reviewed the SARIF change that removed it.

@AlekseyTs @chsienki @jasonmalinowski @AlekseyTs @jaredpar for quick review.