### PR TITLE
Fix docker caching by resetting cache only when mono changes

### DIFF
--- a/eng/docker/Mono/Dockerfile
+++ b/eng/docker/Mono/Dockerfile
@@ -3,6 +3,16 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+FROM ubuntu:16.04 as Info
+
+# install wget
+RUN apt-get update && \
+    apt-get install -y wget
+
+# we always want to download the content of the release file, regardless of cache
+ARG CACHE_BUST=0 
+RUN wget https://download.mono-project.com/repo/ubuntu/dists/nightly-xenial/Release
+
 FROM ubuntu:16.04
 
 # Install the base toolchain we need to build anything
@@ -41,9 +51,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     apt-get clean
 
 
+# Copy will check the hash of the release file. If it's changed it will be copied and everything from this point will re-run regardless of cache status
+COPY --from=Info /Release .
+
 # Update previously installed mono-devel.
-# Cache bust ensures we'll always run the commands following regardless of docker cache status
-ARG CACHE_BUST=0
 RUN apt-get update && apt-get upgrade -y
 
 # Setup User to match Host User, and give superuser permissions


### PR DESCRIPTION
We currently have a 'cache bust' mechanism, that prevents our docker image from caching the mono nightly install steps: We cache the initial install, then update the container every time we run the tests to get up to latest.

In general this is fine, but as the base image gets further away from the 'latest' update, the apt-upgrade takes longer and longer, leading to machine restore time being up to 50% of overall test time.

We have a couple of options, including not updating everything on the box, but this can lead to potentially weird issues where a 'fresh' container build would give different results to a cached one due to dependency differences, which we definitely want to avoid.

This change breaks the container build into two stages: an info stage and a build stage. The info stage simply gets the release info for Mono nightly. The main build then copies this file into the main container before updating. Docker is clever enough to use the hash of the file to determine if it should maintain the cache or not, meaning we'll only update the machine and its dependencies if a new nightly mono has actually been published since the last run. 

There are still some issues with this approach, mainly that running on different physical machines can end up with different dependency sets cached, but they should only ever be slightly out of date, so I'm hopeful we shouldn't see any actual issues.

I have some ideas how to fix this in a much more robust way, but it needs some thinking / infra investment, so this should be considered a medium term fix to try and get the Linux Mono legs to a better, but not perfect, state.


