### PR TITLE
Re-use semantic model when attempting to compute suppress message att…

### DIFF
--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -341,7 +341,10 @@ namespace Microsoft.CodeAnalysis
 
             AttributeData attribute;
             var suppressMessageState = new SuppressMessageAttributeState(compilation);
-            if (!suppressMessageState.IsDiagnosticSuppressed(this, getSemanticModel: tree => compilation.GetSemanticModel(tree), out attribute))
+            if (!suppressMessageState.IsDiagnosticSuppressed(
+                    this,
+                    getSemanticModel: (compilation, tree) => compilation.GetSemanticModel(tree),
+                    out attribute))
             {
                 attribute = null;
             }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis
 
             AttributeData attribute;
             var suppressMessageState = new SuppressMessageAttributeState(compilation);
-            if (!suppressMessageState.IsDiagnosticSuppressed(this, out attribute))
+            if (!suppressMessageState.IsDiagnosticSuppressed(this, getSemanticModel: tree => compilation.GetSemanticModel(tree), out attribute))
             {
                 attribute = null;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -660,7 +660,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         private SemanticModel GetOrCreateSemanticModel(SyntaxTree tree)
-            => CurrentCompilationData.GetOrCreateCachedSemanticModel(tree, AnalyzerExecutor.Compilation, AnalyzerExecutor.CancellationToken);
+            => GetOrCreateSemanticModel(AnalyzerExecutor.Compilation, tree);
+
+        private SemanticModel GetOrCreateSemanticModel(Compilation compilation, SyntaxTree tree)
+            => CurrentCompilationData.GetOrCreateCachedSemanticModel(tree, compilation, AnalyzerExecutor.CancellationToken);
 
         public void ApplyProgrammaticSuppressions(DiagnosticBag reportedDiagnostics, Compilation compilation)
         {
@@ -828,7 +831,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<Diagnostic> diagnostics,
             Compilation compilation,
             SuppressMessageAttributeState suppressMessageState,
-            Func<SyntaxTree, SemanticModel> getSemanticModel)
+            Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel)
         {
             if (diagnostics.IsEmpty)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -1156,7 +1156,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var suppressMessageState = new SuppressMessageAttributeState(compilation);
-            var semanticModelsByTree = new ConcurrentDictionary<SyntaxTree, SemanticModel>();
+            var semanticModelsByTree = new Dictionary<SyntaxTree, SemanticModel>();
             foreach (var diagnostic in diagnostics)
             {
                 if (diagnostic != null)
@@ -1169,11 +1169,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            SemanticModel getSemanticModel(SyntaxTree tree)
+            SemanticModel getSemanticModel(Compilation compilation, SyntaxTree tree)
             {
                 if (!semanticModelsByTree.TryGetValue(tree, out var model))
                 {
-                    model = semanticModelsByTree.GetOrAdd(tree, compilation.GetSemanticModel(tree));
+                    model = compilation.GetSemanticModel(tree);
+                    semanticModelsByTree.Add(tree, model);
                 }
 
                 return model;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _localSuppressionsBySymbol = new ConcurrentDictionary<ISymbol, ImmutableDictionary<string, SuppressMessageInfo>>();
         }
 
-        public Diagnostic ApplySourceSuppressions(Diagnostic diagnostic, ISymbol symbolOpt = null)
+        public Diagnostic ApplySourceSuppressions(Diagnostic diagnostic, Func<SyntaxTree, SemanticModel> getSemanticModel, ISymbol symbolOpt = null)
         {
             if (diagnostic.IsSuppressed)
             {
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             SuppressMessageInfo info;
-            if (IsDiagnosticSuppressed(diagnostic, out info))
+            if (IsDiagnosticSuppressed(diagnostic, getSemanticModel, out info))
             {
                 // Attach the suppression info to the diagnostic.
                 diagnostic = diagnostic.WithIsSuppressed(true);
@@ -117,10 +117,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return diagnostic;
         }
 
-        public bool IsDiagnosticSuppressed(Diagnostic diagnostic, out AttributeData suppressingAttribute)
+        public bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<SyntaxTree, SemanticModel> getSemanticModel, out AttributeData suppressingAttribute)
         {
             SuppressMessageInfo info;
-            if (IsDiagnosticSuppressed(diagnostic, out info))
+            if (IsDiagnosticSuppressed(diagnostic, getSemanticModel, out info))
             {
                 suppressingAttribute = info.Attribute;
                 return true;
@@ -130,10 +130,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return false;
         }
 
-        private bool IsDiagnosticSuppressed(Diagnostic diagnostic, out SuppressMessageInfo info)
-            => IsDiagnosticSuppressed(diagnostic.Id, diagnostic.Location, out info);
+        private bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
+            => IsDiagnosticSuppressed(diagnostic.Id, diagnostic.Location, getSemanticModel, out info);
 
-        private bool IsDiagnosticSuppressed(string id, Location location, out SuppressMessageInfo info)
+        private bool IsDiagnosticSuppressed(string id, Location location, Func<SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
         {
             Debug.Assert(id != null);
             Debug.Assert(location != null);
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // Walk up the syntax tree checking for suppression by any declared symbols encountered
             if (location.IsInSource)
             {
-                var model = _compilation.GetSemanticModel(location.SourceTree);
+                var model = getSemanticModel(location.SourceTree);
                 bool inImmediatelyContainingSymbol = true;
 
                 for (var node = location.SourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _localSuppressionsBySymbol = new ConcurrentDictionary<ISymbol, ImmutableDictionary<string, SuppressMessageInfo>>();
         }
 
-        public Diagnostic ApplySourceSuppressions(Diagnostic diagnostic, Func<SyntaxTree, SemanticModel> getSemanticModel, ISymbol symbolOpt = null)
+        public Diagnostic ApplySourceSuppressions(Diagnostic diagnostic, Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel, ISymbol symbolOpt = null)
         {
             if (diagnostic.IsSuppressed)
             {
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return diagnostic;
         }
 
-        public bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<SyntaxTree, SemanticModel> getSemanticModel, out AttributeData suppressingAttribute)
+        public bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel, out AttributeData suppressingAttribute)
         {
             SuppressMessageInfo info;
             if (IsDiagnosticSuppressed(diagnostic, getSemanticModel, out info))
@@ -130,10 +130,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return false;
         }
 
-        private bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
+        private bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
             => IsDiagnosticSuppressed(diagnostic.Id, diagnostic.Location, getSemanticModel, out info);
 
-        private bool IsDiagnosticSuppressed(string id, Location location, Func<SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
+        private bool IsDiagnosticSuppressed(string id, Location location, Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
         {
             Debug.Assert(id != null);
             Debug.Assert(location != null);
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // Walk up the syntax tree checking for suppression by any declared symbols encountered
             if (location.IsInSource)
             {
-                var model = getSemanticModel(location.SourceTree);
+                var model = getSemanticModel(_compilation, location.SourceTree);
                 bool inImmediatelyContainingSymbol = true;
 
                 for (var node = location.SourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true);


### PR DESCRIPTION
…ribute based suppressions

Current implementation always creates a new semantic model for decoding local suppress message attributes (applied to each symbol). This change attempts to re-use the cached semantic models held by the analyzer driver to avoid rebinding cost.

Fixes VSFeedback issue [#973445](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/973445)

Verified no regression in perf benchmarks:

Before this change:
```
|                      Method | UnrollFactor |        Mean |     Error |    StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 |  Allocated |
|---------------------------- |------------- |------------:|----------:|----------:|------------:|------------:|------------:|------------:|-----------:|----------:|-----------:|
|       CompileMethodsAndEmit |           16 |  4,857.7 ms |  10.11 ms |   7.89 ms |  4,859.1 ms |  4,841.8 ms |  4,868.6 ms |  83000.0000 | 24000.0000 |         - |  505.41 MB |
|           SerializeMetadata |           16 |    280.2 ms |   2.79 ms |   4.09 ms |    280.1 ms |    273.4 ms |    289.3 ms |   3000.0000 |  1000.0000 |         - |    33.2 MB |
|              GetDiagnostics |            1 |  3,580.0 ms |   6.14 ms |   5.13 ms |  3,580.2 ms |  3,572.5 ms |  3,592.2 ms |  78000.0000 | 22000.0000 |         - |  388.35 MB |
| GetDiagnosticsWithAnalyzers |            1 | 13,022.7 ms | 128.31 ms | 157.58 ms | 12,990.0 ms | 12,846.8 ms | 13,534.0 ms | 254000.0000 | 68000.0000 | 3000.0000 | 1523.64 MB |
```

After this change:
```
|                      Method | UnrollFactor |        Mean |    Error |   StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 |  Allocated |
|---------------------------- |------------- |------------:|---------:|---------:|------------:|------------:|------------:|------------:|-----------:|----------:|-----------:|
|       CompileMethodsAndEmit |           16 |  4,864.4 ms | 33.31 ms | 31.15 ms |  4,850.4 ms |  4,836.0 ms |  4,928.2 ms |  83000.0000 | 22000.0000 |         - |   505.5 MB |
|           SerializeMetadata |           16 |    284.4 ms |  2.31 ms |  2.05 ms |    284.7 ms |    279.9 ms |    286.9 ms |   3000.0000 |          - |         - |   33.21 MB |
|              GetDiagnostics |            1 |  3,603.0 ms | 17.84 ms | 14.90 ms |  3,601.8 ms |  3,586.8 ms |  3,640.6 ms |  77000.0000 | 18000.0000 |         - |  388.32 MB |
| GetDiagnosticsWithAnalyzers |            1 | 13,003.7 ms | 68.14 ms | 63.74 ms | 13,002.5 ms | 12,857.8 ms | 13,124.9 ms | 255000.0000 | 68000.0000 | 3000.0000 | 1524.79 MB |
```