### PR TITLE
Performance fix in analyzer driver for CFG based analyzers

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2259,8 +2259,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                                 if (!operationsToAnalyze.IsEmpty)
                                 {
-                                    executeOperationsActions(operationsToAnalyze);
-                                    executeOperationsBlockActions(operationBlocksToAnalyze, operationsToAnalyze, codeBlockActions);
+                                    try
+                                    {
+                                        executeOperationsActions(operationsToAnalyze);
+                                        executeOperationsBlockActions(operationBlocksToAnalyze, operationsToAnalyze, codeBlockActions);
+                                    }
+                                    finally
+                                    {
+                                        AnalyzerExecutor.OnOperationBlockActionsExecuted(operationBlocksToAnalyze);
+                                    }
                                 }
                             }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.FlowAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -1912,6 +1913,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             return true;
+        }
+
+        public void OnOperationBlockActionsExecuted(ImmutableArray<IOperation> operationBlocks)
+        {
+            // Clear _lazyControlFlowGraphMap entries for each operation block after we have executed
+            // all analysis callbacks for the given operation blocks. This avoids holding onto them
+            // for the entire compilation lifetime.
+            // These control flow graphs are created on demand and shared between flow analysis based analyzers.
+
+            if (_lazyControlFlowGraphMap?.Count > 0)
+            {
+                foreach (var operationBlock in operationBlocks)
+                {
+                    var root = operationBlock.GetRootOperation();
+                    _lazyControlFlowGraphMap.TryRemove(root, out _);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
We expose public APIs on IOperation related analysis contexts to allow flow based analyzers to fetch ControlFlowGraph for the operation block. Additionally, the analyzer driver caches the CFGs for operation block (when first requested by some flow based analyzer) to allow sharing CFGs between flow based analyzers. However, we were holding onto these for the entire lifetime of the compilation. This change fixes that by removing the CFG entry once a particular operation block has been fully analyzed.

Fixes VSFeedback issue [#998181](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/998181)

Verified no performance regression in benchmarks:

1. Before this commit:
```
|                      Method | UnrollFactor |        Mean |    Error |   StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 |  Allocated |
|---------------------------- |------------- |------------:|---------:|---------:|------------:|------------:|------------:|------------:|-----------:|----------:|-----------:|
|       CompileMethodsAndEmit |           16 |  4,950.5 ms | 26.68 ms | 24.96 ms |  4,942.9 ms |  4,912.7 ms |  4,996.9 ms |  83000.0000 | 24000.0000 |         - |  506.23 MB |
|           SerializeMetadata |           16 |    294.6 ms |  2.77 ms |  2.72 ms |    294.0 ms |    289.5 ms |    298.8 ms |   3000.0000 |  1000.0000 |         - |   33.21 MB |
|              GetDiagnostics |            1 |  3,661.5 ms | 15.32 ms | 12.79 ms |  3,659.7 ms |  3,642.0 ms |  3,679.7 ms |  78000.0000 | 21000.0000 |         - |  389.27 MB |
| GetDiagnosticsWithAnalyzers |            1 | 13,329.6 ms | 78.06 ms | 73.02 ms | 13,296.6 ms | 13,219.2 ms | 13,459.5 ms | 232000.0000 | 63000.0000 | 2000.0000 | 1399.55 MB |
```

2. After this commit:
```
|                      Method | UnrollFactor |        Mean |    Error |   StdDev |      Median |         Min |         Max |       Gen 0 |      Gen 1 |     Gen 2 |  Allocated |
|---------------------------- |------------- |------------:|---------:|---------:|------------:|------------:|------------:|------------:|-----------:|----------:|-----------:|
|       CompileMethodsAndEmit |           16 |  4,957.1 ms | 45.94 ms | 40.72 ms |  4,945.3 ms |  4,911.2 ms |  5,061.0 ms |  83000.0000 | 22000.0000 |         - |  506.41 MB |
|           SerializeMetadata |           16 |    289.0 ms |  3.66 ms | 10.02 ms |    287.8 ms |    273.5 ms |    318.1 ms |   3000.0000 |          - |         - |   33.21 MB |
|              GetDiagnostics |            1 |  3,659.9 ms | 14.19 ms | 12.57 ms |  3,656.7 ms |  3,644.3 ms |  3,686.5 ms |  78000.0000 | 21000.0000 |         - |  389.26 MB |
| GetDiagnosticsWithAnalyzers |            1 | 13,408.3 ms | 75.15 ms | 58.67 ms | 13,411.2 ms | 13,295.4 ms | 13,498.3 ms | 234000.0000 | 63000.0000 | 3000.0000 | 1409.24 MB |
```