### PR TITLE
Fix: Underselection test bug

### DIFF
--- a/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
@@ -528,6 +528,37 @@ class Program
 }";
             await TestNotUnderselectedAsync<ExpressionSyntax>(testText);
         }
+
+        [Fact]
+        [WorkItem(38708, "https://github.com/dotnet/roslyn/issues/38708")]
+        public async Task TestUnderselectionBug1()
+        {
+            var testText = @"
+class Program
+{
+    public static void Method()
+    {
+        //[|>
+        var str = {|result:"" <|] aaa""|};
+    }
+}";
+            await TestNotUnderselectedAsync<ExpressionSyntax>(testText);
+        }
+
+        [Fact]
+        [WorkItem(38708, "https://github.com/dotnet/roslyn/issues/38708")]
+        public async Task TestUnderselectionBug2()
+        {
+            var testText = @"
+class C {
+    public void M()
+    {
+        Console.WriteLine(""Hello world"");[|
+        {|result:Console.WriteLine(new |]C())|};
+        }
+    }";
+            await TestNotUnderselectedAsync<ExpressionSyntax>(testText);
+        }
         #endregion
 
         #region Attributes

--- a/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
@@ -513,6 +513,23 @@ class C
 
         #endregion
 
+        #region IsUnderselected
+        [Fact]
+        [WorkItem(38708, "https://github.com/dotnet/roslyn/issues/38708")]
+        public async Task TestUnderselectionOnSemicolon()
+        {
+            var testText = @"
+class Program
+{
+    static void Main()
+    {
+        {|result:Main()|}[|;|]
+    }
+}";
+            await TestNotUnderselectedAsync<ExpressionSyntax>(testText);
+        }
+        #endregion
+
         #region Attributes
         [Fact]
         [WorkItem(37584, "https://github.com/dotnet/roslyn/issues/37584")]

--- a/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RefactoringHelpers/RefactoringHelpersTests.cs
@@ -559,6 +559,32 @@ class C {
     }";
             await TestNotUnderselectedAsync<ExpressionSyntax>(testText);
         }
+
+        [Fact]
+        [WorkItem(38708, "https://github.com/dotnet/roslyn/issues/38708")]
+        public async Task TestUnderselection()
+        {
+            var testText = @"
+class C {
+    public void M()
+    {
+        bool a = {|result:[|true || false || true|]|};
+    }";
+            await TestNotUnderselectedAsync<BinaryExpressionSyntax>(testText);
+        }
+
+        [Fact]
+        [WorkItem(38708, "https://github.com/dotnet/roslyn/issues/38708")]
+        public async Task TestUnderselection2()
+        {
+            var testText = @"
+class C {
+    public void M()
+    {
+        bool a = true || [|false || true|] || true;
+    }";
+            await TestUnderselectedAsync<BinaryExpressionSyntax>(testText);
+        }
         #endregion
 
         #region Attributes

--- a/src/Features/Core/Portable/CodeRefactoringHelpers.cs
+++ b/src/Features/Core/Portable/CodeRefactoringHelpers.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
         /// it is the smallest that can be retrieved.
         /// </para>
         /// <para>
-        /// When selection doesn't contain intersect the node in any way it's not considered to not to be underselected.
+        /// When <paramref name="selection"/> doesn't intersect the node in any way it's not considered to be underselected.
         /// </para>
         /// <para>
         /// Null node is always considered underselected.
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            // Selection or node is empty -> can't be uderselected
+            // Selection or node is empty -> can't be underselected
             if (selection.IsEmpty || node.Span.IsEmpty)
             {
                 return false;
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // Only precisely one token of the node is selected -> treat is as empty selection -> not 
-            // under-selected. The rationale is that if a only one Token is selected then the selection 
+            // underselected. The rationale is that if only one Token is selected then the selection 
             // wasn't about precisely getting the one node and nothing else & therefore we should treat 
             // it as empty selection.
             if (node.FullSpan.Contains(selection.Start))
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis
             // of the last child doesn't intersect with the end.
 
             // Node is underselected if either the first (lowest) child ends before the selection has started
-            // of the last child starts before the selection ends (i.e. one of them is completely on the outside of selection).
+            // or the last child starts before the selection ends (i.e. one of them is completely on the outside of selection).
             // It's a crude heuristic but it allows omitting parts of nodes or trivial tokens from the beginning/end 
             // but fires up e.g.: `1 + [|2 + 3|]`.
             return beginningNode.Span.End <= selection.Start || endNode.Span.Start > selection.End - 1;

--- a/src/Features/Core/Portable/CodeRefactoringHelpers.cs
+++ b/src/Features/Core/Portable/CodeRefactoringHelpers.cs
@@ -86,10 +86,10 @@ namespace Microsoft.CodeAnalysis
             // of the last child doesn't intersect with the end.
 
             // Node is underselected if either the first (lowest) child ends before the selection has started
-            // or the last child starts before the selection ends (i.e. one of them is completely on the outside of selection).
+            // or the last child starts after the selection ends (i.e. one of them is completely on the outside of selection).
             // It's a crude heuristic but it allows omitting parts of nodes or trivial tokens from the beginning/end 
             // but fires up e.g.: `1 + [|2 + 3|]`.
-            return beginningNode.Span.End <= selection.Start || endNode.Span.Start > selection.End - 1;
+            return beginningNode.Span.End <= selection.Start || endNode.Span.Start >= selection.End;
         }
 
 

--- a/src/Features/Core/Portable/CodeRefactoringHelpers.cs
+++ b/src/Features/Core/Portable/CodeRefactoringHelpers.cs
@@ -30,35 +30,53 @@ namespace Microsoft.CodeAnalysis
         /// it is the smallest that can be retrieved.
         /// </para>
         /// <para>
+        /// When selection doesn't contain intersect the node in any way it's not considered to not to be underselected.
+        /// </para>
+        /// <para>
         /// Null node is always considered underselected.
         /// </para>
         /// </summary>
         public static bool IsNodeUnderselected(SyntaxNode? node, TextSpan selection)
         {
+            // Selection is null -> it's always underselected
+            // REASON: Easier API use -> underselected node, don't work on it further
             if (node == null)
             {
                 return true;
             }
 
+            // Selection or node is empty -> can't be uderselected
             if (selection.IsEmpty || node.Span.IsEmpty)
             {
                 return false;
             }
 
-            // If selection is larger than node.Span -> can't be underselecting
+            // Selection is larger than node.Span -> can't be underselecting
             if (selection.Contains(node.Span))
             {
                 return false;
             }
 
-            // Only precisely one token is selected -> treat is as empty selection -> not under-selected.
-            // The rationale is that if a only one Token is selected then the selection wasn't about
-            // precisely getting the one node and nothing else & therefore we should treat it as empty
-            // selection.
-            var selectionStartToken = node.FindToken(selection.Start);
-            if (selection.IsAround(selectionStartToken))
+            // Selection doesn't intersect node -> can't be underselecting.
+            // RATIONALE: If there's no intersection then we got the node in some other way, e.g. 
+            // extracting it after user selected `;` at the end of an expression statement 
+            // `foo()[|;|]` for `foo()` node.
+            if (!node.FullSpan.OverlapsWith(selection))
             {
                 return false;
+            }
+
+            // Only precisely one token of the node is selected -> treat is as empty selection -> not 
+            // under-selected. The rationale is that if a only one Token is selected then the selection 
+            // wasn't about precisely getting the one node and nothing else & therefore we should treat 
+            // it as empty selection.
+            if (node.FullSpan.Contains(selection.Start))
+            {
+                var selectionStartToken = node.FindToken(selection.Start);
+                if (selection.IsAround(selectionStartToken))
+                {
+                    return false;
+                }
             }
 
             var beginningNode = node.FindToken(node.Span.Start).Parent;
@@ -66,9 +84,12 @@ namespace Microsoft.CodeAnalysis
 
             // Node is underselected if either the first (lowest) child doesn't contain start of selection
             // of the last child doesn't intersect with the end.
+
+            // Node is underselected if either the first (lowest) child ends before the selection has started
+            // of the last child starts before the selection ends (i.e. one of them is completely on the outside of selection).
             // It's a crude heuristic but it allows omitting parts of nodes or trivial tokens from the beginning/end 
             // but fires up e.g.: `1 + [|2 + 3|]`.
-            return !beginningNode.Span.IntersectsWith(selection.Start) || !endNode.Span.IntersectsWith(selection.End - 1);
+            return beginningNode.Span.End <= selection.Start || endNode.Span.Start > selection.End - 1;
         }
 
 

--- a/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
+++ b/src/Test/Utilities/Portable/MarkedSource/MarkupTestFile.cs
@@ -58,11 +58,12 @@ namespace Roslyn.Test.Utilities
 
             // A stack of span starts along with their associated annotation name.  [||] spans simply
             // have empty string for their annotation name.
-            var spanStartStack = new Stack<Tuple<int, string>>();
+            var spanStartStack = new Stack<(int, string)>();
+            var namedSpanStartStack = new Stack<(int, string)>();
 
             while (true)
             {
-                var matches = new List<Tuple<int, string>>();
+                var matches = new List<(int, string)>();
                 AddMatch(input, PositionString, currentIndexInInput, matches);
                 AddMatch(input, SpanStartString, currentIndexInInput, matches);
                 AddMatch(input, SpanEndString, currentIndexInInput, matches);
@@ -71,7 +72,7 @@ namespace Roslyn.Test.Utilities
                 var namedSpanStartMatch = s_namedSpanStartRegex.Match(input, currentIndexInInput);
                 if (namedSpanStartMatch.Success)
                 {
-                    matches.Add(Tuple.Create(namedSpanStartMatch.Index, namedSpanStartMatch.Value));
+                    matches.Add((namedSpanStartMatch.Index, namedSpanStartMatch.Value));
                 }
 
                 if (matches.Count == 0)
@@ -82,7 +83,7 @@ namespace Roslyn.Test.Utilities
 
                 var orderedMatches = matches.OrderBy((t1, t2) => t1.Item1 - t2.Item1).ToList();
                 if (orderedMatches.Count >= 2 &&
-                    spanStartStack.Count > 0 &&
+                    (spanStartStack.Count > 0 || namedSpanStartStack.Count > 0) &&
                     matches[0].Item1 == matches[1].Item1 - 1)
                 {
                     // We have a slight ambiguity with cases like these:
@@ -92,8 +93,8 @@ namespace Roslyn.Test.Utilities
                     // Is it starting a new match, or ending an existing match.  As a workaround, we
                     // special case these and consider it ending a match if we have something on the
                     // stack already.
-                    if ((matches[0].Item2 == SpanStartString && matches[1].Item2 == SpanEndString && spanStartStack.Peek().Item2 == string.Empty) ||
-                        (matches[0].Item2 == SpanStartString && matches[1].Item2 == NamedSpanEndString && spanStartStack.Peek().Item2 != string.Empty))
+                    if ((matches[0].Item2 == SpanStartString && matches[1].Item2 == SpanEndString && !spanStartStack.IsEmpty()) ||
+                        (matches[0].Item2 == SpanStartString && matches[1].Item2 == NamedSpanEndString && !namedSpanStartStack.IsEmpty()))
                     {
                         orderedMatches.RemoveAt(0);
                     }
@@ -123,7 +124,7 @@ namespace Roslyn.Test.Utilities
                         break;
 
                     case SpanStartString:
-                        spanStartStack.Push(Tuple.Create(matchIndexInOutput, string.Empty));
+                        spanStartStack.Push((matchIndexInOutput, string.Empty));
                         break;
 
                     case SpanEndString:
@@ -132,31 +133,22 @@ namespace Roslyn.Test.Utilities
                             throw new ArgumentException(string.Format("Saw {0} without matching {1}", SpanEndString, SpanStartString));
                         }
 
-                        if (spanStartStack.Peek().Item2.Length > 0)
-                        {
-                            throw new ArgumentException(string.Format("Saw {0} without matching {1}", NamedSpanStartString, NamedSpanEndString));
-                        }
-
                         PopSpan(spanStartStack, tempSpans, matchIndexInOutput);
                         break;
 
                     case NamedSpanStartString:
                         var name = namedSpanStartMatch.Groups[1].Value;
-                        spanStartStack.Push(Tuple.Create(matchIndexInOutput, name));
+                        namedSpanStartStack.Push((matchIndexInOutput, name));
                         break;
 
                     case NamedSpanEndString:
-                        if (spanStartStack.Count == 0)
+                        if (namedSpanStartStack.Count == 0)
                         {
                             throw new ArgumentException(string.Format("Saw {0} without matching {1}", NamedSpanEndString, NamedSpanStartString));
                         }
 
-                        if (spanStartStack.Peek().Item2.Length == 0)
-                        {
-                            throw new ArgumentException(string.Format("Saw {0} without matching {1}", SpanStartString, SpanEndString));
-                        }
 
-                        PopSpan(spanStartStack, tempSpans, matchIndexInOutput);
+                        PopSpan(namedSpanStartStack, tempSpans, matchIndexInOutput);
                         break;
 
                     default:
@@ -167,6 +159,11 @@ namespace Roslyn.Test.Utilities
             if (spanStartStack.Count > 0)
             {
                 throw new ArgumentException(string.Format("Saw {0} without matching {1}", SpanStartString, SpanEndString));
+            }
+
+            if (namedSpanStartStack.Count > 0)
+            {
+                throw new ArgumentException(string.Format("Saw {0} without matching {1}", NamedSpanEndString, NamedSpanEndString));
             }
 
             // Append the remainder of the string.
@@ -187,7 +184,7 @@ namespace Roslyn.Test.Utilities
         }
 
         private static void PopSpan(
-            Stack<Tuple<int, string>> spanStartStack,
+            Stack<(int, string)> spanStartStack,
             IDictionary<string, ArrayBuilder<TextSpan>> spans,
             int finalIndex)
         {
@@ -197,12 +194,12 @@ namespace Roslyn.Test.Utilities
             GetOrAdd(spans, spanStartTuple.Item2, _ => ArrayBuilder<TextSpan>.GetInstance()).Add(span);
         }
 
-        private static void AddMatch(string input, string value, int currentIndex, List<Tuple<int, string>> matches)
+        private static void AddMatch(string input, string value, int currentIndex, List<(int, string)> matches)
         {
             var index = input.IndexOf(value, currentIndex, StringComparison.Ordinal);
             if (index >= 0)
             {
-                matches.Add(Tuple.Create(index, value));
+                matches.Add((index, value));
             }
         }
 


### PR DESCRIPTION
+ Fix for #38708 
+ Enabled interleaving of {| and |] in tests (required for the issue regression tests)
+ Added general tests for IsUnderselected + machinery.