### PR TITLE
Use ConstructWithNullability in InferTypeInAwaitExpression

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TypeInferrer/TypeInferrerTests.vb
@@ -791,5 +791,18 @@ end class"
 End Module"
             Await TestAsync(text, "System.Object", TestMode.Position)
         End Function
+
+        <WorkItem(39333, "https://github.com/dotnet/roslyn/issues/39333")>
+        <Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)>
+        Public Async Function TestInferringAfterAwaitInAsync() As Task
+            Dim text =
+"Imports System.Threading.Tasks
+Class C
+    Private Async Function WaitForIt() As Task(Of Boolean)
+        Return Await [||]
+    End Function
+End Class"
+            Await TestAsync(text, "Task.FromResult(False)", TestMode.Position)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicTypeInferenceService.TypeInferrer.vb
@@ -451,7 +451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return CreateResult(task)
                 End If
 
-                Return types.Select(Function(t) New TypeInferenceInfo(If(t.InferredType.SpecialType = SpecialType.System_Void, task, taskOfT.Construct(t.InferredType))))
+                Return types.Select(Function(t) New TypeInferenceInfo(If(t.InferredType.SpecialType = SpecialType.System_Void, task, taskOfT.ConstructWithNullability(t.InferredType))))
             End Function
 
             Private Function InferTypeInConditionalAccessExpression(conditional As ConditionalAccessExpressionSyntax) As IEnumerable(Of TypeInferenceInfo)


### PR DESCRIPTION
The inferred type may include nullability information, and will fail to be recognized as a symbol without using the correct construct call. 

Fixes #39333 