### PR TITLE
Publish LSP document diagnostics only for relevant documents.

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/DiagnosticHandler.Exports.cs
+++ b/src/VisualStudio/LiveShare/Impl/DiagnosticHandler.Exports.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.LiveShare.LanguageServices;
 using CustomMethods = Microsoft.VisualStudio.LiveShare.LanguageServices.Protocol.CustomMethods;
@@ -18,6 +20,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             : base(diagnosticService)
         {
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ImmutableArray.Create(LanguageNames.CSharp, LanguageNames.VisualBasic);
     }
 
     [Export(LiveShareConstants.CSharpContractName, typeof(ILspNotificationProvider))]
@@ -29,6 +33,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             : base(diagnosticService)
         {
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ImmutableArray.Create(LanguageNames.CSharp);
     }
 
     [Export(LiveShareConstants.VisualBasicContractName, typeof(ILspNotificationProvider))]
@@ -40,17 +46,8 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             : base(diagnosticService)
         {
         }
-    }
 
-    [Export(LiveShareConstants.TypeScriptContractName, typeof(ILspNotificationProvider))]
-    [ExportLspRequestHandler(LiveShareConstants.TypeScriptContractName, CustomMethods.GetDocumentDiagnosticsName)]
-    internal class TypeScriptDiagnosticsHandler : DiagnosticsHandler
-    {
-        [ImportingConstructor]
-        public TypeScriptDiagnosticsHandler(IDiagnosticService diagnosticService)
-            : base(diagnosticService)
-        {
-        }
+        protected override ImmutableArray<string> SupportedLanguages => ImmutableArray.Create(LanguageNames.VisualBasic);
     }
 
     /// <summary>
@@ -65,5 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
             : base(diagnosticService)
         {
         }
+
+        protected override ImmutableArray<string> SupportedLanguages => ImmutableArray.Create("TypeScript");
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/DiagnosticHandler.cs
+++ b/src/VisualStudio/LiveShare/Impl/DiagnosticHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
@@ -22,9 +23,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
     /// open. This type also provides notifications when diagnostics change.
     /// TODO - Move implementation to lower LSP layer once we figure out how to deal with notify / client interactions.
     /// </summary>
-    internal class DiagnosticsHandler : ILspRequestHandler<TextDocumentParams, LSP.Diagnostic[], Solution>, ILspNotificationProvider
+    internal abstract class DiagnosticsHandler : ILspRequestHandler<TextDocumentParams, LSP.Diagnostic[], Solution>, ILspNotificationProvider
     {
         private readonly IDiagnosticService _diagnosticService;
+
+        protected abstract ImmutableArray<string> SupportedLanguages { get; }
 
         public event AsyncEventHandler<LanguageServiceNotifyEventArgs> NotifyAsync;
 
@@ -48,6 +51,12 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare
                 {
                     var document = e.Solution.GetDocument(e.DocumentId);
                     if (document == null || document.FilePath == null)
+                    {
+                        return;
+                    }
+
+                    // Only publish document diagnostics for the languages this provider supports.
+                    if (!SupportedLanguages.Contains(document.Project.Language))
                     {
                         return;
                     }


### PR DESCRIPTION
fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/991786

now that there are LSP providers per language, document diagnostics should be published only for the relevant documents.