### PR TITLE
Fix an assert in IOperationExtension.GetValueUsageInfo

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -7175,6 +7175,69 @@ public class Test
 }");
         }
 
+        [WorkItem(38640, "https://github.com/dotnet/roslyn/issues/38640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task DeclarationPatternInSwitchExpressionArm_UsedLocal()
+        {
+            await TestDiagnosticMissingAsync(
+@"class C
+{
+    string M(object obj)
+    {
+        return obj switch
+        {
+            int [|p2|] => p2.ToString(),
+            _ => ""NoMatch""
+        };
+    }
+}", new TestParameters(options: PreferDiscard, parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8)));
+        }
 
+        [WorkItem(38640, "https://github.com/dotnet/roslyn/issues/38640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task DeclarationPatternInSwitchExpressionArm_UnusedLocal_PreferUnusedLocal()
+        {
+            await TestDiagnosticMissingAsync(
+@"class C
+{
+    string M(object obj)
+    {
+        return obj switch
+        {
+            int [|p2|] => ""Int"",
+            _ => ""NoMatch""
+        };
+    }
+}", new TestParameters(options: PreferUnusedLocal, parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8)));
+        }
+
+        [WorkItem(38640, "https://github.com/dotnet/roslyn/issues/38640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        public async Task DeclarationPatternInSwitchExpressionArm_UnusedLocal_PreferDiscard()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    string M(object obj)
+    {
+        return obj switch
+        {
+            int [|p2|] => ""Int"",
+            _ => ""NoMatch""
+        };
+    }
+}",
+@"class C
+{
+    string M(object obj)
+    {
+        return obj switch
+        {
+            int _ => ""Int"",
+            _ => ""NoMatch""
+        };
+    }
+}", options: PreferDiscard, parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Extensions/OperationExtensions.cs
@@ -73,6 +73,16 @@ namespace Microsoft.CodeAnalysis
                         //
                         return ValueUsageInfo.Write;
 
+                    case ISwitchExpressionArmOperation _:
+                        // A declaration pattern within a switch expression arm is a
+                        // write for the declared local.
+                        // For example, 'x' is defined and assigned the value from 'obj' below:
+                        //      obj switch
+                        //      {
+                        //          X x => ...
+                        //
+                        return ValueUsageInfo.Write;
+
                     case IIsPatternOperation _:
                         // A declaration pattern within an is pattern is a
                         // write for the declared local.


### PR DESCRIPTION
Handle declaration pattern parented by switch expression arm in GetValueUsageInfo.
Fixes #38640