### PR TITLE
Fix SourceText.GetChanges exception on merging certain changes

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -650,6 +650,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestMergeChanges_Overlapping_NewInsideOld_AndOldHasLeadingDeletion_SmallerThanLeadingInsertion()
+        {
+            var original = SourceText.From("012");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 1), "aaa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(3, 0), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aaa2", change1.ToString());
+            Assert.Equal("0aabba2", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 1), "aabba") }, changes);
+        }
+
+        [Fact]
         public void TestMergeChanges_Overlapping_NewInsideOld_AndBothHaveDeletion_NewDeletionSmallerThanOld()
         {
             var original = SourceText.From("01234");

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -637,6 +637,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        [WorkItem(22289, "https://github.com/dotnet/roslyn/issues/22289")]
         public void TestMergeChanges_Overlapping_NewInsideOld_AndOldHasDeletion()
         {
             var original = SourceText.From("01234");
@@ -650,6 +651,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        [WorkItem(22289, "https://github.com/dotnet/roslyn/issues/22289")]
         public void TestMergeChanges_Overlapping_NewInsideOld_AndOldHasLeadingDeletion_SmallerThanLeadingInsertion()
         {
             var original = SourceText.From("012");
@@ -663,6 +665,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        [WorkItem(22289, "https://github.com/dotnet/roslyn/issues/22289")]
         public void TestMergeChanges_Overlapping_NewInsideOld_AndBothHaveDeletion_NewDeletionSmallerThanOld()
         {
             var original = SourceText.From("01234");
@@ -783,6 +786,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        [WorkItem(22289, "https://github.com/dotnet/roslyn/issues/22289")]
         public void TestMergeChanges_SameStart_AndBothHaveDeletion_NewDeletionSmallerThanOld()
         {
             var original = SourceText.From("01234");

--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -637,6 +637,32 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestMergeChanges_Overlapping_NewInsideOld_AndOldHasDeletion()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 3), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(2, 0), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa4", change1.ToString());
+            Assert.Equal("0abba4", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 3), "abba") }, changes);
+        }
+
+        [Fact]
+        public void TestMergeChanges_Overlapping_NewInsideOld_AndBothHaveDeletion_NewDeletionSmallerThanOld()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 3), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(2, 1), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa4", change1.ToString());
+            Assert.Equal("0abb4", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 3), "abb") }, changes);
+        }
+
+        [Fact]
         public void TestMergeChanges_Overlapping_OldInsideNew()
         {
             var original = SourceText.From("Hello World");
@@ -676,6 +702,84 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(1, changes.Count);
             Assert.Equal(new TextSpan(6, 1), changes[0].Span);
             Assert.Equal("Cwazy V", changes[0].NewText);
+        }
+
+        [Fact]
+        public void TestMergeChanges_SameStart()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 0), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(1, 0), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa1234", change1.ToString());
+            Assert.Equal("0bbaa1234", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 0), "bbaa") }, changes);
+        }
+
+        [Fact]
+        public void TestMergeChanges_SameStart_AndOldHasDeletion()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 3), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(1, 0), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa4", change1.ToString());
+            Assert.Equal("0bbaa4", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 3), "bbaa") }, changes);
+        }
+
+        [Fact]
+        public void TestMergeChanges_SameStart_AndNewHasDeletion_SmallerThanOldInsertion()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 0), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(1, 1), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa1234", change1.ToString());
+            Assert.Equal("0bba1234", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 0), "bba") }, changes);
+        }
+
+        [Fact]
+        public void TestMergeChanges_SameStart_AndNewHasDeletion_EqualToOldInsertion()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 0), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(1, 2), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa1234", change1.ToString());
+            Assert.Equal("0bb1234", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 0), "bb") }, changes);
+        }
+
+        [Fact]
+        public void TestMergeChanges_SameStart_AndNewHasDeletion_LargerThanOldInsertion()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 0), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(1, 3), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa1234", change1.ToString());
+            Assert.Equal("0bb234", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 1), "bb") }, changes);
+        }
+
+        [Fact]
+        public void TestMergeChanges_SameStart_AndBothHaveDeletion_NewDeletionSmallerThanOld()
+        {
+            var original = SourceText.From("01234");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(1, 3), "aa"));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(1, 1), "bb"));
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal("0aa4", change1.ToString());
+            Assert.Equal("0bba4", change2.ToString());
+            Assert.Equal(new[] { new TextChange(new TextSpan(1, 3), "bba") }, changes);
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -296,10 +296,10 @@ tryAgain:
                         // new change starts after old change, but overlaps
                         // add as much of the old change as possible and try again
                         var oldChangeLeadingInsertion = newChange.Span.Start - (oldChange.Span.Start + oldDelta);
-                        AddRange(list, new TextChangeRange(oldChange.Span, oldChangeLeadingInsertion));
-                        oldDelta = oldDelta - oldChange.Span.Length + oldChangeLeadingInsertion;
-                        oldChange = new TextChangeRange(new TextSpan(oldChange.Span.Start, 0), oldChange.NewLength - oldChangeLeadingInsertion);
-                        newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length), newChange.NewLength);
+                        var oldChangeLeadingDeletion = Math.Min(oldChange.Span.Length, oldChangeLeadingInsertion);
+                        AddRange(list, new TextChangeRange(new TextSpan(oldChange.Span.Start, oldChangeLeadingDeletion), oldChangeLeadingInsertion));
+                        oldDelta = oldDelta - oldChangeLeadingDeletion + oldChangeLeadingInsertion;
+                        oldChange = new TextChangeRange(new TextSpan(newChange.Span.Start - oldDelta, oldChange.Span.Length - oldChangeLeadingDeletion), oldChange.NewLength - oldChangeLeadingInsertion);
                         goto tryAgain;
                     }
                     else if (newChange.Span.Start == oldChange.Span.Start + oldDelta)
@@ -313,11 +313,11 @@ tryAgain:
                             oldIndex++;
                             goto nextOldChange;
                         }
-                        else if (newChange.Span.Length == 0)
+                        else if (newChange.Span.Length <= oldChange.NewLength)
                         {
-                            // new change is just an insertion, go ahead and tack it on with old change
-                            AddRange(list, new TextChangeRange(oldChange.Span, oldChange.NewLength + newChange.NewLength));
-                            oldDelta = oldDelta - oldChange.Span.Length + oldChange.NewLength;
+                            // new change is smaller than old, go ahead and tack it on with old change
+                            AddRange(list, new TextChangeRange(oldChange.Span, oldChange.NewLength + newChange.NewLength - newChange.Span.Length));
+                            oldDelta = oldDelta - oldChange.Span.Length + oldChange.NewLength - newChange.Span.Length;
                             oldIndex++;
                             newIndex++;
                             goto nextNewChange;

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -315,7 +315,8 @@ tryAgain:
                         }
                         else if (newChange.Span.Length <= oldChange.NewLength)
                         {
-                            // new change is smaller than old, go ahead and tack it on with old change
+                            // new change deletes fewer characters than old change inserted
+                            // add new change insertion, then the remaining trailing characters of the old change insertion
                             AddRange(list, new TextChangeRange(oldChange.Span, oldChange.NewLength + newChange.NewLength - newChange.Span.Length));
                             oldDelta = oldDelta - oldChange.Span.Length + oldChange.NewLength - newChange.Span.Length;
                             oldIndex++;


### PR DESCRIPTION
Closes #22289
Closes #26305

See #22289 for full details on the bug.

#### Summary
After certain `WithChanges` calls, `SourceText.GetChanges` is no longer able to handle the `SourceText` state and throws `ArgumentOutOfRangeException` when called.

#### Notes
- Three of the new tests are failing without my change, other tests added just in case.
- I didn't follow "Hello World" pattern in tests, sorry. I found it a bit hard to remember the offsets when using actual words.
- Not fully confident in the change even though the tests pass. The flow is quite complicated and I feel the current coverage might be insufficient.