### PR TITLE
Update config for snap

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <MajorVersion>3</MajorVersion>
     <MinorVersion>4</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>beta2</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>beta3</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <!-- 

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -54,12 +54,21 @@
       "vsBranch": "master",
       "vsMajorVersion": 16
     },
+    "release/dev16.4-preview2-vs-deps": {
+      "nugetKind": ["Shipping", "NonShipping"],
+      "version": "3.4.*",
+      "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
+      "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
+      "channels": [ "dev16.4p2" ],
+      "vsBranch": "master",
+      "vsMajorVersion": 16
+    },
     "master-vs-deps": {
       "nugetKind": ["Shipping", "NonShipping"],
       "version": "3.4.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
       "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-      "channels": [ "dev16.4", "dev16.4p2" ],
+      "channels": [ "dev16.4", "dev16.4p3" ],
       "vsBranch": "master",
       "vsMajorVersion": 16
     },


### PR DESCRIPTION
Updates publish data and version for 16.4-p3 snap. Merge after we have everything we need merged for a good signed build out of master-vs-deps.