### PR TITLE
Attempt to normalize Location paths before creating URIs

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;

--- a/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/SarifV1ErrorLoggerTests.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
-using System.IO;
-using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers;

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifErrorLoggerTests.cs
@@ -96,28 +96,26 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             {
                 var stream = new MemoryStream();
 
-                using (var logger = CreateLogger(
+                using var logger = CreateLogger(
                         stream,
                         toolName: "",
                         toolFileVersion: "",
                         toolAssemblyVersion: Version.Parse("1.0.0"),
-                        CultureInfo.InvariantCulture))
-                {
-                    var location = Location.Create(
-                        inputPath,
-                        textSpan: default,
-                        lineSpan: default);
+                        CultureInfo.InvariantCulture)
+                var location = Location.Create(
+                    inputPath,
+                    textSpan: default,
+                    lineSpan: default);
 
-                    logger.LogDiagnostic(Diagnostic.Create(
-                        "uriDiagnostic",
-                        category: "",
-                        message: "blank diagnostic",
-                        DiagnosticSeverity.Warning,
-                        DiagnosticSeverity.Warning,
-                        isEnabledByDefault: true,
-                        warningLevel: 3,
-                        location: location));
-                }
+                logger.LogDiagnostic(Diagnostic.Create(
+                    "uriDiagnostic",
+                    category: "",
+                    message: "blank diagnostic",
+                    DiagnosticSeverity.Warning,
+                    DiagnosticSeverity.Warning,
+                    isEnabledByDefault: true,
+                    warningLevel: 3,
+                    location: location));
 
                 var buffer = stream.ToArray();
                 Assert.Equal(

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifErrorLoggerTests.cs
@@ -88,9 +88,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         {
             var isUnix = PathUtilities.IsUnixLikePlatform;
             var paths = new[] {
-                (@"A:\B\C\\..\D.cs", isUnix ? @"A:\B\C\\..\D.cs" : "file:///A:/B/D.cs"),
-                (@"A\B\C\\..\D.cs", isUnix ? @"A\B\C\\..\D.cs" : @"A/B/D.cs")
+                (@"A:\B\C\\..\D.cs", isUnix ? @"A:/B/C/D.cs" : "file:///A:/B/D.cs"),
+                (@"A\B\C\\..\D.cs", isUnix ? @"A%5CB%5CC%5C%5C..%5CD.cs" : @"A/B/D.cs")
             };
+
             foreach (var (inputPath, outputPath) in paths)
             {
                 var stream = new MemoryStream();

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifErrorLoggerTests.cs
@@ -96,26 +96,28 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             {
                 var stream = new MemoryStream();
 
-                using var logger = CreateLogger(
-                        stream,
-                        toolName: "",
-                        toolFileVersion: "",
-                        toolAssemblyVersion: Version.Parse("1.0.0"),
-                        CultureInfo.InvariantCulture)
-                var location = Location.Create(
-                    inputPath,
-                    textSpan: default,
-                    lineSpan: default);
+                using (var logger = CreateLogger(
+                    stream,
+                    toolName: "",
+                    toolFileVersion: "",
+                    toolAssemblyVersion: Version.Parse("1.0.0"),
+                    CultureInfo.InvariantCulture))
+                {
+                    var location = Location.Create(
+                        inputPath,
+                        textSpan: default,
+                        lineSpan: default);
 
-                logger.LogDiagnostic(Diagnostic.Create(
-                    "uriDiagnostic",
-                    category: "",
-                    message: "blank diagnostic",
-                    DiagnosticSeverity.Warning,
-                    DiagnosticSeverity.Warning,
-                    isEnabledByDefault: true,
-                    warningLevel: 3,
-                    location: location));
+                    logger.LogDiagnostic(Diagnostic.Create(
+                        "uriDiagnostic",
+                        category: "",
+                        message: "blank diagnostic",
+                        DiagnosticSeverity.Warning,
+                        DiagnosticSeverity.Warning,
+                        isEnabledByDefault: true,
+                        warningLevel: 3,
+                        location: location));
+                }
 
                 var buffer = stream.ToArray();
                 Assert.Equal(

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV1ErrorLoggerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
@@ -42,7 +43,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
           ""locations"": [
             {
               ""resultFile"": {
-                ""uri"": ""file:///Z:/Main%20Location.cs"",
+                ""uri"": """ + (PathUtilities.IsUnixLikePlatform
+                                    ? "Z:/Main%20Location.cs"
+                                    : "file:///Z:/Main%20Location.cs") + @""",
                 ""region"": {
                   ""startLine"": 1,
                   ""startColumn"": 1,

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV1ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV1ErrorLoggerTests.cs
@@ -63,17 +63,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                   ""endColumn"": 1
                 }
               }
-            },
-            {
-              ""physicalLocation"": {
-                ""uri"": ""a%3Acannot%2Finterpret%2Fas%5Curi"",
-                ""region"": {
-                  ""startLine"": 1,
-                  ""startColumn"": 1,
-                  ""endLine"": 1,
-                  ""endColumn"": 1
-                }
-              }
             }
           ]
         }
@@ -378,6 +367,58 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void DescriptorIdCollision()
         {
             DescriptorIdCollisionImpl();
+        }
+
+        [Fact]
+        public void PathToUri()
+        {
+            PathToUriImpl(@"{{
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""version"": ""1.0.0"",
+  ""runs"": [
+    {{
+      ""tool"": {{
+        ""name"": """",
+        ""version"": ""1.0.0"",
+        ""fileVersion"": """",
+        ""semanticVersion"": ""1.0.0"",
+        ""language"": """"
+      }},
+      ""results"": [
+        {{
+          ""ruleId"": ""uriDiagnostic"",
+          ""level"": ""warning"",
+          ""message"": ""blank diagnostic"",
+          ""locations"": [
+            {{
+              ""resultFile"": {{
+                ""uri"": ""{0}"",
+                ""region"": {{
+                  ""startLine"": 1,
+                  ""startColumn"": 1,
+                  ""endLine"": 1,
+                  ""endColumn"": 1
+                }}
+              }}
+            }}
+          ],
+          ""properties"": {{
+            ""warningLevel"": 3
+          }}
+        }}
+      ],
+      ""rules"": {{
+        ""uriDiagnostic"": {{
+          ""id"": ""uriDiagnostic"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {{
+            ""isEnabledByDefault"": true
+          }}
+        }}
+      }}
+    }}
+  ]
+}}");
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV2ErrorLoggerTests.cs
@@ -61,19 +61,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                   ""endColumn"": 1
                 }
               }
-            },
-            {
-              ""physicalLocation"": {
-                ""artifactLocation"": {
-                  ""uri"": ""a%3Acannot%2Finterpret%2Fas%5Curi""
-                },
-                ""region"": {
-                  ""startLine"": 1,
-                  ""startColumn"": 1,
-                  ""endLine"": 1,
-                  ""endColumn"": 1
-                }
-              }
             }
           ]
         }
@@ -387,6 +374,62 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void DescriptorIdCollision()
         {
             DescriptorIdCollisionImpl();
+        }
+
+        [Fact]
+        public void PathToUri()
+        {
+            PathToUriImpl(@"{{
+  ""$schema"": ""http://json.schemastore.org/sarif-2.1.0"",
+  ""version"": ""2.1.0"",
+  ""runs"": [
+    {{
+      ""results"": [
+        {{
+          ""ruleId"": ""uriDiagnostic"",
+          ""ruleIndex"": 0,
+          ""level"": ""warning"",
+          ""message"": {{
+            ""text"": ""blank diagnostic""
+          }},
+          ""locations"": [
+            {{
+              ""physicalLocation"": {{
+                ""artifactLocation"": {{
+                  ""uri"": ""{0}""
+                }},
+                ""region"": {{
+                  ""startLine"": 1,
+                  ""startColumn"": 1,
+                  ""endLine"": 1,
+                  ""endColumn"": 1
+                }}
+              }}
+            }}
+          ],
+          ""properties"": {{
+            ""warningLevel"": 3
+          }}
+        }}
+      ],
+      ""tool"": {{
+        ""driver"": {{
+          ""name"": """",
+          ""version"": """",
+          ""dottedQuadFileVersion"": ""1.0.0"",
+          ""semanticVersion"": ""1.0.0"",
+          ""language"": """",
+          ""rules"": [
+            {{
+              ""id"": ""uriDiagnostic""
+            }}
+          ]
+        }}
+      }},
+      ""columnKind"": ""utf16CodeUnits""
+    }}
+  ]
+}}");
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV2ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SarifV2ErrorLoggerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
@@ -37,7 +38,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             {
               ""physicalLocation"": {
                 ""artifactLocation"": {
-                  ""uri"": ""file:///Z:/Main%20Location.cs""
+                  ""uri"": """ + (PathUtilities.IsUnixLikePlatform
+                                    ? "Z:/Main%20Location.cs"
+                                    : "file:///Z:/Main%20Location.cs") + @"""
                 },
                 ""region"": {
                   ""startLine"": 1,

--- a/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis
             else
             {
                 // Attempt to normalize the directory separators
-                if (PathUtilities.DirectorySeparatorChar == '\\')
+                if (!PathUtilities.IsUnixLikePlatform)
                 {
                     path = path.Replace(@"\\", @"\");
                     path = PathUtilities.NormalizeWithForwardSlash(path);


### PR DESCRIPTION
The URI path parsing is not the same as Windows path parsing and
sometimes produces incorrect results. However, a canonical Windows
path should produce an equivalent URI. This change uses GetFullPath
for absolute paths passed to the ErrorLogger to normalize the path
before passing it to URIs. For relative paths we try to normalize
the directory separators, but there's no equivalent transformation
that guarantees correctness.

Fixes #37737