### PR TITLE
Do not report ErrorCode.WRN_ExpressionMayIntroduceNullT

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -72,12 +72,9 @@ the compiler didn't look for the name in base interfaces of the interface. Looku
 hierarchy or through usings. We now look in base interfaces and find types declared within them, if any match the name. The type
 could be different than the one that compiler used to find.
 
-10. https://github.com/dotnet/csharplang/blob/master/meetings/2019/LDM-2019-09-11.md In C# `8.0` no warning is reported at the production or dereference of a maybe-null value for a type that is a type parameter that cannot be annotated with `?`, except if the value was produced by `default(T)`.
-In Visual Studio version 16.4, the nullable analysis will be more stringent for such values. Whenever such a value is produced, as warning will be reported. For instance, when invoking a method that returns a `[MaybeNull]T`.
-
-11. https://github.com/dotnet/roslyn/issues/38427 C# `7.0` incorrectly allowed duplicate type constraints with tuple name differences. In *Visual Studio 2019 version 16.4* we will make it an error.
+10. https://github.com/dotnet/roslyn/issues/38427 C# `7.0` incorrectly allowed duplicate type constraints with tuple name differences. In *Visual Studio 2019 version 16.4* this is an error.
     ```C#
     class C<T> where T : I<(int a, int b)>, I<(int c, int d)> { } // error
     ```
 
-12. Previously, the language version was not checked for `this ref` and `this in` orderings of parameter modifiers. In *Visual Studio 2019 version 16.4* these orderings produce an error with langversion below 7.2. See https://github.com/dotnet/roslyn/issues/38486
+11. Previously, the language version was not checked for `this ref` and `this in` orderings of parameter modifiers. In *Visual Studio 2019 version 16.4* these orderings produce an error with langversion below 7.2. See https://github.com/dotnet/roslyn/issues/38486

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1522,13 +1522,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 !type.IsNullableTypeOrTypeParameter();
         }
 
-        private static bool RequiresSafetyWarningWhenNullIntroduced(TypeSymbol type, FlowAnalysisAnnotations annotations)
-        {
-            return
-                (annotations & FlowAnalysisAnnotations.MaybeNull) != 0 &&
-                type.IsTypeParameterDisallowingAnnotation();
-        }
-
         public override BoundNode VisitLocal(BoundLocal node)
         {
             var local = node.LocalSymbol;
@@ -3186,10 +3179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void ReportMaybeNullFromTypeParameterValueIfNeeded(BoundExpression expr, TypeWithState typeWithState, FlowAnalysisAnnotations annotations)
         {
-            if (!expr.IsSuppressed && !typeWithState.IsNotNull && RequiresSafetyWarningWhenNullIntroduced(typeWithState.Type, annotations))
-            {
-                ReportDiagnostic(ErrorCode.WRN_ExpressionMayIntroduceNullT, expr.Syntax, GetTypeAsDiagnosticArgument(expr.Type));
-            }
+            // Not implemented. See https://github.com/dotnet/roslyn/issues/38638 for an alternative.
         }
 
         private void LearnFromEqualsMethod(MethodSymbol method, BoundCall node, TypeWithState receiverType, ImmutableArray<VisitArgumentResult> results)


### PR DESCRIPTION
A warning is reported in 16.4P3 when a member with a generic type marked `[MaybeNull]` is referenced, even when the potentially nullable value is used safely. 

For instance, warnings are reported for the following:

```C#
#nullable enable
using System.Collections.Generic;

class Program
{
    static void M1<T>(List<T> list)
    {
        if (list.Find(_ => true) != null) // warning CS8717: A member returning [MaybeNull] ...
        {
        }
    }

    static void M2<TKey, TValue>(Dictionary<TKey, TValue> d, TKey k) where TKey : notnull
    {
        if (d.TryGetValue(k, out var value)) // warning CS8717: A member returning [MaybeNull]
        {
        }
    }
}
```