### PR TITLE
Show code instead of designer, but only after trying to create the designer loader

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -188,25 +188,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return LoaderName;
             }
 
-            try
+            var frameworkName = new FrameworkName(targetFrameworkMoniker);
+            if (frameworkName.Identifier == ".NETCoreApp" && frameworkName.Version?.Major >= 3)
             {
-                var frameworkName = new FrameworkName(targetFrameworkMoniker);
-
-                if (frameworkName.Identifier == ".NETCoreApp" &&
-                    frameworkName.Version?.Major >= 3)
-                {
-                    if (!(_oleServiceProvider.QueryService<SVsShell>() is IVsShell shell))
-                    {
-                        return null;
-                    }
-
-                    return NewLoaderName;
-                }
-            }
-            catch
-            {
-                // Fall back to the old loader name if there are any failures 
-                // while parsing the TFM.
+                return NewLoaderName;
             }
 
             return LoaderName;

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -129,13 +129,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
                     // We must create the WinForms designer here
                     var loaderName = GetWinFormsLoaderName(vsHierarchy);
-                    if (loaderName is null)
+                    var designerService = (IVSMDDesignerService)_oleServiceProvider.QueryService<SVSMDDesignerService>();
+                    var designerLoader = (IVSMDDesignerLoader)designerService.CreateDesignerLoader(loaderName);
+                    if (designerLoader is null)
                     {
                         goto case "Code";
                     }
-
-                    var designerService = (IVSMDDesignerService)_oleServiceProvider.QueryService<SVSMDDesignerService>();
-                    var designerLoader = (IVSMDDesignerLoader)designerService.CreateDesignerLoader(loaderName);
 
                     try
                     {
@@ -197,13 +196,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     frameworkName.Version?.Major >= 3)
                 {
                     if (!(_oleServiceProvider.QueryService<SVsShell>() is IVsShell shell))
-                    {
-                        return null;
-                    }
-
-                    var newWinFormsDesignerPackage = new Guid("c78ca057-cc29-421f-ad6d-3b0943debdfc");
-                    if (!ErrorHandler.Succeeded(shell.IsPackageInstalled(newWinFormsDesignerPackage, out var installed))
-                        || installed == 0)
                     {
                         return null;
                     }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -196,10 +196,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     return NewLoaderName;
                 }
             }
-            catch	
+            catch
             {
                 // Fall back to the old loader name if there are any failures
-                // while parsing the TFM.	
+                // while parsing the TFM.
             }
 
             return LoaderName;

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -188,10 +188,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 return LoaderName;
             }
 
-            var frameworkName = new FrameworkName(targetFrameworkMoniker);
-            if (frameworkName.Identifier == ".NETCoreApp" && frameworkName.Version?.Major >= 3)
+            try
             {
-                return NewLoaderName;
+                var frameworkName = new FrameworkName(targetFrameworkMoniker);
+                if (frameworkName.Identifier == ".NETCoreApp" && frameworkName.Version?.Major >= 3)
+                {
+                    return NewLoaderName;
+                }
+            }
+            catch	
+            {
+                // Fall back to the old loader name if there are any failures
+                // while parsing the TFM.	
             }
 
             return LoaderName;

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -128,8 +128,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 case "Form":
 
                     // We must create the WinForms designer here
-                    var loaderName = GetWinFormsLoaderName(vsHierarchy);
                     var designerService = (IVSMDDesignerService)_oleServiceProvider.QueryService<SVSMDDesignerService>();
+                    var loaderName = "Microsoft.VisualStudio.Design.ActivateDesignerLoader";
                     var designerLoader = (IVSMDDesignerLoader)designerService.CreateDesignerLoader(loaderName);
                     if (designerLoader is null)
                     {
@@ -173,36 +173,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             ppunkDocData = Marshal.GetIUnknownForObject(textBuffer);
 
             return VSConstants.S_OK;
-        }
-
-        private string? GetWinFormsLoaderName(IVsHierarchy vsHierarchy)
-        {
-            const string LoaderName = "Microsoft.VisualStudio.Design.Serialization.CodeDom.VSCodeDomDesignerLoader";
-            const string NewLoaderName = "Microsoft.VisualStudio.Design.Core.Serialization.CodeDom.VSCodeDomDesignerLoader";
-
-            // If this is a netcoreapp3.0 (or newer), we must create the newer WinForms designer.
-            // TODO: This check will eventually move into the WinForms designer itself.
-            if (!vsHierarchy.TryGetTargetFrameworkMoniker((uint)VSConstants.VSITEMID.Root, out var targetFrameworkMoniker) ||
-                string.IsNullOrWhiteSpace(targetFrameworkMoniker))
-            {
-                return LoaderName;
-            }
-
-            try
-            {
-                var frameworkName = new FrameworkName(targetFrameworkMoniker);
-                if (frameworkName.Identifier == ".NETCoreApp" && frameworkName.Version?.Major >= 3)
-                {
-                    return NewLoaderName;
-                }
-            }
-            catch
-            {
-                // Fall back to the old loader name if there are any failures
-                // while parsing the TFM.
-            }
-
-            return LoaderName;
         }
 
         public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)


### PR DESCRIPTION
Related to https://github.com/dotnet/winforms-designer/issues/942

This is needed because the winforms designer would like to show a gold bar in VS if the user tries to load the new .NET Core designer without the VSIX installed. The existing logic goes to the "code" view immediately if the VSIX is not installed. 

I've removed the detection of the VSIX from this code, and will move that into `DesignerActivationService.CreateDesignerLoader()` in the Visual Studio source, which will allow us to show the error message before going to code view.