### PR TITLE
Change inline rename dialog to be more uniquely identifiable

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
@@ -14,7 +14,7 @@
              MinWidth="300"
              Cursor="Arrow"
              Focusable="True"
-             AutomationProperties.AutomationId="Rename"
+             AutomationProperties.AutomationId="Microsoft.CodeAnalysis.EditorFeatures.InlineRenameDialog"
              UseLayoutRounding="True">
 
     <UserControl.Resources>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/Dashboard/Dashboard.xaml
@@ -14,8 +14,14 @@
              MinWidth="300"
              Cursor="Arrow"
              Focusable="True"
-             AutomationProperties.AutomationId="Microsoft.CodeAnalysis.EditorFeatures.InlineRenameDialog"
+             AutomationProperties.AutomationId="Microsoft.CodeAnalysis.EditorFeatures.InlineRenameDialog" 
              UseLayoutRounding="True">
+    <!-- 
+        !!!IMPORTANT!!! 
+        The automation string of this dialog, "Microsoft.CodeAnalysis.EditorFeatures.InlineRenameDialog", 
+        is being used by 3rd parties to assist in a better inline rename experience for screen readers. 
+        Do not change this automation id.
+    -->
 
     <UserControl.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
Change the AutomationId of Inline Rename to be uniquely identifiable. This is to aid screen readers who need to work specifically around the behavior of inline rename, which has an unfriendly focus model for screen readers. 