### PR TITLE
Use resource strings for validating warning text

### DIFF
--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -1690,7 +1690,7 @@ class C
             Assert.Equal("42.M", nodeWithWarning.ToFullString());
 
             var warning = nodeWithWarning.GetAnnotations(WarningAnnotation.Kind).Single();
-            var expectedWarningMessage = WorkspacesResources.Warning_adding_imports_will_bring_an_extension_method_into_scope_with_the_same_name_as_member_access.Replace("{0}", "M");
+            var expectedWarningMessage = string.Format(WorkspacesResources.Warning_adding_imports_will_bring_an_extension_method_into_scope_with_the_same_name_as_member_access, "M");
 
             Assert.Equal(expectedWarningMessage, WarningAnnotation.GetDescription(warning));
         }

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -1681,20 +1681,18 @@ class C
 }", safe: true, useSymbolAnnotations);
 
             var doc = await GetDocument(source, useSymbolAnnotations);
-
             OptionSet options = await doc.GetOptionsAsync();
 
             var imported = await ImportAdder.AddImportsFromSyntaxesAsync(doc, true, options);
-
             var root = await imported.GetSyntaxRootAsync();
-
             var nodeWithWarning = root.GetAnnotatedNodes(WarningAnnotation.Kind).Single();
 
             Assert.Equal("42.M", nodeWithWarning.ToFullString());
 
             var warning = nodeWithWarning.GetAnnotations(WarningAnnotation.Kind).Single();
+            var expectedWarningMessage = WorkspacesResources.Warning_adding_imports_will_bring_an_extension_method_into_scope_with_the_same_name_as_member_access.Replace("{0}", "M");
 
-            Assert.Equal("Adding imports will bring an extension method into scope with the same name as 'M'", WarningAnnotation.GetDescription(warning));
+            Assert.Equal(expectedWarningMessage, WarningAnnotation.GetDescription(warning));
         }
         #endregion
     }

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
@@ -1433,14 +1433,20 @@ Friend Class C
         Return AddressOf 42.M
     End Function
 End Class", safe:=True, useSymbolAnnotations)
+
             Dim doc = Await GetDocument(source, useSymbolAnnotations)
             Dim options As OptionSet = Await doc.GetOptionsAsync()
+
             Dim imported = Await ImportAdder.AddImportsFromSyntaxesAsync(doc, True, options)
             Dim root = Await imported.GetSyntaxRootAsync()
             Dim nodeWithWarning = root.GetAnnotatedNodes(WarningAnnotation.Kind).Single()
+
             Assert.Equal("42.M" & vbCrLf, nodeWithWarning.ToFullString())
+
             Dim warning = nodeWithWarning.GetAnnotations(WarningAnnotation.Kind).Single()
-            Assert.Equal("Adding imports will bring an extension method into scope with the same name as 'M'", WarningAnnotation.GetDescription(warning))
+            Dim expectedWarningMessage = WorkspacesResources.Warning_adding_imports_will_bring_an_extension_method_into_scope_with_the_same_name_as_member_access.Replace("{0}", "M")
+
+            Assert.Equal(expectedWarningMessage, WarningAnnotation.GetDescription(warning))
         End Function
 
 #End Region

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/AddImportsTests.vb
@@ -1444,7 +1444,7 @@ End Class", safe:=True, useSymbolAnnotations)
             Assert.Equal("42.M" & vbCrLf, nodeWithWarning.ToFullString())
 
             Dim warning = nodeWithWarning.GetAnnotations(WarningAnnotation.Kind).Single()
-            Dim expectedWarningMessage = WorkspacesResources.Warning_adding_imports_will_bring_an_extension_method_into_scope_with_the_same_name_as_member_access.Replace("{0}", "M")
+            Dim expectedWarningMessage = String.Format(WorkspacesResources.Warning_adding_imports_will_bring_an_extension_method_into_scope_with_the_same_name_as_member_access, "M")
 
             Assert.Equal(expectedWarningMessage, WarningAnnotation.GetDescription(warning))
         End Function


### PR DESCRIPTION
Tests were using non-localized strings to verify warning text. Running on Spanish pool caused them to fail.