### PR TITLE
Handle intellicode star in display text prefix

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/Helpers.cs
@@ -139,8 +139,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will introduce this support and we will get rid of relying on the "★" then.
+        // We check both the display text and the display text prefix to account for IntelliCode item providers
+        // that may be using the prefix to include the ★.
         internal static bool IsPreferredItem(this RoslynCompletionItem completionItem)
-            => completionItem.DisplayText.StartsWith("★");
+            => completionItem.DisplayText.StartsWith("★") || completionItem.DisplayTextPrefix.StartsWith("★");
 
         // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will introduce this support and we will get rid of relying on the "★" then.


### PR DESCRIPTION
Currently, commit-if-unique does not work in TypeScript and JavaScript files.
This is because TypeScript adds the IntelliCode star to completion items in the display text prefix and therefore they are not currently deduplicated from the perspective of the ItemManager.
Here, we update the implementation of `IsPreferredItem` to handle this case.

Note that we do not need to update the override for VSCompletionItems because there's no equivalent prefix field (also, I'm not convinced that that override is even used, but I'm not sure enough to remove it).