### PR TITLE
Fix for control flow graph when combining using declarations with labels

### DIFF
--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUsingStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUsingStatement.cs
@@ -4840,6 +4840,325 @@ Block[B10] - Exit
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
         }
 
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_12()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M()
+    /*<bind>*/{
+        int a = 0;
+        int b = 1;
+label1:
+        using var c = new P();
+        int d = 2;
+label2:
+label3:
+        using var e = new P();
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+Block[B0] - Entry
+    Statements (0)
+    Next (Regular) Block[B1]
+        Entering: {R1}
+.locals {R1}
+{
+    Locals: [System.Int32 a] [System.Int32 b] [P c] [System.Int32 d] [P e]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (3)
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'a = 0')
+              Left: 
+                ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'a = 0')
+              Right: 
+                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'b = 1')
+              Left: 
+                ILocalReferenceOperation: b (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'b = 1')
+              Right: 
+                ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 1) (Syntax: '1')
+            ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'c = new P()')
+              Left: 
+                ILocalReferenceOperation: c (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'c = new P()')
+              Right: 
+                IObjectCreationOperation (Constructor: P..ctor()) (OperationKind.ObjectCreation, Type: P) (Syntax: 'new P()')
+                  Arguments(0)
+                  Initializer: 
+                    null
+        Next (Regular) Block[B2]
+            Entering: {R2} {R3}
+    .try {R2, R3}
+    {
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (2)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'd = 2')
+                  Left: 
+                    ILocalReferenceOperation: d (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'd = 2')
+                  Right: 
+                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 2) (Syntax: '2')
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'e = new P()')
+                  Left: 
+                    ILocalReferenceOperation: e (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'e = new P()')
+                  Right: 
+                    IObjectCreationOperation (Constructor: P..ctor()) (OperationKind.ObjectCreation, Type: P) (Syntax: 'new P()')
+                      Arguments(0)
+                      Initializer: 
+                        null
+            Next (Regular) Block[B3]
+                Entering: {R4} {R5}
+        .try {R4, R5}
+        {
+            Block[B3] - Block
+                Predecessors: [B2]
+                Statements (0)  
+                Next (Regular) Block[B10]
+                    Finalizing: {R6} {R7}
+                    Leaving: {R5} {R4} {R3} {R2} {R1}
+        }
+        .finally {R6}
+        {
+            Block[B4] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B6]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'e = new P()')
+                      Operand: 
+                        ILocalReferenceOperation: e (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'e = new P()')
+                Next (Regular) Block[B5]
+            Block[B5] - Block
+                Predecessors: [B4]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'e = new P()')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'e = new P()')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: e (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'e = new P()')
+                      Arguments(0)
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B4] [B5]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    .finally {R7}
+    {
+        Block[B7] - Block
+            Predecessors (0)
+            Statements (0)
+            Jump if True (Regular) to Block[B9]
+                IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'c = new P()')
+                  Operand: 
+                    ILocalReferenceOperation: c (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'c = new P()')
+            Next (Regular) Block[B8]
+        Block[B8] - Block
+            Predecessors: [B7]
+            Statements (1)
+                IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'c = new P()')
+                  Instance Receiver: 
+                    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'c = new P()')
+                      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                        (ImplicitReference)
+                      Operand: 
+                        ILocalReferenceOperation: c (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'c = new P()')
+                  Arguments(0)
+            Next (Regular) Block[B9]
+        Block[B9] - Block
+            Predecessors: [B7] [B8]
+            Statements (0)
+            Next (StructuredExceptionHandling) Block[null]
+    }
+}
+Block[B10] - Exit
+    Predecessors: [B3]
+    Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_13()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M()
+    /*<bind>*/{
+        if (true)
+            label1:
+                using var a = new P();
+        if (true)
+            label2:
+            label3:
+                using var b = new P();
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+    Block[B0] - Entry
+        Statements (0)
+        Next (Regular) Block[B1]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (0)
+        Jump if False (Regular) to Block[B7]
+            ILiteralOperation (OperationKind.Literal, Type: System.Boolean, Constant: True) (Syntax: 'true')
+        Next (Regular) Block[B2]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [P a]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                  Right: 
+                    IObjectCreationOperation (Constructor: P..ctor()) (OperationKind.ObjectCreation, Type: P, IsInvalid) (Syntax: 'new P()')
+                      Arguments(0)
+                      Initializer: 
+                        null
+            Next (Regular) Block[B3]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B3] - Block
+                Predecessors: [B2]
+                Statements (0)
+                Next (Regular) Block[B7]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2} {R1}
+        }
+        .finally {R4}
+        {
+            Block[B4] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B6]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                Next (Regular) Block[B5]
+            Block[B5] - Block
+                Predecessors: [B4]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsInvalid, IsImplicit) (Syntax: 'a = new P()')
+                      Arguments(0)
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B4] [B5]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B7] - Block
+        Predecessors: [B1] [B3]
+        Statements (0)
+        Jump if False (Regular) to Block[B13]
+            ILiteralOperation (OperationKind.Literal, Type: System.Boolean, Constant: True) (Syntax: 'true')
+        Next (Regular) Block[B8]
+            Entering: {R5}
+    .locals {R5}
+    {
+        Locals: [P b]
+        Block[B8] - Block
+            Predecessors: [B7]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                  Left: 
+                    ILocalReferenceOperation: b (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                  Right: 
+                    IObjectCreationOperation (Constructor: P..ctor()) (OperationKind.ObjectCreation, Type: P, IsInvalid) (Syntax: 'new P()')
+                      Arguments(0)
+                      Initializer: 
+                        null
+            Next (Regular) Block[B9]
+                Entering: {R6} {R7}
+        .try {R6, R7}
+        {
+            Block[B9] - Block
+                Predecessors: [B8]
+                Statements (0)
+                Next (Regular) Block[B13]
+                    Finalizing: {R8}
+                    Leaving: {R7} {R6} {R5}
+        }
+        .finally {R8}
+        {
+            Block[B10] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B12]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                      Operand: 
+                        ILocalReferenceOperation: b (OperationKind.LocalReference, Type: P, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                Next (Regular) Block[B11]
+            Block[B11] - Block
+                Predecessors: [B10]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: b (OperationKind.LocalReference, Type: P, IsInvalid, IsImplicit) (Syntax: 'b = new P()')
+                      Arguments(0)
+                Next (Regular) Block[B12]
+            Block[B12] - Block
+                Predecessors: [B10] [B11]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B13] - Exit
+        Predecessors: [B7] [B9]
+        Statements (0)
+";
+            var expectedDiagnostics = new[]{
+                // file.cs(12,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //             label1:
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, @"label1:
+                using var a = new P();").WithLocation(12, 13),
+                // file.cs(15,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //             label2:
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, @"label2:
+            label3:
+                using var b = new P();").WithLocation(15, 13)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact, WorkItem(32100, "https://github.com/dotnet/roslyn/issues/32100")]
         public void UsingDeclaration_SingleDeclaration()
@@ -4999,6 +5318,70 @@ class C : IDisposable
             var expectedDiagnostics = DiagnosticDescription.None;
 
             VerifyOperationTreeAndDiagnosticsForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact, WorkItem(32100, "https://github.com/dotnet/roslyn/issues/32100")]
+        public void UsingDeclaration_MultipleDeclaration_WithLabels()
+        {
+            string source = @"
+using System;
+#pragma warning disable CS0164
+class C : IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    public static void M1()
+    /*<bind>*/{
+    label1:
+        using var a = new C();
+    label2:
+    label3:
+        using var b = new C();
+    }/*</bind>*/
+}
+";
+            string expectedOperationTree = @"
+IBlockOperation (2 statements, 2 locals) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
+      Locals: Local_1: C a
+        Local_2: C b
+      ILabeledOperation (Label: label1) (OperationKind.Labeled, Type: null) (Syntax: 'label1: ...  = new C();')
+        Statement: 
+          IVariableDeclarationGroupOperation (1 declarations, DeclarationKind: Using) (OperationKind.VariableDeclarationGroup, Type: null) (Syntax: 'using var a = new C();')
+            IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'var a = new C()')
+              Declarators:
+                  IVariableDeclaratorOperation (Symbol: C a) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'a = new C()')
+                    Initializer: 
+                      IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= new C()')
+                        IObjectCreationOperation (Constructor: C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'new C()')
+                          Arguments(0)
+                          Initializer: 
+                            null
+              Initializer: 
+                null
+      ILabeledOperation (Label: label2) (OperationKind.Labeled, Type: null) (Syntax: 'label2: ...  = new C();')
+        Statement: 
+          ILabeledOperation (Label: label3) (OperationKind.Labeled, Type: null) (Syntax: 'label3: ...  = new C();')
+            Statement: 
+              IVariableDeclarationGroupOperation (1 declarations, DeclarationKind: Using) (OperationKind.VariableDeclarationGroup, Type: null) (Syntax: 'using var b = new C();')
+                IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration, Type: null) (Syntax: 'var b = new C()')
+                  Declarators:
+                      IVariableDeclaratorOperation (Symbol: C b) (OperationKind.VariableDeclarator, Type: null) (Syntax: 'b = new C()')
+                        Initializer: 
+                          IVariableInitializerOperation (OperationKind.VariableInitializer, Type: null) (Syntax: '= new C()')
+                            IObjectCreationOperation (Constructor: C..ctor()) (OperationKind.ObjectCreation, Type: C) (Syntax: 'new C()')
+                              Arguments(0)
+                              Initializer: 
+                                null
+                  Initializer: 
+                    null
+";
+
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<BlockSyntax>(source, expectedOperationTree, expectedDiagnostics);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUsingStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUsingStatement.cs
@@ -5450,6 +5450,314 @@ class P : System.IDisposable
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
         }
 
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_17()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M(bool b)
+    /*<bind>*/{
+        if (b)
+            goto label1;
+        int x = 0;
+        label1:
+        using var a = this;
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+    Block[B0] - Entry
+        Statements (0)
+        Next (Regular) Block[B1]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [System.Int32 x] [P a]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (0)
+            Jump if False (Regular) to Block[B2]
+                IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+            Next (Regular) Block[B3]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Left: 
+                    ILocalReferenceOperation: x (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Right: 
+                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+            Next (Regular) Block[B3]
+        Block[B3] - Block
+            Predecessors: [B1] [B2]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Right: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P) (Syntax: 'this')
+            Next (Regular) Block[B4]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B4] - Block
+                Predecessors: [B3]
+                Statements (0)
+                Next (Regular) Block[B8]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2} {R1}
+        }
+        .finally {R4}
+        {
+            Block[B5] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B7]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'a = this')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B5]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'a = this')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'a = this')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                      Arguments(0)
+                Next (Regular) Block[B7]
+            Block[B7] - Block
+                Predecessors: [B5] [B6]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B8] - Exit
+        Predecessors: [B4]
+        Statements (0)
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_18()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M(bool b)
+    /*<bind>*/{
+        label1:
+        using var a = this;
+        if (b)
+            goto label1;
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+    Block[B0] - Entry
+        Statements (0)
+        Next (Regular) Block[B1]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [P a]
+        Block[B1] - Block
+            Predecessors: [B0] [B2]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Right: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P) (Syntax: 'this')
+            Next (Regular) Block[B2]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B2] - Block
+                Predecessors: [B1]
+                Statements (0)
+                Jump if False (Regular) to Block[B6]
+                    IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2} {R1}
+                Next (Regular) Block[B1]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2}
+        }
+        .finally {R4}
+        {
+            Block[B3] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B5]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'a = this')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                Next (Regular) Block[B4]
+            Block[B4] - Block
+                Predecessors: [B3]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'a = this')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'a = this')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                      Arguments(0)
+                Next (Regular) Block[B5]
+            Block[B5] - Block
+                Predecessors: [B3] [B4]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B6] - Exit
+        Predecessors: [B2]
+        Statements (0)
+";
+            var expectedDiagnostics = new[]{
+                // file.cs(14,13): error CS8649: A goto cannot jump to a location before a using declaration within the same block.
+                //             goto label1;
+                Diagnostic(ErrorCode.ERR_GoToBackwardJumpOverUsingVar, "goto label1;").WithLocation(14, 13)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_19()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M(bool b)
+    /*<bind>*/{
+        if (b)
+            goto label1;
+        int x = 0;
+        label1:
+        using var a = this;
+        if (b)
+            goto label1;
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+    Block[B0] - Entry
+        Statements (0)
+        Next (Regular) Block[B1]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [System.Int32 x] [P a]
+        Block[B1] - Block
+            Predecessors: [B0]
+            Statements (0)
+            Jump if False (Regular) to Block[B2]
+                IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+            Next (Regular) Block[B3]
+        Block[B2] - Block
+            Predecessors: [B1]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Left: 
+                    ILocalReferenceOperation: x (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Right: 
+                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+            Next (Regular) Block[B3]
+        Block[B3] - Block
+            Predecessors: [B1] [B2] [B4]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Right: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P) (Syntax: 'this')
+            Next (Regular) Block[B4]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B4] - Block
+                Predecessors: [B3]
+                Statements (0)
+                Jump if False (Regular) to Block[B8]
+                    IParameterReferenceOperation: b (OperationKind.ParameterReference, Type: System.Boolean) (Syntax: 'b')
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2} {R1}
+                Next (Regular) Block[B3]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2}
+        }
+        .finally {R4}
+        {
+            Block[B5] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B7]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'a = this')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B5]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'a = this')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'a = this')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                      Arguments(0)
+                Next (Regular) Block[B7]
+            Block[B7] - Block
+                Predecessors: [B5] [B6]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B8] - Exit
+        Predecessors: [B4]
+        Statements (0)
+";
+            var expectedDiagnostics = new[]{
+                // file.cs(17,13): error CS8649: A goto cannot jump to a location before a using declaration within the same block.
+                //             goto label1;
+                Diagnostic(ErrorCode.ERR_GoToBackwardJumpOverUsingVar, "goto label1;").WithLocation(17, 13)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact, WorkItem(32100, "https://github.com/dotnet/roslyn/issues/32100")]
         public void UsingDeclaration_SingleDeclaration()

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUsingStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IUsingStatement.cs
@@ -5159,6 +5159,297 @@ class P : System.IDisposable
             VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
         }
 
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_14()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M()
+    /*<bind>*/{
+        goto label1;
+        int x = 0;
+        label1:
+        using var a = this;
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+    Block[B0] - Entry
+        Statements (0)
+        Next (Regular) Block[B2]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [System.Int32 x] [P a]
+        Block[B1] - Block [UnReachable]
+            Predecessors (0)
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Left: 
+                    ILocalReferenceOperation: x (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Right: 
+                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B0] [B1]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Right: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P) (Syntax: 'this')
+            Next (Regular) Block[B3]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B3] - Block
+                Predecessors: [B2]
+                Statements (0)
+                Next (Regular) Block[B7]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2} {R1}
+        }
+        .finally {R4}
+        {
+            Block[B4] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B6]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'a = this')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                Next (Regular) Block[B5]
+            Block[B5] - Block
+                Predecessors: [B4]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'a = this')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'a = this')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                      Arguments(0)
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B4] [B5]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B7] - Exit
+        Predecessors: [B3]
+        Statements (0)
+";
+            var expectedDiagnostics = new[]{
+                // file.cs(12,9): warning CS0162: Unreachable code detected
+                //         int x = 0;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "int").WithLocation(12, 9)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_15()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M()
+    /*<bind>*/{
+        label1:
+        using var a = this;
+        goto label1;
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+      Block[B0] - Entry
+      Statements (0)
+        Next (Regular) Block[B1]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [P a]
+        Block[B1] - Block
+            Predecessors: [B0] [B2]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Right: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P) (Syntax: 'this')
+            Next (Regular) Block[B2]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B2] - Block
+                Predecessors: [B1]
+                Statements (0)
+                Next (Regular) Block[B1]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2}
+        }
+        .finally {R4}
+        {
+            Block[B3] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B5]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'a = this')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                Next (Regular) Block[B4]
+            Block[B4] - Block
+                Predecessors: [B3]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'a = this')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'a = this')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                      Arguments(0)
+                Next (Regular) Block[B5]
+            Block[B5] - Block
+                Predecessors: [B3] [B4]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B6] - Exit [UnReachable]
+        Predecessors (0)
+        Statements (0)
+";
+            var expectedDiagnostics = new[]{
+                // file.cs(13,9): error CS8649: A goto cannot jump to a location before a using declaration within the same block.
+                //         goto label1;
+                Diagnostic(ErrorCode.ERR_GoToBackwardJumpOverUsingVar, "goto label1;").WithLocation(13, 9)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)]
+        [Fact]
+        public void UsingDeclaration_Flow_16()
+        {
+            string source = @"
+#pragma  warning disable CS0815, CS0219, CS0164
+class P : System.IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void M()
+    /*<bind>*/{
+        goto label1;
+        int x = 0;
+        label1:
+        using var a = this;
+        goto label1;
+    }/*</bind>*/
+
+}
+";
+            string expectedGraph = @"
+    Block[B0] - Entry
+        Statements (0)
+        Next (Regular) Block[B2]
+            Entering: {R1}
+    .locals {R1}
+    {
+        Locals: [System.Int32 x] [P a]
+        Block[B1] - Block [UnReachable]
+            Predecessors (0)
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Left: 
+                    ILocalReferenceOperation: x (IsDeclaration: True) (OperationKind.LocalReference, Type: System.Int32, IsImplicit) (Syntax: 'x = 0')
+                  Right: 
+                    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 0) (Syntax: '0')
+            Next (Regular) Block[B2]
+        Block[B2] - Block
+            Predecessors: [B0] [B1] [B3]
+            Statements (1)
+                ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Left: 
+                    ILocalReferenceOperation: a (IsDeclaration: True) (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                  Right: 
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: P) (Syntax: 'this')
+            Next (Regular) Block[B3]
+                Entering: {R2} {R3}
+        .try {R2, R3}
+        {
+            Block[B3] - Block
+                Predecessors: [B2]
+                Statements (0)
+                Next (Regular) Block[B2]
+                    Finalizing: {R4}
+                    Leaving: {R3} {R2}
+        }
+        .finally {R4}
+        {
+            Block[B4] - Block
+                Predecessors (0)
+                Statements (0)
+                Jump if True (Regular) to Block[B6]
+                    IIsNullOperation (OperationKind.IsNull, Type: System.Boolean, IsImplicit) (Syntax: 'a = this')
+                      Operand: 
+                        ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                Next (Regular) Block[B5]
+            Block[B5] - Block
+                Predecessors: [B4]
+                Statements (1)
+                    IInvocationOperation (virtual void System.IDisposable.Dispose()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'a = this')
+                      Instance Receiver: 
+                        IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.IDisposable, IsImplicit) (Syntax: 'a = this')
+                          Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+                            (ImplicitReference)
+                          Operand: 
+                            ILocalReferenceOperation: a (OperationKind.LocalReference, Type: P, IsImplicit) (Syntax: 'a = this')
+                      Arguments(0)
+                Next (Regular) Block[B6]
+            Block[B6] - Block
+                Predecessors: [B4] [B5]
+                Statements (0)
+                Next (StructuredExceptionHandling) Block[null]
+        }
+    }
+    Block[B7] - Exit [UnReachable]
+        Predecessors (0)
+        Statements (0)
+";
+            var expectedDiagnostics = new[]{
+                // file.cs(12,9): warning CS0162: Unreachable code detected
+                //         int x = 0;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "int").WithLocation(12, 9),
+                // file.cs(15,9): error CS8649: A goto cannot jump to a location before a using declaration within the same block.
+                //         goto label1;
+                Diagnostic(ErrorCode.ERR_GoToBackwardJumpOverUsingVar, "goto label1;").WithLocation(15, 9)
+            };
+
+            VerifyFlowGraphAndDiagnosticsForTest<BlockSyntax>(source, expectedGraph, expectedDiagnostics);
+        }
+
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact, WorkItem(32100, "https://github.com/dotnet/roslyn/issues/32100")]
         public void UsingDeclaration_SingleDeclaration()

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1391,8 +1391,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             switch (operation)
             {
-                case IVariableDeclarationGroupOperation declarationGroup { DeclarationKind: VariableDeclarationKind.Using }:
-                case IVariableDeclarationGroupOperation declarationGroup { DeclarationKind: VariableDeclarationKind.AsynchronousUsing }:
+                case IVariableDeclarationGroupOperation declarationGroup when declarationGroup.DeclarationKind == VariableDeclarationKind.Using || declarationGroup.DeclarationKind == VariableDeclarationKind.AsynchronousUsing:
                     var followingStatements = ImmutableArray.Create(statements, startIndex + 1, statements.Length - startIndex - 1);
                     VisitUsingVariableDeclarationOperation(declarationGroup, followingStatements);
                     return true;

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1377,12 +1377,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         }
 
         /// <summary>
-        /// Visits a node that is possibly a using <see cref="VariableDeclarationGroupOperation"/>
+        /// Visits a node that is possibly a using <see cref="IVariableDeclarationGroupOperation"/>
         /// </summary>
         /// <param name="operation">The statement to visit</param>
         /// <param name="statements">All statements in the block containing this node</param>
         /// <param name="startIndex">The current statement being visited in <paramref name="statements"/></param>
-        /// <param name="visitedUsingDeclaration">Set to true if this visited a using <see cref="VariableDeclarationGroupOperation"/> operation</param>
+        /// <param name="visitedUsingDeclaration">Set to true if this visited a using <see cref="IVariableDeclarationGroupOperation"/> operation</param>
         /// <remarks>
         /// The operation being visited is not necessarily equal to statements[startIndex]. 
         /// When traversing down a set of labels, we set operation to the label.Operation and recurse, but statements[startIndex] still refers to the original parent label 
@@ -1393,7 +1393,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             switch (operation.Kind)
             {
                 case OperationKind.VariableDeclarationGroup:
-                    var declarationGroup = (VariableDeclarationGroupOperation)operation;
+                    var declarationGroup = (IVariableDeclarationGroupOperation)operation;
                     if (declarationGroup.DeclarationKind != VariableDeclarationKind.Using && declarationGroup.DeclarationKind != VariableDeclarationKind.AsynchronousUsing)
                     {
                         goto default;
@@ -1404,6 +1404,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     break;
                 case OperationKind.Labeled:
                     var labelOperation = (ILabeledOperation)operation;
+                    if (labelOperation.Operation is null)
+                    {
+                        goto default;
+                    }
                     VisitLabel(labelOperation.Label);
                     VisitPossibleUsingDeclaration(labelOperation.Operation, statements, startIndex, out visitedUsingDeclaration);
                     break;
@@ -6867,7 +6871,7 @@ oneMoreTime:
             return GetCaptureReference(captureOutput, operation);
         }
 
-        private void VisitUsingVariableDeclarationOperation(VariableDeclarationGroupOperation operation, ImmutableArray<IOperation> statements)
+        private void VisitUsingVariableDeclarationOperation(IVariableDeclarationGroupOperation operation, ImmutableArray<IOperation> statements)
         {
             IOperation saveCurrentStatement = _currentStatement;
             _currentStatement = operation;
@@ -6880,7 +6884,7 @@ oneMoreTime:
             BlockOperation logicalBlock = new BlockOperation(
                 operations: statements,
                 locals: ImmutableArray<ILocalSymbol>.Empty,
-                operation.OwningSemanticModel,
+                ((Operation)operation).OwningSemanticModel,
                 operation.Syntax,
                 operation.Type,
                 operation.ConstantValue,

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1396,7 +1396,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     var followingStatements = ImmutableArray.Create(statements, startIndex + 1, statements.Length - startIndex - 1);
                     VisitUsingVariableDeclarationOperation(declarationGroup, followingStatements);
                     return true;
-                case ILabeledOperation labelOperation { Operation: object }:
+                case ILabeledOperation labelOperation when labelOperation.Operation is object:
                     VisitLabel(labelOperation.Label);
                     return TryVisitPossibleUsingDeclaration(labelOperation.Operation, statements, startIndex);
                 default:

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1391,7 +1391,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         {
             switch (operation)
             {
-                case IVariableDeclarationGroupOperation declarationGroup when declarationGroup.DeclarationKind == VariableDeclarationKind.Using || declarationGroup.DeclarationKind == VariableDeclarationKind.AsynchronousUsing:
+                case IVariableDeclarationGroupOperation declarationGroup { DeclarationKind: VariableDeclarationKind.Using }:
+                case IVariableDeclarationGroupOperation declarationGroup { DeclarationKind: VariableDeclarationKind.AsynchronousUsing }:
                     var followingStatements = ImmutableArray.Create(statements, startIndex + 1, statements.Length - startIndex - 1);
                     VisitUsingVariableDeclarationOperation(declarationGroup, followingStatements);
                     return true;

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -1395,7 +1395,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                     var followingStatements = ImmutableArray.Create(statements, startIndex + 1, statements.Length - startIndex - 1);
                     VisitUsingVariableDeclarationOperation(declarationGroup, followingStatements);
                     return true;
-                case ILabeledOperation labelOperation when labelOperation.Operation is object:
+                case ILabeledOperation labelOperation { Operation: object }:
                     VisitLabel(labelOperation.Label);
                     return TryVisitPossibleUsingDeclaration(labelOperation.Operation, statements, startIndex);
                 default:


### PR DESCRIPTION
This fixes an issue in CFG where we incorrectly handle using declarations that fall under labels. It follows a similar pattern to how we handle lowering in the local re-writer.