### PR TITLE
Feature: Add wrap all elements for initializer expressions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Wrapping/IntializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/IntializerExpressionWrappingTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Wrapping;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
+{
+    public class IntializerExpressionWrappingTests : AbstractWrappingTests
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpWrappingCodeRefactoringProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestTwoValuesWrappingCases()
+        {
+            await TestAllWrappingCasesAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ 1, 2 };
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {1,
+                          2};
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {
+            1,
+            2};
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {1,
+            2};
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {
+            1,2};
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {
+            1, 2};
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Wrapping/IntializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/IntializerExpressionWrappingTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
-        public async Task TestTwoValuesWrappingCases()
+        public async Task TestWrappingShortInitializerExpression()
         {
             await TestAllWrappingCasesAsync(
 @"class C {
@@ -67,6 +67,70 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
             1, 2};
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestWrappingLongIntializerExpression()
+        {
+            await TestAllWrappingCasesAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog"" };
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {""the"",
+                          ""quick"",
+                          ""brown"",
+                          ""fox"",
+                          ""jumps"",
+                          ""over"",
+                          ""the"",
+                          ""lazy"",
+                          ""dog""};
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {
+            ""the"",
+            ""quick"",
+            ""brown"",
+            ""fox"",
+            ""jumps"",
+            ""over"",
+            ""the"",
+            ""lazy"",
+            ""dog""};
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {""the"",
+            ""quick"",
+            ""brown"",
+            ""fox"",
+            ""jumps"",
+            ""over"",
+            ""the"",
+            ""lazy"",
+            ""dog""};
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {
+            ""the"",""quick"",""brown"",""fox"",""jumps"",""over"",""the"",""lazy"",""dog""};
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] {
+            ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""};
+     }
+}"
+);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Wrapping/IntializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/IntializerExpressionWrappingTests.cs
@@ -17,6 +17,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
             => new CSharpWrappingCodeRefactoringProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestNoWrappingSuggestions()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ 1 };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
         public async Task TestTwoValuesWrappingCases()
         {
             await TestAllWrappingCasesAsync(

--- a/src/Features/CSharp/Portable/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping
                 new CSharpArgumentWrapper(),
                 new CSharpParameterWrapper(),
                 new CSharpBinaryExpressionWrapper(),
-                new CSharpChainedExpressionWrapper());
+                new CSharpChainedExpressionWrapper(),
+                new CSharpInitializerExpressionWrapper());
 
         [ImportingConstructor]
         public CSharpWrappingCodeRefactoringProvider()

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
+{
+    internal class CSharpInitializerExpressionWrapper : AbstractCSharpSeparatedSyntaxListWrapper<InitializerExpressionSyntax, ExpressionSyntax>
+    {
+        protected override string Align_wrapped_items => FeaturesResources.Align_wrapped_arguments;
+        protected override string Indent_all_items => FeaturesResources.Indent_all_arguments;
+        protected override string Indent_wrapped_items => FeaturesResources.Indent_wrapped_arguments;
+        protected override string Unwrap_all_items => FeaturesResources.Unwrap_all_arguments;
+        protected override string Unwrap_and_indent_all_items => FeaturesResources.Unwrap_and_indent_all_arguments;
+        protected override string Unwrap_list => FeaturesResources.Unwrap_argument_list;
+        protected override string Wrap_every_item => FeaturesResources.Wrap_every_argument;
+        protected override string Wrap_long_list => FeaturesResources.Wrap_long_argument_list;
+
+        protected override SeparatedSyntaxList<ExpressionSyntax> GetListItems(InitializerExpressionSyntax listSyntax)
+            => listSyntax.Expressions;
+
+        protected override bool PositionIsApplicable(SyntaxNode root, int position, SyntaxNode declaration, InitializerExpressionSyntax listSyntax)
+        {
+            return true;
+        }
+
+        protected override InitializerExpressionSyntax TryGetApplicableList(SyntaxNode node)
+            => node switch
+            {
+                InitializerExpressionSyntax initializerExpressionSyntax => initializerExpressionSyntax,
+                _ => (InitializerExpressionSyntax)null,
+            };
+    }
+}

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         protected override SeparatedSyntaxList<ExpressionSyntax> GetListItems(InitializerExpressionSyntax listSyntax)
             => listSyntax.Expressions;
 
-        protected override bool PositionIsApplicable(SyntaxNode root, int position, SyntaxNode declaration, InitializerExpressionSyntax listSyntax) 
+        protected override bool PositionIsApplicable(SyntaxNode root, int position, SyntaxNode declaration, InitializerExpressionSyntax listSyntax)
             => true;
 
         protected override InitializerExpressionSyntax TryGetApplicableList(SyntaxNode node)

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
 {
@@ -26,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
             => node switch
             {
                 InitializerExpressionSyntax initializerExpressionSyntax => initializerExpressionSyntax,
-                _ => (InitializerExpressionSyntax)null,
+                _ => null,
             };
     }
 }

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -4,14 +4,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
 {
     internal class CSharpInitializerExpressionWrapper : AbstractCSharpSeparatedSyntaxListWrapper<InitializerExpressionSyntax, ExpressionSyntax>
     {
-        protected override string Align_wrapped_items => FeaturesResources.Align_wrapped_arguments;
-        protected override string Indent_all_items => FeaturesResources.Indent_all_arguments;
-        protected override string Indent_wrapped_items => FeaturesResources.Indent_wrapped_arguments;
-        protected override string Unwrap_all_items => FeaturesResources.Unwrap_all_arguments;
-        protected override string Unwrap_and_indent_all_items => FeaturesResources.Unwrap_and_indent_all_arguments;
-        protected override string Unwrap_list => FeaturesResources.Unwrap_argument_list;
-        protected override string Wrap_every_item => FeaturesResources.Wrap_every_argument;
-        protected override string Wrap_long_list => FeaturesResources.Wrap_long_argument_list;
+        protected override string Align_wrapped_items => FeaturesResources.Align_wrapped_elements;
+        protected override string Indent_all_items => FeaturesResources.Indent_all_elements;
+        protected override string Indent_wrapped_items => FeaturesResources.Indent_wrapped_elements;
+        protected override string Unwrap_all_items => FeaturesResources.Unwrap_all_elements;
+        protected override string Unwrap_and_indent_all_items => FeaturesResources.Unwrap_and_indent_all_elements;
+        protected override string Unwrap_list => FeaturesResources.Unwrap_element_list;
+        protected override string Wrap_every_item => FeaturesResources.Wrap_every_element;
+        protected override string Wrap_long_list => FeaturesResources.Wrap_long_element_list;
 
         protected override SeparatedSyntaxList<ExpressionSyntax> GetListItems(InitializerExpressionSyntax listSyntax)
             => listSyntax.Expressions;

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -19,10 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         protected override SeparatedSyntaxList<ExpressionSyntax> GetListItems(InitializerExpressionSyntax listSyntax)
             => listSyntax.Expressions;
 
-        protected override bool PositionIsApplicable(SyntaxNode root, int position, SyntaxNode declaration, InitializerExpressionSyntax listSyntax)
-        {
-            return true;
-        }
+        protected override bool PositionIsApplicable(SyntaxNode root, int position, SyntaxNode declaration, InitializerExpressionSyntax listSyntax) 
+            => true;
 
         protected override InitializerExpressionSyntax TryGetApplicableList(SyntaxNode node)
             => node switch

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -564,6 +564,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Align wrapped elements.
+        /// </summary>
+        internal static string Align_wrapped_elements {
+            get {
+                return ResourceManager.GetString("Align_wrapped_elements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Align wrapped parameters.
         /// </summary>
         internal static string Align_wrapped_parameters {
@@ -2076,6 +2085,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Indent all elements.
+        /// </summary>
+        internal static string Indent_all_elements {
+            get {
+                return ResourceManager.GetString("Indent_all_elements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Indent all parameters.
         /// </summary>
         internal static string Indent_all_parameters {
@@ -2090,6 +2108,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Indent_wrapped_arguments {
             get {
                 return ResourceManager.GetString("Indent_wrapped_arguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indent wrapped elements.
+        /// </summary>
+        internal static string Indent_wrapped_elements {
+            get {
+                return ResourceManager.GetString("Indent_wrapped_elements", resourceCulture);
             }
         }
         
@@ -4003,6 +4030,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unwrap all elements.
+        /// </summary>
+        internal static string Unwrap_all_elements {
+            get {
+                return ResourceManager.GetString("Unwrap_all_elements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unwrap all parameters.
         /// </summary>
         internal static string Unwrap_all_parameters {
@@ -4017,6 +4053,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Unwrap_and_indent_all_arguments {
             get {
                 return ResourceManager.GetString("Unwrap_and_indent_all_arguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unwrap and indent all elements.
+        /// </summary>
+        internal static string Unwrap_and_indent_all_elements {
+            get {
+                return ResourceManager.GetString("Unwrap_and_indent_all_elements", resourceCulture);
             }
         }
         
@@ -4044,6 +4089,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Unwrap_call_chain {
             get {
                 return ResourceManager.GetString("Unwrap_call_chain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unwrap element list.
+        /// </summary>
+        internal static string Unwrap_element_list {
+            get {
+                return ResourceManager.GetString("Unwrap_element_list", resourceCulture);
             }
         }
         
@@ -4636,7 +4690,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a &apos;using&apos; statement or a &apos;using&apos; declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the &apos;finally&apos; region, say &apos;x?.Dispose()&apos;. If the object is explicitly disposed within the try region or the dispose ownership is transferred to another object  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a &apos;using&apos; statement or a &apos;using&apos; declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the &apos;finally&apos; region, say &apos;x?.Dispose()&apos;. If the object is explicitly disposed within the try region or the dispose ownership is transferred to another object [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string UseRecommendedDisposePatternDescription {
             get {
@@ -4790,6 +4844,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Wrap every element.
+        /// </summary>
+        internal static string Wrap_every_element {
+            get {
+                return ResourceManager.GetString("Wrap_every_element", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Wrap every parameter.
         /// </summary>
         internal static string Wrap_every_parameter {
@@ -4822,6 +4885,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Wrap_long_call_chain {
             get {
                 return ResourceManager.GetString("Wrap_long_call_chain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrap long element list.
+        /// </summary>
+        internal static string Wrap_long_element_list {
+            get {
+                return ResourceManager.GetString("Wrap_long_element_list", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1711,4 +1711,28 @@ This version used in: {2}</value>
   <data name="Add_null_checks_for_all_parameters" xml:space="preserve">
     <value>Add null checks for all parameters</value>
   </data>
+  <data name="Align_wrapped_elements" xml:space="preserve">
+    <value>Align wrapped elements</value>
+  </data>
+  <data name="Indent_all_elements" xml:space="preserve">
+    <value>Indent all elements</value>
+  </data>
+  <data name="Indent_wrapped_elements" xml:space="preserve">
+    <value>Indent wrapped elements</value>
+  </data>
+  <data name="Unwrap_all_elements" xml:space="preserve">
+    <value>Unwrap all elements</value>
+  </data>
+  <data name="Unwrap_and_indent_all_elements" xml:space="preserve">
+    <value>Unwrap and indent all elements</value>
+  </data>
+  <data name="Unwrap_element_list" xml:space="preserve">
+    <value>Unwrap element list</value>
+  </data>
+  <data name="Wrap_every_element" xml:space="preserve">
+    <value>Wrap every element</value>
+  </data>
+  <data name="Wrap_long_element_list" xml:space="preserve">
+    <value>Wrap long element list</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Zarovnat zalomené argumenty</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Zarovnat zalomené parametry</target>
@@ -247,6 +252,11 @@
         <target state="translated">Odsadit všechny argumenty</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Odsadit všechny parametry</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Odsadit zalomené argumenty</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Zrušit zalomení všech argumentů</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Zrušit zalomení všech parametrů</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Zrušit zalomení všech argumentů a odsadit je</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Nezalamovat posloupnost volání</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Zalomit každý argument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Zalomit každý parametr</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Zalomit dlouhou posloupnost volání</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Umschlossene Argumente ausrichten</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Umschlossene Parameter ausrichten</target>
@@ -247,6 +252,11 @@
         <target state="translated">Alle Argumente einrücken</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Alle Parameter einrücken</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Umschlossene Argumente einrücken</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Alle Argumente entpacken</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Alle Parameter entpacken</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Alle Argumente entpacken und einrücken</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Zeilenumbruch für Aufrufkette aufheben</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Jedes Argument umschließen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Alle Parameter umschließen</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Lange Aufrufkette umbrechen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Alinear argumentos ajustados</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Alinear parámetros ajustados</target>
@@ -247,6 +252,11 @@
         <target state="translated">Aplicar sangría a todos los argumentos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Aplicar sangría a todos los parámetros</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Argumentos con la sangría ajustada</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Desajustar todos los argumentos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Desajustar todos los parámetros</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Desajustar todos los argumentos y aplicarles sangría</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Desencapsular la cadena de llamada</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Ajustar todos los argumentos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Ajustar todos los parámetros</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Encapsular la cadena de llamada larga</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Aligner les arguments inclus dans un wrapper</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Aligner les paramètres inclus dans un wrapper</target>
@@ -247,6 +252,11 @@
         <target state="translated">Mettre en retrait tous les arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Mettre en retrait tous les paramètres</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Mettre en retrait les arguments inclus dans un wrapper</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Exclure du wrapper tous les arguments</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Exclure du wrapper tous les paramètres</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Exclure du wrapper tous les arguments et les mettre en retrait</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Ne pas effectuer le retour à la ligne d'une chaîne d'appels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Inclure dans un wrapper chaque argument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Wrapper chaque paramètre</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Effectuer le retour à la ligne d'une longue chaîne d'appels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Allinea gli argomenti con ritorno a capo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Allinea i parametri con ritorno a capo</target>
@@ -247,6 +252,11 @@
         <target state="translated">Imposta rientro per tutti gli argomenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Imposta rientro per tutti i parametri</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Imposta rientro per argomenti con ritorno a capo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Annulla ritorno a capo per tutti gli argomenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Annulla ritorno a capo per tutti i parametri</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Annulla il ritorno a capo e imposta il rientro per tutti gli argomenti</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Annulla ritorno a capo per la catena di chiamate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Imposta ritorno a capo per ogni argomento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Imposta ritorno a capo per ogni parametro</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Applica ritorno a capo alla catena di chiamate lunga</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">折り返された引数を揃える</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">折り返されたパラメーターを調整します</target>
@@ -247,6 +252,11 @@
         <target state="translated">すべての引数にインデントを設定します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">すべてのパラメーターにインデントを設定します</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">折り返された引数にインデントを設定します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">すべての引数の折り返しを解除</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">すべてのパラメーターの折り返しを解除します</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">折り返しを解除してすべての引数にインデントを設定します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">呼び出しチェーンのラップ解除</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">すべての引数を折り返します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">すべてのパラメーターを折り返します</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">長い呼び出しチェーンのラップ</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">줄 바꿈 된 인수 맞춤</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">줄 바꿈 된 매개 변수 맞춤</target>
@@ -247,6 +252,11 @@
         <target state="translated">모든 인수 들여쓰기</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">모든 매개 변수 들여쓰기</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">줄 바꿈 된 인수 들여쓰기</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">모든 인수 줄 바꿈 조정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">모든 매개 변수 줄 바꿈 조정</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">모든 인수 줄 바꿈 조정 및 들여쓰기</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">호출 체인 래핑 해제</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">모든 인수 줄 바꿈</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">모든 매개 변수 줄 바꿈</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">긴 호출 체인 래핑</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Dopasuj opakowane argumenty</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Dopasuj opakowane parametry</target>
@@ -247,6 +252,11 @@
         <target state="translated">Dodaj wcięcie dla wszystkich argumentów</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Dodaj wcięcie dla wszystkich parametrów</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Dodaj wcięcie dla opakowanych argumentów</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Odpakuj wszystkie argumenty</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Odpakuj wszystkie parametry</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Odpakuj wszystkie argumenty i dodaj dla nich wcięcie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Cofnij zawijanie łańcucha wywołań</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Opakuj każdy argument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Opakuj każdy parametr</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Zawijaj długi łańcuch wywołań</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Alinhar argumentos encapsulados</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Alinhar os parâmetros encapsulados</target>
@@ -247,6 +252,11 @@
         <target state="translated">Recuar todos os argumentos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Recuar todos os parâmetros</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Recuar argumentos encapsulados</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Desencapsular todos os argumentos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Desencapsular todos os parâmetros</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Desencapsular e recuar todos os argumentos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Desencapsular cadeia de chamadas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Encapsular cada argumento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Encapsular cada parâmetro</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Encapsular cadeia longa de chamadas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Выровнять свернутые аргументы</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Выровнять свернутые параметры</target>
@@ -247,6 +252,11 @@
         <target state="translated">Добавить отступы для всех аргументов</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Добавить отступы для всех параметров</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Добавить отступы для свернутых аргументов</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Развернуть все аргументы</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Развернуть все параметры</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Развернуть все аргументы и удалить отступы для них</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Развернуть цепочку вызовов</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Свернуть каждый аргумент</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Свернуть каждый параметр</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Свернуть длинную цепочку вызовов</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Sarmalanan bağımsız değişkenleri hizala</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">Sarmalanan parametreleri hizala</target>
@@ -247,6 +252,11 @@
         <target state="translated">Tüm bağımsız değişkenleri girintile</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">Tüm parametreleri girintile</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">Sarmalanan bağımsız değişkenleri girintile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">Tüm bağımsız değişkenlerin sarmalamasını kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">Tüm parametrelerin sarmalamasını kaldır</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">Sarmalamayı kaldır ve tüm bağımsız değişkenleri girintile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">Çağrı zincirinin sarmalamasını kaldır</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">Her bağımsız değişkeni sarmala</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Her parametreyi sarmala</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Uzun çağrı zincirini sarmala</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">对齐包装的参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">对齐包装参数</target>
@@ -247,6 +252,11 @@
         <target state="translated">缩进所有参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">缩进所有参数</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">缩进包装的参数</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">解开所有参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">打开所有参数</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">展开和缩进所有参数</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">对调用链解包</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">包装每个参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">包装每个参数</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">包装长调用链</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">對齊包裝的引數</target>
         <note />
       </trans-unit>
+      <trans-unit id="Align_wrapped_elements">
+        <source>Align wrapped elements</source>
+        <target state="new">Align wrapped elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Align_wrapped_parameters">
         <source>Align wrapped parameters</source>
         <target state="translated">對齊包裝的參數</target>
@@ -247,6 +252,11 @@
         <target state="translated">將所有引數縮排</target>
         <note />
       </trans-unit>
+      <trans-unit id="Indent_all_elements">
+        <source>Indent all elements</source>
+        <target state="new">Indent all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Indent_all_parameters">
         <source>Indent all parameters</source>
         <target state="translated">將所有餐數縮排</target>
@@ -255,6 +265,11 @@
       <trans-unit id="Indent_wrapped_arguments">
         <source>Indent wrapped arguments</source>
         <target state="translated">將包裝的引數縮排</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Indent_wrapped_elements">
+        <source>Indent wrapped elements</source>
+        <target state="new">Indent wrapped elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Indent_wrapped_parameters">
@@ -497,6 +512,11 @@
         <target state="translated">將所有引數取消換行</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_all_elements">
+        <source>Unwrap all elements</source>
+        <target state="new">Unwrap all elements</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_all_parameters">
         <source>Unwrap all parameters</source>
         <target state="translated">將所有參數取消換行</target>
@@ -505,6 +525,11 @@
       <trans-unit id="Unwrap_and_indent_all_arguments">
         <source>Unwrap and indent all arguments</source>
         <target state="translated">將所有引數取消換行並縮排</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_and_indent_all_elements">
+        <source>Unwrap and indent all elements</source>
+        <target state="new">Unwrap and indent all elements</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_and_indent_all_parameters">
@@ -520,6 +545,11 @@
       <trans-unit id="Unwrap_call_chain">
         <source>Unwrap call chain</source>
         <target state="translated">將呼叫鏈結取消包裝</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Unwrap_expression">
@@ -642,6 +672,11 @@
         <target state="translated">包裝每個引數</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">將每個參數換行</target>
@@ -660,6 +695,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">包裝長呼叫鏈結</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">


### PR DESCRIPTION
Users will now be offered wrapping refactor options similar to functions with multiple arguments and parameters. The following refactor options are available for initializer expressions:

- Wrap every
- Unwrap and indent
- Wrap long list

I added 3 unit tests to test:

- Initializer that should offer no suggestion
- Small initializer with a few values
- Long initializer with 9 values

This implements the request from issue #37428