### PR TITLE
Remove analyzer workarounds for using declarations

### DIFF
--- a/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/DisposeAnalysis/DisposeObjectsBeforeLosingScopeDiagnosticAnalyzer.cs
@@ -125,13 +125,6 @@ namespace Microsoft.CodeAnalysis.DisposeAnalysis
                     ComputeDiagnostics(disposeDataAtExit, notDisposedDiagnostics, mayBeNotDisposedDiagnostics,
                         disposeAnalysisResult, pointsToAnalysisResult);
 
-                    if (disposeAnalysisResult.ControlFlowGraph.OriginalOperation.HasAnyOperationDescendant(o => o.Kind == OperationKind.None))
-                    {
-                        // Workaround for https://github.com/dotnet/roslyn/issues/32100
-                        // Bail out in presence of OperationKind.None - not implemented IOperation.
-                        return;
-                    }
-
                     // Report diagnostics preferring *not* disposed diagnostics over may be not disposed diagnostics
                     // and avoiding duplicates.
                     foreach (var diagnostic in notDisposedDiagnostics.Concat(mayBeNotDisposedDiagnostics))

--- a/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.BlockAnalyzer.cs
@@ -342,17 +342,6 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                                     case IConditionalOperation conditional when conditional.IsRef:
                                     case ISimpleAssignmentOperation assignment when assignment.IsRef:
                                         return false;
-
-                                    default:
-                                        // Workaround for https://github.com/dotnet/roslyn/issues/32100
-                                        // Bail out in presence of OperationKind.None - not implemented IOperation.
-                                        if (operation.Kind == OperationKind.None)
-                                        {
-                                            hasOperationNoneDescendant = true;
-                                            return false;
-                                        }
-
-                                        break;
                                 }
                             }
 


### PR DESCRIPTION
Remove workarounds introduced introduced in https://github.com/dotnet/roslyn/pull/36734 as #32100 is now implemented.
