### PR TITLE
Prevent removing all whitespace when formatting unrecognized whitespace charactes

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -9498,5 +9498,27 @@ enum TestEnum
 }", changedOptionSet: changingOptions);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        [WorkItem(38895, "https://github.com/dotnet/roslyn/issues/38895")]
+        public async Task FormattingNbsp()
+        {
+            await AssertFormatAsync(
+                @"
+class C
+{
+    List<C> list = new List<C>
+    {
+new C()
+    };
+}",
+                @"
+class C
+{
+    List<C> list = new List<C>
+    {
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;new&nbsp;C()
+    };
+}".Replace("&nbsp;", "\u00A0"));
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38895.

Also used C# tuple instead of `ValueTuple` as the return type of a related method.

---

As I understand it, the issue here is that:

1. Spacing formatting is suppressed within multiline collection initializers:

    https://github.com/dotnet/roslyn/blob/e8a7d91cc01b8904a876b362598a468337c169e7/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs#L391-L396

2. When formatting is suppressed, whitespace-only trivia is still normalized to remove unknown whitespace characters:

    https://github.com/dotnet/roslyn/blob/e8a7d91cc01b8904a876b362598a468337c169e7/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.cs#L151-L154

But when unknown whitespace characters are the only whitespace characters, this leads to zero whitespace between the two tokens and thus often to invalid code. This PR fixes that by replacing the unknown whitespace with a single space.

The result should be valid code, but likely one with weird whitespace formatting (see the unit test, where the `new C()` line has no indentation after formatting). I think it would be nice if formatting wasn't suppressed for multiline collection initializes, but I don't understand the reasons behind that and so I think it's outside the scope of this PR.