### PR TITLE
Include source files w/o method bodies in the PDB documents

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
@@ -232,6 +232,7 @@ int y = 1;
     <file id=""2"" name=""USED2.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
     <file id=""3"" name=""b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""C0-51-F0-6F-D3-ED-44-A2-11-4D-03-70-89-20-A6-05-11-62-14-BE"" />
     <file id=""4"" name=""a.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""F0-C4-23-63-A5-89-B9-29-AF-94-07-85-2F-3A-40-D3-70-14-8F-9B"" />
+    <file id=""5"" name=""UNUSED.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D9"" />
   </files>
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -305,6 +306,7 @@ class C { void M() { } }
 <symbols>
   <files>
     <file id=""1"" name=""a\..\a.cs"" language=""C#"" checksumAlgorithm=""406ea660-64cf-4c82-b6f0-42d48172a799"" checksum=""AB-00-7F-1D-23-D5"" />
+    <file id=""2"" name=""C:\a\..\b.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""36-39-3C-83-56-97-F2-F0-60-95-A4-A0-32-C6-32-C7-B2-4B-16-92"" />
   </files>
   <methods>
     <method containingType=""C"" name=""M"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/CheckSumTest.cs
@@ -287,7 +287,7 @@ class C
 </symbols>");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void NoResolver()
         {
             var comp = CSharpCompilation.Create(

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -10511,6 +10511,7 @@ public class C
 @"<symbols>
   <files>
     <file id=""1"" name=""C:\Async.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""DB-EB-2A-06-7B-2F-0E-0D-67-8A-00-2C-58-7A-28-06-05-6C-3D-CE"" />
+    <file id=""2"" name=""HIDDEN.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""8A-92-EE-2F-D6-6F-C0-69-F4-A8-54-CB-11-BE-A3-06-76-2C-9C-98"" />
   </files>
   <methods>
     <method containingType=""C"" name=""M1"">
@@ -10577,6 +10578,7 @@ partial class C
 <symbols>
   <files>
     <file id=""1"" name=""constructor.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""EA-D6-0A-16-6C-6A-BC-C1-5D-98-0F-B7-4B-78-13-93-FB-C7-C2-5A"" />
+    <file id=""2"" name=""initializer.cs"" language=""C#"" checksumAlgorithm=""SHA1"" checksum=""84-32-24-D7-FE-32-63-BA-41-D5-17-A2-D5-90-23-B8-12-3C-AF-D5"" />
   </files>
   <methods>
     <method containingType=""C"" name="".ctor"">

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -11040,7 +11040,7 @@ class Program
             }
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         [WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")]
         public void FilesOneWithNoMethodBody()
         {
@@ -11090,7 +11090,7 @@ class C
 ");
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
+        [Fact]
         [WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")]
         public void SingleFileWithNoMethodBody()
         {

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -11040,7 +11040,7 @@ class Program
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         [WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")]
         public void FilesOneWithNoMethodBody()
         {
@@ -11090,7 +11090,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop)]
         [WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")]
         public void SingleFileWithNoMethodBody()
         {

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2068,8 +2068,6 @@ namespace Microsoft.CodeAnalysis
             // takes priority over the syntax tree pass, which will not embed.
             if (!embeddedTexts.IsEmpty())
             {
-                var embeddedDocuments = ArrayBuilder<Cci.DebugSourceDocument>.GetInstance();
-
                 foreach (var text in embeddedTexts)
                 {
                     Debug.Assert(!string.IsNullOrEmpty(text.FilePath));
@@ -2083,11 +2081,8 @@ namespace Microsoft.CodeAnalysis
                             () => text.GetDebugSourceInfo());
 
                         documentsBuilder.AddDebugDocument(document);
-                        embeddedDocuments.Add(document);
                     }
                 }
-
-                documentsBuilder.EmbeddedDocuments = embeddedDocuments.ToImmutableAndFree();
             }
 
             // Add debug documents for all trees with distinct paths.

--- a/src/Compilers/Core/Portable/Emit/DebugDocumentsBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/DebugDocumentsBuilder.cs
@@ -47,6 +47,9 @@ namespace Microsoft.CodeAnalysis.Emit
             _debugDocuments.Add(document.Location, document);
         }
 
+        internal ImmutableArray<Cci.DebugSourceDocument> GetAllDebugDocuments()
+            => _debugDocuments.Values.ToImmutableArray();
+
         internal Cci.DebugSourceDocument TryGetDebugDocument(string path, string basePath)
         {
             return TryGetDebugDocumentForNormalizedPath(NormalizeDebugDocumentPath(path, basePath));

--- a/src/Compilers/Core/Portable/Emit/DebugDocumentsBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/DebugDocumentsBuilder.cs
@@ -3,8 +3,7 @@
 using Roslyn.Utilities;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
@@ -19,7 +18,6 @@ namespace Microsoft.CodeAnalysis.Emit
         private readonly ConcurrentDictionary<string, Cci.DebugSourceDocument> _debugDocuments;
         private readonly ConcurrentCache<(string, string), string> _normalizedPathsCache;
         private readonly SourceReferenceResolver _resolverOpt;
-        private ImmutableArray<Cci.DebugSourceDocument> _embeddedDocuments;
 
         public DebugDocumentsBuilder(SourceReferenceResolver resolverOpt, bool isDocumentNameCaseSensitive)
         {
@@ -31,13 +29,6 @@ namespace Microsoft.CodeAnalysis.Emit
                     StringComparer.OrdinalIgnoreCase);
 
             _normalizedPathsCache = new ConcurrentCache<(string, string), string>(16);
-            _embeddedDocuments = ImmutableArray<Cci.DebugSourceDocument>.Empty;
-        }
-
-        internal ImmutableArray<Cci.DebugSourceDocument> EmbeddedDocuments
-        {
-            get { return _embeddedDocuments; }
-            set { Debug.Assert(value != null); _embeddedDocuments = value; }
         }
 
         internal int DebugDocumentCount => _debugDocuments.Count;
@@ -47,8 +38,8 @@ namespace Microsoft.CodeAnalysis.Emit
             _debugDocuments.Add(document.Location, document);
         }
 
-        internal ImmutableArray<Cci.DebugSourceDocument> GetAllDebugDocuments()
-            => _debugDocuments.Values.ToImmutableArray();
+        internal IReadOnlyDictionary<string, Cci.DebugSourceDocument> DebugDocuments
+            => _debugDocuments;
 
         internal Cci.DebugSourceDocument TryGetDebugDocument(string path, string basePath)
         {

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -756,5 +756,20 @@ namespace Microsoft.Cci
                 GetDocumentIndex(document);
             }
         }
+
+        /// <summary>
+        /// Write document entries for all debug documents that does not yet have an entry.
+        /// </summary>
+        /// <remarks>
+        /// This is done after serializing method debug info to ensure that we embed all requested
+        /// text even if there are no corresponding sequence points.
+        /// </remarks>
+        public void WriteRemainingDebugDocuments(IEnumerable<DebugSourceDocument> documents)
+        {
+            foreach (var document in documents)
+            {
+                GetDocumentIndex(document);
+            }
+        }
     }
 }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -748,7 +748,7 @@ namespace Microsoft.Cci
         /// This is done after serializing method debug info to ensure that we embed all requested
         /// text even if there are no corresponding sequence points.
         /// </remarks>
-        public void WriteRemainingEmbeddedDocuments(IEnumerable<DebugSourceDocument> embeddedDocuments)
+        public void WriteRemainingEmbeddedDocuments(ImmutableArray<DebugSourceDocument> embeddedDocuments)
         {
             foreach (var document in embeddedDocuments)
             {
@@ -764,7 +764,7 @@ namespace Microsoft.Cci
         /// This is done after serializing method debug info to ensure that we embed all requested
         /// text even if there are no corresponding sequence points.
         /// </remarks>
-        public void WriteRemainingDebugDocuments(IEnumerable<DebugSourceDocument> documents)
+        public void WriteRemainingDebugDocuments(ImmutableArray<DebugSourceDocument> documents)
         {
             foreach (var document in documents)
             {

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -571,6 +571,11 @@ namespace Microsoft.Cci
                 return documentIndex;
             }
 
+            return AddDocumentIndex(document);
+        }
+
+        private int AddDocumentIndex(DebugSourceDocument document)
+        {
             Guid algorithmId;
             ReadOnlySpan<byte> checksum;
             ReadOnlySpan<byte> embeddedSource;
@@ -596,7 +601,7 @@ namespace Microsoft.Cci
                 embeddedSource = null;
             }
 
-            documentIndex = _symWriter.DefineDocument(
+            int documentIndex = _symWriter.DefineDocument(
                 document.Location,
                 document.Language,
                 document.LanguageVendor,
@@ -753,7 +758,7 @@ namespace Microsoft.Cci
                 .Where(kvp => !_documentIndex.ContainsKey(kvp.Value))
                 .OrderBy(kvp => kvp.Key))
             {
-                GetDocumentIndex(kvp.Value);
+                AddDocumentIndex(kvp.Value);
             }
         }
     }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -749,7 +749,9 @@ namespace Microsoft.Cci
         /// </remarks>
         public void WriteRemainingDebugDocuments(IReadOnlyDictionary<string, DebugSourceDocument> documents)
         {
-            foreach (var kvp in documents.OrderBy(kvp => kvp.Key))
+            foreach (var kvp in documents
+                .Where(kvp => !_documentIndex.ContainsKey(kvp.Value))
+                .OrderBy(kvp => kvp.Key))
             {
                 GetDocumentIndex(kvp.Value);
             }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -5,11 +5,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -742,33 +741,17 @@ namespace Microsoft.Cci
         }
 
         /// <summary>
-        /// Write document entries for any embedded text document that does not yet have an entry.
+        /// Write document entries for all debug documents that do not yet have an entry.
         /// </summary>
         /// <remarks>
         /// This is done after serializing method debug info to ensure that we embed all requested
         /// text even if there are no corresponding sequence points.
         /// </remarks>
-        public void WriteRemainingEmbeddedDocuments(ImmutableArray<DebugSourceDocument> embeddedDocuments)
+        public void WriteRemainingDebugDocuments(IReadOnlyDictionary<string, DebugSourceDocument> documents)
         {
-            foreach (var document in embeddedDocuments)
+            foreach (var kvp in documents.OrderBy(kvp => kvp.Key))
             {
-                Debug.Assert(!document.GetSourceInfo().EmbeddedTextBlob.IsDefault);
-                GetDocumentIndex(document);
-            }
-        }
-
-        /// <summary>
-        /// Write document entries for all debug documents that does not yet have an entry.
-        /// </summary>
-        /// <remarks>
-        /// This is done after serializing method debug info to ensure that we embed all requested
-        /// text even if there are no corresponding sequence points.
-        /// </remarks>
-        public void WriteRemainingDebugDocuments(ImmutableArray<DebugSourceDocument> documents)
-        {
-            foreach (var document in documents)
-            {
-                GetDocumentIndex(document);
+                GetDocumentIndex(kvp.Value);
             }
         }
     }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -768,6 +768,21 @@ namespace Microsoft.Cci
             }
         }
 
+        /// <summary>
+        /// Add document entries for all debug documents that does not yet have an entry.
+        /// </summary>
+        /// <remarks>
+        /// This is done after serializing method debug info to ensure that we embed all requested
+        /// text even if there are no corresponding sequence points.
+        /// </remarks>
+        public void AddRemainingDebugDocuments(IEnumerable<DebugSourceDocument> documents)
+        {
+            foreach (var document in documents)
+            {
+                GetOrAddDocument(document, _documentIndex);
+            }
+        }
+
         #endregion
 
         #region Edit and Continue

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -761,7 +761,9 @@ namespace Microsoft.Cci
         /// </remarks>
         public void AddRemainingDebugDocuments(IReadOnlyDictionary<string, DebugSourceDocument> documents)
         {
-            foreach (var kvp in documents.OrderBy(kvp => kvp.Key))
+            foreach (var kvp in documents
+                .Where(kvp => !_documentIndex.ContainsKey(kvp.Value))
+                .OrderBy(kvp => kvp.Key))
             {
                 GetOrAddDocument(kvp.Value, _documentIndex);
             }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -753,33 +753,17 @@ namespace Microsoft.Cci
         }
 
         /// <summary>
-        /// Add document entries for any embedded text document that does not yet have an entry.
+        /// Add document entries for all debug documents that do not yet have an entry.
         /// </summary>
         /// <remarks>
         /// This is done after serializing method debug info to ensure that we embed all requested
         /// text even if there are no corresponding sequence points.
         /// </remarks>
-        public void AddRemainingEmbeddedDocuments(ImmutableArray<DebugSourceDocument> documents)
+        public void AddRemainingDebugDocuments(IReadOnlyDictionary<string, DebugSourceDocument> documents)
         {
-            foreach (var document in documents)
+            foreach (var kvp in documents.OrderBy(kvp => kvp.Key))
             {
-                Debug.Assert(document.GetSourceInfo().EmbeddedTextBlob != null);
-                GetOrAddDocument(document, _documentIndex);
-            }
-        }
-
-        /// <summary>
-        /// Add document entries for all debug documents that does not yet have an entry.
-        /// </summary>
-        /// <remarks>
-        /// This is done after serializing method debug info to ensure that we embed all requested
-        /// text even if there are no corresponding sequence points.
-        /// </remarks>
-        public void AddRemainingDebugDocuments(ImmutableArray<DebugSourceDocument> documents)
-        {
-            foreach (var document in documents)
-            {
-                GetOrAddDocument(document, _documentIndex);
+                GetOrAddDocument(kvp.Value, _documentIndex);
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -759,7 +759,7 @@ namespace Microsoft.Cci
         /// This is done after serializing method debug info to ensure that we embed all requested
         /// text even if there are no corresponding sequence points.
         /// </remarks>
-        public void AddRemainingEmbeddedDocuments(IEnumerable<DebugSourceDocument> documents)
+        public void AddRemainingEmbeddedDocuments(ImmutableArray<DebugSourceDocument> documents)
         {
             foreach (var document in documents)
             {
@@ -775,7 +775,7 @@ namespace Microsoft.Cci
         /// This is done after serializing method debug info to ensure that we embed all requested
         /// text even if there are no corresponding sequence points.
         /// </remarks>
-        public void AddRemainingDebugDocuments(IEnumerable<DebugSourceDocument> documents)
+        public void AddRemainingDebugDocuments(ImmutableArray<DebugSourceDocument> documents)
         {
             foreach (var document in documents)
             {

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -103,8 +103,7 @@ namespace Microsoft.Cci
 #endif
                 }
 
-                nativePdbWriterOpt.WriteRemainingEmbeddedDocuments(mdWriter.Module.DebugDocumentsBuilder.EmbeddedDocuments);
-                nativePdbWriterOpt.WriteRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.GetAllDebugDocuments());
+                nativePdbWriterOpt.WriteRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.DebugDocuments);
             }
 
             Stream peStream = getPeStream();
@@ -152,8 +151,7 @@ namespace Microsoft.Cci
             BlobBuilder portablePdbToEmbed = null;
             if (mdWriter.EmitPortableDebugMetadata)
             {
-                mdWriter.AddRemainingEmbeddedDocuments(mdWriter.Module.DebugDocumentsBuilder.EmbeddedDocuments);
-                mdWriter.AddRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.GetAllDebugDocuments());
+                mdWriter.AddRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.DebugDocuments);
 
                 // The algorithm must be specified for deterministic builds (checked earlier).
                 Debug.Assert(!isDeterministic || context.Module.PdbChecksumAlgorithm.Name != null);

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Cci
                 }
 
                 nativePdbWriterOpt.WriteRemainingEmbeddedDocuments(mdWriter.Module.DebugDocumentsBuilder.EmbeddedDocuments);
+                nativePdbWriterOpt.WriteRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.GetAllDebugDocuments());
             }
 
             Stream peStream = getPeStream();
@@ -152,6 +153,7 @@ namespace Microsoft.Cci
             if (mdWriter.EmitPortableDebugMetadata)
             {
                 mdWriter.AddRemainingEmbeddedDocuments(mdWriter.Module.DebugDocumentsBuilder.EmbeddedDocuments);
+                mdWriter.AddRemainingDebugDocuments(mdWriter.Module.DebugDocumentsBuilder.GetAllDebugDocuments());
 
                 // The algorithm must be specified for deterministic builds (checked earlier).
                 Debug.Assert(!isDeterministic || context.Module.PdbChecksumAlgorithm.Name != null);

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/ChecksumTests.vb
@@ -248,6 +248,7 @@ End Class
     <files>
         <file id="1" name="b:\base\line.vb" language="VB"/>
         <file id="2" name="q:\absolute\line.vb" language="VB"/>
+        <file id="3" name="b:\base\b.vb" language="VB" checksumAlgorithm="SHA1" checksum="F9-90-00-9D-9E-45-97-F2-3D-67-1C-D8-47-A8-9B-DA-4A-91-AA-7F"/>
     </files>
     <methods>
         <method containingType="C" name="M">
@@ -312,6 +313,7 @@ End Class
         <file id="3" name="b:\base\c.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DC"/>
         <file id="4" name="b:\base\d.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DD"/>
         <file id="5" name="b:\base\e.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DE"/>
+        <file id="6" name="b:\base\file.vb" language="VB" checksumAlgorithm="SHA1" checksum="C2-46-C6-34-F6-20-D3-FE-28-B9-D8-62-0F-A9-FB-2F-89-E7-48-23"/>
     </files>
     <methods>
         <method containingType="C" name="M">
@@ -363,6 +365,7 @@ End Class
         <file id="1" name="a.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a79a" checksum="AB-00-7F-1D-23-DA"/>
         <file id="2" name="./a.vb" language="VB"/>
         <file id="3" name="b.vb" language="VB"/>
+        <file id="4" name="file.vb" language="VB" checksumAlgorithm="SHA1" checksum="23-C1-6B-94-B0-D4-06-26-C8-D2-82-21-63-07-53-11-4D-5A-02-BC"/>
     </files>
     <methods>
         <method containingType="C" name="M">

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBExternalSourceDirectiveTests.vb
@@ -46,6 +46,7 @@ End Class
 <symbols>
     <files>
         <file id="1" name="C:\abc\def.vb" language="VB"/>
+        <file id="2" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="70-82-DD-9A-57-B3-BE-57-7E-E8-B4-AE-B8-1E-1B-75-38-9D-13-C9"/>
     </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
@@ -120,6 +121,7 @@ End Class
     <files>
         <file id="1" name="C:\abc\def.vb" language="VB"/>
         <file id="2" name="C:\abc\def2.vb" language="VB"/>
+        <file id="3" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="DB-A9-94-EF-BC-DF-10-C9-60-0F-C0-C4-9F-E4-77-F9-37-CF-E1-CE"/>
     </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
@@ -359,6 +361,9 @@ End Class
             ' Care about the fact that there are no sequence points or referenced files
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="B6-80-9E-65-43-38-00-C1-35-7F-AE-D0-60-F2-24-44-A8-11-C2-63"/>
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main" format="windows">
@@ -418,6 +423,9 @@ End Class
             ' Care about the fact that no files are referenced
             compilation.VerifyPdb(
 <symbols>
+    <files>
+        <file id="1" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="73-05-84-40-AC-E0-15-63-CC-FE-BD-9A-99-23-AA-BD-24-40-24-44"/>
+    </files>
     <entryPoint declaringType="C1" methodName="Main"/>
     <methods>
         <method containingType="C1" name="Main" format="windows">
@@ -503,6 +511,9 @@ End Class
     <files>
         <file id="1" name="C:\abc\def1.vb" language="VB"/>
         <file id="2" name="C:\abc\def2.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="12-34"/>
+        <file id="3" name="b.vb" language="VB" checksumAlgorithm="SHA1" checksum="7F-D8-35-3F-B4-08-17-37-3E-37-30-26-2A-3F-0C-20-6F-48-2A-7A"/>
+        <file id="4" name="BOGUS.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="12-34"/>
+        <file id="5" name="C:\Abc\ACTUAL.vb" language="VB" checksumAlgorithm="SHA1" checksum="27-52-E9-85-5A-AC-31-05-A5-6F-70-40-55-3A-9C-43-D2-07-0D-4B"/>
     </files>
     <entryPoint declaringType="C1" methodName="Main" parameterNames="args"/>
     <methods>
@@ -704,6 +715,7 @@ End Module
 <symbols>
     <files>
         <file id="1" name="C:\abc\def.vb" language="VB"/>
+        <file id="2" name="a.vb" language="VB" checksumAlgorithm="SHA1" checksum="D2-FF-05-F8-B7-A2-25-B0-96-D9-97-2F-05-F8-F0-B5-81-8D-98-1D"/>
     </files>
     <entryPoint declaringType="Program" methodName="Main"/>
     <methods>
@@ -757,6 +769,7 @@ End Class
 <symbols>
     <files>
         <file id="1" name="C:\Folder1\Test2.vb" language="VB" checksumAlgorithm="406ea660-64cf-4c82-b6f0-42d48172a799" checksum="DB-78-88-82-72-1B-2B-27-C9-05-79-D5-FE-2A-04-18"/>
+        <file id="2" name="C:\Folder1\Folder2\Test1.vb" language="VB" checksumAlgorithm="SHA1" checksum="B9-49-3D-62-89-9B-B2-2F-B6-72-90-A1-2D-01-11-89-B4-C2-83-B4"/>
     </files>
     <methods>
         <method containingType="Test1" name="Main">

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -4615,7 +4615,7 @@ End Class"
             End Using
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
         <WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")>
         Public Sub FilesOneWithNoMethodBody()
             Dim source1 =
@@ -4659,7 +4659,7 @@ End Class
 ")
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(WindowsDesktopOnly), Reason:=ConditionalSkipReason.NativePdbRequiresDesktop)>
         <WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")>
         Public Sub SingleFileWithNoMethodBody()
             Dim source =

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTests.vb
@@ -4614,5 +4614,70 @@ End Class"
                 result.Diagnostics.Verify(Diagnostic(ERRID.FTL_InvalidInputFileName).WithArguments("test\\?.pdb").WithLocation(1, 1))
             End Using
         End Sub
+
+        <Fact>
+        <WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")>
+        Public Sub FilesOneWithNoMethodBody()
+            Dim source1 =
+"Imports System
+
+Class C
+    Public Shared Sub Main()
+        Console.WriteLine()
+    End Sub
+End Class
+"
+            Dim source2 =
+"
+' no code
+"
+
+            Dim tree1 = Parse(source1, "f:/build/goo.vb")
+            Dim tree2 = Parse(source2, "f:/build/nocode.vb")
+            Dim c = CreateCompilation({tree1, tree2}, options:=TestOptions.DebugDll)
+
+            c.VerifyPdb("
+<symbols>
+  <files>
+    <file id=""1"" name=""f:/build/goo.vb"" language=""VB"" checksumAlgorithm=""SHA1"" checksum=""48-27-3C-50-9D-24-D4-0D-51-87-6C-E2-FB-2F-AA-1C-80-96-0B-B7"" />
+    <file id=""2"" name=""f:/build/nocode.vb"" language=""VB"" checksumAlgorithm=""SHA1"" checksum=""40-43-2C-44-BA-1C-C7-1A-B3-F3-68-E5-96-7C-65-9D-61-85-D5-44"" />
+  </files>
+  <methods>
+    <method containingType=""C"" name=""Main"">
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""29"" document=""1"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""28"" document=""1"" />
+        <entry offset=""0x7"" startLine=""6"" startColumn=""5"" endLine=""6"" endColumn=""12"" document=""1"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x8"">
+        <namespace name=""System"" importlevel=""file"" />
+        <currentnamespace name="""" />
+      </scope>
+    </method>
+  </methods>
+</symbols>
+")
+        End Sub
+
+        <Fact>
+        <WorkItem(38954, "https://github.com/dotnet/roslyn/issues/38954")>
+        Public Sub SingleFileWithNoMethodBody()
+            Dim source =
+"
+' no code
+"
+
+            Dim tree = Parse(source, "f:/build/nocode.vb")
+            Dim c = CreateCompilation({tree}, options:=TestOptions.DebugDll)
+
+            c.VerifyPdb("
+<symbols>
+  <files>
+    <file id=""1"" name=""f:/build/nocode.vb"" language=""VB"" checksumAlgorithm=""SHA1"" checksum=""40-43-2C-44-BA-1C-C7-1A-B3-F3-68-E5-96-7C-65-9D-61-85-D5-44"" />
+  </files>
+  <methods />
+</symbols>
+")
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -972,7 +972,7 @@ class C1
             }, _telemetryLog);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/39271")]
         public async Task BreakMode_RudeEdits_DocumentWithoutSequencePoints()
         {
             var source1 = "abstract class C { public abstract void M(); }";


### PR DESCRIPTION
Fixes #38954

Currently the compiler does not list source files in the debug documents in the PDB that are part of the compilation but do not have any method body. These documents are only added in order to support sequence points.