### PR TITLE
Completion: support local language identifiers and en-us keywords

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3050,7 +3050,7 @@ class C
         {
             void goo(int x)
             {
-              İFADE ifade = null;
+              IFADE ifade = null;
               $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
                     state.SendTypeChars("if")
                     Await state.WaitForAsynchronousOperationsAsync()
@@ -3063,6 +3063,28 @@ class C
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestMatchWithTurkishIWorkaround5() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class İFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              İFADE ifade = null;
+                $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("if")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("if")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround6() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3082,7 +3104,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround6() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround7() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3103,7 +3125,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround7() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround8() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3124,7 +3146,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround8() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround9() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3146,7 +3168,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround9() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround10() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3066,28 +3066,6 @@ class C
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
-        class İFADE {}
-        class ifTest {}
-        class C
-        {
-            void goo(int x)
-            {
-              İFADE ifade = null;
-                $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
-                    state.SendTypeChars("if")
-                    Await state.WaitForAsynchronousOperationsAsync()
-                    Await state.AssertSelectedCompletionItem("if")
-                End Using
-            End Using
-
-        End Function
-
-        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround6() As Task
-            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
-                Using state = TestStateFactory.CreateCSharpTestState(
-                               <Document><![CDATA[
         class TARİFE { }
         class C
         {
@@ -3104,7 +3082,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround7() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround6() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3125,7 +3103,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround8() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround7() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3146,7 +3124,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround9() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround8() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
@@ -3168,7 +3146,7 @@ class C
 
         <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestMatchWithTurkishIWorkaround10() As Task
+        Public Async Function TestMatchWithTurkishIWorkaround9() As Task
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3044,7 +3044,7 @@ class C
             Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
                 Using state = TestStateFactory.CreateCSharpTestState(
                                <Document><![CDATA[
-        class İFADE {}
+        class IFADE {}
         class ifTest {}
         class C
         {

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3018,6 +3018,176 @@ class C
 
         End Function
 
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround3() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class TARIFE { }
+        class C
+        {
+            void goo(int x)
+            {
+                var t = new $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("tarif")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("TARIFE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround4() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class İFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              İFADE ifade = null;
+              $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("if")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("if")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround5() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class İFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              İFADE ifade = null;
+                $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("if")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("if")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround6() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class TARİFE { }
+        class C
+        {
+            void goo(int x)
+            {
+                var obj = new $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("tarif")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("TARİFE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround7() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class İFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              var obj = new $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("ifad")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("İFADE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround8() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class IFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              var obj = new $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("ifad")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("IFADE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround9() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class IFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              IFADE ifade = null;
+              $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("IF")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("if")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround10() As Task
+            Using New CultureContext(New CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateCSharpTestState(
+                               <Document><![CDATA[
+        class İFADE {}
+        class ifTest {}
+        class C
+        {
+            void goo(int x)
+            {
+              İFADE ifade = null;
+                $$]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                    state.SendTypeChars("IF")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("if")
+                End Using
+            End Using
+
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TargetTypePreselection1() As Task
             Using state = TestStateFactory.CreateCSharpTestState(

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -3008,6 +3008,235 @@ End Class
             End Using
         End Function
 
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround1() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class C
+    Sub goo(x As Integer)
+        String.$$
+]]></Document>)
+                    state.SendTypeChars("is")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("IsInterned")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(588, "https://github.com/dotnet/roslyn/issues/588")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround2() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class C
+    Sub goo(x As Integer)
+        String.$$]]></Document>)
+                    state.SendTypeChars("ı")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem()
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround3() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class TARIFE
+
+End Class
+Class C
+    Sub goo(x As Integer)
+        Dim t As $$
+]]></Document>)
+                    state.SendTypeChars("tarif")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("TARIFE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround4() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class IFADE
+
+End Class
+Class ifTest
+
+End Class
+
+Class C
+    Sub goo(x As Integer)
+        Dim ifade As IFADE
+        $$]]></Document>)
+                    state.SendTypeChars("if")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("If")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround5() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class İFADE
+
+End Class
+Class ifTest
+
+End Class
+
+Class C
+    Sub goo(x As Integer)
+        Dim ifade As İFADE
+        $$
+]]></Document>)
+                    state.SendTypeChars("if")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("If")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround6() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class TARİFE
+
+End Class
+Class C
+    Sub goo(x As Integer)
+        Dim obj As $$
+]]></Document>)
+                    state.SendTypeChars("tarif")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("TARİFE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround7() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class İFADE
+
+End Class
+Class ifTest
+
+End Class
+
+Class C
+    Sub goo(x As Integer)
+        Dim obj As $$
+]]></Document>)
+                    state.SendTypeChars("ifad")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("İFADE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround8() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class IFADE
+
+End Class
+Class ifTest
+
+End Class
+
+Class C
+    Sub goo(x As Integer)
+        Dim obj As $$
+]]></Document>)
+                    state.SendTypeChars("ifad")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("IFADE")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround9() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class IFADE
+
+End Class
+Class ifTest
+
+End Class
+
+Class C
+    Sub goo(x As Integer)
+        Dim ifade_ As İFADE
+        $$]]></Document>)
+                    state.SendTypeChars("IF")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("If")
+                End Using
+            End Using
+
+        End Function
+
+        <WorkItem(29938, "https://github.com/dotnet/roslyn/issues/29938")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestMatchWithTurkishIWorkaround10() As Task
+            Using New CultureContext(New Globalization.CultureInfo("tr-TR", useUserOverride:=False))
+                Using state = TestStateFactory.CreateVisualBasicTestState(
+                               <Document><![CDATA[
+Class İFADE
+
+End Class
+Class ifTest
+
+End Class
+
+Class C
+    Sub goo(x As Integer)
+        Dim ifade As İFADE
+        $$
+]]></Document>)
+                    state.SendTypeChars("IF")
+                    Await state.WaitForAsynchronousOperationsAsync()
+                    Await state.AssertSelectedCompletionItem("If")
+                End Using
+            End Using
+
+        End Function
+
         <ExportLanguageService(GetType(ISnippetInfoService), LanguageNames.VisualBasic), System.Composition.Shared>
         Friend Class MockSnippetInfoService
             Implements ISnippetInfoService

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -87,7 +87,11 @@ namespace Microsoft.CodeAnalysis.Completion
             var patternMatcher = GetPatternMatcher(pattern, culture, includeMatchSpans);
             var match = patternMatcher.GetFirstMatch(completionItemText);
 
-            if (culture.Equals(EnUSCultureInfo))
+            // We still have making checks for language having different to English capitalization,
+            // for example, for Turkish with dotted and dotless i capitalization totally diferent from English.
+            // Now we escaping from the second check for English languages.
+            // Maybe we can escape as well for more similar languages in case if we meet performance issues.
+            if (culture.ThreeLetterWindowsLanguageName.Equals(EnUSCultureInfo.ThreeLetterWindowsLanguageName))
             {
                 return match;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/29938

Tests borrowed from https://github.com/dotnet/roslyn/pull/30391
Idea of implementation is suggested by @jasonmalinowski 