### PR TITLE
Disable IDE dispose analyzers by default

### DIFF
--- a/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposableFieldsShouldBeDisposedTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DisposeAnalysis
     public sealed class DisposableFieldsShouldBeDisposedTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (new DisposableFieldsShouldBeDisposedDiagnosticAnalyzer(), null);
+            => (new DisposableFieldsShouldBeDisposedDiagnosticAnalyzer(isEnabledByDefault: true), null);
 
         private Task TestDiagnosticsAsync(string initialMarkup, params DiagnosticDescription[] expectedDiagnostics)
             => TestDiagnosticsAsync(initialMarkup, parseOptions: null, expectedDiagnostics);

--- a/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/EditorFeatures/CSharpTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DisposeAnalysis
     public sealed class DisposeObjectsBeforeLosingScopeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (new DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer(), null);
+            => (new DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer(isEnabledByDefault: true), null);
 
         private Task TestDiagnosticsAsync(string initialMarkup, params DiagnosticDescription[] expectedDiagnostics)
             => TestDiagnosticsAsync(initialMarkup, parseOptions: null, expectedDiagnostics);

--- a/src/EditorFeatures/VisualBasicTest/DisposeAnalysis/DisposableFieldsShouldBeDisposedTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DisposeAnalysis/DisposableFieldsShouldBeDisposedTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.DisposeAnalysis
     Public Class DisposableFieldsShouldBeDisposedTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
-            Return (New DisposableFieldsShouldBeDisposedDiagnosticAnalyzer(), Nothing)
+            Return (New DisposableFieldsShouldBeDisposedDiagnosticAnalyzer(isEnabledByDefault:=True), Nothing)
         End Function
 
         ' Ensure that we explicitly test missing diagnostic, which has no corresponding code fix (non-fixable diagnostic).

--- a/src/EditorFeatures/VisualBasicTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DisposeAnalysis/DisposeObjectsBeforeLosingScopeTests.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.DisposeAnalysis
     Public Class DisposeObjectsBeforeLosingScopeTests
         Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
-            Return (New DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer(), Nothing)
+            Return (New DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer(isEnabledByDefault:=True), Nothing)
         End Function
 
         ' Ensure that we explicitly test missing diagnostic, which has no corresponding code fix (non-fixable diagnostic).

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposableFieldsShouldBeDisposedDiagnosticAnalyzer.cs
@@ -20,17 +20,33 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
     internal sealed class DisposableFieldsShouldBeDisposedDiagnosticAnalyzer
         : AbstractCodeQualityDiagnosticAnalyzer
     {
-        private static readonly DiagnosticDescriptor s_disposableFieldsShouldBeDisposedRule = CreateDescriptor(
-            IDEDiagnosticIds.DisposableFieldsShouldBeDisposedDiagnosticId,
-            title: new LocalizableResourceString(nameof(FeaturesResources.Disposable_fields_should_be_disposed), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            messageFormat: new LocalizableResourceString(nameof(FeaturesResources.Disposable_field_0_is_never_disposed), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            description: new LocalizableResourceString(nameof(FeaturesResources.DisposableFieldsShouldBeDisposedDescription), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            isUnneccessary: false);
+        private readonly DiagnosticDescriptor _disposableFieldsShouldBeDisposedRule;
 
         public DisposableFieldsShouldBeDisposedDiagnosticAnalyzer()
-            : base(ImmutableArray.Create(s_disposableFieldsShouldBeDisposedRule), GeneratedCodeAnalysisFlags.Analyze)
+            : this(isEnabledByDefault: false)
         {
         }
+
+        // internal for test purposes.
+        internal DisposableFieldsShouldBeDisposedDiagnosticAnalyzer(bool isEnabledByDefault)
+            : this(CreateDescriptor(isEnabledByDefault))
+        {
+        }
+
+        private DisposableFieldsShouldBeDisposedDiagnosticAnalyzer(DiagnosticDescriptor descriptor)
+            : base(ImmutableArray.Create(descriptor), GeneratedCodeAnalysisFlags.Analyze)
+        {
+            _disposableFieldsShouldBeDisposedRule = descriptor;
+        }
+
+        private static DiagnosticDescriptor CreateDescriptor(bool isEnabledByDefault)
+            => CreateDescriptor(
+                IDEDiagnosticIds.DisposableFieldsShouldBeDisposedDiagnosticId,
+                title: new LocalizableResourceString(nameof(FeaturesResources.Disposable_fields_should_be_disposed), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                messageFormat: new LocalizableResourceString(nameof(FeaturesResources.Disposable_field_0_is_never_disposed), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                description: new LocalizableResourceString(nameof(FeaturesResources.DisposableFieldsShouldBeDisposedDescription), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                isUnneccessary: false,
+                isEnabledByDefault: isEnabledByDefault);
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
 
@@ -45,30 +61,32 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
                 // Register a symbol start action to analyze all named types.
                 compilationContext.RegisterSymbolStartAction(
-                    symbolStartContext => SymbolAnalyzer.OnSymbolStart(symbolStartContext, disposeAnalysisHelper),
+                    symbolStartContext => SymbolAnalyzer.OnSymbolStart(symbolStartContext, _disposableFieldsShouldBeDisposedRule, disposeAnalysisHelper),
                     SymbolKind.NamedType);
             });
         }
 
         private sealed class SymbolAnalyzer
         {
+            private readonly DiagnosticDescriptor _disposableFieldsShouldBeDisposedRule;
             private readonly ImmutableHashSet<IFieldSymbol> _disposableFields;
             private readonly ConcurrentDictionary<IFieldSymbol, /*disposed*/bool> _fieldDisposeValueMap;
             private readonly DisposeAnalysisHelper _disposeAnalysisHelper;
             private bool _hasErrors;
             private bool _hasDisposeMethod;
 
-            public SymbolAnalyzer(ImmutableHashSet<IFieldSymbol> disposableFields, DisposeAnalysisHelper disposeAnalysisHelper)
+            public SymbolAnalyzer(DiagnosticDescriptor disposableFieldsShouldBeDisposedRule, ImmutableHashSet<IFieldSymbol> disposableFields, DisposeAnalysisHelper disposeAnalysisHelper)
             {
                 Debug.Assert(!disposableFields.IsEmpty);
 
+                _disposableFieldsShouldBeDisposedRule = disposableFieldsShouldBeDisposedRule;
                 _disposableFields = disposableFields;
                 _disposeAnalysisHelper = disposeAnalysisHelper;
                 _fieldDisposeValueMap = new ConcurrentDictionary<IFieldSymbol, bool>();
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public static void OnSymbolStart(SymbolStartAnalysisContext symbolStartContext, DisposeAnalysisHelper disposeAnalysisHelper)
+            public static void OnSymbolStart(SymbolStartAnalysisContext symbolStartContext, DiagnosticDescriptor disposableFieldsShouldBeDisposedRule, DisposeAnalysisHelper disposeAnalysisHelper)
             {
                 // We only want to analyze types which are disposable (implement System.IDisposable directly or indirectly)
                 // and have at least one disposable field.
@@ -84,7 +102,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                     return;
                 }
 
-                var analyzer = new SymbolAnalyzer(disposableFields, disposeAnalysisHelper);
+                var analyzer = new SymbolAnalyzer(disposableFieldsShouldBeDisposedRule, disposableFields, disposeAnalysisHelper);
 
                 // Register an operation block action to analyze disposable assignments and dispose invocations for fields.
                 symbolStartContext.RegisterOperationBlockStartAction(analyzer.OnOperationBlockStart);
@@ -124,7 +142,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                     if (!disposed)
                     {
                         // Disposable field '{0}' is never disposed
-                        var diagnostic = Diagnostic.Create(s_disposableFieldsShouldBeDisposedRule, field.Locations[0], field.Name);
+                        var diagnostic = Diagnostic.Create(_disposableFieldsShouldBeDisposedRule, field.Locations[0], field.Name);
                         symbolEndContext.ReportDiagnostic(diagnostic);
                     }
                 }
@@ -218,7 +236,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                         {
                             if (_disposeAnalysisHelper.TryGetOrComputeResult(
                                 operationBlockStartContext, containingMethod,
-                                s_disposableFieldsShouldBeDisposedRule,
+                                _disposableFieldsShouldBeDisposedRule,
                                 InterproceduralAnalysisKind.None,
                                 trackInstanceFields: false,
                                 out _, out var pointsToAnalysisResult) &&
@@ -256,7 +274,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
                     // Perform dataflow analysis to compute dispose value of disposable fields at the end of dispose method.
                     if (_disposeAnalysisHelper.TryGetOrComputeResult(operationBlockStartContext, containingMethod,
-                        s_disposableFieldsShouldBeDisposedRule,
+                        _disposableFieldsShouldBeDisposedRule,
                         InterproceduralAnalysisKind.ContextSensitive,
                         trackInstanceFields: true,
                         disposeAnalysisResult: out var disposeAnalysisResult,

--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
@@ -20,24 +20,44 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
     internal sealed class DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer
         : AbstractCodeQualityDiagnosticAnalyzer
     {
-        private static readonly DiagnosticDescriptor s_disposeObjectsBeforeLosingScopeRule = CreateDescriptor(
-            IDEDiagnosticIds.DisposeObjectsBeforeLosingScopeDiagnosticId,
-            title: new LocalizableResourceString(nameof(FeaturesResources.Dispose_objects_before_losing_scope), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            messageFormat: new LocalizableResourceString(nameof(FeaturesResources.Disposable_object_created_by_0_is_never_disposed), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            description: new LocalizableResourceString(nameof(FeaturesResources.UseRecommendedDisposePatternDescription), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            isUnneccessary: false);
-
-        private static readonly DiagnosticDescriptor s_useRecommendedDisposePatternRule = CreateDescriptor(
-            IDEDiagnosticIds.UseRecommendedDisposePatternDiagnosticId,
-            title: new LocalizableResourceString(nameof(FeaturesResources.Use_recommended_dispose_pattern), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            messageFormat: new LocalizableResourceString(nameof(FeaturesResources.Use_recommended_dispose_pattern_to_ensure_that_object_created_by_0_is_disposed_on_all_paths_using_statement_declaration_or_try_finally), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            description: new LocalizableResourceString(nameof(FeaturesResources.UseRecommendedDisposePatternDescription), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
-            isUnneccessary: false);
+        private readonly DiagnosticDescriptor _disposeObjectsBeforeLosingScopeRule;
+        private readonly DiagnosticDescriptor _useRecommendedDisposePatternRule;
 
         public DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer()
-            : base(ImmutableArray.Create(s_disposeObjectsBeforeLosingScopeRule, s_useRecommendedDisposePatternRule), GeneratedCodeAnalysisFlags.None)
+           : this(isEnabledByDefault: false)
         {
         }
+
+        // internal for test purposes.
+        internal DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer(bool isEnabledByDefault)
+            : this(CreateDisposeObjectsBeforeLosingScopeRule(isEnabledByDefault), CreateUseRecommendedDisposePatternRule(isEnabledByDefault))
+        {
+        }
+
+        public DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer(DiagnosticDescriptor disposeObjectsBeforeLosingScopeRule, DiagnosticDescriptor useRecommendedDisposePatternRule)
+            : base(ImmutableArray.Create(disposeObjectsBeforeLosingScopeRule, useRecommendedDisposePatternRule), GeneratedCodeAnalysisFlags.None)
+        {
+            _disposeObjectsBeforeLosingScopeRule = disposeObjectsBeforeLosingScopeRule;
+            _useRecommendedDisposePatternRule = useRecommendedDisposePatternRule;
+        }
+
+        private static DiagnosticDescriptor CreateDisposeObjectsBeforeLosingScopeRule(bool isEnabledByDefault)
+            => CreateDescriptor(
+                IDEDiagnosticIds.DisposeObjectsBeforeLosingScopeDiagnosticId,
+                title: new LocalizableResourceString(nameof(FeaturesResources.Dispose_objects_before_losing_scope), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                messageFormat: new LocalizableResourceString(nameof(FeaturesResources.Disposable_object_created_by_0_is_never_disposed), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                description: new LocalizableResourceString(nameof(FeaturesResources.UseRecommendedDisposePatternDescription), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                isUnneccessary: false,
+                isEnabledByDefault: isEnabledByDefault);
+
+        private static DiagnosticDescriptor CreateUseRecommendedDisposePatternRule(bool isEnabledByDefault)
+            => CreateDescriptor(
+                IDEDiagnosticIds.UseRecommendedDisposePatternDiagnosticId,
+                title: new LocalizableResourceString(nameof(FeaturesResources.Use_recommended_dispose_pattern), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                messageFormat: new LocalizableResourceString(nameof(FeaturesResources.Use_recommended_dispose_pattern_to_ensure_that_object_created_by_0_is_disposed_on_all_paths_using_statement_declaration_or_try_finally), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                description: new LocalizableResourceString(nameof(FeaturesResources.UseRecommendedDisposePatternDescription), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                isUnneccessary: false,
+                isEnabledByDefault: isEnabledByDefault);
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
 
@@ -89,7 +109,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
 
             // Compute dispose dataflow analysis result for the operation block.
             if (disposeAnalysisHelper.TryGetOrComputeResult(operationBlockContext, containingMethod,
-                s_disposeObjectsBeforeLosingScopeRule,
+                _disposeObjectsBeforeLosingScopeRule,
                 InterproceduralAnalysisKind.ContextSensitive,
                 trackInstanceFields: false,
                 out var disposeAnalysisResult, out var pointsToAnalysisResult,
@@ -195,7 +215,7 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                             continue;
                         }
 
-                        var rule = isNotDisposed ? s_disposeObjectsBeforeLosingScopeRule : s_useRecommendedDisposePatternRule;
+                        var rule = isNotDisposed ? _disposeObjectsBeforeLosingScopeRule : _useRecommendedDisposePatternRule;
 
                         // Ensure that we do not include multiple lines for the object creation expression in the diagnostic message.
                         var objectCreationText = syntax.ToString();


### PR DESCRIPTION
We are going to disable the DFA based IDE dispose analyzers (IDE0067, IDE0068 and IDE0069) by default as they need more performance tuning to handle large method bodies (method bodies which are 1000s of lines of code) with large control flow graphs.

#38984 has been filed to track turning these analyzers back on by default when the issue has been fixed.