### PR TITLE
Do not return favorites in expansions of null values.

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -79,7 +79,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             foreach (var member in allMembers)
             {
-                if (member.IsFavorite && !value.IsNull) // Favorites are never static
+                // Favorites are currently never static
+                if (member.IsFavorite && !value.IsNull)
                 {
                     favoritesMembersByName.Add(member.Name, member);
                 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             foreach (var member in allMembers)
             {
-                if (member.IsFavorite)
+                if (member.IsFavorite && !value.IsNull) // Favorites are never static
                 {
                     favoritesMembersByName.Add(member.Name, member);
                 }


### PR DESCRIPTION
Fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1010026. This bug causes a tremendous number of non-fatal watsons in concord when hit.