### PR TITLE
Fixed incorrect IDE0044 (Make field readonly) when the field is accessed by refeference.

### DIFF
--- a/src/EditorFeatures/CSharpTest/MakeFieldReadonly/MakeFieldReadonlyTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeFieldReadonly/MakeFieldReadonlyTests.cs
@@ -1137,5 +1137,49 @@ class MyClass
     [|private fixed byte b[8];|]
 }");
         }
+
+        [WorkItem(38995, "https://github.com/dotnet/roslyn/issues/38995")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)]
+        public async Task FieldAssignedToLocalRef()
+        {
+            await TestMissingAsync(
+@"
+class Program
+{
+    [|int i;|]
+
+    void M()
+    {
+        ref var value = ref i;
+        value += 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeFieldReadonly)]
+        public async Task FieldAssignedToLocalReadOnlyRef()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class Program
+{
+    [|int i;|]
+
+    void M()
+    {
+        ref readonly var value = ref i;
+    }
+}",
+@"
+class Program
+{
+    [|readonly int i;|]
+
+    void M()
+    {
+        ref readonly var value = ref i;
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
@@ -22,21 +22,23 @@ namespace Microsoft.CodeAnalysis
         public static ValueUsageInfo GetValueUsageInfo(this IOperation operation)
         {
             /*
-            |    code         | Read | Write | ReadableRef | WritableRef | NonReadWriteRef |
-            | x.Prop = 1      |      |  ✔️   |             |             |                 |
-            | x.Prop += 1     |  ✔️  |  ✔️   |             |             |                 |
-            | x.Prop++        |  ✔️  |  ✔️   |             |             |                 |
-            | Foo(x.Prop)     |  ✔️  |       |             |             |                 |
-            | Foo(x.Prop),    |      |       |     ✔️      |             |                 |
+            |    code                  | Read | Write | ReadableRef | WritableRef | NonReadWriteRef |
+            | x.Prop = 1               |      |  ✔️   |             |             |                 |
+            | x.Prop += 1              |  ✔️  |  ✔️   |             |             |                 |
+            | x.Prop++                 |  ✔️  |  ✔️   |             |             |                 |
+            | Foo(x.Prop)              |  ✔️  |       |             |             |                 |
+            | Foo(x.Prop),             |      |       |     ✔️      |             |                 |
                where void Foo(in T v)
-            | Foo(out x.Prop) |      |       |             |     ✔️      |                 |
-            | Foo(ref x.Prop) |      |       |     ✔️      |     ✔️      |                 |
-            | nameof(x)       |      |       |             |             |       ✔️        | ️
-            | sizeof(x)       |      |       |             |             |       ✔️        | ️
-            | typeof(x)       |      |       |             |             |       ✔️        | ️
-            | out var x       |      |  ✔️   |             |             |                 | ️
-            | case X x:       |      |  ✔️   |             |             |                 | ️
-            | obj is X x      |      |  ✔️   |             |             |                 |
+            | Foo(out x.Prop)          |      |       |             |     ✔️      |                 |
+            | Foo(ref x.Prop)          |      |       |     ✔️      |     ✔️      |                 |
+            | nameof(x)                |      |       |             |             |       ✔️        | ️
+            | sizeof(x)                |      |       |             |             |       ✔️        | ️
+            | typeof(x)                |      |       |             |             |       ✔️        | ️
+            | out var x                |      |  ✔️   |             |             |                 | ️
+            | case X x:                |      |  ✔️   |             |             |                 | ️
+            | obj is X x               |      |  ✔️   |             |             |                 |
+            | ref var x =              |      |       |     ✔️      |     ✔️      |                 |
+            | ref readonly var x =     |      |       |     ✔️      |             |                 |
 
             */
             if (operation is ILocalReferenceOperation localReference &&
@@ -143,6 +145,20 @@ namespace Microsoft.CodeAnalysis
             else if (operation.IsInLeftOfDeconstructionAssignment(out _))
             {
                 return ValueUsageInfo.Write;
+            }
+            else if (operation.Parent is IVariableInitializerOperation variableInitializerOperation)
+            {
+                if (variableInitializerOperation.Parent is IVariableDeclaratorOperation variableDeclaratorOperation)
+                {
+                    switch (variableDeclaratorOperation.Symbol.RefKind)
+                    {
+                        case RefKind.Ref:
+                            return ValueUsageInfo.ReadableWritableReference;
+
+                        case RefKind.RefReadOnly:
+                            return ValueUsageInfo.ReadableReference;
+                    }
+                }
             }
 
             return ValueUsageInfo.Read;


### PR DESCRIPTION
In OperationExtensions there is an extension method **GetValueUsageInfo** which should return whether a given operation performs any read, write, etc.

The **MakeFieldReadonlyDiagnosticAnalyzer** class uses this information to infer whether a field can be made readonly. GetValueUsageInfo doesn't perform any analysis when the operation's parent is variable initializer and in that case it always returns **ValueUsageInfo.Read** which causes the diagnostic analyzer to wrongly suggest to make a field readonly.

Here is example where it fails:

``` csharp
class Program
{
    int i;

    void M()
    {
        ref var value = ref i;
        value += 1;
    }
}
```
 I've added a case inside GetValueUsageInfo to correctly handle this situation and also introduced 2 new unit tests to verify it is working. I am unsure however if somewhere there isn't something that depends on the method returning incorrectly ValueUsageInfo.Read for such cases.

Fixes #38995.