### PR TITLE
Subscribe to OnModuleInstanceLoad/OnModuleInstanceUnload events only when managed debugging is being used

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioDebugStateChangeListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioDebugStateChangeListener.cs
@@ -32,6 +32,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 
             DkmCustomMessage IDkmCustomMessageForwardReceiver.SendLower(DkmCustomMessage customMessage)
             {
+                // Initialize the listener before OnModuleInstanceLoad/OnModuleInstanceUnload can be triggered.
+                // These events are only called when managed debugging is being used due to RuntimeId=DkmRuntimeId.Clr filter in vsdconfigxml.
                 _listener = (VisualStudioDebugStateChangeListener)customMessage.Parameter1;
                 return null;
             }
@@ -75,9 +77,12 @@ namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
             _encService = workspace.Services.GetRequiredService<IEditAndContinueWorkspaceService>();
         }
 
+        /// <summary>
+        /// Called by the debugger when a debugging session starts and managed debugging is being used.
+        /// </summary>
         public void StartDebugging()
         {
-            // hook up a callbacks (the call blocks until the message is processed):
+            // Hook up a callbacks (the call blocks until the message is processed).
             using (DebuggerComponent.ManagedEditAndContinueService())
             {
                 DkmCustomMessage.Create(

--- a/src/VisualStudio/Core/Def/ManagedEditAndContinueService.vsdconfigxml
+++ b/src/VisualStudio/Core/Def/ManagedEditAndContinueService.vsdconfigxml
@@ -27,8 +27,10 @@
           </Filter>
           <Interface Name="IDkmCustomMessageForwardReceiver"/>
         </InterfaceGroup>
-        <InterfaceGroup>
-          <NoFilter/>
+        <InterfaceGroup CallOnlyWhenLoaded="true">
+          <Filter>
+            <RuntimeId RequiredValue="DkmRuntimeId.Clr"/>
+          </Filter>
           <Interface Name="IDkmModuleInstanceLoadNotification"/>
           <Interface Name="IDkmModuleInstanceUnloadNotification"/>
         </InterfaceGroup>


### PR DESCRIPTION
Avoids loading Roslyn when debugging native code only.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/940318