### PR TITLE
Run integration tests with .NET Core SDK shipped with VS (#2)

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -331,10 +331,13 @@ function SetVisualStudioBootstrapperBuildArgs() {
 # Core function for running our unit / integration tests tests
 function TestUsingOptimizedRunner() {
 
-  # Tests need to locate .NET Core SDK
-  $dotnet = InitializeDotNetCli
+  if (!$testVsi) {
+    # Unit tests need to locate .NET Core SDK from build environment
+    $dotnet = InitializeDotNetCli
 
-  if ($testVsi) {
+  } else {
+    # Integrations tests use the .NET Core SDK provided by VS
+
     Deploy-VsixViaTool
 
     if ($ci) {


### PR DESCRIPTION
Integration tests were being run with the dotnet SDK from the
build environment. This broke when VS updated to creating new
.NET Core projects against a TFM not supported by the version
of the SDK we were building against.

This change allows the .NET Core SDK that shipped with VS to
be found when running integration tests. Which is likely the
desired behavior.

Fixes #39588