### PR TITLE
Fix SkipLocalsInit with stackalloc

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -64,6 +64,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private LocalDefinition _returnTemp;
 
+        /// <summary>
+        /// True if there was a localloc anywhere in the method. This will affect
+        /// whether or not we require the locals init flag to be marked, since locals
+        /// init affects localloc.
+        /// </summary>
+        private bool _sawStackalloc;
+
         public CodeGenerator(
             MethodSymbol method,
             BoundStatement boundBody,
@@ -188,9 +195,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private bool IsStackLocal(LocalSymbol local) => IsStackLocal(local, _stackLocals);
 
-        public void Generate()
+        public void Generate(out bool hasStackalloc)
         {
             this.GenerateImpl();
+            hasStackalloc = _sawStackalloc;
 
             Debug.Assert(_asyncCatchHandlerOffset < 0);
             Debug.Assert(_asyncYieldPoints == null);

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -65,9 +65,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private LocalDefinition _returnTemp;
 
         /// <summary>
-        /// True if there was a localloc anywhere in the method. This will affect
-        /// whether or not we require the locals init flag to be marked, since locals
-        /// init affects localloc.
+        /// True if there was a <see cref="ILOpCode.Localloc"/> anywhere in the method. This will
+        /// affect whether or not we require the locals init flag to be marked, since locals init
+        /// affects <see cref="ILOpCode.Localloc"/>.
         /// </summary>
         private bool _sawStackalloc;
 
@@ -205,9 +205,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Debug.Assert(_asyncResumePoints == null);
         }
 
-        public void Generate(out int asyncCatchHandlerOffset, out ImmutableArray<int> asyncYieldPoints, out ImmutableArray<int> asyncResumePoints)
+        public void Generate(
+            out int asyncCatchHandlerOffset,
+            out ImmutableArray<int> asyncYieldPoints,
+            out ImmutableArray<int> asyncResumePoints,
+            out bool hasStackAlloc)
         {
             this.GenerateImpl();
+            hasStackAlloc = _sawStackalloc;
             Debug.Assert(_asyncCatchHandlerOffset >= 0);
 
             asyncCatchHandlerOffset = _builder.GetILOffsetFromMarker(_asyncCatchHandlerOffset);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1910,6 +1910,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitConvertedStackAllocExpression(BoundConvertedStackAllocExpression expression, bool used)
         {
+            _sawStackalloc = true;
             EmitExpression(expression.Count, used);
 
             // the only sideeffect of a localloc is a nondeterministic and generally fatal StackOverflow.

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1910,13 +1910,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitConvertedStackAllocExpression(BoundConvertedStackAllocExpression expression, bool used)
         {
-            _sawStackalloc = true;
             EmitExpression(expression.Count, used);
 
             // the only sideeffect of a localloc is a nondeterministic and generally fatal StackOverflow.
             // we can ignore that if the actual result is unused
             if (used)
             {
+                _sawStackalloc = true;
                 _builder.EmitOpCode(ILOpCode.Localloc);
             }
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1448,7 +1448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (isAsyncStateMachine)
                 {
-                    codeGen.Generate(out int asyncCatchHandlerOffset, out var asyncYieldPoints, out var asyncResumePoints);
+                    codeGen.Generate(out int asyncCatchHandlerOffset, out var asyncYieldPoints, out var asyncResumePoints, out hasStackalloc);
 
                     // The exception handler IL offset is used by the debugger to treat exceptions caught by the marked catch block as "user unhandled".
                     // This is important for async void because async void exceptions generally result in the process being terminated,

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1411,7 +1411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var optimizations = compilation.Options.OptimizationLevel;
 
             ILBuilder builder = new ILBuilder(moduleBuilder, localSlotManager, optimizations, method.AreLocalsZeroed);
-            bool hasStackalloc = false;
+            bool hasStackalloc;
             DiagnosticBag diagnosticsForThisMethod = DiagnosticBag.GetInstance();
             try
             {

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1411,6 +1411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var optimizations = compilation.Options.OptimizationLevel;
 
             ILBuilder builder = new ILBuilder(moduleBuilder, localSlotManager, optimizations, method.AreLocalsZeroed);
+            bool hasStackalloc = false;
             DiagnosticBag diagnosticsForThisMethod = DiagnosticBag.GetInstance();
             try
             {
@@ -1468,7 +1469,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    codeGen.Generate();
+                    codeGen.Generate(out hasStackalloc);
 
                     if ((object)kickoffMethod != null)
                     {
@@ -1531,6 +1532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     debugDocumentProvider,
                     builder.RealizedExceptionHandlers,
                     builder.AreLocalsZeroed,
+                    hasStackalloc,
                     builder.GetAllScopes(),
                     builder.HasDynamicLocal,
                     importScopeOpt,

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -9121,12 +9121,20 @@ public class C
         int *ptr = stackalloc int[10];
         System.Console.WriteLine(ptr[0]);
     }
+
+    [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
+    public unsafe void M3()
+    {
+       int* p = stackalloc int[10]; // unused
+    }
 }";
             var verifier = CompileAndVerifyWithSkipLocalsInit(src);
             Assert.Null(verifier.HasLocalsInit("C.M1")); // no locals
             Assert.False(verifier.HasLocalsInit("C.M1", realIL: true));
             Assert.Null(verifier.HasLocalsInit("C.M2")); // no locals
             Assert.True(verifier.HasLocalsInit("C.M2", realIL: true));
+            Assert.Null(verifier.HasLocalsInit("C.M3")); // no locals
+            Assert.False(verifier.HasLocalsInit("C.M3", realIL: true));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -9122,7 +9122,6 @@ public class C
         System.Console.WriteLine(ptr[0]);
     }
 
-    [System.Runtime.CompilerServices.SkipLocalsInitAttribute]
     public unsafe void M3()
     {
        int* p = stackalloc int[10]; // unused

--- a/src/Compilers/Core/Portable/CodeGen/MethodBody.cs
+++ b/src/Compilers/Core/Portable/CodeGen/MethodBody.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
             DebugDocumentProvider debugDocumentProvider,
             ImmutableArray<Cci.ExceptionHandlerRegion> exceptionHandlers,
             bool areLocalsZeroed,
+            bool hasStackalloc,
             ImmutableArray<Cci.LocalScope> localScopes,
             bool hasDynamicLocalVariables,
             Cci.IImportScope importScopeOpt,
@@ -75,6 +76,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
             _locals = locals;
             _exceptionHandlers = exceptionHandlers;
             _areLocalsZeroed = areLocalsZeroed;
+            HasStackalloc = hasStackalloc;
             _localScopes = localScopes;
             _hasDynamicLocalVariables = hasDynamicLocalVariables;
             _importScopeOpt = importScopeOpt;
@@ -144,5 +146,10 @@ namespace Microsoft.CodeAnalysis.CodeGen
         public ImmutableArray<LambdaDebugInfo> LambdaDebugInfo => _lambdaDebugInfo;
 
         public ImmutableArray<ClosureDebugInfo> ClosureDebugInfo => _closureDebugInfo;
+
+        /// <summary>
+        /// True if there's a stackalloc somewhere in the method.
+        /// </summary>
+        public bool HasStackalloc { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
@@ -113,6 +113,8 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 ImmutableArray<Cci.ExceptionHandlerRegion> Cci.IMethodBody.ExceptionRegions =>
                     ImmutableArray<Cci.ExceptionHandlerRegion>.Empty;
 
+                bool Cci.IMethodBody.HasStackalloc => false;
+
                 bool Cci.IMethodBody.AreLocalsZeroed => false;
 
                 ImmutableArray<Cci.ILocalDefinition> Cci.IMethodBody.LocalVariables =>

--- a/src/Compilers/Core/Portable/PEWriter/Members.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Members.cs
@@ -329,6 +329,11 @@ namespace Microsoft.Cci
         bool AreLocalsZeroed { get; }
 
         /// <summary>
+        /// True if there's a stackalloc somewhere in the method.
+        /// </summary>
+        bool HasStackalloc { get; }
+
+        /// <summary>
         /// The local variables of the method.
         /// </summary>
         ImmutableArray<ILocalDefinition> LocalVariables { get; }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2933,7 +2933,8 @@ namespace Microsoft.Cci
                 exceptionRegionCount: exceptionRegions.Length,
                 hasSmallExceptionRegions: MayUseSmallExceptionHeaders(exceptionRegions),
                 localVariablesSignature: localSignatureHandleOpt,
-                attributes: (methodBody.AreLocalsZeroed ? MethodBodyAttributes.InitLocals : 0));
+                attributes: (methodBody.AreLocalsZeroed ? MethodBodyAttributes.InitLocals : 0),
+                hasDynamicStackAllocation: methodBody.HasStackalloc);
 
             // Don't do small body method caching during deterministic builds until this issue is fixed
             // https://github.com/dotnet/roslyn/issues/7595

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -1611,6 +1611,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       debugDocumentProvider,
                                       builder.RealizedExceptionHandlers,
                                       areLocalsZeroed:=True,
+                                      hasStackalloc:=False,
                                       localScopes,
                                       hasDynamicLocalVariables:=False,
                                       importScopeOpt:=importScopeOpt,

--- a/src/Test/Utilities/Portable/Metadata/ILValidation.cs
+++ b/src/Test/Utilities/Portable/Metadata/ILValidation.cs
@@ -300,6 +300,22 @@ namespace Roslyn.Test.Utilities
             return result.ToString();
         }
 
+        public static unsafe MethodBodyBlock GetMethodBodyBlock(this ImmutableArray<byte> ilArray)
+        {
+            fixed (byte* ilPtr = ilArray.AsSpan())
+            {
+                int offset = 0;
+                // skip padding:
+                while (offset < ilArray.Length && ilArray[offset] == 0)
+                {
+                    offset++;
+                }
+
+                var reader = new BlobReader(ilPtr + offset, ilArray.Length - offset);
+                return MethodBodyBlock.Create(reader);
+            }
+        }
+
         public static Dictionary<int, string> GetSequencePointMarkers(string pdbXml, string source = null)
         {
             var doc = new XmlDocument() { XmlResolver = null };


### PR DESCRIPTION
stackalloc is affected by the locals init flag, but the locals init
flag is only present if the fat IL header is used, which is not
preferred if the method is small and has no locals. S.R.M added
a parameter to allow callers to indicate that stackalloc is present
and thus localsinit should be respected when deciding to use the
fat or tiny IL header. This change tracks whether there is a stackalloc
while doing codegen and plumbs the result into S.R.M.