### PR TITLE
Revert "Use new Span/Memory APIs on System.Collections.Immutable"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -181,7 +181,7 @@
     <SourceBrowserVersion>1.0.21</SourceBrowserVersion>
     <StreamJsonRpcVersion>2.1.55</StreamJsonRpcVersion>
     <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
-    <SystemCollectionsImmutableVersion>1.6.0</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemCommandLineExperimentalVersion>0.1.0-alpha-63729-01</SystemCommandLineExperimentalVersion>
     <SystemCommandLineRenderingVersion>0.1.0-alpha-63729-01</SystemCommandLineRenderingVersion>
     <SystemDrawingCommonVersion>4.5.0</SystemDrawingCommonVersion>

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -9,7 +9,6 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Threading;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -839,8 +838,8 @@ public class C
                 AssertEx.NotEqual(image1, image2, message: $"Expecting difference for includePrivateMembers={includePrivateMembers} case, but they matched.");
             }
 
-            var mvid1 = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(new ImmutableMemoryStream(image1));
-            var mvid2 = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(new ImmutableMemoryStream(image2));
+            var mvid1 = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(new MemoryStream(image1.DangerousGetUnderlyingArray()));
+            var mvid2 = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(new MemoryStream(image2.DangerousGetUnderlyingArray()));
 
             if (!includePrivateMembers)
             {

--- a/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Collections/ImmutableArrayExtensionsTests.cs
@@ -377,6 +377,17 @@ namespace Microsoft.CodeAnalysis.UnitTests.Collections
         }
 
         [Fact]
+        public void DangerousCreateFromUnderlyingArray()
+        {
+            var array = new[] { 1, 2, 3, 4 };
+            var copy = array;
+            var immutable = ImmutableArrayExtensions.DangerousCreateFromUnderlyingArray(ref copy);
+            Assert.Null(copy);
+            AssertEx.Equal(array, immutable);
+            Assert.Same(array, ImmutableArrayExtensions.DangerousGetUnderlyingArray(immutable));
+        }
+
+        [Fact]
         public void ZipAsArray()
         {
             var empty = ImmutableArray.Create<object>();

--- a/src/Compilers/Core/CodeAnalysisTest/Emit/EmitBaselineTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/EmitBaselineTests.cs
@@ -20,22 +20,17 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
             var peReader = peModule.Module.PEReaderOpt;
 
             var mdBytes = peReader.GetMetadata().GetContent();
-            unsafe
-            {
-                fixed (byte* ptr = mdBytes.AsSpan())
-                {
-                    var mdModule = ModuleMetadata.CreateFromMetadata((IntPtr)ptr, mdBytes.Length);
+            var mdBytesHandle = GCHandle.Alloc(mdBytes.DangerousGetUnderlyingArray(), GCHandleType.Pinned);
+            var mdModule = ModuleMetadata.CreateFromMetadata(mdBytesHandle.AddrOfPinnedObject(), mdBytes.Length);
 
-                    Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, debugInfoProvider));
-                    Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(peModule, null));
-                    Assert.Throws<ArgumentException>(() => EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, debugInfoProvider));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(peModule, null));
+            Assert.Throws<ArgumentException>(() => EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider));
 
-                    Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, debugInfoProvider, localSigProvider, true));
-                    Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(peModule, null, localSigProvider, true));
-                    Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider, null, true));
-                    Assert.NotNull(EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider, localSigProvider, true));
-                }
-            }
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(null, debugInfoProvider, localSigProvider, true));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(peModule, null, localSigProvider, true));
+            Assert.Throws<ArgumentNullException>(() => EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider, null, true));
+            Assert.NotNull(EmitBaseline.CreateInitialBaseline(mdModule, debugInfoProvider, localSigProvider, true));
         }
     }
 }

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -6,7 +6,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis
@@ -523,6 +525,27 @@ namespace Microsoft.CodeAnalysis
             }
 
             return count;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ImmutableArrayProxy<T>
+        {
+            internal T[] MutableArray;
+        }
+
+        // TODO(https://github.com/dotnet/corefx/issues/34126): Remove when System.Collections.Immutable
+        // provides a Span API
+        internal static T[] DangerousGetUnderlyingArray<T>(this ImmutableArray<T> array)
+            => Unsafe.As<ImmutableArray<T>, ImmutableArrayProxy<T>>(ref array).MutableArray;
+
+        internal static ReadOnlySpan<T> AsSpan<T>(this ImmutableArray<T> array)
+            => array.DangerousGetUnderlyingArray();
+
+        internal static ImmutableArray<T> DangerousCreateFromUnderlyingArray<T>(ref T[] array)
+        {
+            var proxy = new ImmutableArrayProxy<T> { MutableArray = array };
+            array = null;
+            return Unsafe.As<ImmutableArrayProxy<T>, ImmutableArray<T>>(ref proxy);
         }
 
         internal static Dictionary<K, ImmutableArray<T>> ToDictionary<K, T>(this ImmutableArray<T> items, Func<T, K> keySelector, IEqualityComparer<K> comparer = null)

--- a/src/Test/Utilities/Portable/FX/PinnedMetadata.cs
+++ b/src/Test/Utilities/Portable/FX/PinnedMetadata.cs
@@ -1,30 +1,32 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Roslyn.Test.Utilities
 {
     internal class PinnedMetadata : IDisposable
     {
-        private MemoryHandle _handle;
-
-        public unsafe IntPtr Pointer => (IntPtr)_handle.Pointer;
+        private GCHandle _bytes; // non-readonly as Free() mutates to prevent double-free.
         public readonly MetadataReader Reader;
+        public readonly IntPtr Pointer;
         public readonly int Size;
 
         public unsafe PinnedMetadata(ImmutableArray<byte> metadata)
         {
-            _handle = metadata.AsMemory().Pin();
+            _bytes = GCHandle.Alloc(metadata.DangerousGetUnderlyingArray(), GCHandleType.Pinned);
+            this.Pointer = _bytes.AddrOfPinnedObject();
             this.Size = metadata.Length;
-            this.Reader = new MetadataReader((byte*)_handle.Pointer, Size, MetadataReaderOptions.None, null);
+            this.Reader = new MetadataReader((byte*)this.Pointer, this.Size, MetadataReaderOptions.None, null);
         }
 
         public void Dispose()
         {
-            _handle.Dispose();
+            _bytes.Free();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ImmutableArrayExtensions.cs
@@ -5,27 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
     internal static class ImmutableArrayExtensions
     {
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ImmutableArrayProxy<T>
-        {
-            internal T[]? MutableArray;
-        }
-
-        internal static ImmutableArray<T> DangerousCreateFromUnderlyingArray<T>(ref T[]? array)
-        {
-            var proxy = new ImmutableArrayProxy<T> { MutableArray = array };
-            array = null;
-            return Unsafe.As<ImmutableArrayProxy<T>, ImmutableArray<T>>(ref proxy);
-        }
-
         internal static bool Contains<T>(this ImmutableArray<T> items, T item, IEqualityComparer<T>? equalityComparer)
             => items.IndexOf(item, 0, equalityComparer) >= 0;
 

--- a/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis
             public ImmutableArray<byte> ToImmutableArray()
             {
                 var array = ToArray();
-                return Roslyn.Utilities.ImmutableArrayExtensions.DangerousCreateFromUnderlyingArray(ref array);
+                return ImmutableArrayExtensions.DangerousCreateFromUnderlyingArray(ref array);
             }
 
             protected int CurrentChunkIndex { get { return GetChunkIndex(this.position); } }


### PR DESCRIPTION
Reverts dotnet/roslyn#38809

Getting VS to be happy with the new System.Collections.Immutable version is proving pretty tricky, so we are gonna have this PR here in case we need to flow it in to get a working insertion.