### PR TITLE
Don't MEF import core Roslyn language service type in SolutionExplore…

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersCommandHandler.cs
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         private readonly AnalyzerItemsTracker _tracker;
         private readonly AnalyzerReferenceManager _analyzerReferenceManager;
         private readonly IServiceProvider _serviceProvider;
-        private readonly ICodeActionEditHandlerService _editHandlerService;
 
         private ContextMenuController _analyzerFolderContextMenuController;
         private ContextMenuController _analyzerContextMenuController;
@@ -72,13 +71,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         public AnalyzersCommandHandler(
             AnalyzerItemsTracker tracker,
             AnalyzerReferenceManager analyzerReferenceManager,
-            [Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider,
-            ICodeActionEditHandlerService editHandlerService)
+            [Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider)
         {
             _tracker = tracker;
             _analyzerReferenceManager = analyzerReferenceManager;
             _serviceProvider = serviceProvider;
-            _editHandlerService = editHandlerService;
         }
 
         /// <summary>
@@ -432,6 +429,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
 
                 var componentModel = (IComponentModel)_serviceProvider.GetService(typeof(SComponentModel));
                 var waitIndicator = componentModel.GetService<IWaitIndicator>();
+                var editHandlerService = componentModel.GetService<ICodeActionEditHandlerService>();
 
                 try
                 {
@@ -450,7 +448,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                                 {
                                     var newSolution = selectedDiagnostic.GetSolutionWithUpdatedAnalyzerConfigSeverityAsync(selectedAction.Value, project, waitContext.CancellationToken).WaitAndGetResult(waitContext.CancellationToken);
                                     var operations = ImmutableArray.Create<CodeActionOperation>(new ApplyChangesOperation(newSolution));
-                                    _editHandlerService.Apply(
+                                    editHandlerService.Apply(
                                         _workspace,
                                         fromDocument: null,
                                         operations: operations,

--- a/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzerCommandHandlerTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzerCommandHandlerTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
                 isEnabledByDefault:=True)
             Dim diagnosticItem = New LegacyDiagnosticItem(Nothing, descriptor, ReportDiagnostic.Error, Nothing)
 
-            Dim handler = New AnalyzersCommandHandler(Nothing, Nothing, Nothing, Nothing)
+            Dim handler = New AnalyzersCommandHandler(Nothing, Nothing, Nothing)
             Dim shown = handler.DiagnosticContextMenuController.ShowContextMenu({diagnosticItem}, Nothing)
             Debug.Assert(Not shown)
         End Sub


### PR DESCRIPTION
…rShim

My recent [change](https://github.com/dotnet/roslyn/pull/37795/commits/03c9021af53e648c74a496a1a5e53a2dc616540c#diff-f7b9587085c9a364f8b4727f4599ebc5R76) caused an RPS regression where creating a new C++ project, which leads to us loading the Roslyn SolutionExplorerShim, now also loads Roslyn language service and all underlying Roslyn assemblies. This change avoids MEF importing the Roslyn type in AnalyzerCommandHandler constructor and instead gets it lazily.

In future, we should add an analyzer to prevent SolutionExplorerShim from MEF importing any core Roslyn services.

**Verified that Roslyn language services are no longer loaded on creating a C++ project.**