### PR TITLE
Variable suggestions show duplicated filter buttons on completion window

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterSet.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterSet.cs
@@ -29,6 +29,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         // use the same reference to the instance of CompletionFilter.
         private static readonly ImmutableDictionary<string, FilterWithMask> s_filterMap;
 
+        // Distinct list of all filters.
+        private static readonly ImmutableArray<FilterWithMask> s_filters;
+
         private BitVector32 _vector;
         private static readonly int s_expanderMask;
 
@@ -54,7 +57,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         static FilterSet()
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, FilterWithMask>();
+            var mapBuilder = ImmutableDictionary.CreateBuilder<string, FilterWithMask>();
+            var arrayBuilder = ImmutableArray.CreateBuilder<FilterWithMask>();
+
             var previousMask = 0;
 
             NamespaceFilter = CreateCompletionFilterAndAddToBuilder(FeaturesResources.Namespaces, 'n', WellKnownTags.Namespace);
@@ -75,7 +80,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             SnippetFilter = CreateCompletionFilterAndAddToBuilder(FeaturesResources.Snippets, 't', WellKnownTags.Snippet);
             TargetTypedFilter = CreateCompletionFilterAndAddToBuilder(FeaturesResources.Target_type_matches, 'j', WellKnownTags.TargetTypeMatch);
 
-            s_filterMap = builder.ToImmutable();
+            s_filterMap = mapBuilder.ToImmutable();
+            s_filters = arrayBuilder.ToImmutable();
 
             s_expanderMask = BitVector32.CreateMask(previousMask);
 
@@ -91,9 +97,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 var filter = CreateCompletionFilter(displayText, tags, accessKey);
                 previousMask = BitVector32.CreateMask(previousMask);
 
+                var filterWithMask = new FilterWithMask(filter, previousMask);
+                arrayBuilder.Add(filterWithMask);
+
                 foreach (var tag in tags)
                 {
-                    builder.Add(tag, new FilterWithMask(filter, previousMask));
+                    mapBuilder.Add(tag, filterWithMask);
                 }
 
                 return filter;
@@ -173,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 builder.Add(new CompletionFilterWithState(Expander, isAvailable: true, isSelected: false));
             }
 
-            foreach (var filterWithMask in s_filterMap.Values)
+            foreach (var filterWithMask in s_filters)
             {
                 if (_vector[filterWithMask.Mask])
                 {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterSet.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/FilterSet.cs
@@ -25,11 +25,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
     internal sealed class FilterSet
     {
         // Cache all the VS completion filters which essentially make them singletons.
-        // Because all items that should be filtered using the same filter button must 
-        // use the same reference to the instance of CompletionFilter.
+        // Need to map item tags such as Class, Interface, Local, Enum to filter buttons.
+        // There can be tags mapping to the same button:
+        // Local -> Locals and Parameters, Parameter -> Locals and Parameters.
         private static readonly ImmutableDictionary<string, FilterWithMask> s_filterMap;
 
         // Distinct list of all filters.
+        // Need to iterate over a distinct list of filters 
+        // to create a filter list covering a completion session.
         private static readonly ImmutableArray<FilterWithMask> s_filters;
 
         private BitVector32 _vector;

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -181,6 +181,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private bool FiltersMatch(List<CompletionFilter> expectedMatchingFilters, RoslynCompletion.CompletionItem item)
         {
             var matchingFilters = FilterSet.GetFilters(item);
+
+            // Check that the list has no duplicates.
+            Assert.Equal(matchingFilters.Count, matchingFilters.Distinct().Count());
             return expectedMatchingFilters.SetEquals(matchingFilters);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/39381

There are two items tags Locals and Parameters mapping to the same filter: Locals-And-Parameters. Now we display two filter icons Locals-And-Parameters in the completion popup. Need to display just a single one for both them together.


**Customer and scenario info**
In an intellisense session, if there are locals or parameters provided to completion, we display duplicated icons for Locals-And-Parameters.

![image](https://user-images.githubusercontent.com/5455484/67519816-80cf3c80-f65c-11e9-99ca-a80748c5b934.png)


**Who is impacted by this bug?**
Typing for C#/VB developers confuse them with a weird UI.

**Bugs fixed**
Fixes #39381

**What is the customer scenario and impact of the bug?**

Scenario: In an intellisense session, if there are locals or parameters provided to completion.
Impact: UI confusing users

**What is the workaround?**
None

**How was the bug found?**
Dogfooding

**If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed?**
This is a regression introduced with https://github.com/dotnet/roslyn/pull/38904 in 16.4 P2.
Test harness compares sets and didn't check for duplicates. 

**Testing**
1. Verified manually.
2. Added a check for duplicates to all completion provider tests checking filters.