### PR TITLE
Enable logging of informational telemetry for analyzers/fixers/refact…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -300,12 +300,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                using (RoslynEventSource.LogInformationalBlock(FunctionId.CodeFixes_GetCodeFixesAsync, fixer, cancellationToken))
-                {
-                    await AppendFixesOrConfigurationsAsync(
-                        document, span, diagnostics, fixAllForInSpan, result, fixer,
-                        hasFix: d => this.GetFixableDiagnosticIds(fixer, extensionManager).Contains(d.Id),
-                        getFixes: dxs =>
+                await AppendFixesOrConfigurationsAsync(
+                    document, span, diagnostics, fixAllForInSpan, result, fixer,
+                    hasFix: d => this.GetFixableDiagnosticIds(fixer, extensionManager).Contains(d.Id),
+                    getFixes: dxs =>
+                    {
+                        using (RoslynEventSource.LogInformationalBlock(FunctionId.CodeFixes_GetCodeFixesAsync, fixer, cancellationToken))
                         {
                             if (fixAllForInSpan)
                             {
@@ -316,9 +316,9 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                             {
                                 return GetCodeFixesAsync(document, span, fixer, isBlocking, dxs, cancellationToken);
                             }
-                        },
-                        cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
+                        }
+                    },
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 // Just need the first result if we are doing fix all in span
                 if (fixAllForInSpan && result.Any()) return;

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -114,26 +114,18 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
                 foreach (var provider in GetProviders(document))
                 {
                     tasks.Add(Task.Run(
-                        () => GetRefactoringsAsync(provider), cancellationToken));
+                        () =>
+                        {
+                            using (RoslynEventSource.LogInformationalBlock(FunctionId.Refactoring_CodeRefactoringService_GetRefactoringsAsync, provider, cancellationToken))
+                            {
+                                return GetRefactoringFromProviderAsync(document, state, provider, extensionManager, isBlocking, cancellationToken);
+                            }
+                        },
+                        cancellationToken));
                 }
 
                 var results = await Task.WhenAll(tasks).ConfigureAwait(false);
                 return results.WhereNotNull().ToImmutableArray();
-            }
-
-            Task<CodeRefactoring> GetRefactoringsAsync(CodeRefactoringProvider provider)
-            {
-                if (isPerProviderLoggingEnabled)
-                {
-                    using (RoslynEventSource.LogInformationalBlock(FunctionId.Refactoring_CodeRefactoringService_GetRefactoringsAsync, provider.ToString(), cancellationToken))
-                    {
-                        return GetRefactoringFromProviderAsync(document, state, provider, extensionManager, isBlocking, cancellationToken);
-                    }
-                }
-                else
-                {
-                    return GetRefactoringFromProviderAsync(document, state, provider, extensionManager, isBlocking, cancellationToken);
-                }
             }
         }
 

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -104,11 +104,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             bool isBlocking,
             CancellationToken cancellationToken)
         {
-            var extensionManager = document.Project.Solution.Workspace.Services.GetService<IExtensionManager>();
-            var isPerProviderLoggingEnabled = RoslynEventSource.Instance.IsEnabled(EventLevel.Informational, EventKeywords.None);
-
             using (Logger.LogBlock(FunctionId.Refactoring_CodeRefactoringService_GetRefactoringsAsync, cancellationToken))
             {
+                var extensionManager = document.Project.Solution.Workspace.Services.GetService<IExtensionManager>();
                 var tasks = new List<Task<CodeRefactoring>>();
 
                 foreach (var provider in GetProviders(document))

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -4,10 +4,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -106,37 +108,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             public async Task<bool> TryGetAsync(List<DiagnosticData> list, CancellationToken cancellationToken)
             {
+                var containsFullResult = true;
+                var loggingEnabled = RoslynEventSource.Instance.IsEnabled(EventLevel.Informational, EventKeywords.None);
+
                 try
                 {
-                    var containsFullResult = true;
                     foreach (var stateSet in _stateSets)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        containsFullResult &= await TryGetSyntaxAndSemanticDiagnosticsAsync(stateSet, list, cancellationToken).ConfigureAwait(false);
-
-                        // check whether compilation end code fix is enabled
-                        if (!_document.Project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.CompilationEndCodeFix))
+                        if (loggingEnabled)
                         {
-                            continue;
-                        }
-
-                        // check whether heuristic is enabled
-                        if (_blockForData && _document.Project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.UseCompilationEndCodeFixHeuristic))
-                        {
-                            var avoidLoadingData = true;
-                            var state = stateSet.GetProjectState(_project.Id);
-                            var result = await state.GetAnalysisDataAsync(_document, avoidLoadingData, cancellationToken).ConfigureAwait(false);
-
-                            // no previous compilation end diagnostics in this file.
-                            var version = await GetDiagnosticVersionAsync(_project, cancellationToken).ConfigureAwait(false);
-                            if (state.IsEmpty(_document.Id) || result.Version != version)
+                            using (RoslynEventSource.LogInformationalBlock(FunctionId.DiagnosticAnalyzerService_GetDiagnosticsForSpanAsync, stateSet.Analyzer.GetAnalyzerId(), cancellationToken))
                             {
-                                continue;
+                                await ProcessStateSetAsync(stateSet).ConfigureAwait(false);
                             }
                         }
-
-                        containsFullResult &= await TryGetProjectDiagnosticsAsync(stateSet, GetProjectDiagnosticsAsync, list, cancellationToken).ConfigureAwait(false);
+                        else
+                        {
+                            await ProcessStateSetAsync(stateSet).ConfigureAwait(false);
+                        }
                     }
 
                     // if we are blocked for data, then we should always have full result.
@@ -146,6 +135,36 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                 {
                     throw ExceptionUtilities.Unreachable;
+                }
+
+                async Task ProcessStateSetAsync(StateSet stateSet)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    containsFullResult &= await TryGetSyntaxAndSemanticDiagnosticsAsync(stateSet, list, cancellationToken).ConfigureAwait(false);
+
+                    // check whether compilation end code fix is enabled
+                    if (!_document.Project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.CompilationEndCodeFix))
+                    {
+                        return;
+                    }
+
+                    // check whether heuristic is enabled
+                    if (_blockForData && _document.Project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.UseCompilationEndCodeFixHeuristic))
+                    {
+                        var avoidLoadingData = true;
+                        var state = stateSet.GetProjectState(_project.Id);
+                        var result = await state.GetAnalysisDataAsync(_document, avoidLoadingData, cancellationToken).ConfigureAwait(false);
+
+                        // no previous compilation end diagnostics in this file.
+                        var version = await GetDiagnosticVersionAsync(_project, cancellationToken).ConfigureAwait(false);
+                        if (state.IsEmpty(_document.Id) || result.Version != version)
+                        {
+                            return;
+                        }
+                    }
+
+                    containsFullResult &= await TryGetProjectDiagnosticsAsync(stateSet, GetProjectDiagnosticsAsync, list, cancellationToken).ConfigureAwait(false);
                 }
             }
 

--- a/src/Workspaces/Core/Portable/Log/EtwLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/EtwLogger.cs
@@ -40,18 +40,18 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         public void LogBlockStart(FunctionId functionId, LogMessage logMessage, int uniquePairId, CancellationToken cancellationToken)
         {
-            RoslynEventSource.Instance.BlockStart(GetMessage(logMessage), functionId, uniquePairId);
+            _source.BlockStart(GetMessage(logMessage), functionId, uniquePairId);
         }
 
         public void LogBlockEnd(FunctionId functionId, LogMessage logMessage, int uniquePairId, int delta, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                RoslynEventSource.Instance.BlockCanceled(functionId, delta, uniquePairId);
+                _source.BlockCanceled(functionId, delta, uniquePairId);
             }
             else
             {
-                RoslynEventSource.Instance.BlockStop(functionId, delta, uniquePairId);
+                _source.BlockStop(functionId, delta, uniquePairId);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -466,5 +466,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Liveshare_SyntacticTagger,
 
         CommandHandler_GoToBase,
+
+        DiagnosticAnalyzerService_GetDiagnosticsForSpanAsync,
+        CodeFixes_GetCodeFixesAsync,
     }
 }

--- a/src/Workspaces/Core/Portable/Log/RoslynEventSource.LogBlock.cs
+++ b/src/Workspaces/Core/Portable/Log/RoslynEventSource.LogBlock.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         /// if the specified <paramref name="functionId"/> was explicitly enabled.
         /// Instead it checks if the <see cref="RoslynEventSource"/> was enabled at <see cref="EventLevel.Informational"/> level.
         /// </summary>
-        public static IDisposable LogInformationalBlock(FunctionId functionId, object entity, CancellationToken cancellationToken)
+        public static LogBlock LogInformationalBlock(FunctionId functionId, object entity, CancellationToken cancellationToken)
             => LogBlock.Create(functionId, entity, EventLevel.Informational, cancellationToken);
 
         /// <summary>
@@ -29,14 +29,14 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         /// if the specified <paramref name="functionId"/> was explicitly enabled.
         /// Instead it checks if the <see cref="RoslynEventSource"/> was enabled at <see cref="EventLevel.Informational"/> level.
         /// </summary>
-        public static IDisposable LogInformationalBlock(FunctionId functionId, string message, CancellationToken cancellationToken)
+        public static LogBlock LogInformationalBlock(FunctionId functionId, string message, CancellationToken cancellationToken)
             => LogBlock.Create(functionId, message, EventLevel.Informational, cancellationToken);
 
         /// <summary>
         /// This tracks the logged message. On instantiation, it logs 'Started block' with other event data.
         /// On dispose, it logs 'Ended block' with the same event data so we can track which block started and ended when looking at logs.
         /// </summary>
-        private struct LogBlock : IDisposable
+        internal struct LogBlock : IDisposable
         {
             private readonly FunctionId _functionId;
             private readonly object? _entityForMessage;
@@ -135,6 +135,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                     return;
                 }
 
+                Debug.Assert(_message != null);
+
                 if (!_startLogged)
                 {
                     // User enabled logging after the block start.
@@ -142,8 +144,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                     Instance.BlockStart(_message, _functionId, _blockId);
                     _startLogged = true;
                 }
-
-                Debug.Assert(_message != null);
 
                 // This delta is valid for durations of < 25 days
                 var delta = Environment.TickCount - _tick;

--- a/src/Workspaces/Core/Portable/Log/RoslynEventSource.LogBlock.cs
+++ b/src/Workspaces/Core/Portable/Log/RoslynEventSource.LogBlock.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.Internal.Log
+{
+    internal partial class RoslynEventSource
+    {
+        // Regardless of how many tasks we can run in parallel on the machine, we likely won't need more than 256
+        // instrumentation points in flight at a given time.
+        // Use an object pool since we may be logging up to 1-10k events/second
+        private static readonly ObjectPool<RoslynLogBlock> s_pool = new ObjectPool<RoslynLogBlock>(() => new RoslynLogBlock(s_pool), Math.Min(Environment.ProcessorCount * 8, 256));
+
+        /// <summary>
+        /// next unique block id that will be given to each LogBlock
+        /// </summary>
+        private static int s_lastUniqueBlockId;
+
+        /// <summary>
+        /// Logs a block with the given <paramref name="message"/> and specified <paramref name="functionId"/>.
+        /// On dispose of the returned disposable object, it logs the 'tick' count between the start and end of the block.
+        /// Unlike other logging methods on <see cref="RoslynEventSource"/>, this method does not check
+        /// if the specified <paramref name="functionId"/> was explicitly enabled.
+        /// Instead it checks if the <see cref="RoslynEventSource"/> was enabled at <see cref="EventLevel.Informational"/> level.
+        /// </summary>
+        public static IDisposable LogInformationalBlock(FunctionId functionId, string message, CancellationToken cancellationToken)
+            => LogBlock(functionId, message, EventLevel.Informational, cancellationToken);
+
+        private static IDisposable LogBlock(FunctionId functionId, string message, EventLevel requiredEventLevel, CancellationToken cancellationToken)
+        {
+            if (!Instance.IsEnabled(requiredEventLevel, EventKeywords.None))
+            {
+                return EmptyLogBlock.Instance;
+            }
+
+            return CreateLogBlock(functionId, message, cancellationToken);
+        }
+
+        /// <summary>
+        /// return next unique pair id
+        /// </summary>
+        private static int GetNextUniqueBlockId()
+        {
+            return Interlocked.Increment(ref s_lastUniqueBlockId);
+        }
+
+        private static IDisposable CreateLogBlock(FunctionId functionId, string message, CancellationToken cancellationToken)
+        {
+            var block = s_pool.Allocate();
+            var blockId = GetNextUniqueBlockId();
+            block.Construct(functionId, message, blockId, cancellationToken);
+            return block;
+        }
+
+        /// <summary>
+        /// This tracks the logged message. On instantiation, it logs 'Started block' with other event data.
+        /// On dispose, it logs 'Ended block' with the same event data so we can track which block started and ended when looking at logs.
+        /// </summary>
+        private class RoslynLogBlock : IDisposable
+        {
+            private readonly ObjectPool<RoslynLogBlock> _pool;
+            private CancellationToken _cancellationToken;
+
+            private FunctionId _functionId;
+            private int _tick;
+            private int _blockId;
+
+            public RoslynLogBlock(ObjectPool<RoslynLogBlock> pool)
+            {
+                _pool = pool;
+            }
+
+            public void Construct(FunctionId functionId, string message, int blockId, CancellationToken cancellationToken)
+            {
+                _functionId = functionId;
+                _tick = Environment.TickCount;
+                _blockId = blockId;
+                _cancellationToken = cancellationToken;
+
+                Instance.BlockStart(message, functionId, blockId);
+            }
+
+            public void Dispose()
+            {
+                // This delta is valid for durations of < 25 days
+                var delta = Environment.TickCount - _tick;
+
+                if (_cancellationToken.IsCancellationRequested)
+                {
+                    Instance.BlockCanceled(_functionId, delta, _blockId);
+                }
+                else
+                {
+                    Instance.BlockStop(_functionId, delta, _blockId);
+                }
+
+                // Free this block back to the pool
+                _pool.Free(this);
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Log/RoslynEventSource.cs
+++ b/src/Workspaces/Core/Portable/Log/RoslynEventSource.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// "\\clrmain\tools\managed\etw\eventRegister\bin\Debug\eventRegister.exe" Microsoft.CodeAnalysis.Workspaces.dll
     /// </summary>
     [EventSource(Name = "RoslynEventSource")]
-    internal sealed class RoslynEventSource : EventSource
+    internal sealed partial class RoslynEventSource : EventSource
     {
         // might not "enabled" but we always have this singleton alive
         public static readonly RoslynEventSource Instance = new RoslynEventSource();

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -160,31 +160,10 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 Contract.ThrowIfNull(_storage);
 
-                var tickCount = Environment.TickCount;
-                try
+                using (RoslynEventSource.LogInformationalBlock(FunctionId.Workspace_Recoverable_RecoverRootAsync, _containingTree.FilePath, cancellationToken))
                 {
-                    if (RoslynEventSource.Instance.IsEnabled(EventLevel.Informational, EventKeywords.None))
-                    {
-                        RoslynEventSource.Instance.BlockStart(_containingTree.FilePath, FunctionId.Workspace_Recoverable_RecoverRootAsync, blockId: 0);
-                    }
-
                     using var stream = await _storage.ReadStreamAsync(cancellationToken).ConfigureAwait(false);
                     return RecoverRoot(stream, cancellationToken);
-                }
-                finally
-                {
-                    if (RoslynEventSource.Instance.IsEnabled(EventLevel.Informational, EventKeywords.None))
-                    {
-                        var tick = Environment.TickCount - tickCount;
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            RoslynEventSource.Instance.BlockCanceled(FunctionId.Workspace_Recoverable_RecoverRootAsync, tick, blockId: 0);
-                        }
-                        else
-                        {
-                            RoslynEventSource.Instance.BlockStop(FunctionId.Workspace_Recoverable_RecoverRootAsync, tick, blockId: 0);
-                        }
-                    }
                 }
             }
 
@@ -193,30 +172,10 @@ namespace Microsoft.CodeAnalysis.Host
                 Contract.ThrowIfNull(_storage);
 
                 var tickCount = Environment.TickCount;
-                try
+                using (RoslynEventSource.LogInformationalBlock(FunctionId.Workspace_Recoverable_RecoverRoot, _containingTree.FilePath, cancellationToken))
                 {
-                    if (RoslynEventSource.Instance.IsEnabled(EventLevel.Informational, EventKeywords.None))
-                    {
-                        RoslynEventSource.Instance.BlockStart(_containingTree.FilePath, FunctionId.Workspace_Recoverable_RecoverRoot, blockId: 0);
-                    }
-
                     using var stream = _storage.ReadStream(cancellationToken);
                     return RecoverRoot(stream, cancellationToken);
-                }
-                finally
-                {
-                    if (RoslynEventSource.Instance.IsEnabled(EventLevel.Informational, EventKeywords.None))
-                    {
-                        var tick = Environment.TickCount - tickCount;
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            RoslynEventSource.Instance.BlockCanceled(FunctionId.Workspace_Recoverable_RecoverRoot, tick, blockId: 0);
-                        }
-                        else
-                        {
-                            RoslynEventSource.Instance.BlockStop(FunctionId.Workspace_Recoverable_RecoverRoot, tick, blockId: 0);
-                        }
-                    }
                 }
             }
 


### PR DESCRIPTION
…orings executed during Ctrl + .

If user enables informational RoslynEventSource telemetry following the steps at https://aka.ms/reportPerf, we log the execution times for each analyzer/fixer/refactorings when computing the code fixes and refactorings to show in the light bulb. This will help us identify slow analyzers/fixers/refactorings that lead to UI delays with "Gathering suggestions" dialog.



**Customer and scenario info**
**Who is impacted by this bug?**
Users seeing UI delays on Ctrl + . to bring up the light bulb cannot provide actionable performance traces.

**Bugs fixed**
Additional telemetry to help diagnose VSO [#944957](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/944957) in future

**What is the customer scenario and impact of the bug?**
We are seeing UI delays in Ctrl + . code path, where users see prolonged "Gathering suggestions" dialog. This delay can be caused by any IDE or third party extension (analyzer/fixer/refactoring) that run on this code path. Currently, we do not log telemetry to aid identifying the slow extension. This change allows users to provide actionable performance data for this code path.

**What is the workaround?**
N/A

**How was the bug found?**
UI delay VSO [#944957](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/944957)

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
This is a new top UI delay for 16.3. We are adding additional telemetry to help us investigate this better in future.

**Testing**
Verified the new telemetry is indeed logged.