### PR TITLE
Run integration tests with .NET Core SDK shipped with VS

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -331,6 +331,9 @@ function SetVisualStudioBootstrapperBuildArgs() {
 # Core function for running our unit / integration tests tests
 function TestUsingOptimizedRunner() {
 
+  # Capture the Path so we can revert it for integration tests
+  $originalPath = $env:PATH
+
   # Tests need to locate .NET Core SDK
   $dotnet = InitializeDotNetCli
 
@@ -417,9 +420,26 @@ function TestUsingOptimizedRunner() {
     $args += " $dll"
   }
 
+  if ($testVsi) {
+    # Capture the Environment variables altered by `InitializeDotNetCli` so we can revert to them
+    $alteredDotNetMultiLevelLookup = $env:DOTNET_MULTILEVEL_LOOKUP
+    $alteredPath = $env:PATH
+
+    # Resolve runtime, shared framework, or SDK from other locations for integration tests
+    $env:DOTNET_MULTILEVEL_LOOKUP = $null
+    $env:PATH = $originalPath
+  }
+
   try {
     Exec-Console $runTests $args
-  } finally {
+  }
+  finally {
+    if ($testVsi) {
+      # Revert the environment variables to the state `InitializeDotNetCli` left them in
+      $env:DOTNET_MULTILEVEL_LOOKUP = $alteredDotNetMultiLevelLookup
+      $env:PATH = $alteredPath
+    }
+
     Get-Process "xunit*" -ErrorAction SilentlyContinue | Stop-Process
     if ($testIOperation) {
       Remove-Item env:\ROSLYN_TEST_IOPERATION


### PR DESCRIPTION
Integration tests were being run with the dotnet SDK from the build environment. This broke when VS updated to creating new .NET Core projects against a TFM not supported by the version of the SDK we were building against.

This change allows the .NET Core SDK that shipped with VS to be found when running integration tests. Which is likely the desired behavior.

Fixes #39588