### PR TITLE
Use lifted operator in generated Equals if the underlying type's operator would have been used

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -55,6 +55,20 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool IsNullable([NotNullWhen(returnValue: true)] this ITypeSymbol? symbol)
             => symbol?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
 
+        public static bool IsNullable(
+            [NotNullWhen(true)] this ITypeSymbol? symbol,
+            [NotNullWhen(true)] out ITypeSymbol? underlyingType)
+        {
+            if (IsNullable(symbol))
+            {
+                underlyingType = ((INamedTypeSymbol)symbol).TypeArguments[0];
+                return true;
+            }
+
+            underlyingType = null;
+            return false;
+        }
+
         public static bool IsModuleType([NotNullWhen(returnValue: true)] this ITypeSymbol? symbol)
         {
             return symbol?.TypeKind == TypeKind.Module;
@@ -92,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         /// <summary>
-        /// Returns the corresponding symbol in this type or a base type that implements 
+        /// Returns the corresponding symbol in this type or a base type that implements
         /// interfaceMember (either implicitly or explicitly), or null if no such symbol exists
         /// (which might be either because this type doesn't implement the container of
         /// interfaceMember, or this type doesn't supply a member that successfully implements
@@ -105,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             CancellationToken cancellationToken)
         {
             // This method can return multiple results.  Consider the case of:
-            // 
+            //
             // interface IGoo<X> { void Goo(X x); }
             //
             // class C : IGoo<int>, IGoo<string> { void Goo(int x); void Goo(string x); }
@@ -140,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             //
             // interface I { void Goo(); }
             //
-            // class B { } 
+            // class B { }
             //
             // class C : B, I { }
             //
@@ -167,11 +181,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var constructedInterfaces = typeSymbol.AllInterfaces.Where(i =>
                 SymbolEquivalenceComparer.Instance.Equals(i.OriginalDefinition, originalInterfaceType));
 
-            // Try to get the compilation for the symbol we're searching for, 
+            // Try to get the compilation for the symbol we're searching for,
             // which can help identify matches with the call to SymbolFinder.OriginalSymbolsMatch.
             // OriginalSymbolMatch allows types to be matched across different assemblies
             // if they are considered to be the same type, which provides a more accurate
-            // implementations list for interfaces. 
+            // implementations list for interfaces.
             var typeSymbolProject = solution.GetProject(typeSymbolAndProjectId.ProjectId);
             var interfaceMemberProject = solution.GetProject(interfaceMemberAndProjectId.ProjectId);
 
@@ -750,7 +764,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 }
                 else if (result != r)
                 {
-                    // We have more specific types on both left and right, so we 
+                    // We have more specific types on both left and right, so we
                     // cannot succeed in picking a better type list. Bail out now.
                     return null;
                 }
@@ -781,7 +795,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         private static bool? IsMoreSpecificThan(this ITypeSymbol t1, ITypeSymbol t2)
         {
-            // SPEC: A type parameter is less specific than a non-type parameter. 
+            // SPEC: A type parameter is less specific than a non-type parameter.
 
             var isTypeParameter1 = t1 is ITypeParameterSymbol;
             var isTypeParameter2 = t2 is ITypeParameterSymbol;
@@ -813,7 +827,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // UNDONE: Strip off the dynamics.
 
             // SPEC: An array type is more specific than another
-            // SPEC: array type (with the same number of dimensions) 
+            // SPEC: array type (with the same number of dimensions)
             // SPEC: if the element type of the first is
             // SPEC: more specific than the element type of the second.
 
@@ -828,7 +842,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return arr1.ElementType.IsMoreSpecificThan(arr2.ElementType);
             }
 
-            // SPEC EXTENSION: We apply the same rule to pointer types. 
+            // SPEC EXTENSION: We apply the same rule to pointer types.
 
             if (t1 is IPointerTypeSymbol)
             {
@@ -840,7 +854,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             // SPEC: A constructed type is more specific than another
             // SPEC: constructed type (with the same number of type arguments) if at least one type
             // SPEC: argument is more specific and no type argument is less specific than the
-            // SPEC: corresponding type argument in the other. 
+            // SPEC: corresponding type argument in the other.
 
             var n1 = t1 as INamedTypeSymbol;
             var n2 = t2 as INamedTypeSymbol;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -221,8 +221,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 var valueIEquatable = memberType?.IsValueType == true && ImplementsIEquatable(memberType, iequatableType);
                 if (valueIEquatable || memberType?.IsTupleType == true)
                 {
-                    // If it's a value type and implements IEquatable<T>, Or if it's a tuple, then 
-                    // just call directly into .Equals. This keeps the code simple and avoids an 
+                    // If it's a value type and implements IEquatable<T>, Or if it's a tuple, then
+                    // just call directly into .Equals. This keeps the code simple and avoids an
                     // unnecessary null check.
                     //
                     //      this.a.Equals(other.a)
@@ -329,6 +329,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             if (typeSymbol != null)
             {
+                if (typeSymbol.IsNullable(out var underlyingType))
+                {
+                    typeSymbol = underlyingType;
+                }
+
                 if (typeSymbol.IsEnumType())
                 {
                     return true;
@@ -350,7 +355,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     case SpecialType.System_Single:
                     case SpecialType.System_Double:
                     case SpecialType.System_String:
-                    case SpecialType.System_Nullable_T:
                     case SpecialType.System_DateTime:
                         return true;
                 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxGeneratorExtensions_CreateEqualsMethod.cs
@@ -208,12 +208,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
                 var memberType = member.GetSymbolType();
 
-                if (IsPrimitiveValueType(memberType))
+                if (ShouldUseEqualityOperator(memberType))
                 {
-                    // If we have one of the well known primitive types, then just use '==' to compare
-                    // the values.
-                    //
-                    //      this.a == other.a
                     expressions.Add(factory.ValueEqualsExpression(thisSymbol, otherSymbol));
                     continue;
                 }
@@ -325,7 +321,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return false;
         }
 
-        private static bool IsPrimitiveValueType(ITypeSymbol typeSymbol)
+        private static bool ShouldUseEqualityOperator(ITypeSymbol typeSymbol)
         {
             if (typeSymbol != null)
             {


### PR DESCRIPTION
Closes #39236

