### PR TITLE
NoWarn NU5128 instead of suppressing dependencies

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -209,8 +209,6 @@
   <PropertyGroup Condition="'$(IsPackable)' == 'true' and '$(IsAnalyzer)' == 'true'">
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeContentInPack>false</IncludeContentInPack>
   </PropertyGroup>
   

--- a/eng/targets/PackageProject.targets
+++ b/eng/targets/PackageProject.targets
@@ -1,12 +1,12 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <!-- 
-    Include this targets file in project that build packages but no binaries.
+    Include this targets file in projects that build meta-packages.
   -->
   
   <!-- 
-    Projects in this directory do not produce useful binaries, they are only used to generate packages. 
-    Build target only needs to build their project dependencies (via ResolveProjectReferences).
+    Projects that import this targets file do not produce binaries, they are only used to generate packages. 
+    The Build target only needs to build the project's dependencies (via ResolveProjectReferences).
   -->
   <Target Name="CoreBuild" DependsOnTargets="ResolveProjectReferences">
     <MakeDir Directories="$(IntermediateOutputPath)" ContinueOnError="True"/>
@@ -14,5 +14,8 @@
 
   <PropertyGroup>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/CodeStyle/CSharp/CodeFixes/Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.csproj
+++ b/src/CodeStyle/CSharp/CodeFixes/Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.csproj
@@ -15,6 +15,8 @@
       .NET Compiler Platform ("Roslyn") code style analyzers for C#.
     </PackageDescription>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <Target Name="_GetFilesToPackage">

--- a/src/CodeStyle/VisualBasic/CodeFixes/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.vbproj
+++ b/src/CodeStyle/VisualBasic/CodeFixes/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes.vbproj
@@ -15,6 +15,8 @@
       .NET Compiler Platform ("Roslyn") code style analyzers for Visual Basic.
     </PackageDescription>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <Target Name="_GetFilesToPackage">

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
@@ -12,8 +12,6 @@
     <IsSourcePackage>true</IsSourcePackage>
     <PackageId>Microsoft.CodeAnalysis.Debugging</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") debug information encoders and decoders.
     </PackageDescription>

--- a/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
+++ b/src/Dependencies/CodeAnalysis.Debugging/Microsoft.CodeAnalysis.Debugging.Package.csproj
@@ -15,6 +15,8 @@
     <PackageDescription>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") debug information encoders and decoders.
     </PackageDescription>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
@@ -15,6 +15,8 @@
     <PackageDescription>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") pooled objects.
     </PackageDescription>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.Package.csproj
@@ -12,8 +12,6 @@
     <IsSourcePackage>true</IsSourcePackage>
     <PackageId>Microsoft.CodeAnalysis.PooledObjects</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>
       Package containing sources of Microsoft .NET Compiler Platform ("Roslyn") pooled objects.
     </PackageDescription>

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.Package.csproj
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.Package.csproj
@@ -7,8 +7,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.Compilers</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>
       Compiler layer of the .NET Compiler Platform ("Roslyn").
       Install this package to get both C# and Visual Basic support.

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Package.csproj
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Package.csproj
@@ -7,8 +7,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.EditorFeatures</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>
       .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor.
     </PackageDescription>

--- a/src/NuGet/Microsoft.CodeAnalysis.Package.csproj
+++ b/src/NuGet/Microsoft.CodeAnalysis.Package.csproj
@@ -17,6 +17,8 @@
       - "Microsoft.CodeAnalysis.CSharp" (only the C# compiler)
       - "Microsoft.CodeAnalysis.VisualBasic (only the VB compiler)
     </PackageDescription>
+    <!-- Remove once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet/Microsoft.CodeAnalysis.Package.csproj
+++ b/src/NuGet/Microsoft.CodeAnalysis.Package.csproj
@@ -7,8 +7,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>
       .NET Compiler Platform ("Roslyn").
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.Package.csproj
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.Package.csproj
@@ -7,8 +7,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.Scripting</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>
       Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.
     </PackageDescription>

--- a/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
+++ b/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
@@ -6,8 +6,6 @@
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.NETCore.Compilers</NuspecPackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>
       CoreCLR-compatible versions of the C# and VB compilers for use in MSBuild.

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -6,8 +6,6 @@
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.Net.Compilers.Toolset</NuspecPackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>
       .NET Compilers Toolset Package.
@@ -17,7 +15,8 @@
       $(RoslynPackageDescriptionDetails)
     </PackageDescription>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
-    <NoWarn>$(NoWarn);NU5100</NoWarn>
+    <!-- Remove NU5128 once https://github.com/NuGet/Home/issues/8583 is fixed -->
+    <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
 
     <_DependsOn Condition="'$(TargetFramework)' == 'net472'">InitializeDesktopCompilerArtifacts</_DependsOn>
     <_DependsOn Condition="'$(TargetFramework)' == 'netcoreapp2.1'">InitializeCoreClrCompilerArtifacts</_DependsOn>

--- a/src/NuGet/Microsoft.Net.Compilers/Microsoft.Net.Compilers.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers/Microsoft.Net.Compilers.Package.csproj
@@ -6,8 +6,6 @@
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.Net.Compilers</NuspecPackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageDescription>
       .NET Compilers package.

--- a/src/NuGet/VisualStudio/VS.ExternalAPIs.Roslyn.Package.csproj
+++ b/src/NuGet/VisualStudio/VS.ExternalAPIs.Roslyn.Package.csproj
@@ -10,8 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>VS.ExternalAPIs.Roslyn</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>CoreXT package for the VS build</PackageDescription>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
 

--- a/src/NuGet/VisualStudio/VS.Tools.Roslyn.Package.csproj
+++ b/src/NuGet/VisualStudio/VS.Tools.Roslyn.Package.csproj
@@ -10,8 +10,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>VS.Tools.Roslyn</PackageId>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- https://github.com/NuGet/Home/issues/8583 -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>CoreXT package for Roslyn compiler toolset.</PackageDescription>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
 


### PR DESCRIPTION
Our NuGet meta-packages were not being generated with package dependencies because they were being suppressed.  Temporary workaround for https://github.com/NuGet/Home/issues/8583