### PR TITLE
Pool analyzer diagnostic reporters

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.AnalyzerDiagnosticReporter.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.AnalyzerDiagnosticReporter.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal partial class AnalyzerExecutor
+    {
+        /// <summary>
+        /// Pooled object that carries the info needed to process
+        /// a reported diagnostic from a syntax node action.
+        /// </summary>
+        private sealed class AnalyzerDiagnosticReporter
+        {
+            public readonly Action<Diagnostic> AddDiagnosticAction;
+
+            private static readonly ObjectPool<AnalyzerDiagnosticReporter> s_objectPool =
+                new ObjectPool<AnalyzerDiagnosticReporter>(() => new AnalyzerDiagnosticReporter(), 10);
+
+            public static AnalyzerDiagnosticReporter GetInstance(
+                SyntaxTree contextTree,
+                TextSpan? span,
+                Compilation compilation,
+                DiagnosticAnalyzer analyzer,
+                bool isSyntaxDiagnostic,
+                Action<Diagnostic> addNonCategorizedDiagnosticOpt,
+                Action<Diagnostic, DiagnosticAnalyzer, bool> addCategorizedLocalDiagnosticOpt,
+                Action<Diagnostic, DiagnosticAnalyzer> addCategorizedNonLocalDiagnosticOpt,
+                Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> shouldSuppressGeneratedCodeDiagnostic,
+                CancellationToken cancellationToken)
+            {
+                var item = s_objectPool.Allocate();
+                item._contextTree = contextTree;
+                item._span = span;
+                item._compilation = compilation;
+                item._analyzer = analyzer;
+                item._isSyntaxDiagnostic = isSyntaxDiagnostic;
+                item._addNonCategorizedDiagnosticOpt = addNonCategorizedDiagnosticOpt;
+                item._addCategorizedLocalDiagnosticOpt = addCategorizedLocalDiagnosticOpt;
+                item._addCategorizedNonLocalDiagnosticOpt = addCategorizedNonLocalDiagnosticOpt;
+                item._shouldSuppressGeneratedCodeDiagnostic = shouldSuppressGeneratedCodeDiagnostic;
+                item._cancellationToken = cancellationToken;
+                return item;
+            }
+
+            public void Free()
+            {
+                _contextTree = default!;
+                _span = default;
+                _compilation = default!;
+                _analyzer = default!;
+                _isSyntaxDiagnostic = default;
+                _addNonCategorizedDiagnosticOpt = default!;
+                _addCategorizedLocalDiagnosticOpt = default!;
+                _addCategorizedNonLocalDiagnosticOpt = default!;
+                _shouldSuppressGeneratedCodeDiagnostic = default!;
+                _cancellationToken = default;
+                s_objectPool.Free(this);
+            }
+
+            private SyntaxTree _contextTree;
+            private TextSpan? _span;
+            private Compilation _compilation;
+            private DiagnosticAnalyzer _analyzer;
+            private bool _isSyntaxDiagnostic;
+            private Action<Diagnostic> _addNonCategorizedDiagnosticOpt;
+            private Action<Diagnostic, DiagnosticAnalyzer, bool> _addCategorizedLocalDiagnosticOpt;
+            private Action<Diagnostic, DiagnosticAnalyzer> _addCategorizedNonLocalDiagnosticOpt;
+            private Func<Diagnostic, DiagnosticAnalyzer, Compilation, CancellationToken, bool> _shouldSuppressGeneratedCodeDiagnostic;
+            private CancellationToken _cancellationToken;
+
+            // Pooled objects are initialized in their GetInstance method
+#pragma warning disable 8618
+            private AnalyzerDiagnosticReporter()
+            {
+                AddDiagnosticAction = AddDiagnostic;
+            }
+#pragma warning restore 8618
+
+            private void AddDiagnostic(Diagnostic diagnostic)
+            {
+                if (_shouldSuppressGeneratedCodeDiagnostic(diagnostic, _analyzer, _compilation, _cancellationToken))
+                {
+                    return;
+                }
+
+                if (_addCategorizedLocalDiagnosticOpt == null)
+                {
+                    RoslynDebug.Assert(_addNonCategorizedDiagnosticOpt != null);
+                    _addNonCategorizedDiagnosticOpt(diagnostic);
+                    return;
+                }
+
+                Debug.Assert(_addNonCategorizedDiagnosticOpt == null);
+                RoslynDebug.Assert(_addCategorizedNonLocalDiagnosticOpt != null);
+
+                if (diagnostic.Location.IsInSource &&
+                    _contextTree == diagnostic.Location.SourceTree &&
+                    (!_span.HasValue || _span.Value.IntersectsWith(diagnostic.Location.SourceSpan)))
+                {
+                    _addCategorizedLocalDiagnosticOpt(diagnostic, _analyzer, _isSyntaxDiagnostic);
+                }
+                else
+                {
+                    _addCategorizedNonLocalDiagnosticOpt(diagnostic, _analyzer);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This has shown up as a significant source of allocations. The design
here is that when an analyzer reports a diagnostic we may need to filter
or alter it based on some configuration. Previously we stored the
configuration information by closing over captured variables, but that
could be very expensive if it's being done for every analyzer
invocation. Since we can only really execute one analyzer per running
thread on the machine, the actual number of concurrent objects we need
to create is approximately the number of running threads. Pooling is a
good solution to this problem.

Before:
```

|                      Method |    Mean |   Error |  StdDev |  Median |     Min |     Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |--------:|--------:|--------:|--------:|--------:|--------:|------------:|-----------:|----------:|----------:|
| GetDiagnosticsWithAnalyzers | 16.28 s | 0.149 s | 0.268 s | 16.23 s | 15.76 s | 16.97 s | 200000.0000 | 59000.0000 | 2000.0000 |   1.48 GB |
```

After:
```
|                      Method |    Mean |   Error |  StdDev |  Median |     Min |     Max |       Gen 0 |      Gen 1 |     Gen 2 | Allocated |
|---------------------------- |--------:|--------:|--------:|--------:|--------:|--------:|------------:|-----------:|----------:|----------:|
| GetDiagnosticsWithAnalyzers | 15.77 s | 0.176 s | 0.519 s | 15.67 s | 14.96 s | 17.07 s | 184000.0000 | 55000.0000 | 2000.0000 |   1.36 GB |
```

Note: I don't think this is that much faster -- my machine wasn't completely quiet during the noise measurements, but I do believe that bytes allocated is accurate and a significant improvement.