### PR TITLE
Track local telemetry during remote LSP experimentation for comparison.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -208,7 +208,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 }
 
                 // TODO - Cleanup once experiment completed - https://github.com/dotnet/roslyn/projects/45#card-27261853
-                var latencyTracker = ShouldLogLocalTelemetry(document.Project.Language) ? new RequestLatencyTracker(SyntacticLspLogger.RequestType.SyntacticTagger) : null;
+                var latencyTracker = ShouldLogLocalTelemetry(document.Project.Language)
+                    ? new RequestLatencyTracker(SyntacticLspLogger.RequestType.SyntacticTagger) : null;
                 using (latencyTracker)
                 {
                     // preemptively parse file in background so that when we are called from tagger from UI thread, we have tree ready.

--- a/src/VisualStudio/LiveShare/Impl/Client/Tagger/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Tagger/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -179,8 +179,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
                     return;
                 }
 
-                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                var text = await tree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 var snapshot = text.FindCorrespondingEditorTextSnapshot();
                 if (snapshot == null)
                 {
@@ -188,7 +187,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
                 }
 
                 var classifiedSpans = ClassificationUtilities.GetOrCreateClassifiedSpanList();
-                await classificationService.AddRemoteSyntacticClassificationsAsync(document, TextSpan.FromBounds(0, tree.Length), classifiedSpans, cancellationToken).ConfigureAwait(false);
+                await classificationService.AddRemoteSyntacticClassificationsAsync(document, TextSpan.FromBounds(0, text.Length), classifiedSpans, cancellationToken).ConfigureAwait(false);
 
                 using var tagSpans = SharedPools.Default<List<ITagSpan<IClassificationTag>>>().GetPooledObject();
                 ClassificationUtilities.Convert(_typeMap, snapshot, classifiedSpans, tagSpans.Object.Add);

--- a/src/Workspaces/Core/Portable/Log/RequestLatencyTracker.cs
+++ b/src/Workspaces/Core/Portable/Log/RequestLatencyTracker.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.CodeAnalysis.Internal.Log;
 
-namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Classification
+namespace Microsoft.CodeAnalysis.Internal.Log
 {
     internal sealed class RequestLatencyTracker : IDisposable
     {


### PR DESCRIPTION
track local telemetry for syntax classifications during LSP guest session.  the idea here is that walking the tree is fast, longest operation is actually building it, so that's the best comparison to make