### PR TITLE
Hook up "Run Code Analysis" commands in Visual Studio to execute Rosl…

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
             }
 
-            private static bool FullAnalysisEnabled(Project project, bool forceAnalyzerRun)
+            internal static bool FullAnalysisEnabled(Project project, bool forceAnalyzerRun)
             {
                 if (forceAnalyzerRun)
                 {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -75,6 +75,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         public async Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
         {
+            // Perf optimization. check whether we want to analyze this project or not.
+            if (!Executor.FullAnalysisEnabled(project, forceAnalyzerRun: false))
+            {
+                return;
+            }
+
+            await AnalyzeProjectAsync(project, forceAnalyzerRun: false, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task ForceAnalyzeProjectAsync(Project project, CancellationToken cancellationToken)
+            => AnalyzeProjectAsync(project, forceAnalyzerRun: true, cancellationToken);
+
+        private async Task AnalyzeProjectAsync(Project project, bool forceAnalyzerRun, CancellationToken cancellationToken)
+        {
             try
             {
                 var stateSets = GetStateSetsForFullSolutionAnalysis(_stateManager.GetOrUpdateStateSets(project), project).ToList();
@@ -91,7 +105,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var includeSuppressedDiagnostics = true;
                 var analyzerDriverOpt = await _compilationManager.CreateAnalyzerDriverAsync(project, activeAnalyzers, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
-                var forceAnalyzerRun = false;
                 var result = await _executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
                 if (result.FromCache)
                 {

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -11,61 +11,66 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal interface IDiagnosticAnalyzerService
     {
         /// <summary>
-        /// re-analyze given projects and documents
+        /// Re-analyze given projects and documents
         /// </summary>
         void Reanalyze(Workspace workspace, IEnumerable<ProjectId> projectIds = null, IEnumerable<DocumentId> documentIds = null, bool highPriority = false);
 
         /// <summary>
-        /// get specific diagnostics currently stored in the source. returned diagnostic might be out-of-date if solution has changed but analyzer hasn't run for the new solution.
+        /// Get specific diagnostics currently stored in the source. returned diagnostic might be out-of-date if solution has changed but analyzer hasn't run for the new solution.
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetSpecificCachedDiagnosticsAsync(Workspace workspace, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// get diagnostics currently stored in the source. returned diagnostic might be out-of-date if solution has changed but analyzer hasn't run for the new solution.
+        /// Get diagnostics currently stored in the source. returned diagnostic might be out-of-date if solution has changed but analyzer hasn't run for the new solution.
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Workspace workspace, ProjectId projectId = null, DocumentId documentId = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// get specific diagnostics for the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
+        /// Get specific diagnostics for the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(Solution solution, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// get diagnostics for the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
+        /// Get diagnostics for the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId projectId = null, DocumentId documentId = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// true if given project has any diagnostics
+        /// Force computes diagnostics and raises diagnostic events for the given project or solution. all diagnostics returned should be up-to-date with respect to the given project or solution.
+        /// </summary>
+        Task ForceAnalyzeAsync(Solution solution, ProjectId projectId = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// True if given project has any diagnostics
         /// </summary>
         bool ContainsDiagnostics(Workspace workspace, ProjectId projectId);
 
         /// <summary>
-        /// get diagnostics of the given diagnostic ids from the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
+        /// Get diagnostics of the given diagnostic ids from the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
         /// Note that for project case, this method returns diagnostics from all project documents as well. Use <see cref="GetProjectDiagnosticsForIdsAsync(Solution, ProjectId, ImmutableHashSet{string}, bool, CancellationToken)"/>
         /// if you want to fetch only project diagnostics without source locations.
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId projectId = null, DocumentId documentId = null, ImmutableHashSet<string> diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// get project diagnostics (diagnostics with no source location) of the given diagnostic ids from the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
+        /// Get project diagnostics (diagnostics with no source location) of the given diagnostic ids from the given solution. all diagnostics returned should be up-to-date with respect to the given solution.
         /// Note that this method doesn't return any document diagnostics. Use <see cref="GetDiagnosticsForIdsAsync(Solution, ProjectId, DocumentId, ImmutableHashSet{string}, bool, CancellationToken)"/> to also fetch those.
         /// </summary>
         Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId projectId = null, ImmutableHashSet<string> diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// try to return up to date diagnostics for the given span for the document.
+        /// Try to return up to date diagnostics for the given span for the document.
         ///
-        /// it will return true if it was able to return all up-to-date diagnostics.
+        /// It will return true if it was able to return all up-to-date diagnostics.
         ///  otherwise, false indicating there are some missing diagnostics in the diagnostic list
         /// </summary>
         Task<bool> TryAppendDiagnosticsForSpanAsync(Document document, TextSpan range, List<DiagnosticData> diagnostics, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// return up to date diagnostics for the given span for the document
+        /// Return up to date diagnostics for the given span for the document
         ///
-        /// this can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet.
-        /// if diagnosticIdOpt is not null, it gets diagnostics only for this given diagnosticIdOpt value
+        /// This can be expensive since it is force analyzing diagnostics if it doesn't have up-to-date one yet.
+        /// If diagnosticIdOpt is not null, it gets diagnostics only for this given diagnosticIdOpt value
         /// </summary>
         Task<IEnumerable<DiagnosticData>> GetDiagnosticsForSpanAsync(Document document, TextSpan range, string diagnosticIdOpt = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default);
 

--- a/src/VisualStudio/Core/Def/Commands.vsct
+++ b/src/VisualStudio/Core/Def/Commands.vsct
@@ -372,6 +372,10 @@
         </Strings>
       </Button>
 
+      <!-- Run code analysis commands -->
+      
+      <!-- "Run Code Analysis on <%ProjectName%>" command for Top level "Build" and "Analyze" menus.
+           "ECMD_RUNFXCOPSEL" is actually defined in stdidcmd.h, we're just referencing it here -->      
       <Button guid="guidVSStd2K" id="ECMD_RUNFXCOPSEL" priority="0x0000" type="Button">
         <CommandFlag>TextChanges</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -379,6 +383,19 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>Run Code &amp;Analysis on Selection</ButtonText>
+        </Strings>
+      </Button>
+      
+      <!-- "Run Code Analysis" command for Solution Explorer "Analyze and Code Cleanup" context menu for project node -->      
+      <Button guid="guidRoslynGrpId" id="cmdidRunCodeAnalysisForProject" priority="0x0000" type="Button">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_ANALYZE_GENERAL"/>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <Strings>
+          <ButtonText>Run C&amp;ode Analysis</ButtonText>
+          <CanonicalName>RunCodeAnalysisForProject</CanonicalName>
+          <LocCanonicalName>RunCodeAnalysisForProject</LocCanonicalName>
+          <CommandName>RunCodeAnalysisForProject</CommandName>
         </Strings>
       </Button>
     </Buttons>
@@ -559,6 +576,8 @@
       <IDSymbol name="grpErrorListDiagnosticSeverityItems"     value="0x012a" />
 
       <IDSymbol name="cmdidGoToImplementation"        value="0x0200" />
+
+      <IDSymbol name="cmdidRunCodeAnalysisForProject"  value="0x0201" />
     </GuidSymbol>
 
     <GuidSymbol name="guidCSharpInteractiveCommandSet" value="{1492db0a-85a2-4e43-bf0d-ce55b89a8cc6}">

--- a/src/VisualStudio/Core/Def/Commands.vsct
+++ b/src/VisualStudio/Core/Def/Commands.vsct
@@ -371,6 +371,16 @@
           <LocCanonicalName>ResetVisualBasicInteractiveFromProject</LocCanonicalName>
         </Strings>
       </Button>
+
+      <Button guid="guidVSStd2K" id="ECMD_RUNFXCOPSEL" priority="0x0000" type="Button">
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <Strings>
+          <ButtonText>Run Code &amp;Analysis on Selection</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <Menus>
@@ -482,6 +492,7 @@
 
   <UsedCommands>
     <UsedCommand guid="guidVSStd2K" id="ECMD_INSERTCOMMENT" />
+    <UsedCommand guid="guidVSStd2K" id="ECMD_RUNFXCOPSEL"/>
   </UsedCommands>
 
   <Symbols>

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/Api/ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/Api/ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
@@ -7,6 +7,24 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis.Api
 {
     internal interface ILegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor
     {
+        /// <summary>
+        /// Gets a list of the diagnostics that are provided by this service.
+        /// If the given <paramref name="hierarchyOpt"/> is non-null and corresponds to an existing project in the workspace, then gets the diagnostics for the project.
+        /// Otherwise, returns the global set of diagnostics enabled for the workspace.
+        /// </summary>
+        /// <returns>A mapping from analyzer name to the diagnostics produced by that analyzer</returns>
+        /// <remarks>
+        /// This is used by the Ruleset Editor from ManagedSourceCodeAnalysis.dll in VisualStudio.
+        /// </remarks>
         IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy hierarchyOpt);
+
+        /// <summary>
+        /// Runs all the applicable NuGet and VSIX diagnostic analyzers for the given project OR current solution in background and updates the error list.
+        /// </summary>
+        /// <param name="hierarchyOpt">
+        /// If non-null hierarchy for a project, then analyzers are run on the project.
+        /// Otherwise, analyzers are run on the current solution.
+        /// </param>
+        void RunAnalyzers(IVsHierarchy hierarchyOpt);
     }
 }

--- a/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/LegacyCodeAnalysis/LegacyCodeAnalysisVisualStudioDiagnosticAnalyzerServiceAccessor.cs
@@ -26,5 +26,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.LegacyCodeAnalysis
 
         public IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy hierarchyOpt)
             => _implementation.GetAllDiagnosticDescriptors(hierarchyOpt);
+
+        public void RunAnalyzers(IVsHierarchy hierarchyOpt)
+            => _implementation.RunAnalyzers(hierarchyOpt);
     }
 }

--- a/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
@@ -44,10 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 
             public const int GoToImplementation = 0x0200;
 
-            // Run Code Analysis commands.
-            // The IDs are actually defined in stdidcmd.h, we're just referencing it here.
-            public const int ECMD_RUNFXCOPSEL = 1647;
-            public const int ECMD_RUNFXCOPPROJCTX = 1648;
+            public const int RunCodeAnalysisForProject = 0x0201;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
+++ b/src/VisualStudio/Core/Def/ID.RoslynCommands.cs
@@ -43,6 +43,11 @@ namespace Microsoft.VisualStudio.LanguageServices
             public const int ErrorListSetSeverityDefault = 0x0129;
 
             public const int GoToImplementation = 0x0200;
+
+            // Run Code Analysis commands.
+            // The IDs are actually defined in stdidcmd.h, we're just referencing it here.
+            public const int ECMD_RUNFXCOPSEL = 1647;
+            public const int ECMD_RUNFXCOPPROJCTX = 1648;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/IVisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/IVisualStudioDiagnosticAnalyzerService.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -10,13 +13,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
     {
         /// <summary>
         /// Gets a list of the diagnostics that are provided by this service.
-        /// If the given <paramref name="hierarchyOpt"/> is non-null and corresponds to an existing project in the workspace, then gets the diagnostics for the project.
+        /// If the given <paramref name="hierarchy"/> is non-null and corresponds to an existing project in the workspace, then gets the diagnostics for the project.
         /// Otherwise, returns the global set of diagnostics enabled for the workspace.
         /// </summary>
         /// <returns>A mapping from analyzer name to the diagnostics produced by that analyzer</returns>
         /// <remarks>
         /// This is used by the Ruleset Editor from ManagedSourceCodeAnalysis.dll in VisualStudio.
         /// </remarks>
-        IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy hierarchyOpt);
+        IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy? hierarchy);
+
+        /// <summary>
+        /// Runs all the applicable NuGet and VSIX diagnostic analyzers for the given project OR current solution in background and updates the error list.
+        /// </summary>
+        /// <param name="hierarchy">
+        /// If non-null hierarchy for a project, then analyzers are run on the project.
+        /// Otherwise, analyzers are run on the current solution.
+        /// </param>
+        void RunAnalyzers(IVsHierarchy? hierarchy);
+
+        /// <summary>
+        /// Initializes the service.
+        /// </summary>
+        void Initialize(IServiceProvider serviceProvider);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -1,14 +1,25 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.ComponentModel.Design;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 {
@@ -17,19 +28,56 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
     {
         private readonly VisualStudioWorkspace _workspace;
         private readonly IDiagnosticAnalyzerService _diagnosticService;
+        private readonly IThreadingContext _threadingContext;
+        private readonly IVsHierarchyItemManager _vsHierarchyItemManager;
+
+        private IServiceProvider? _serviceProvider;
 
         [ImportingConstructor]
-        public VisualStudioDiagnosticAnalyzerService(VisualStudioWorkspace workspace, IDiagnosticAnalyzerService diagnosticService)
+        public VisualStudioDiagnosticAnalyzerService(
+            VisualStudioWorkspace workspace,
+            IDiagnosticAnalyzerService diagnosticService,
+            IThreadingContext threadingContext,
+            IVsHierarchyItemManager vsHierarchyItemManager)
         {
             _workspace = workspace;
             _diagnosticService = diagnosticService;
+            _threadingContext = threadingContext;
+            _vsHierarchyItemManager = vsHierarchyItemManager;
+        }
+
+        public void Initialize(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+
+            // Hook up the "Run Code Analysis" menu command for CPS based managed projects.
+            var menuCommandService = (IMenuCommandService)_serviceProvider.GetService(typeof(IMenuCommandService));
+            if (menuCommandService != null)
+            {
+                AddCommand(menuCommandService, ID.RoslynCommands.ECMD_RUNFXCOPSEL, OnRunCodeAnalysisForSelectedProject, OnRunCodeAnalysisForSelectedProjectStatus);
+            }
+
+            return;
+
+            // Local functions
+            static OleMenuCommand AddCommand(
+                IMenuCommandService menuCommandService,
+                int commandId,
+                EventHandler invokeHandler,
+                EventHandler beforeQueryStatus)
+            {
+                var commandIdWithGroupId = new CommandID(VSConstants.VSStd2K, commandId);
+                var command = new OleMenuCommand(invokeHandler, delegate { }, beforeQueryStatus, commandIdWithGroupId);
+                menuCommandService.AddCommand(command);
+                return command;
+            }
         }
 
         // *DO NOT DELETE*
         // This is used by Ruleset Editor from ManagedSourceCodeAnalysis.dll.
-        public IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy hierarchyOpt)
+        public IReadOnlyDictionary<string, IEnumerable<DiagnosticDescriptor>> GetAllDiagnosticDescriptors(IVsHierarchy? hierarchy)
         {
-            if (hierarchyOpt == null)
+            if (hierarchy == null)
             {
                 return Transform(_diagnosticService.CreateDiagnosticDescriptorsPerReference(projectOpt: null));
             }
@@ -37,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             // Analyzers are only supported for C# and VB currently.
             var projectsWithHierarchy = _workspace.CurrentSolution.Projects
                 .Where(p => p.Language == LanguageNames.CSharp || p.Language == LanguageNames.VisualBasic)
-                .Where(p => _workspace.GetHierarchy(p.Id) == hierarchyOpt);
+                .Where(p => _workspace.GetHierarchy(p.Id) == hierarchy);
 
             if (projectsWithHierarchy.Count() <= 1)
             {
@@ -73,6 +121,155 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         {
             // unfortunately, we had to do this since ruleset editor and us are set to use this signature
             return map.ToDictionary(kv => kv.Key, kv => (IEnumerable<DiagnosticDescriptor>)kv.Value);
+        }
+
+        private void OnRunCodeAnalysisForSelectedProjectStatus(object sender, EventArgs e)
+        {
+            var command = (OleMenuCommand)sender;
+
+            // We hook up the "Run Code Analysis" menu commands for CPS based managed projects.
+            // These commands are already hooked up for csproj based projects in StanCore, but those will eventually go away.
+            var visible = TryGetSelectedProjectHierarchy(out var hierarchy) &&
+                hierarchy.IsCapabilityMatch("CPS") &&
+                hierarchy.IsCapabilityMatch(".NET");
+            var enabled = false;
+
+            if (visible)
+            {
+                if (hierarchy.TryGetProject(out var project))
+                {
+                    // Change to show the name of the project as part of the menu item display text.
+                    command.Text = string.Format(ServicesVSResources.Run_Code_Analysis_on_0, project.Name);
+                }
+
+                enabled = !IsBuildActive();
+            }
+
+            if (command.Visible != visible)
+            {
+                command.Visible = visible;
+            }
+            if (command.Enabled != enabled)
+            {
+                command.Enabled = enabled;
+            }
+        }
+
+        private void OnRunCodeAnalysisForSelectedProject(object sender, EventArgs args)
+        {
+            if (TryGetSelectedProjectHierarchy(out var hierarchy))
+            {
+                RunAnalyzers(hierarchy);
+            }
+        }
+
+        public void RunAnalyzers(IVsHierarchy? hierarchy)
+        {
+            var project = GetProject(hierarchy);
+            var projectOrSolutionName = project?.Name ?? PathUtilities.GetFileName(_workspace.CurrentSolution.FilePath) ?? "Solution";
+
+            // Add a message to VS status bar that we are running code analysis.
+            var waitDialogMessage = string.Format(ServicesVSResources.Running_code_analysis_for_0, projectOrSolutionName);
+            var statusBar = _serviceProvider?.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
+            statusBar?.SetText(waitDialogMessage);
+
+            // Force complete analyzer execution in background.
+            Task.Run(async () =>
+            {
+                await _diagnosticService.ForceAnalyzeAsync(_workspace.CurrentSolution, project?.Id, CancellationToken.None).ConfigureAwait(false);
+
+                // Add a message to VS status bar that we completed executing code analysis.
+                await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var notificationMesage = string.Format(ServicesVSResources.Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh, projectOrSolutionName);
+                statusBar?.SetText(notificationMesage);
+            });
+        }
+
+        private Project? GetProject(IVsHierarchy? hierarchy)
+        {
+            if (hierarchy != null)
+            {
+                var projectMap = _workspace.Services.GetRequiredService<IHierarchyItemToProjectIdMap>();
+                var projectHierarchyItem = _vsHierarchyItemManager.GetHierarchyItem(hierarchy, VSConstants.VSITEMID_ROOT);
+                if (projectMap.TryGetProjectId(projectHierarchyItem, targetFrameworkMoniker: null, out var projectId))
+                {
+                    return _workspace.CurrentSolution.GetProject(projectId);
+                }
+            }
+
+            return null;
+        }
+
+        private bool TryGetSelectedProjectHierarchy([NotNullWhen(returnValue: true)] out IVsHierarchy? hierarchy)
+        {
+            hierarchy = null;
+
+            // Get the DTE service and make sure there is an open solution
+            if (!(_serviceProvider?.GetService(typeof(EnvDTE.DTE)) is EnvDTE.DTE dte) ||
+                dte.Solution == null)
+            {
+                return false;
+            }
+
+            var selectionHierarchy = IntPtr.Zero;
+            var selectionContainer = IntPtr.Zero;
+
+            // Get the current selection in the shell
+            if (_serviceProvider.GetService(typeof(SVsShellMonitorSelection)) is IVsMonitorSelection monitorSelection)
+            {
+                try
+                {
+                    monitorSelection.GetCurrentSelection(out selectionHierarchy, out var itemId, out var multiSelect, out selectionContainer);
+                    if (selectionHierarchy != IntPtr.Zero)
+                    {
+                        hierarchy = Marshal.GetObjectForIUnknown(selectionHierarchy) as IVsHierarchy;
+                        Debug.Assert(hierarchy != null);
+                        return hierarchy != null;
+                    }
+                }
+                catch (Exception)
+                {
+                    // If anything went wrong, just ignore it
+                }
+                finally
+                {
+                    // Make sure we release the COM pointers in any case
+                    if (selectionHierarchy != IntPtr.Zero)
+                    {
+                        Marshal.Release(selectionHierarchy);
+                    }
+
+                    if (selectionContainer != IntPtr.Zero)
+                    {
+                        Marshal.Release(selectionContainer);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsBuildActive()
+        {
+            // Using KnownUIContexts is faster in case when SBM's package was not loaded yet
+            if (KnownUIContexts.SolutionBuildingContext != null)
+            {
+                return KnownUIContexts.SolutionBuildingContext.IsActive;
+            }
+            else
+            {
+                // Unlikely case that above service is not available, let's try Solution Build Manager
+                if (_serviceProvider?.GetService(typeof(SVsSolutionBuildManager)) is IVsSolutionBuildManager buildManager)
+                {
+                    buildManager.QueryBuildManagerBusy(out var buildBusy);
+                    return buildBusy != 0;
+                }
+                else
+                {
+                    Debug.Fail("Unable to determine whether build is active or not");
+                    return true;
+                }
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -127,6 +127,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             this.ComponentModel.GetService<AnalyzerConfigDocumentAsSolutionItemHandler>().Initialize(this);
             this.ComponentModel.GetService<VisualStudioAddSolutionItemService>().Initialize(this);
 
+            this.ComponentModel.GetService<IVisualStudioDiagnosticAnalyzerService>().Initialize(this);
+
             LoadAnalyzerNodeComponents();
 
             LoadComponentsBackgroundAsync(cancellationToken).Forget();

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -588,11 +588,20 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code analysis completed for &apos;{0}&apos;. Please wait for the error list to refresh..
+        ///   Looks up a localized string similar to Code analysis completed for &apos;{0}&apos;..
         /// </summary>
-        internal static string Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh {
+        internal static string Code_analysis_completed_for_0 {
             get {
-                return ResourceManager.GetString("Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh", resourceCulture);
+                return ResourceManager.GetString("Code_analysis_completed_for_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Code analysis completed for Solution..
+        /// </summary>
+        internal static string Code_analysis_completed_for_Solution {
+            get {
+                return ResourceManager.GetString("Code_analysis_completed_for_Solution", resourceCulture);
             }
         }
         
@@ -2823,6 +2832,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Running_code_analysis_for_0 {
             get {
                 return ResourceManager.GetString("Running_code_analysis_for_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running code analysis for Solution....
+        /// </summary>
+        internal static string Running_code_analysis_for_Solution {
+            get {
+                return ResourceManager.GetString("Running_code_analysis_for_Solution", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -588,6 +588,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Code analysis completed for &apos;{0}&apos;. Please wait for the error list to refresh..
+        /// </summary>
+        internal static string Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh {
+            get {
+                return ResourceManager.GetString("Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Code block preferences:.
         /// </summary>
         internal static string Code_block_preferences_colon {
@@ -2796,6 +2805,24 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Review_Changes {
             get {
                 return ResourceManager.GetString("Review_Changes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run Code Analysis on {0}.
+        /// </summary>
+        internal static string Run_Code_Analysis_on_0 {
+            get {
+                return ResourceManager.GetString("Run_Code_Analysis_on_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running code analysis for &apos;{0}&apos;....
+        /// </summary>
+        internal static string Running_code_analysis_for_0 {
+            get {
+                return ResourceManager.GetString("Running_code_analysis_for_0", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1338,7 +1338,13 @@ I agree to all of the foregoing:</value>
   <data name="Running_code_analysis_for_0" xml:space="preserve">
     <value>Running code analysis for '{0}'...</value>
   </data>
-  <data name="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh" xml:space="preserve">
-    <value>Code analysis completed for '{0}'. Please wait for the error list to refresh.</value>
+  <data name="Running_code_analysis_for_Solution" xml:space="preserve">
+    <value>Running code analysis for Solution...</value>
+  </data>
+  <data name="Code_analysis_completed_for_0" xml:space="preserve">
+    <value>Code analysis completed for '{0}'.</value>
+  </data>
+  <data name="Code_analysis_completed_for_Solution" xml:space="preserve">
+    <value>Code analysis completed for Solution.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -1332,4 +1332,13 @@ I agree to all of the foregoing:</value>
   <data name="A_new_editorconfig_file_was_detected_at_the_root_of_your_solution_Would_you_like_to_make_it_a_solution_item" xml:space="preserve">
     <value>A new .editorconfig file was detected at the root of your solution. Would you like to make it a solution item?</value>
   </data>
+  <data name="Run_Code_Analysis_on_0" xml:space="preserve">
+    <value>Run Code Analysis on {0}</value>
+  </data>
+  <data name="Running_code_analysis_for_0" xml:space="preserve">
+    <value>Running code analysis for '{0}'...</value>
+  </data>
+  <data name="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh" xml:space="preserve">
+    <value>Code analysis completed for '{0}'. Please wait for the error list to refresh.</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.cs.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">&amp;Výchozí</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Seřadit direktivy &amp;using</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.de.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">&amp;Standard</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">&amp;Using-Anweisungen sortieren</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.es.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">Pre&amp;determinado</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Ordenar instrucciones &amp;Using</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.fr.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">Par &amp;défaut</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Trier les &amp;using</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.it.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">Pre&amp;definito</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Ordina &amp;using</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">using の並べ替え(&amp;U)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ja.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">既定(&amp;D)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ko.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">기본값(&amp;D)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Using 정렬(&amp;U)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.pl.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">&amp;Domyślny</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Sortuj &amp;użycia</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.pt-BR.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">&amp;Padrão</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Classificar &amp;Usos</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ru.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">&amp;По умолчанию</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">Сортировать д&amp;ирективы using</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.tr.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">&amp;Varsayılan</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">&amp;Using’leri Sırala</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hans.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">默认值(&amp;D)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">对 using 排序(&amp;U)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hant.xlf
@@ -212,6 +212,21 @@
         <target state="translated">OpenActiveRuleSet</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|ButtonText">
+        <source>Run C&amp;ode Analysis</source>
+        <target state="new">Run C&amp;ode Analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|CommandName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidRunCodeAnalysisForProject|LocCanonicalName">
+        <source>RunCodeAnalysisForProject</source>
+        <target state="new">RunCodeAnalysisForProject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidSetSeverityDefault|ButtonText">
         <source>&amp;Default</source>
         <target state="translated">預設(&amp;D)</target>

--- a/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/Commands.vsct.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Commands.vsct">
     <body>
+      <trans-unit id="ECMD_RUNFXCOPSEL|ButtonText">
+        <source>Run Code &amp;Analysis on Selection</source>
+        <target state="new">Run Code &amp;Analysis on Selection</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidCSharpOrganizeSortUsings|ButtonText">
         <source>Sort &amp;Usings</source>
         <target state="translated">排序 Using(&amp;U)</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Klasifikace</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Klasifikace</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Obarvit regulární výrazy</target>
@@ -427,6 +432,16 @@
         <target state="translated">Zkontrolovat změny</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Spouštění procesů s nízkou prioritou na pozadí</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Zobrazit seznam pro doplňování</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Zobrazit seznam pro doplňování</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Cílový obor názvů:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Klassifizierungen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Reguläre Ausdrücke farbig hervorheben</target>
@@ -427,6 +432,16 @@
         <target state="translated">Änderungen überprüfen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Hintergrundprozesse mit niedriger Priorität werden ausgeführt.</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Vervollständigungsliste anzeigen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Vervollständigungsliste anzeigen</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Zielnamespace:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Klassifizierungen</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Mostrar lista de finalización</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Espacio de nombres de destino:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Clasificaciones</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Colorear expresiones regulares</target>
@@ -427,6 +432,16 @@
         <target state="translated">Revisar cambios</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Ejecutando procesos en segundo plano de baja prioridad</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Mostrar lista de finalización</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Clasificaciones</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Classifications</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Coloriser les expressions régulières</target>
@@ -427,6 +432,16 @@
         <target state="translated">Passer en revue les changements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Exécution des processus d’arrière-plan basse priorité</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Afficher la liste de saisie semi-automatique</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Afficher la liste de saisie semi-automatique</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Espace de noms cible :</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Classifications</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Classificazioni</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Colora espressioni regolari</target>
@@ -427,6 +432,16 @@
         <target state="translated">Esamina modifiche</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Esecuzione di processi in background con priorità bassa</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Mostra l'elenco di completamento</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Classificazioni</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Mostra l'elenco di completamento</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Spazio dei nomi di destinazione:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -77,6 +77,11 @@
         <target state="translated">分類</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">正規表現をカラー化</target>
@@ -427,6 +432,16 @@
         <target state="translated">変更のプレビュー</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">優先度の低いバックグラウンド プロセスを実行しています</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">入力候補一覧の表示</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -77,9 +77,14 @@
         <target state="translated">分類</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -492,11 +492,6 @@
         <target state="translated">入力候補一覧の表示</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">ターゲット名前空間:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -77,6 +77,11 @@
         <target state="translated">분류</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">정규식 색 지정</target>
@@ -427,6 +432,16 @@
         <target state="translated">변경 내용 검토</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">낮은 우선 순위 백그라운드 프로세스 실행 중</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">완성 목록 표시</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -492,11 +492,6 @@
         <target state="translated">완성 목록 표시</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">대상 네임스페이스:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -77,9 +77,14 @@
         <target state="translated">분류</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Klasyfikacje</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Koloruj wyrażenia regularne</target>
@@ -427,6 +432,16 @@
         <target state="translated">Przejrzyj zmiany</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Uruchamianie procesów w tle o niskim priorytecie</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Pokaż listę uzupełniania</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Pokaż listę uzupełniania</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Docelowa przestrzeń nazw:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Klasyfikacje</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Classificações</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Mostrar a lista de conclusão</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Namespace de Destino:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Classificações</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Colorir expressões regulares</target>
@@ -427,6 +432,16 @@
         <target state="translated">Revisar alterações</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Executando processos de baixa prioridade em segundo plano</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Mostrar a lista de conclusão</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Показать список завершения</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Целевое пространство имен:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Классификации</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Выделить регулярные выражения цветом</target>
@@ -427,6 +432,16 @@
         <target state="translated">Проверить изменения</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Запуск фоновых процессов с низким приоритетом</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Показать список завершения</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Классификации</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Sınıflandırmalar</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">Normal ifadeleri renklendir</target>
@@ -427,6 +432,16 @@
         <target state="translated">Değişiklikleri Gözden Geçir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">Düşük öncelikli arka plan işlemleri çalıştırılıyor</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">Tamamlama listesini göster</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -77,9 +77,14 @@
         <target state="translated">Sınıflandırmalar</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -492,11 +492,6 @@
         <target state="translated">Tamamlama listesini göster</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">Hedef Ad Alanı:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -77,6 +77,11 @@
         <target state="translated">分类</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">为正规表达式着色</target>
@@ -427,6 +432,16 @@
         <target state="translated">预览更改</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">正在运行低优先级后台进程</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">显示完成列表</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -492,11 +492,6 @@
         <target state="translated">显示完成列表</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">目标命名空间:</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -77,9 +77,14 @@
         <target state="translated">分类</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -77,6 +77,11 @@
         <target state="translated">分類</target>
         <note />
       </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
+        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
+        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
         <source>Colorize regular expressions</source>
         <target state="translated">為規則運算式添加色彩</target>
@@ -427,6 +432,16 @@
         <target state="translated">檢閱變更</target>
         <note />
       </trans-unit>
+      <trans-unit id="Run_Code_Analysis_on_0">
+        <source>Run Code Analysis on {0}</source>
+        <target state="new">Run Code Analysis on {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_0">
+        <source>Running code analysis for '{0}'...</source>
+        <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">
         <source>Running low priority background processes</source>
         <target state="translated">正在執行低優先順序背景流程</target>
@@ -475,6 +490,11 @@
       <trans-unit id="Show_completion_list">
         <source>Show completion list</source>
         <target state="translated">顯示自動完成清單</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Solution">
+        <source>Solution</source>
+        <target state="new">Solution</target>
         <note />
       </trans-unit>
       <trans-unit id="Target_Namespace_colon">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -77,9 +77,14 @@
         <target state="translated">分類</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_analysis_completed_for_0_Please_wait_for_the_error_list_to_refresh">
-        <source>Code analysis completed for '{0}'. Please wait for the error list to refresh.</source>
-        <target state="new">Code analysis completed for '{0}'. Please wait for the error list to refresh.</target>
+      <trans-unit id="Code_analysis_completed_for_0">
+        <source>Code analysis completed for '{0}'.</source>
+        <target state="new">Code analysis completed for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Code_analysis_completed_for_Solution">
+        <source>Code analysis completed for Solution.</source>
+        <target state="new">Code analysis completed for Solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="Colorize_regular_expressions">
@@ -440,6 +445,11 @@
       <trans-unit id="Running_code_analysis_for_0">
         <source>Running code analysis for '{0}'...</source>
         <target state="new">Running code analysis for '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Running_code_analysis_for_Solution">
+        <source>Running code analysis for Solution...</source>
+        <target state="new">Running code analysis for Solution...</target>
         <note />
       </trans-unit>
       <trans-unit id="Running_low_priority_background_processes">

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -492,11 +492,6 @@
         <target state="translated">顯示自動完成清單</target>
         <note />
       </trans-unit>
-      <trans-unit id="Solution">
-        <source>Solution</source>
-        <target state="new">Solution</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Target_Namespace_colon">
         <source>Target Namespace:</source>
         <target state="translated">目標命名空間:</target>

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -515,6 +515,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Function IsCompilationEndAnalyzer(analyzer As DiagnosticAnalyzer, project As Project, compilation As Compilation) As Boolean Implements IDiagnosticAnalyzerService.IsCompilationEndAnalyzer
                 Throw New NotImplementedException()
             End Function
+
+            Public Function ForceAnalyzeAsync(solution As Solution, Optional projectId As ProjectId = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task Implements IDiagnosticAnalyzerService.ForceAnalyzeAsync
+                Throw New NotImplementedException()
+            End Function
         End Class
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/EditAndContinueTestHelper.vb
@@ -119,6 +119,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             Public Function IsCompilationEndAnalyzer(analyzer As DiagnosticAnalyzer, project As Project, compilation As Compilation) As Boolean Implements IDiagnosticAnalyzerService.IsCompilationEndAnalyzer
                 Throw New NotImplementedException()
             End Function
+
+            Public Function ForceAnalyzeAsync(solution As Solution, Optional projectId As ProjectId = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task Implements IDiagnosticAnalyzerService.ForceAnalyzeAsync
+                Throw New NotImplementedException()
+            End Function
         End Class
     End Class
 End Namespace


### PR DESCRIPTION
…yn analyzers.

Closes #38051: Users can now use this command to force complete all the analyzers on a project/solution (includes NuGet based + VSIX based analyzers, including IDE code style analyzers).

Complements #39544: Users can now potentially disable continuous analyzer execution  during live analysis and instead execute them on demand with these commands.

Few things to note:
1. This change hooks up new "Run Code Analysis on ProjectName" menu commands for CPS based managed projects. These commands are already hooked up for csproj based legacy projects in StanCore, but that should eventually go away.
2. ~~This change only hooks up these new commands for top level Build and Analyze menus. Adding these to "Analyzer and Code Cleanup" context menus for project/solution in solution explorer is much trickier as the command groups are defined in StanCore. I will do so in a separate PR.~~ Implemented with https://github.com/dotnet/roslyn/pull/39596/commits/38e4eda41251b043d5a92d696506de38243db315
3. This change also exposes a "RunAnalyzers" API for StanCore, so we can trigger analyzer execution when user executes run code analysis on solution/csproj based project. There is a VS side [PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/211392) that will consume this functionality to make the experience uniform across all "Run Code Analysis" commands.