### PR TITLE
Parse test analyzer data using InvariantCulture

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
@@ -133,7 +133,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
                 for (var j = 0; j < data.Length; j++)
                 {
                     double result;
-                    if (!double.TryParse(data[j], NumberStyles.Float | NumberStyles.AllowThousands, EnsureEnglishUICulture.PreferredOrNull, out result))
+                    if (!double.TryParse(data[j], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out result))
                     {
                         // no data for this analyzer for this particular run
                         result = double.NaN;


### PR DESCRIPTION
Fixes #39248.

I quickly went over all other references to `EnsureEnglishUICulture.PreferredOrNull` and to my knowledge this is the only place where it is used to parse numeric data, so I don't believe its behavior needs to be changed.