### PR TITLE
Support non-monotonic transfer for local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.ILocalState.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.ILocalState.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// 3. Meet(Top, X) = X
         ///
         /// </summary>
-        protected abstract void Meet(ref TLocalState self, ref TLocalState other);
+        protected abstract bool Meet(ref TLocalState self, ref TLocalState other);
 
         internal interface ILocalState
         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -71,11 +71,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override LocalFunctionState CreateLocalFunctionState() => new LocalFunctionState(UnreachableState());
 
-        protected override void Meet(ref LocalState self, ref LocalState other)
+        protected override bool Meet(ref LocalState self, ref LocalState other)
         {
+            var old = self;
             self.Alive &= other.Alive;
             self.Reported &= other.Reported;
             Debug.Assert(!self.Alive || !self.Reported);
+            return self.Alive != old.Alive;
         }
 
         protected override bool Join(ref LocalState self, ref LocalState other)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1295,11 +1295,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void SetStateAndTrackForFinally(ref LocalState state, int slot, NullableFlowState newState)
         {
             state[slot] = newState;
-            if (newState == NullableFlowState.MaybeNull && _tryState.HasValue)
+            if (newState == NullableFlowState.MaybeNull && NonMonotonicState.HasValue)
             {
-                var tryState = _tryState.Value;
+                var tryState = NonMonotonicState.Value;
                 tryState[slot] = NullableFlowState.MaybeNull;
-                _tryState = tryState;
+                NonMonotonicState = tryState;
             }
         }
 
@@ -7818,15 +7818,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override void Meet(ref LocalState self, ref LocalState other)
+        protected override bool Meet(ref LocalState self, ref LocalState other)
         {
             if (!self.Reachable)
-                return;
+                return false;
 
             if (!other.Reachable)
             {
                 self = other.Clone();
-                return;
+                return true;
             }
 
             if (self.Capacity != other.Capacity)
@@ -7835,7 +7835,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Normalize(ref other);
             }
 
-            self.Meet(in other);
+            return self.Meet(in other);
         }
 
         protected override bool Join(ref LocalState self, ref LocalState other)

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -6233,7 +6233,7 @@ class Program
         void Local()
         {
 /*<bind>*/
-            if ("""".Length == 0)
+            if (false)
             {
                 x = 1;
             }
@@ -6247,6 +6247,8 @@ class Program
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
+            // This is a conservative approximation, ignoring whether the branch containing
+            // the assignment is reachable
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.ReadOutside));
@@ -6459,7 +6461,7 @@ class Program
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
             Assert.Equal("x", GetSymbolNamesJoined(dataFlowAnalysisResults.AlwaysAssigned));
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsIn));
-            // N.B. This is not technically correct. The branch assigning y is unreachable, so
+            // N.B. This is not as precise as possible. The branch assigning y is unreachable, so
             // the result does not technically flow out. This is a conservative approximation.
             Assert.Equal("x, y", GetSymbolNamesJoined(dataFlowAnalysisResults.DataFlowsOut));
             Assert.Null(GetSymbolNamesJoined(dataFlowAnalysisResults.ReadInside));


### PR DESCRIPTION
Local function flow analysis has always been special-cased for definite
assignment, and specifically for definite assignment with monotonic
assignment. This change implements the same non-monotonic tracking that
we use for try-finally for local functions. This is a conservative
analysis, meaning that certain rare cases may not transfer as much
information as possible. It's currently assumed that these cases are
rare enough to not be frustrating. No safety problems should be present
in the conservative analysis.

Fixes #14400
Fixes #14214