### PR TITLE
Implicit numeric casts shouldn't be recommended to be removed if doing so loses precision

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -2111,6 +2111,22 @@ class A : Attribute
 }");
         }
 
+        [WorkItem(39042, "https://github.com/dotnet/roslyn/issues/39042")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveNecessaryCastForImplicitNumericCastsThatLoseInformation()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using System;
+
+class A
+{
+    public A(long x)
+    {
+        long y = (long)[|(double)x|];
+    }
+}");
+        }
+
         #region Interface Casts
 
         [WorkItem(545889, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545889")]

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -500,7 +500,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     expressionToCastType.IsImplicit &&
                     (expressionToCastType.IsNumeric || expressionToCastType.IsConstantExpression))
                 {
-                    return true;
+                    // Some implicit numeric conversions can cause loss of precision and must not be removed.
+                    return !IsRequiredImplicitNumericConversion(expressionType, castType);
                 }
 
                 if (!castToOuterType.IsBoxing &&


### PR DESCRIPTION
Fixes #39042 . This check already existed in other code paths, but wasn't in this short circuit path.

Verified manually and all tests pass locally.