### PR TITLE
Update HideBaseCodeFixProvider to follow preferred modifier order

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -72,7 +72,7 @@ class App : Application
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
-        public async Task TestAddNewToMember()
+        public async Task TestAddNewToField()
         {
             await TestInRegularAndScriptAsync(
 @"class Application
@@ -132,5 +132,49 @@ class B : A { [|internal const int i = 1;|] }
 class B : A { internal new const int i = 1; }
 ");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
+        public async Task TestAddNewToDisorderedModifiers() =>
+            await TestInRegularAndScript1Async(
+@"class Application
+{
+    public static string Test;
+}
+
+class App : Application
+{
+    [|static public int Test;|]
+}",
+@"class Application
+{
+    public static string Test;
+}
+
+class App : Application
+{
+    static public new int Test;
+}");
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
+        public async Task TestAddNewToOrderedModifiersWithTrivia() =>
+            await TestInRegularAndScript1Async(
+@"class Application
+{
+    public string Test;
+}
+
+class App : Application
+{
+    [|/* start */ public /* middle */ readonly /* end */ int Test;|]
+}",
+@"class Application
+{
+    public string Test;
+}
+
+class App : Application
+{
+    /* start */ public /* middle */ new readonly /* end */ int Test;
+}");
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -35,7 +35,7 @@ class App : Application
 
 class App : Application
 {
-    public new static App Current { get; set; }
+    public static new App Current { get; set; }
 }");
         }
 
@@ -65,7 +65,7 @@ class App : Application
 
 class App : Application
 {
-    public new static void Method()
+    public static new void Method()
     {
     }
 }");

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -33,13 +33,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
             {
                 var root = await _document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-                var newNode = await GetNewNode(_node, cancellationToken).ConfigureAwait(false);
+                var newNode = await GetNewNodeAsync(_node, cancellationToken).ConfigureAwait(false);
                 var newRoot = root.ReplaceNode(_node, newNode);
 
                 return _document.WithSyntaxRoot(newRoot);
             }
 
-            private async Task<SyntaxNode> GetNewNode(SyntaxNode node, CancellationToken cancellationToken)
+            private async Task<SyntaxNode> GetNewNodeAsync(SyntaxNode node, CancellationToken cancellationToken)
             {
                 var generator = SyntaxGenerator.GetGenerator(_document);
                 var newNode = generator.WithModifiers(node, generator.GetModifiers(node).WithIsNew(true));

--- a/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
             SyntaxNode memberDeclaration)
         {
             var modifiers = _syntaxFacts.GetModifiers(memberDeclaration);
-            if (!IsOrdered(preferredOrder, modifiers))
+            if (!AbstractOrderModifiersHelpers.IsOrdered(preferredOrder, modifiers))
             {
                 if (severity.WithDefaultSeverity(DiagnosticSeverity.Hidden) == ReportDiagnostic.Hidden)
                 {
@@ -89,26 +89,6 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
                         DiagnosticHelper.Create(Descriptor, modifiers.First().GetLocation(), severity, additionalLocations: null, properties: null));
                 }
             }
-        }
-
-        private bool IsOrdered(Dictionary<int, int> preferredOrder, SyntaxTokenList modifiers)
-        {
-            if (modifiers.Count >= 2)
-            {
-                var lastOrder = int.MinValue;
-                foreach (var modifier in modifiers)
-                {
-                    var currentOrder = preferredOrder.TryGetValue(modifier.RawKind, out var value) ? value : int.MaxValue;
-                    if (currentOrder < lastOrder)
-                    {
-                        return false;
-                    }
-
-                    lastOrder = currentOrder;
-                }
-            }
-
-            return true;
         }
     }
 }

--- a/src/Features/Core/Portable/OrderModifiers/OrderModifiersHelpers.cs
+++ b/src/Features/Core/Portable/OrderModifiers/OrderModifiersHelpers.cs
@@ -17,6 +17,26 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
 
         protected abstract int GetKeywordKind(string trimmed);
 
+        public static bool IsOrdered(Dictionary<int, int> preferredOrder, SyntaxTokenList modifiers)
+        {
+            if (modifiers.Count >= 2)
+            {
+                var lastOrder = int.MinValue;
+                foreach (var modifier in modifiers)
+                {
+                    var currentOrder = preferredOrder.TryGetValue(modifier.RawKind, out var value) ? value : int.MaxValue;
+                    if (currentOrder < lastOrder)
+                    {
+                        return false;
+                    }
+
+                    lastOrder = currentOrder;
+                }
+            }
+
+            return true;
+        }
+
         public bool TryGetOrComputePreferredOrder(string value, out Dictionary<int, int> preferredOrder)
         {
             if (string.IsNullOrWhiteSpace(value))


### PR DESCRIPTION
To fit the default preferred order (IDE0036).

![image](https://user-images.githubusercontent.com/45985406/67158828-ca273f80-f36f-11e9-9d1d-c3eb6feef7a1.png)
![image](https://user-images.githubusercontent.com/45985406/67158831-d7dcc500-f36f-11e9-99cb-015db5e03054.png)