### PR TITLE
Non-localized key in naming styles in .editorconfig

### DIFF
--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigFileGenerator.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Options
         {
             editorconfig.AppendLine($"#### {WorkspacesResources.Naming_styles} ####");
 
-            var namingStylePreferences = optionSet.GetOption(SimplificationOptions.NamingPreferences, language);
+            var namingStylePreferences = optionSet.GetOption(SimplificationOptions.NamingPreferences, "en");
             var serializedNameMap = AssignNamesToNamingStyleElements(namingStylePreferences);
             var ruleNameMap = AssignNamesToNamingStyleRules(namingStylePreferences, serializedNameMap);
             var referencedElements = new HashSet<Guid>();


### PR DESCRIPTION
From https://github.com/dotnet/roslyn/issues/39602

Naming styles parts in .editorconfig contains localized **key**.
`serializedNameMap` should be English, not localized language.