### PR TITLE
Handle null Display string in FxCopAnalyzersSuggestedActionCallback

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers;
 using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -87,11 +88,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 return;
             }
 
-            // Only show if the VSIX and NuGet are not installed, the info bar hasn't been shown this session,
-            // and the user is candidate based on light bulb usage.
+            // Only show if following conditions are satisfied:
+            // 1. Info bar hasn't been shown this session
+            // 2. FxCopAnalyzers VSIX is not installed 
+            // 3. FxCopAnalyzers NuGet is not installed
+            // 4. There are no unresolved analyzer references for active project and
+            // 5. User is candidate based on light bulb usage.
             if (!_infoBarChecked &&
                 !IsVsixInstalled() &&
-                !IsNuGetInstalled() &&
+                !IsNuGetInstalled(out var hasUnresolvedAnalyzerReference) &&
+                !hasUnresolvedAnalyzerReference &&
                 IsCandidate(action))
             {
                 ShowInfoBarIfNecessary();
@@ -123,8 +129,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             return _vsixInstallStatus == FxCopAnalyzersInstallStatus.Installed;
         }
 
-        private bool IsNuGetInstalled()
+        private bool IsNuGetInstalled(out bool hasUnresolvedAnalyzerReference)
         {
+            hasUnresolvedAnalyzerReference = false;
             if (_nugetInstallStatusForCurrentSolution != FxCopAnalyzersInstallStatus.Installed)
             {
                 var activeDocumentId = _documentTrackingService.TryGetActiveDocument();
@@ -139,16 +146,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                     return false;
                 }
 
+                var foundAnalyzerReference = false;
                 foreach (var analyzerReference in document.Project.AnalyzerReferences)
                 {
-                    if (ChildAnalyzerNuGetPackageIds.Contains(analyzerReference.Display))
+                    if (analyzerReference is UnresolvedAnalyzerReference)
+                    {
+                        hasUnresolvedAnalyzerReference = true;
+                        continue;
+                    }
+
+                    var display = analyzerReference.Display;
+                    if (display != null &&
+                        ChildAnalyzerNuGetPackageIds.Contains(display))
                     {
                         // We set installed to ensure we don't go through this again next time a
                         // suggested action is called for any document in current solution.
                         _nugetInstallStatusForCurrentSolution = FxCopAnalyzersInstallStatus.Installed;
-                        return true;
+                        foundAnalyzerReference = true;
                     }
                 }
+
+                return foundAnalyzerReference;
             }
 
             return false;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioAnalyzer.cs
@@ -149,6 +149,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             public override object Id
                 => _underlying.Id;
 
+            public override string Display
+                => _underlying.Display;
+
             public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language)
             {
                 // TODO: ensure the file watcher is subscribed

--- a/src/VisualStudio/Core/Test/Diagnostics/FxCopAnalyzersSuggestedActionCallbackTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/FxCopAnalyzersSuggestedActionCallbackTests.vb
@@ -1,0 +1,73 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+Imports Roslyn.Test.Utilities
+Imports Roslyn.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
+    Public Class FxCopAnalyzersSuggestedActionCallbackTests
+        <Fact>
+        <WorkItem(39092, "https://github.com/dotnet/roslyn/issues/39092")>
+        Public Sub TestIsNuGetInstalled()
+            ' Verify with FxCop analyzer reference
+            Dim fxcopAnalyzerReference = New CustomAnalyzerReference(fullPath:="c:\Microsoft.CodeQuality.Analyzers.dll",
+                                                                     display:="Microsoft.CodeQuality.Analyzers")
+            Dim analyzerReferences As IEnumerable(Of AnalyzerReference) = {fxcopAnalyzerReference}
+            Dim hasUnresolvedAnalyzerReference = False
+            Assert.True(FxCopAnalyzersSuggestedActionCallback.IsNuGetInstalled(analyzerReferences, hasUnresolvedAnalyzerReference))
+            Assert.False(hasUnresolvedAnalyzerReference)
+
+            ' Verify with analyzer reference with null Display
+            Dim analyzerReferenceWithNullDisplay = New CustomAnalyzerReference(fullPath:="c:\temp.dll",
+                                                                               display:=Nothing)
+            analyzerReferences = {analyzerReferenceWithNullDisplay}
+            hasUnresolvedAnalyzerReference = False
+            Assert.False(FxCopAnalyzersSuggestedActionCallback.IsNuGetInstalled(analyzerReferences, hasUnresolvedAnalyzerReference))
+            Assert.False(hasUnresolvedAnalyzerReference)
+
+            ' Verify with unresolved analyzer reference
+            Dim unresolvedAnalyzerReference = New UnresolvedAnalyzerReference(unresolvedPath:="c:\temp.dll")
+            analyzerReferences = {unresolvedAnalyzerReference}
+            hasUnresolvedAnalyzerReference = False
+            Assert.False(FxCopAnalyzersSuggestedActionCallback.IsNuGetInstalled(analyzerReferences, hasUnresolvedAnalyzerReference))
+            Assert.True(hasUnresolvedAnalyzerReference)
+
+            ' Verify with a mix of all the above analyzer reference kinds.
+            analyzerReferences = {fxcopAnalyzerReference, analyzerReferenceWithNullDisplay, unresolvedAnalyzerReference}
+            hasUnresolvedAnalyzerReference = False
+            Assert.True(FxCopAnalyzersSuggestedActionCallback.IsNuGetInstalled(analyzerReferences, hasUnresolvedAnalyzerReference))
+            Assert.True(hasUnresolvedAnalyzerReference)
+        End Sub
+
+        Private NotInheritable Class CustomAnalyzerReference
+            Inherits AnalyzerReference
+
+            Public Sub New(fullPath As String, display As String)
+                Me.FullPath = fullPath
+                Me.Display = display
+            End Sub
+
+            Public Overrides ReadOnly Property FullPath As String
+            Public Overrides ReadOnly Property Display As String
+
+            Public Overrides ReadOnly Property Id As Object
+                Get
+                    Return FullPath
+                End Get
+            End Property
+
+            Public Overrides Function GetAnalyzersForAllLanguages() As ImmutableArray(Of DiagnosticAnalyzer)
+                Return ImmutableArray(Of DiagnosticAnalyzer).Empty
+            End Function
+
+            Public Overrides Function GetAnalyzers(language As String) As ImmutableArray(Of DiagnosticAnalyzer)
+                Return ImmutableArray(Of DiagnosticAnalyzer).Empty
+            End Function
+        End Class
+    End Class
+End Namespace


### PR DESCRIPTION
Fixes #39092
Also fix VisualStudioUnresolvedAnalyzerReference to correctly forward the Display value to the underlying analyzer reference.