### PR TITLE
Generate proper nullability annotation for IEquatable.Equals

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -1573,6 +1573,119 @@ parameters: CSharp6);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestImplementIEquatableOnStructInNullableContextWithUnannotatedMetadata()
+        {
+            await TestWithPickMembersDialogAsync(
+@"#nullable enable
+
+struct Foo
+{
+    public int Bar { get; }
+    [||]
+}",
+@"#nullable enable
+
+using System;
+
+struct Foo : IEquatable<Foo>
+{
+    public int Bar { get; }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is Foo foo && Equals(foo);
+    }
+
+    public bool Equals(Foo other)
+    {
+        return Bar == other.Bar;
+    }
+}",
+chosenSymbols: null,
+optionsCallback: options => EnableOption(options, ImplementIEquatableId),
+parameters: new TestParameters(TestOptions.Regular8));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestImplementIEquatableOnStructInNullableContextWithAnnotatedMetadata()
+        {
+            await TestWithPickMembersDialogAsync(
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""false"">
+        <Document><![CDATA[
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+struct Foo
+{
+    public bool Bar { get; }
+    [||]
+}
+
+namespace System
+{
+    public class Object { }
+    public struct Boolean { }
+
+    public interface IEquatable<T>
+    {
+        bool Equals([AllowNull] T other);
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    public sealed class AllowNullAttribute : Attribute { }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>",
+@"
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+struct Foo : IEquatable<Foo>
+{
+    public bool Bar { get; }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is Foo foo && Equals(foo);
+    }
+
+    public bool Equals(Foo other)
+    {
+        return Bar == other.Bar;
+    }
+}
+
+namespace System
+{
+    public class Object { }
+    public struct Boolean { }
+
+    public interface IEquatable<T>
+    {
+        bool Equals([AllowNull] T other);
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    public sealed class AllowNullAttribute : Attribute { }
+}
+",
+chosenSymbols: null,
+optionsCallback: options => EnableOption(options, ImplementIEquatableId),
+parameters: new TestParameters(TestOptions.Regular8, retainNonFixableDiagnostics: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
         public async Task TestImplementIEquatableOnClass()
         {
             await TestWithPickMembersDialogAsync(
@@ -1606,6 +1719,121 @@ class Program : IEquatable<Program>
 chosenSymbols: null,
 optionsCallback: options => EnableOption(options, ImplementIEquatableId),
 parameters: CSharp6);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestImplementIEquatableOnClassInNullableContextWithUnannotatedMetadata()
+        {
+            await TestWithPickMembersDialogAsync(
+@"#nullable enable
+
+class Foo
+{
+    public int Bar { get; }
+    [||]
+}",
+@"#nullable enable
+
+using System;
+
+class Foo : IEquatable<Foo>
+{
+    public int Bar { get; }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as Foo);
+    }
+
+    public bool Equals(Foo? other)
+    {
+        return other != null &&
+               Bar == other.Bar;
+    }
+}",
+chosenSymbols: null,
+optionsCallback: options => EnableOption(options, ImplementIEquatableId),
+parameters: new TestParameters(TestOptions.Regular8));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestImplementIEquatableOnClassInNullableContextWithAnnotatedMetadata()
+        {
+            await TestWithPickMembersDialogAsync(
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""false"">
+        <Document><![CDATA[
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class Foo
+{
+    public bool Bar { get; }
+    [||]
+}
+
+namespace System
+{
+    public class Object { }
+    public struct Boolean { }
+
+    public interface IEquatable<T>
+    {
+        bool Equals([AllowNull] T other);
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    public sealed class AllowNullAttribute : Attribute { }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>",
+@"
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class Foo : IEquatable<Foo>
+{
+    public bool Bar { get; }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as Foo);
+    }
+
+    public bool Equals(Foo? other)
+    {
+        return other != null &&
+               Bar == other.Bar;
+    }
+}
+
+namespace System
+{
+    public class Object { }
+    public struct Boolean { }
+
+    public interface IEquatable<T>
+    {
+        bool Equals([AllowNull] T other);
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    public sealed class AllowNullAttribute : Attribute { }
+}
+",
+chosenSymbols: null,
+optionsCallback: options => EnableOption(options, ImplementIEquatableId),
+parameters: new TestParameters(TestOptions.Regular8, retainNonFixableDiagnostics: true));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -1736,7 +1736,7 @@ class Foo
 
 using System;
 
-class Foo : IEquatable<Foo>
+class Foo : IEquatable<Foo?>
 {
     public int Bar { get; }
 
@@ -1799,7 +1799,7 @@ namespace System.Diagnostics.CodeAnalysis
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-class Foo : IEquatable<Foo>
+class Foo : IEquatable<Foo?>
 {
     public bool Bar { get; }
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -47,12 +47,12 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         }
 
         public async Task<IMethodSymbol> GenerateIEquatableEqualsMethodAsync(
-            Document document, INamedTypeSymbol namedType,
+            Document document, SyntaxNode typeDeclaration, INamedTypeSymbol namedType,
             ImmutableArray<ISymbol> members, CancellationToken cancellationToken)
         {
-            var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            return document.GetLanguageService<SyntaxGenerator>().CreateIEqutableEqualsMethod(
-                compilation, namedType, members,
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            return document.GetLanguageService<SyntaxGenerator>().CreateIEquatableEqualsMethod(
+                semanticModel, typeDeclaration, namedType, members,
                 s_specializedFormattingAnnotation, cancellationToken);
         }
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/AbstractGenerateEqualsAndGetHashCodeService.cs
@@ -47,12 +47,12 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         }
 
         public async Task<IMethodSymbol> GenerateIEquatableEqualsMethodAsync(
-            Document document, SyntaxNode typeDeclaration, INamedTypeSymbol namedType,
-            ImmutableArray<ISymbol> members, CancellationToken cancellationToken)
+            Document document, INamedTypeSymbol namedType,
+            ImmutableArray<ISymbol> members, INamedTypeSymbol constructedEquatableType, CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             return document.GetLanguageService<SyntaxGenerator>().CreateIEquatableEqualsMethod(
-                semanticModel, typeDeclaration, namedType, members,
+                semanticModel, namedType, members, constructedEquatableType,
                 s_specializedFormattingAnnotation, cancellationToken);
         }
 

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
@@ -65,9 +65,11 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                     methods.Add(await CreateEqualsMethodAsync(cancellationToken).ConfigureAwait(false));
                 }
 
-                if (_implementIEquatable)
+                var constructedTypeToImplement = await GetConstructedTypeToImplementAsync(cancellationToken).ConfigureAwait(false);
+
+                if (constructedTypeToImplement is object)
                 {
-                    methods.Add(await CreateIEquatableEqualsMethodAsync(cancellationToken).ConfigureAwait((bool)false));
+                    methods.Add(await CreateIEquatableEqualsMethodAsync(constructedTypeToImplement, cancellationToken).ConfigureAwait((bool)false));
                 }
 
                 if (_generateGetHashCode)
@@ -82,16 +84,12 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 
                 var (oldType, newType) = await AddMethodsAsync(methods, cancellationToken).ConfigureAwait(false);
 
-                if (_implementIEquatable)
+                if (constructedTypeToImplement is object)
                 {
-                    var compilation = await _document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                    var equatableType = compilation.GetTypeByMetadataName(typeof(IEquatable<>).FullName);
-                    var constructed = equatableType.Construct(_containingType);
-
                     var generator = _document.GetLanguageService<SyntaxGenerator>();
 
                     newType = generator.AddInterfaceType(newType,
-                        generator.TypeExpression(constructed));
+                        generator.TypeExpression(constructedTypeToImplement));
                 }
 
                 var newDocument = await UpdateDocumentAndAddImportsAsync(
@@ -102,6 +100,23 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                     newDocument, cancellationToken).ConfigureAwait(false);
 
                 return formattedDocument;
+            }
+
+            private async Task<INamedTypeSymbol> GetConstructedTypeToImplementAsync(CancellationToken cancellationToken)
+            {
+                if (!_implementIEquatable)
+                    return null;
+
+                var semanticModel = await _document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var equatableType = semanticModel.Compilation.GetTypeByMetadataName(typeof(IEquatable<>).FullName);
+
+                var useNullableTypeArgument =
+                    !_containingType.IsValueType
+                    && semanticModel.GetNullableContext(_typeDeclaration.SpanStart).AnnotationsEnabled();
+
+                return useNullableTypeArgument
+                    ? equatableType.ConstructWithNullability(_containingType.WithNullability(NullableAnnotation.Annotated))
+                    : equatableType.Construct(_containingType);
             }
 
             private async Task<Document> UpdateDocumentAndAddImportsAsync(SyntaxNode oldType, SyntaxNode newType, CancellationToken cancellationToken)
@@ -204,11 +219,11 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                     : service.GenerateEqualsMethodAsync(_document, _containingType, _selectedMembers, cancellationToken);
             }
 
-            private async Task<IMethodSymbol> CreateIEquatableEqualsMethodAsync(CancellationToken cancellationToken)
+            private async Task<IMethodSymbol> CreateIEquatableEqualsMethodAsync(INamedTypeSymbol constructedEquatableType, CancellationToken cancellationToken)
             {
                 var service = _document.GetLanguageService<IGenerateEqualsAndGetHashCodeService>();
                 return await service.GenerateIEquatableEqualsMethodAsync(
-                    _document, _typeDeclaration, _containingType, _selectedMembers, cancellationToken).ConfigureAwait(false);
+                    _document, _containingType, _selectedMembers, constructedEquatableType, cancellationToken).ConfigureAwait(false);
             }
 
             public override string Title

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeAction.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             private readonly bool _implementIEquatable;
             private readonly bool _generateOperators;
             private readonly Document _document;
+            private readonly SyntaxNode _typeDeclaration;
             private readonly INamedTypeSymbol _containingType;
             private readonly ImmutableArray<ISymbol> _selectedMembers;
             private readonly TextSpan _textSpan;
@@ -36,6 +37,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             public GenerateEqualsAndGetHashCodeAction(
                 Document document,
                 TextSpan textSpan,
+                SyntaxNode typeDeclaration,
                 INamedTypeSymbol containingType,
                 ImmutableArray<ISymbol> selectedMembers,
                 bool generateEquals,
@@ -44,6 +46,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 bool generateOperators)
             {
                 _document = document;
+                _typeDeclaration = typeDeclaration;
                 _containingType = containingType;
                 _selectedMembers = selectedMembers;
                 _textSpan = textSpan;
@@ -205,7 +208,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             {
                 var service = _document.GetLanguageService<IGenerateEqualsAndGetHashCodeService>();
                 return await service.GenerateIEquatableEqualsMethodAsync(
-                    _document, _containingType, _selectedMembers, cancellationToken).ConfigureAwait(false);
+                    _document, _typeDeclaration, _containingType, _selectedMembers, cancellationToken).ConfigureAwait(false);
             }
 
             public override string Title

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             private readonly bool _generateGetHashCode;
             private readonly GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider _service;
             private readonly Document _document;
+            private readonly SyntaxNode _typeDeclaration;
             private readonly INamedTypeSymbol _containingType;
             private readonly ImmutableArray<ISymbol> _viableMembers;
             private readonly ImmutableArray<PickMembersOption> _pickMembersOptions;
@@ -28,6 +29,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider service,
                 Document document,
                 TextSpan textSpan,
+                SyntaxNode typeDeclaration,
                 INamedTypeSymbol containingType,
                 ImmutableArray<ISymbol> viableMembers,
                 ImmutableArray<PickMembersOption> pickMembersOptions,
@@ -36,6 +38,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             {
                 _service = service;
                 _document = document;
+                _typeDeclaration = typeDeclaration;
                 _containingType = containingType;
                 _viableMembers = viableMembers;
                 _pickMembersOptions = pickMembersOptions;
@@ -60,7 +63,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 }
 
                 // If we presented the user any options, then persist whatever values
-                // the user chose.  That way we'll keep that as the default for the 
+                // the user chose.  That way we'll keep that as the default for the
                 // next time the user opens the dialog.
                 var workspace = _document.Project.Solution.Workspace;
                 var implementIEqutableOption = result.Options.FirstOrDefault(o => o.Id == ImplementIEquatableId);
@@ -85,7 +88,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 var generatorOperators = (generateOperatorsOption?.Value).GetValueOrDefault();
 
                 var action = new GenerateEqualsAndGetHashCodeAction(
-                    _document, _textSpan, _containingType, result.Members,
+                    _document, _textSpan, _typeDeclaration, _containingType, result.Members,
                     _generateEquals, _generateGetHashCode, implementIEquatable, generatorOperators);
                 return await action.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/IGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/IGenerateEqualsAndGetHashCodeService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         /// Generates an implementation of <see cref="IEquatable{T}.Equals"/> that works by
         /// comparing the provided <paramref name="members"/>.
         /// </summary>
-        Task<IMethodSymbol> GenerateIEquatableEqualsMethodAsync(Document document, SyntaxNode typeDeclaration, INamedTypeSymbol namedType, ImmutableArray<ISymbol> members, CancellationToken cancellationToken);
+        Task<IMethodSymbol> GenerateIEquatableEqualsMethodAsync(Document document, INamedTypeSymbol namedType, ImmutableArray<ISymbol> members, INamedTypeSymbol constructedEquatableType, CancellationToken cancellationToken);
 
         /// <summary>
         /// Generates an override of <see cref="object.GetHashCode"/> that computes a reasonable

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/IGenerateEqualsAndGetHashCodeService.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/IGenerateEqualsAndGetHashCodeService.cs
@@ -35,13 +35,13 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
         /// Generates an implementation of <see cref="IEquatable{T}.Equals"/> that works by
         /// comparing the provided <paramref name="members"/>.
         /// </summary>
-        Task<IMethodSymbol> GenerateIEquatableEqualsMethodAsync(Document document, INamedTypeSymbol namedType, ImmutableArray<ISymbol> members, CancellationToken cancellationToken);
+        Task<IMethodSymbol> GenerateIEquatableEqualsMethodAsync(Document document, SyntaxNode typeDeclaration, INamedTypeSymbol namedType, ImmutableArray<ISymbol> members, CancellationToken cancellationToken);
 
         /// <summary>
         /// Generates an override of <see cref="object.GetHashCode"/> that computes a reasonable
         /// hash based on the provided <paramref name="members"/>.  The generated function will
         /// defer to HashCode.Combine if it exists.  Otherwise, it will determine if it should
-        /// generate code directly in-line to compute the hash, or defer to something like 
+        /// generate code directly in-line to compute the hash, or defer to something like
         /// <see cref="ValueTuple.GetHashCode"/> to provide a reasonable alternative.
         /// </summary>
         Task<IMethodSymbol> GenerateGetHashCodeMethodAsync(Document document, INamedTypeSymbol namedType, ImmutableArray<ISymbol> members, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -249,6 +249,36 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// Creates a parameter symbol that can be used to describe a parameter declaration.
         /// </summary>
+        internal static IParameterSymbol CreateParameterSymbol(
+            IParameterSymbol parameter,
+            ImmutableArray<AttributeData>? attributes = null,
+            RefKind? refKind = null,
+            bool? isParams = null,
+            ITypeSymbol type = null,
+            Optional<string> name = default,
+            bool? isOptional = null,
+            bool? hasDefaultValue = null,
+            Optional<object> defaultValue = default)
+        {
+            return new CodeGenerationParameterSymbol(
+                containingType: null,
+                attributes ?? parameter.GetAttributes(),
+                refKind ?? parameter.RefKind,
+                isParams ?? parameter.IsParams,
+                type ?? parameter.Type,
+                name.HasValue ? name.Value : parameter.Name,
+                isOptional ?? parameter.IsOptional,
+                hasDefaultValue ?? parameter.HasExplicitDefaultValue,
+                defaultValue.HasValue
+                    ? defaultValue.Value
+                    : parameter.HasExplicitDefaultValue
+                        ? parameter.ExplicitDefaultValue
+                        : null);
+        }
+
+        /// <summary>
+        /// Creates a parameter symbol that can be used to describe a parameter declaration.
+        /// </summary>
         public static ITypeParameterSymbol CreateTypeParameterSymbol(string name, int ordinal = 0)
         {
             return CreateTypeParameter(


### PR DESCRIPTION
Fixes #39243, fixes #38069

If you take the first commit (adding tests) without the second commit (implementation change), you will actually get a debug assertion failure when the name simplifier tries to simplify the generated `[AllowNull]` name:

https://github.com/dotnet/roslyn/blob/97b75fcb5807881b0e768357b82c1a3476a3ec2c/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs#L157-L162

I don't know how important this is.

Since `[AllowNull]` is no longer generated when generating the Equals method, it isn't interfering with this PR.

Stack trace:

<details>

```
   at System.Diagnostics.Debug.Assert(Boolean condition)
   at Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetRemappedSymbols() in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Compilation\MemberSemanticModel.cs:line 160
   at Microsoft.CodeAnalysis.CSharp.SyntaxTreeSemanticModel.CreateSpeculativeAttributeSemanticModel(Int32 position, AttributeSyntax attribute, Binder binder, AliasSymbol aliasOpt, NamedTypeSymbol attributeType) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Compilation\SyntaxTreeSemanticModel.cs:line 746
   at Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.TryGetSpeculativeSemanticModel(Int32 position, AttributeSyntax attribute, SemanticModel& speculativeModel) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Compilation\CSharpSemanticModel.cs:line 2554
   at Microsoft.CodeAnalysis.CSharp.CSharpExtensions.TryGetSpeculativeSemanticModel(SemanticModel semanticModel, Int32 position, AttributeSyntax attribute, SemanticModel& speculativeModel) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\CSharpExtensions.cs:line 1136
   at Microsoft.CodeAnalysis.CSharp.Utilities.SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(SyntaxNode nodeToSpeculate, SemanticModel semanticModel, Int32 position, Boolean isInNamespaceOrTypeContext) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Utilities\SpeculationAnalyzer.cs:line 142
   at Microsoft.CodeAnalysis.CSharp.Utilities.SpeculationAnalyzer.CreateSpeculativeSemanticModelForNode(SyntaxNode originalNode, SyntaxNode nodeToSpeculate, SemanticModel semanticModel) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Utilities\SpeculationAnalyzer.cs:line 103
   at Microsoft.CodeAnalysis.CSharp.Utilities.SpeculationAnalyzer.CreateSpeculativeSemanticModel(SyntaxNode originalNode, SyntaxNode nodeToSpeculate, SemanticModel semanticModel) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Utilities\SpeculationAnalyzer.cs:line 96
   at Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer`7.EnsureSpeculativeSemanticModel() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Utilities\AbstractSpeculationAnalyzer.cs:line 185
   at Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer`7.get_SpeculativeSemanticModel() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Utilities\AbstractSpeculationAnalyzer.cs:line 149
   at Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer`7.ReplacementChangesSemantics(SyntaxNode currentOriginalNode, SyntaxNode currentReplacedNode, SyntaxNode originalRoot, Boolean skipVerificationForCurrentNode) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Utilities\AbstractSpeculationAnalyzer.cs:line 419
   at Microsoft.CodeAnalysis.Shared.Utilities.AbstractSpeculationAnalyzer`7.ReplacementChangesSemantics() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Utilities\AbstractSpeculationAnalyzer.cs:line 408
   at Microsoft.CodeAnalysis.CSharp.Extensions.ExpressionSyntaxExtensions.CanReplaceWithReducedName(NameSyntax name, TypeSyntax reducedName, SemanticModel semanticModel, CancellationToken cancellationToken) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Extensions\ExpressionSyntaxExtensions.cs:line 2218
   at Microsoft.CodeAnalysis.CSharp.Extensions.ExpressionSyntaxExtensions.TryReduce(NameSyntax name, SemanticModel semanticModel, TypeSyntax& replacementNode, TextSpan& issueSpan, OptionSet optionSet, CancellationToken cancellationToken) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Extensions\ExpressionSyntaxExtensions.cs:line 1774
   at Microsoft.CodeAnalysis.CSharp.Extensions.ExpressionSyntaxExtensions.TryReduceExplicitName(ExpressionSyntax expression, SemanticModel semanticModel, TypeSyntax& replacementNode, TextSpan& issueSpan, OptionSet optionSet, CancellationToken cancellationToken) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Extensions\ExpressionSyntaxExtensions.cs:line 809
   at Microsoft.CodeAnalysis.CSharp.Extensions.ExpressionSyntaxExtensions.TryReduceOrSimplifyExplicitName(ExpressionSyntax expression, SemanticModel semanticModel, ExpressionSyntax& replacementNode, TextSpan& issueSpan, OptionSet optionSet, CancellationToken cancellationToken) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Extensions\ExpressionSyntaxExtensions.cs:line 767
   at Microsoft.CodeAnalysis.CSharp.Simplification.CSharpNameReducer.SimplifyName(SyntaxNode node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\CSharpNameReducer.cs:line 48
   at Microsoft.CodeAnalysis.CSharp.Simplification.AbstractCSharpReducer.AbstractReductionRewriter.SimplifyNode[TNode](TNode node, SyntaxNode newNode, SyntaxNode parentNode, Func`5 simplifier) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\AbstractCSharpReducer.AbstractReductionRewriter.cs:line 125
   at Microsoft.CodeAnalysis.CSharp.Simplification.AbstractCSharpReducer.AbstractReductionRewriter.SimplifyExpression[TExpression](TExpression expression, SyntaxNode newNode, Func`5 simplifier) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\AbstractCSharpReducer.AbstractReductionRewriter.cs:line 149
   at Microsoft.CodeAnalysis.CSharp.Simplification.CSharpNameReducer.Rewriter.VisitAliasQualifiedName(AliasQualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\CSharpNameReducer.Rewriter.cs:line 47
   at Microsoft.CodeAnalysis.CSharp.Syntax.AliasQualifiedNameSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Syntax.Generated.cs:line 429
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Syntax\CSharpSyntaxRewriter.cs:line 39
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitQualifiedName(QualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Main.Generated.cs:line 2615
   at Microsoft.CodeAnalysis.CSharp.Simplification.CSharpNameReducer.Rewriter.VisitQualifiedName(QualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\CSharpNameReducer.Rewriter.cs:line 65
   at Microsoft.CodeAnalysis.CSharp.Syntax.QualifiedNameSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Syntax.Generated.cs:line 155
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Syntax\CSharpSyntaxRewriter.cs:line 39
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitQualifiedName(QualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Main.Generated.cs:line 2615
   at Microsoft.CodeAnalysis.CSharp.Simplification.CSharpNameReducer.Rewriter.VisitQualifiedName(QualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\CSharpNameReducer.Rewriter.cs:line 65
   at Microsoft.CodeAnalysis.CSharp.Syntax.QualifiedNameSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Syntax.Generated.cs:line 155
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Syntax\CSharpSyntaxRewriter.cs:line 39
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitQualifiedName(QualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Main.Generated.cs:line 2615
   at Microsoft.CodeAnalysis.CSharp.Simplification.CSharpNameReducer.Rewriter.VisitQualifiedName(QualifiedNameSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\CSharpNameReducer.Rewriter.cs:line 65
   at Microsoft.CodeAnalysis.CSharp.Syntax.QualifiedNameSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Syntax.Generated.cs:line 155
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Syntax\CSharpSyntaxRewriter.cs:line 39
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitAttribute(AttributeSyntax node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Main.Generated.cs:line 3734
   at Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Generated\Syntax.xml.Syntax.Generated.cs:line 13507
   at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node) in C:\Users\Joseph\Source\Repos\roslyn\src\Compilers\CSharp\Portable\Syntax\CSharpSyntaxRewriter.cs:line 39
   at Microsoft.CodeAnalysis.CSharp.Simplification.AbstractCSharpReducer.AbstractReductionRewriter.VisitNodeOrToken(SyntaxNodeOrToken nodeOrToken, SemanticModel semanticModel, Boolean simplifyAllDescendants) in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\CSharp\Portable\Simplification\Reducers\AbstractCSharpReducer.AbstractReductionRewriter.cs:line 188
   at Microsoft.CodeAnalysis.Simplification.AbstractSimplificationService`3.<>c__DisplayClass10_1.<<ReduceAsync>b__0>d.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Simplification\AbstractSimplificationService.cs:line 248
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Simplification.AbstractSimplificationService`3.<ReduceAsyncInternal>d__9.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Simplification\AbstractSimplificationService.cs:line 137
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Simplification.AbstractSimplificationService`3.<ReduceAsync>d__8.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Simplification\AbstractSimplificationService.cs:line 76
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Simplification.Simplifier.<ReduceAsync>d__14.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\Simplification\Simplifier.cs:line 165
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.CodeActions.CodeAction.<CleanupDocumentAsync>d__29.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\CodeActions\CodeAction.cs:line 274
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.CodeActions.CodeAction.<PostProcessChangesAsync>d__27.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\CodeActions\CodeAction.cs:line 234
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.CodeActions.CodeAction.<PostProcessAsync>d__26.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\CodeActions\CodeAction.cs:line 203
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.CodeActions.CodeAction.<GetOperationsCoreAsync>d__16.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\CodeActions\CodeAction.cs:line 89
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers.GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.GenerateEqualsAndGetHashCodeWithDialogCodeAction.<ComputeOperationsAsync>d__10.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Features\Core\Portable\GenerateEqualsAndGetHashCodeFromMembers\GenerateEqualsAndHashWithDialogCodeAction.cs:line 90
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.<GetOperationsAsync>d__1.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\CodeActions\CodeActionWithOptions.cs:line 37
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.CodeActions.CodeActionWithOptions.<GetOperationsCoreAsync>d__2.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\Workspaces\Core\Portable\CodeActions\CodeActionWithOptions.cs:line 51
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.AbstractCodeActionOrUserDiagnosticTest.<VerifyActionAndGetOperationsAsync>d__31.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\EditorFeatures\TestUtilities\CodeActions\AbstractCodeActionOrUserDiagnosticTest.cs:line 565
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.AbstractCodeActionOrUserDiagnosticTest.<TestActionAsync>d__27.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\EditorFeatures\TestUtilities\CodeActions\AbstractCodeActionOrUserDiagnosticTest.cs:line 404
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.AbstractCodeActionOrUserDiagnosticTest.<TestAsync>d__26.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\EditorFeatures\TestUtilities\CodeActions\AbstractCodeActionOrUserDiagnosticTest.cs:line 388
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.AbstractCodeActionOrUserDiagnosticTest.<TestInRegularAndScript1Async>d__24.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\EditorFeatures\TestUtilities\CodeActions\AbstractCodeActionOrUserDiagnosticTest.cs:line 351
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.GenerateEqualsAndGetHashCodeFromMembers.GenerateEqualsAndGetHashCodeFromMembersTests.<TestImplementIEquatableOnClassInNullableContextWithAnnotatedMetadata>d__53.MoveNext() in C:\Users\Joseph\Source\Repos\roslyn\src\EditorFeatures\CSharpTest\GenerateFromMembers\GenerateEqualsAndGetHashCodeFromMembers\GenerateEqualsAndGetHashCodeFromMembersTests.cs:line 1762
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```

</details>