### PR TITLE
Fix crash where we are not always finding text snapshots

### DIFF
--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -357,7 +356,7 @@ namespace Microsoft.CodeAnalysis.Text
                 return GetChangeRanges(oldSnapshot, oldText.Length, newSnapshot);
             }
 
-            private IReadOnlyList<TextChangeRange> GetChangeRanges(ITextImage oldImage, int oldTextLength, ITextImage newImage)
+            private IReadOnlyList<TextChangeRange> GetChangeRanges(ITextImage? oldImage, int oldTextLength, ITextImage? newImage)
             {
                 if (oldImage == null ||
                     newImage == null ||

--- a/src/EditorFeatures/Text/Extensions.cs
+++ b/src/EditorFeatures/Text/Extensions.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -17,20 +18,20 @@ namespace Microsoft.CodeAnalysis.Text
         public static ITextBuffer GetTextBuffer(this SourceTextContainer textContainer)
             => TryGetTextBuffer(textContainer) ?? throw new ArgumentException(TextEditorResources.textContainer_is_not_a_SourceTextContainer_that_was_created_from_an_ITextBuffer, nameof(textContainer));
 
-        public static ITextBuffer TryGetTextBuffer(this SourceTextContainer textContainer)
+        public static ITextBuffer? TryGetTextBuffer(this SourceTextContainer? textContainer)
             => (textContainer as TextBufferContainer)?.TryFindEditorTextBuffer();
 
         /// <summary>
-        /// Returns the ITextSnapshot behind this SourceText, or null if it wasn't created from one.
+        /// Returns the <see cref="ITextSnapshot"/> behind this <see cref="SourceText"/>, or null if it wasn't created from one.
         /// 
-        /// Note that multiple ITextSnapshots may map to the same SourceText instance if
-        /// ITextSnapshot.Version.ReiteratedVersionNumber doesn't change.
+        /// Note that multiple <see cref="ITextSnapshot"/>s may map to the same <see cref="SourceText"/> instance if it's
+        /// <see cref="ITextVersion.ReiteratedVersionNumber" /> doesn't change.
         /// </summary>
         /// <returns>The underlying ITextSnapshot.</returns>
-        public static ITextSnapshot FindCorrespondingEditorTextSnapshot(this SourceText text)
+        public static ITextSnapshot? FindCorrespondingEditorTextSnapshot(this SourceText? text)
             => (text as SnapshotSourceText)?.TryFindEditorSnapshot();
 
-        internal static ITextImage TryFindCorrespondingEditorTextImage(this SourceText text)
+        internal static ITextImage? TryFindCorrespondingEditorTextImage(this SourceText? text)
             => (text as SnapshotSourceText)?.TextImage;
 
         internal static TextLine AsTextLine(this ITextSnapshotLine line)
@@ -48,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// <summary>
         /// Gets the workspace corresponding to the text buffer.
         /// </summary>
-        public static Workspace GetWorkspace(this ITextBuffer buffer)
+        public static Workspace? GetWorkspace(this ITextBuffer buffer)
         {
             var container = buffer.AsTextContainer();
             if (Workspace.TryGetWorkspace(container, out var workspace))
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// associated with the buffer if it is linked into multiple projects or is part of a Shared Project. In this case, the <see cref="Workspace"/>
         /// is responsible for keeping track of which of these <see cref="Document"/>s is in the current project context.
         /// </summary>
-        public static Document GetOpenDocumentInCurrentContextWithChanges(this ITextSnapshot text)
+        public static Document? GetOpenDocumentInCurrentContextWithChanges(this ITextSnapshot text)
             => text.AsText().GetOpenDocumentInCurrentContextWithChanges();
 
         /// <summary>
@@ -90,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// with the specified text's container, or the text's container isn't associated with a workspace,
         /// then the method returns false.
         /// </summary>
-        internal static Document GetDocumentWithFrozenPartialSemantics(this SourceText text, CancellationToken cancellationToken)
+        internal static Document? GetDocumentWithFrozenPartialSemantics(this SourceText text, CancellationToken cancellationToken)
         {
             var document = text.GetOpenDocumentInCurrentContextWithChanges();
             return document?.WithFrozenPartialSemantics(cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using Roslyn.Utilities;
@@ -19,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 var ids = workspace.GetRelatedDocumentIds(text.Container);
                 var sol = workspace.CurrentSolution.WithDocumentText(ids, text, PreservationMode.PreserveIdentity);
-                return ids.Select(id => sol.GetDocument(id)).Where(d => d != null);
+                return ids.Select(id => sol.GetDocument(id)).WhereNotNull();
             }
 
             return SpecializedCollections.EmptyEnumerable<Document>();
@@ -29,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// Gets the document from the corresponding workspace's current solution that is associated with the source text's container 
         /// in its current project context, updated to contain the same text as the source if necessary.
         /// </summary>
-        public static Document GetOpenDocumentInCurrentContextWithChanges(this SourceText text)
+        public static Document? GetOpenDocumentInCurrentContextWithChanges(this SourceText text)
         {
             if (Workspace.TryGetWorkspace(text.Container, out var workspace))
             {
@@ -59,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 var sol = workspace.CurrentSolution;
                 var ids = workspace.GetRelatedDocumentIds(container);
-                return ids.Select(id => sol.GetDocument(id)).Where(d => d != null);
+                return ids.Select(id => sol.GetDocument(id)).WhereNotNull();
             }
 
             return SpecializedCollections.EmptyEnumerable<Document>();
@@ -69,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// Gets the document from the corresponding workspace's current solution that is associated with the text container 
         /// in its current project context.
         /// </summary>
-        public static Document GetOpenDocumentInCurrentContext(this SourceTextContainer container)
+        public static Document? GetOpenDocumentInCurrentContext(this SourceTextContainer container)
         {
             if (Workspace.TryGetWorkspace(container, out var workspace))
             {


### PR DESCRIPTION
Given this is not a reliable crash, my guess is the problem is we are sometimes processing an older Solution snapshot. Asking a specific SourceText for the specific ITextSnapshot it came from could fail
if that snapshot had been GC'ed, whereas going to the container first and asking for the buffer directly should be more reliable. Either way we now also handle the null case.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1010045