### PR TITLE
Rely on PDB document table for identification of design-time-only source files

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -972,24 +972,34 @@ class C1
             }, _telemetryLog);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/39271")]
+        [Fact]
         public async Task BreakMode_RudeEdits_DocumentWithoutSequencePoints()
         {
             var source1 = "abstract class C { public abstract void M(); }";
+            var dir = Temp.CreateDirectory();
+            var sourceFile = dir.CreateFile("a.cs").WriteAllText(source1);
 
-            using var workspace = TestWorkspace.CreateCSharp(source1);
+            using var workspace = new TestWorkspace();
 
-            var project = workspace.CurrentSolution.Projects.Single();
-            var (_, moduleId) = EmitAndLoadLibraryToDebuggee(source1, project.Id);
-            var document1 = workspace.CurrentSolution.Projects.Single().Documents.Single();
+            // the workspace starts with a version of the source that's not updated with the output of single file generator (or design-time build):
+            var document1 = workspace.CurrentSolution.
+                AddProject("test", "test", LanguageNames.CSharp).
+                AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.Mscorlib40)).
+                AddDocument("test.cs", SourceText.From(source1, Encoding.UTF8), filePath: sourceFile.Path);
+
+            var project = document1.Project;
+            workspace.ChangeSolution(project.Solution);
+
+            var (_, moduleId) = EmitAndLoadLibraryToDebuggee(source1, project.Id, sourceFilePath: sourceFile.Path);
 
             var service = CreateEditAndContinueService(workspace);
 
+            // do not initialize the document state - we will detect the state based on the PDB content.
             var debuggingSession = StartDebuggingSession(service, initialState: CommittedSolution.DocumentState.None);
 
             service.StartEditSession();
 
-            // change the source (rude edit):
+            // change the source (rude edit since the base document content matches the PDB checksum, so the document is not out-of-sync):
             workspace.ChangeDocument(document1.Id, SourceText.From("abstract class C { public abstract void M(); public abstract void N(); }"));
             var document2 = workspace.CurrentSolution.Projects.Single().Documents.Single();
 

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -167,26 +167,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 if (isMissing)
                 {
                     // Source file is not listed in the PDB. This may happen for a couple of reasons:
-                    // 1) The source file contains no method bodies
-                    // 2) The library wasn't built with that source file - the file has been added before debugging session started but after build captured it.
-                    //    This is the case for WPF .g.i.cs files.
-                    // 
-                    // In case [1] we can't currently determine whether the document matches or not
-                    // In case [2] there is no need to synchronize the document.
-                    // 
-                    // TODO:
-                    // Once https://github.com/dotnet/roslyn/issues/38954 is implemented we can consider all source files that are not present in the PDB design-time-only.
-
-                    if (document.FilePath.EndsWith(".g.i.cs") || document.FilePath.EndsWith(".g.i.vb"))
-                    {
-                        matchingDocument = null;
-                        newState = DocumentState.DesignTimeOnly;
-                    }
-                    else
-                    {
-                        matchingDocument = document;
-                        newState = DocumentState.MatchesDebuggee;
-                    }
+                    // The library wasn't built with that source file - the file has been added before debugging session started but after build captured it.
+                    // This is the case for WPF .g.i.cs files.
+                    matchingDocument = null;
+                    newState = DocumentState.DesignTimeOnly;
                 }
                 else if (matchingSourceText != null)
                 {
@@ -238,6 +222,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             if (symChecksum.IsDefault)
             {
                 return (Source: null, IsMissing: true);
+            }
+
+            if (!PathUtilities.IsAbsolute(sourceFilePath))
+            {
+                EditAndContinueWorkspaceService.Log.Write("Error calculating checksum for source file '{0}': path not absolute", sourceFilePath);
+                return (Source: null, IsMissing: false);
             }
 
             try


### PR DESCRIPTION
Use document list in PDB as the definitive indicator of whether a source file is design-time-only or not. This is now possible due to https://github.com/dotnet/roslyn/pull/39136.

Fixes https://github.com/dotnet/roslyn/issues/39271.
Fixes ADO [899910](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/899910): Pop up a "Edit and Continue" dialog without ENC about C# uwp app