### PR TITLE
Fix Host Object Access in Interactive

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1537,7 +1537,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return TryBindInteractiveReceiver(syntax, currentType, declaringType);
+                return TryBindInteractiveReceiver(syntax, declaringType);
             }
         }
 
@@ -1795,7 +1795,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return TryBindInteractiveReceiver(node, currentType, declaringType);
+                return TryBindInteractiveReceiver(node, declaringType);
             }
         }
 
@@ -1810,29 +1810,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return containingMember;
         }
 
-        private bool IsInstanceContext()
+        private BoundExpression TryBindInteractiveReceiver(SyntaxNode syntax, NamedTypeSymbol memberDeclaringType)
         {
-            var containingMember = this.ContainingMemberOrLambda;
-            do
-            {
-                if (containingMember.IsStatic)
-                {
-                    return false;
-                }
-                if (containingMember.Kind == SymbolKind.NamedType)
-                {
-                    break;
-                }
-                containingMember = containingMember.ContainingSymbol;
-            } while ((object)containingMember != null);
-            return true;
-        }
-
-        private BoundExpression TryBindInteractiveReceiver(SyntaxNode syntax, NamedTypeSymbol currentType, NamedTypeSymbol memberDeclaringType)
-        {
-            if (currentType.TypeKind == TypeKind.Submission
-                // check the current member has access to `this`
-                && IsInstanceContext())
+            if (this.ContainingType.TypeKind == TypeKind.Submission
+                // check we have access to `this`
+                && isInstanceContext())
             {
                 if (memberDeclaringType.TypeKind == TypeKind.Submission)
                 {
@@ -1850,6 +1832,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return null;
+
+            bool isInstanceContext()
+            {
+                var containingMember = this.ContainingMemberOrLambda;
+                do
+                {
+                    if (containingMember.IsStatic)
+                    {
+                        return false;
+                    }
+                    if (containingMember.Kind == SymbolKind.NamedType)
+                    {
+                        break;
+                    }
+                    containingMember = containingMember.ContainingSymbol;
+                } while ((object)containingMember != null);
+                return true;
+            }
         }
 
         public BoundExpression BindNamespaceOrTypeOrExpression(ExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1803,14 +1803,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // We skip intervening lambdas and local functions to find the actual member.
             var containingMember = this.ContainingMemberOrLambda;
-            do
+            while (containingMember.Kind != SymbolKind.NamedType && (object)containingMember.ContainingSymbol != null && containingMember.ContainingSymbol.Kind != SymbolKind.NamedType)
             {
-                if (containingMember.Kind == SymbolKind.NamedType)
-                {
-                    break;
-                }
                 containingMember = containingMember.ContainingSymbol;
-            } while ((object)containingMember != null);
+            }
             return containingMember;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1803,23 +1803,33 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // We skip intervening lambdas and local functions to find the actual member.
             var containingMember = this.ContainingMemberOrLambda;
-            while (containingMember.Kind != SymbolKind.NamedType && (object)containingMember.ContainingSymbol != null && containingMember.ContainingSymbol.Kind != SymbolKind.NamedType)
+            do
             {
+                if (containingMember.Kind == SymbolKind.NamedType)
+                {
+                    break;
+                }
                 containingMember = containingMember.ContainingSymbol;
-            }
+            } while ((object)containingMember != null);
             return containingMember;
         }
 
         private bool IsInstanceContext()
         {
             var containingMember = this.ContainingMemberOrLambda;
-            while (containingMember.Kind != SymbolKind.NamedType && (object)containingMember.ContainingSymbol != null && containingMember.ContainingSymbol.Kind != SymbolKind.NamedType)
+            do
             {
                 if (containingMember.IsStatic)
+                {
                     return false;
+                }
+                if (containingMember.Kind == SymbolKind.NamedType)
+                {
+                    break;
+                }
                 containingMember = containingMember.ContainingSymbol;
-            }
-            return !containingMember.IsStatic;
+            } while ((object)containingMember != null);
+            return true;
         }
 
         private BoundExpression TryBindInteractiveReceiver(SyntaxNode syntax, NamedTypeSymbol currentType, NamedTypeSymbol memberDeclaringType)

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1786,14 +1786,14 @@ typeof(Microsoft.CodeAnalysis.Scripting.Script)
 
         [Fact]
         [WorkItem(39565, "https://github.com/dotnet/roslyn/issues/39565")]
-        public async Task Regression39565()
+        public async Task MethodCallWithImplicitReceiverAndOutVar()
         {
             var code = @"
-            if(TryGetValue(out var result)){
-                _ = result;
-            }
-            return true;
-            ";
+if(TryGetValue(out var result)){
+    _ = result;
+}
+return true;
+";
 
             var result = await CSharpScript.EvaluateAsync<bool>(code, globalsType: typeof(E), globals: new E());
             Assert.True(result);
@@ -1808,12 +1808,12 @@ typeof(Microsoft.CodeAnalysis.Scripting.Script)
         public void StaticMethodCannotAccessGlobalInstance()
         {
             var code = @"
-			static bool M()
-			{
-				return Value;
-			}
-			return M();
-            ";
+static bool M()
+{
+	return Value;
+}
+return M();
+";
 
             var script = CSharpScript.Create<bool>(code, globalsType: typeof(F));
             ScriptingTestHelpers.AssertCompilationError(() => script.RunAsync(new F()).Wait(),
@@ -1827,16 +1827,16 @@ typeof(Microsoft.CodeAnalysis.Scripting.Script)
         public void StaticLocalFunctionCannotAccessGlobalInstance()
         {
             var code = @"
-			bool M()
-			{
-				return Inner();
-				static bool Inner()
-				{
-					return Value;
-				}
-			}
-			return M();
-            ";
+bool M()
+{
+	return Inner();
+	static bool Inner()
+	{
+		return Value;
+	}
+}
+return M();
+";
 
             var script = CSharpScript.Create<bool>(code, globalsType: typeof(F));
             ScriptingTestHelpers.AssertCompilationError(() => script.RunAsync(new F()).Wait(),
@@ -1849,16 +1849,16 @@ typeof(Microsoft.CodeAnalysis.Scripting.Script)
         public async Task LocalFunctionCanAccessGlobalInstance()
         {
             var code = @"
-			bool M()
-			{
-				return Inner();
-				bool Inner()
-				{
-					return Value;
-				}
-			}
-			return M();
-            ";
+bool M()
+{
+	return Inner();
+	bool Inner()
+	{
+		return Value;
+	}
+}
+return M();
+";
 
             var result = await CSharpScript.EvaluateAsync<bool>(code, globalsType: typeof(F), globals: new F());
             Assert.True(result);

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1774,6 +1773,95 @@ typeof(Microsoft.CodeAnalysis.Scripting.Script)
                         break;
                 }
             }
+        }
+
+        public class E
+        {
+            public bool TryGetValue(out object obj)
+            {
+                obj = new object();
+                return true;
+            }
+        }
+
+        [Fact]
+        [WorkItem(39565, "https://github.com/dotnet/roslyn/issues/39565")]
+        public async Task Regression39565()
+        {
+            var code = @"
+            if(TryGetValue(out var result)){
+                _ = result;
+            }
+            return true;
+            ";
+
+            var result = await CSharpScript.EvaluateAsync<bool>(code, globalsType: typeof(E), globals: new E());
+            Assert.True(result);
+        }
+
+        public class F
+        {
+            public bool Value = true;
+        }
+
+        [Fact]
+        public void StaticMethodCannotAccessGlobalInstance()
+        {
+            var code = @"
+			static bool M()
+			{
+				return Value;
+			}
+			return M();
+            ";
+
+            var script = CSharpScript.Create<bool>(code, globalsType: typeof(F));
+            ScriptingTestHelpers.AssertCompilationError(() => script.RunAsync(new F()).Wait(),
+                    // (4,12): error CS0120: An object reference is required for the non-static field, method, or property 'InteractiveSessionTests.F.Value'
+                    // 				return Value;
+                    Diagnostic(ErrorCode.ERR_ObjectRequired, "Value").WithArguments("Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.InteractiveSessionTests.F.Value").WithLocation(4, 12));
+        }
+
+        [Fact]
+        [WorkItem(39581, "https://github.com/dotnet/roslyn/issues/39581")]
+        public void StaticLocalFunctionCannotAccessGlobalInstance()
+        {
+            var code = @"
+			bool M()
+			{
+				return Inner();
+				static bool Inner()
+				{
+					return Value;
+				}
+			}
+			return M();
+            ";
+
+            var script = CSharpScript.Create<bool>(code, globalsType: typeof(F));
+            ScriptingTestHelpers.AssertCompilationError(() => script.RunAsync(new F()).Wait(),
+                    // (7,13): error CS0120: An object reference is required for the non-static field, method, or property 'InteractiveSessionTests.F.Value'
+                    // 					return Value;
+                    Diagnostic(ErrorCode.ERR_ObjectRequired, "Value").WithArguments("Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.InteractiveSessionTests.F.Value").WithLocation(7, 13));
+        }
+
+        [Fact]
+        public async Task LocalFunctionCanAccessGlobalInstance()
+        {
+            var code = @"
+			bool M()
+			{
+				return Inner();
+				bool Inner()
+				{
+					return Value;
+				}
+			}
+			return M();
+            ";
+
+            var result = await CSharpScript.EvaluateAsync<bool>(code, globalsType: typeof(F), globals: new F());
+            Assert.True(result);
         }
 
         #endregion

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1147,6 +1147,14 @@ static T G<T>(T t, Func<T, Task<T>> f)
             Assert.Equal(3, state.ReturnValue);
         }
 
+        [Fact, WorkItem(39548, "https://github.com/dotnet/roslyn/issues/39548")]
+        public async Task PatternVariableDeclaration()
+        {
+            var state = await CSharpScript.RunAsync("var x = (false, 4);");
+            state = await state.ContinueWithAsync("x is (false, var y)");
+            Assert.Equal(true, state.ReturnValue);
+        }
+
         #endregion
 
         #region References


### PR DESCRIPTION
Fixes #39565
Fixes #39581
Fixes #39548

Note that instead of reporting `error CS8422: A static local function cannot contain a reference to 'this' or 'base'.` we instead report `error CS0120: An object reference is required for the non-static field, method, or property`

Given that this is an extremely edge scenario in scripting I think that's not too much of an issue?

Also fixing #39581 is a breaking change. I highly doubt it's one anyone's hit, but insofar as that's true, maybe there's no point fixing it?