### PR TITLE
Do not wait for output writer thread to complete when aborting execution in IW

### DIFF
--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.LazyRemoteService.cs
@@ -30,17 +30,16 @@ namespace Microsoft.CodeAnalysis.Interactive
                 SkipInitialization = skipInitialization;
             }
 
-            public void Dispose(bool joinThreads)
+            public void Dispose()
             {
                 // Cancel the creation of the process if it is in progress.
                 // If it is the cancellation will clean up all resources allocated during the creation.
                 CancellationSource.Cancel();
 
                 // If the value has been calculated already, dispose the service.
-                InitializedRemoteService initializedService;
-                if (InitializedService.TryGetValue(out initializedService) && initializedService.ServiceOpt != null)
+                if (InitializedService.TryGetValue(out var initializedService))
                 {
-                    initializedService.ServiceOpt.Dispose(joinThreads);
+                    initializedService.ServiceOpt?.Dispose();
                 }
             }
 
@@ -67,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         if (initializing)
                         {
                             // kill the process without triggering auto-reset:
-                            remoteService.Dispose(joinThreads: false);
+                            remoteService.Dispose();
                         }
                     });
 
@@ -82,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     if (!initializationResult.Success)
                     {
                         Host.ReportProcessExited(remoteService.Process);
-                        remoteService.Dispose(joinThreads: false);
+                        remoteService.Dispose();
 
                         return default;
                     }

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -124,8 +124,8 @@ namespace Microsoft.CodeAnalysis.Interactive
                 }
             }
 
-            // Dispose may called anytime.
-            internal void Dispose(bool joinThreads)
+            // Dispose may called anytime, on any thread.
+            internal void Dispose()
             {
                 // There can be a call from host initiated from OnProcessExit. 
                 // We should not proceed with disposing if _disposeSemaphore is locked.
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 InitiateTermination(Process, _processId);
 
-                if (joinThreads)
+                if (_host._joinOutputWritingThreadsOnDisposal)
                 {
                     try
                     {

--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             public readonly Process Process;
             public readonly Service Service;
             private readonly int _processId;
-            private SemaphoreSlim _disposeSemaphore = new SemaphoreSlim(initialCount: 1);
+            private readonly SemaphoreSlim _disposeSemaphore = new SemaphoreSlim(initialCount: 1);
 
             // output pumping threads (stream output from stdout/stderr of the host process to the output/errorOutput writers)
             private InteractiveHost _host;              // nulled on dispose
@@ -140,22 +140,25 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 InitiateTermination(Process, _processId);
 
-                try
+                if (joinThreads)
                 {
-                    _readOutputThread?.Join();
-                }
-                catch (ThreadStateException)
-                {
-                    // thread hasn't started	
-                }
+                    try
+                    {
+                        _readOutputThread?.Join();
+                    }
+                    catch (ThreadStateException)
+                    {
+                        // thread hasn't started	
+                    }
 
-                try
-                {
-                    _readErrorOutputThread?.Join();
-                }
-                catch (ThreadStateException)
-                {
-                    // thread hasn't started	
+                    try
+                    {
+                        _readErrorOutputThread?.Join();
+                    }
+                    catch (ThreadStateException)
+                    {
+                        // thread hasn't started	
+                    }
                 }
 
                 // null the host so that we don't attempt to write to the buffer anymore:

--- a/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
+++ b/src/Interactive/HostTest/AbstractInteractiveHostTests.cs
@@ -28,10 +28,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
         private static readonly FieldInfo s_ipcServerChannelListenerThread = typeof(IpcServerChannel).GetField("_listenerThread", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        internal static void DisposeInteractiveHostProcess(InteractiveHost process)
+        internal static void DisposeInteractiveHostProcess(InteractiveHost host)
         {
-            IpcServerChannel serverChannel = process._ServerChannel;
-            process.Dispose();
+            var serverChannel = host._ServerChannel;
+            host.Dispose();
 
             var listenerThread = (Thread)s_ipcServerChannelListenerThread.GetValue(serverChannel);
             listenerThread.Join();

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
         public InteractiveHostTests()
         {
-            _host = new InteractiveHost(typeof(CSharpReplServiceProvider), ".", millisecondsTimeout: -1);
+            _host = new InteractiveHost(typeof(CSharpReplServiceProvider), ".", millisecondsTimeout: -1, joinOutputWritingThreadsOnDisposal: true);
 
             RedirectOutput();
 

--- a/src/Interactive/HostTest/StressTests.cs
+++ b/src/Interactive/HostTest/StressTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
 
         private InteractiveHost CreateProcess()
         {
-            var p = new InteractiveHost(typeof(CSharpReplServiceProvider), ".", millisecondsTimeout: 1);
+            var p = new InteractiveHost(typeof(CSharpReplServiceProvider), ".", millisecondsTimeout: 1, joinOutputWritingThreadsOnDisposal: true);
             _processes.Add(p);
             return p;
         }


### PR DESCRIPTION
Joining the threads might cause deadlock if Dispose is executing on UI thread since the output writing threads are dispatching to UI thread to write the output.

Fixes https://github.com/dotnet/roslyn/issues/36022

