### PR TITLE
Dispose of StringWriter after merging token text.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -357,20 +357,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' grab the part that doesn't contain the preceding and trailing trivia.
 
             Dim builder = PooledStringBuilder.GetInstance()
-            Dim writer As New IO.StringWriter(builder)
+            Using writer As New IO.StringWriter(builder)
 
-            firstToken.WriteTo(writer)
-            secondToken.WriteTo(writer)
+                firstToken.WriteTo(writer)
+                secondToken.WriteTo(writer)
 
-            Dim leadingWidth = firstToken.GetLeadingTriviaWidth()
-            Dim trailingWidth = secondToken.GetTrailingTriviaWidth()
-            Dim fullWidth = firstToken.FullWidth + secondToken.FullWidth
+                Dim leadingWidth = firstToken.GetLeadingTriviaWidth()
+                Dim trailingWidth = secondToken.GetTrailingTriviaWidth()
+                Dim fullWidth = firstToken.FullWidth + secondToken.FullWidth
 
-            Debug.Assert(builder.Length = fullWidth)
-            Debug.Assert(builder.Length >= leadingWidth + trailingWidth)
+                Debug.Assert(builder.Length = fullWidth)
+                Debug.Assert(builder.Length >= leadingWidth + trailingWidth)
 
-            Return builder.ToStringAndFree(leadingWidth, fullWidth - leadingWidth - trailingWidth)
-
+                Return builder.ToStringAndFree(leadingWidth, fullWidth - leadingWidth - trailingWidth)
+            End Using
         End Function
 
         Private Shared Function MergeTokenText(firstToken As SyntaxToken, secondToken As SyntaxToken, thirdToken As SyntaxToken) As String
@@ -378,21 +378,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             ' grab the part that doesn't contain the preceding and trailing trivia.
 
             Dim builder = PooledStringBuilder.GetInstance()
-            Dim writer As New IO.StringWriter(builder)
+            Using writer As New IO.StringWriter(builder)
 
-            firstToken.WriteTo(writer)
-            secondToken.WriteTo(writer)
-            thirdToken.WriteTo(writer)
+                firstToken.WriteTo(writer)
+                secondToken.WriteTo(writer)
+                thirdToken.WriteTo(writer)
 
-            Dim leadingWidth = firstToken.GetLeadingTriviaWidth()
-            Dim trailingWidth = thirdToken.GetTrailingTriviaWidth()
-            Dim fullWidth = firstToken.FullWidth + secondToken.FullWidth + thirdToken.FullWidth
+                Dim leadingWidth = firstToken.GetLeadingTriviaWidth()
+                Dim trailingWidth = thirdToken.GetTrailingTriviaWidth()
+                Dim fullWidth = firstToken.FullWidth + secondToken.FullWidth + thirdToken.FullWidth
 
-            Debug.Assert(builder.Length = fullWidth)
-            Debug.Assert(builder.Length >= leadingWidth + trailingWidth)
+                Debug.Assert(builder.Length = fullWidth)
+                Debug.Assert(builder.Length >= leadingWidth + trailingWidth)
 
-            Return builder.ToStringAndFree(leadingWidth, fullWidth - leadingWidth - trailingWidth)
-
+                Return builder.ToStringAndFree(leadingWidth, fullWidth - leadingWidth - trailingWidth)
+            End Using
         End Function
 
         Private Function GetCurrentSyntaxNodeIfApplicable(<Out()> ByRef curSyntaxNode As VisualBasicSyntaxNode) As BlockContext


### PR DESCRIPTION
Small change, where we dispose of the string writer.