### PR TITLE
Completion: provide all candidate symbols for overloads in lambda expressions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10048,6 +10048,52 @@ namespace ThenIncludeIntellisenseBug
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CompletionForLambdaWithOverloads()
+        {
+            var markup = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace ClassLibrary1
+{
+    class SomeItem
+    {
+        public string A;
+        public int B;
+    }
+    class SomeCollection<T> : List<T>
+    {
+        public virtual SomeCollection<T> Include(string path) => null;
+    }
+
+    static class Extensions
+    {
+        public static IList<T> Include<T, TProperty>(this IList<T> source, Expression<Func<T, TProperty>> path)
+            => null;
+
+        public static IList Include(this IList source, string path) => null;
+
+        public static IList<T> Include<T>(this IList<T> source, string path) => null;
+    }
+
+    class Program 
+    {
+        void M(SomeCollection<SomeItem> c)
+        {
+            var a = from m in c.Include(t => t.$$);
+        }
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "Substring");
+            await VerifyItemExistsAsync(markup, "A");
+            await VerifyItemExistsAsync(markup, "B");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CompletionInsideMethodsWithNonFunctionsAsArguments()
         {
             var markup = @"

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -8066,6 +8066,58 @@ End Namespace"
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function CompletionForLambdaWithOverloads() As Task
+            Dim source =
+<code><![CDATA[
+Imports System.Linq.Expressions
+Imports System.Collections
+Imports System
+Imports System.Collections.Generic
+
+Namespace VBTest
+    Public Class SomeItem
+        Public A As String
+        Public B As Integer
+    End Class
+
+    Class SomeCollection(Of T)
+        Inherits List(Of T)
+        Public Overridable Function Include(path As String) As SomeCollection(Of T)
+            Return Nothing
+        End Function
+    End Class
+
+    Module Extensions
+        <System.Runtime.CompilerServices.Extension>
+        Public Function Include(Of T, TProperty)(ByVal source As IList(Of T), path As Expression(Of Func(Of T, TProperty))) As IList(Of T)
+            Return Nothing
+        End Function
+
+        <System.Runtime.CompilerServices.Extension>
+       Public Function Include(ByVal source As IList, path As String) As IList
+            Return Nothing
+        End Function
+
+        <System.Runtime.CompilerServices.Extension>
+        Public Function Include(Of T)(ByVal source As IList(Of T), path As String) As IList(Of T)
+            Return Nothing
+        End Function
+    End Module
+
+    Class Program
+        Sub M(c As SomeCollection(Of SomeItem))
+            Dim a = From m In c.Include(Function(t) t.$$)
+        End Sub
+    End Class
+End Namespace
+]]></code>.Value
+
+            Await VerifyItemExistsAsync(source, "Substring")
+            Await VerifyItemExistsAsync(source, "A")
+            Await VerifyItemExistsAsync(source, "B")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CompletionInsideMethodsWithNonFunctionsAsArguments() As Task
             Dim source =
 <code><![CDATA[

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -66,9 +66,9 @@ namespace Microsoft.CodeAnalysis.Recommendations
             var invocationExpression = lambdaSyntax.Parent.Parent.Parent;
             var arguments = syntaxFactsService.GetArgumentsOfInvocationExpression(invocationExpression);
             var ordinalInInvocation = arguments.IndexOf(lambdaSyntax.Parent);
+            var expressionOfInvocationExpression = syntaxFactsService.GetExpressionOfInvocationExpression(invocationExpression);
 
-            var invocation = _context.SemanticModel.GetSymbolInfo(invocationExpression, _cancellationToken);
-            var candidateSymbols = invocation.GetAllSymbols();
+            var candidateSymbols = _context.SemanticModel.GetMemberGroup(expressionOfInvocationExpression, _cancellationToken);
 
             // parameter.Ordinal is the ordinal within (a,b,c) => b.
             // For candidate symbols of (a,b,c) => b., get types of all possible b.

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -68,6 +68,8 @@ namespace Microsoft.CodeAnalysis.Recommendations
             var ordinalInInvocation = arguments.IndexOf(lambdaSyntax.Parent);
             var expressionOfInvocationExpression = syntaxFactsService.GetExpressionOfInvocationExpression(invocationExpression);
 
+            // Get all members potentially matching the invocation expression.
+            // We filter them out based on ordinality later.
             var candidateSymbols = _context.SemanticModel.GetMemberGroup(expressionOfInvocationExpression, _cancellationToken);
 
             // parameter.Ordinal is the ordinal within (a,b,c) => b.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/39468