### PR TITLE
Remove experiment for "sorting completion list by matching"

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.PatternMatching;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -206,16 +205,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return HandleAllItemsFilteredOut(reason, data.SelectedFilters, completionRules);
             }
 
-            var experimentationService = document?.Project.Solution.Workspace.Services.GetService<IExperimentationService>();
-
-            if (experimentationService?.IsExperimentEnabled(WellKnownExperimentNames.SortCompletionListByMatch) == true)
-            {
-                // Sort the items by pattern matching results.
-                // Note that we want to preserve the original alphabetical order for items with same pattern match score,
-                // but `ArrayBuilder.Sort` isn't stable. Therefore we have to add a monotonically increasing integer
-                // to `MatchResult` to archieve this.
-                builder.Sort(MatchResult.SortingComparer);
-            }
+            // Sort the items by pattern matching results.
+            // Note that we want to preserve the original alphabetical order for items with same pattern match score,
+            // but `ArrayBuilder.Sort` isn't stable. Therefore we have to add a monotonically increasing integer
+            // to `MatchResult` to archieve this.
+            builder.Sort(MatchResult.SortingComparer);
 
             var initialListOfItemsToBeIncluded = builder.ToImmutableAndFree();
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6028,7 +6028,7 @@ namespace NS2
 
         <WorkItem(38253, "https://github.com/dotnet/roslyn/issues/38253")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function SortItemsByPatternMatchIfExperimentEnabled() As Task
+        Public Async Function SortItemsByPatternMatch() As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                               <Document>
 namespace NS
@@ -6057,9 +6057,6 @@ namespace NS
 
                 state.Workspace.Options = state.Workspace.Options _
                     .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)
-
-                Dim experimentService = state.GetService(Of TestExperimentationService)()
-                experimentService.SetExperimentOption(WellKnownExperimentNames.SortCompletionListByMatch, True)
 
                 state.SendTypeChars("task")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -6075,61 +6072,6 @@ namespace NS
                         "BTask2",
                         "BTask3",
                         "ATaAaSaKa"
-                    }
-
-                state.AssertItemsInOrder(expectedOrder)
-            End Using
-        End Function
-
-        <WorkItem(38253, "https://github.com/dotnet/roslyn/issues/38253")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function SortItemsAlphabeticallyIfExperimentDisabled() As Task
-            Using state = TestStateFactory.CreateCSharpTestState(
-                              <Document>
-namespace NS
-{
-    class C
-    {
-        void M()
-        {
-            $$
-        }
-    }
-
-    class Task { }
-
-    class BTask1 { }
-    class BTask2 { }
-    class BTask3 { }
-
-
-    class Task1 { }
-    class Task2 { }
-    class Task3 { }
-
-    class ATaAaSaKa { }
-} </Document>, extraExportedTypes:={GetType(TestExperimentationService)}.ToList())
-
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)
-
-                Dim experimentService = state.GetService(Of TestExperimentationService)()
-                experimentService.SetExperimentOption(WellKnownExperimentNames.SortCompletionListByMatch, False)
-
-                state.SendTypeChars("task")
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.AssertSelectedCompletionItem(displayText:="Task")
-
-                Dim expectedOrder =
-                    {
-                        "ATaAaSaKa",
-                        "BTask1",
-                        "BTask2",
-                        "BTask3",
-                        "Task",
-                        "Task1",
-                        "Task2",
-                        "Task3"
                     }
 
                 state.AssertItemsInOrder(expectedOrder)

--- a/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
+++ b/src/Workspaces/Core/Portable/Experiments/IExperimentationService.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CodeAnalysis.Experiments
         public const string TypeImportCompletion = "Roslyn.TypeImportCompletion";
         public const string TargetTypedCompletionFilter = "Roslyn.TargetTypedCompletionFilter";
         public const string NativeEditorConfigSupport = "Roslyn.NativeEditorConfigSupport";
-        public const string SortCompletionListByMatch = "Roslyn.SortCompletionListByMatch";
 
         // Syntactic LSP experiment treatments.
         public const string SyntacticExp_LiveShareTagger_Remote = "Roslyn.LspTagger";


### PR DESCRIPTION
We have been running the experiment of "sorting completion list by matching" (#38499) internally for a couple months now, thing seems to be working well. So I'm removing the experiment which would enable this new behavior for everybody. 

@vatsalyaagrawal @ivanbasov @jinujoseph Please let me know if you have any concerns