### PR TITLE
Completion: VSMac TypeScript completion doesn't commit with Enter

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -114,8 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // We can be called before for ShouldCommitCompletion. However, that call does not provide rules applied for the completion item.
             // Now we check for the commit charcter in the context of Rules that could change the list of commit characters.
 
-            // Tab, Enter and Null (call invoke commit) are always commit characters. 
-            if (typeChar != '\t' && typeChar != '\n' && typeChar != '\0' && !IsCommitCharacter(serviceRules, roslynItem, typeChar, filterText))
+            if (!Helpers.IsStandardCommitCharacter(typeChar) && !IsCommitCharacter(serviceRules, roslynItem, typeChar, filterText))
             {
                 // Returning None means we complete the current session with a void commit. 
                 // The Editor then will try to trigger a new completion session for the character.
@@ -321,24 +320,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
 
             // general rule: if the filtering text exactly matches the start of the item then it must be a filter character
-            if (TextTypedSoFarMatchesItem(item, textTypedSoFar))
+            if (Helpers.TextTypedSoFarMatchesItem(item, textTypedSoFar))
             {
                 return false;
             }
 
             // Fall back to the default rules for this language's completion service.
             return completionRules.DefaultCommitCharacters.IndexOf(ch) >= 0;
-        }
-
-        internal static bool TextTypedSoFarMatchesItem(CompletionItem item, string textTypedSoFar)
-        {
-            if (textTypedSoFar.Length > 0)
-            {
-                return item.DisplayText.StartsWith(textTypedSoFar, StringComparison.CurrentCultureIgnoreCase) ||
-                       item.FilterText.StartsWith(textTypedSoFar, StringComparison.CurrentCultureIgnoreCase);
-            }
-
-            return false;
         }
 
         internal static bool SendEnterThroughToEditor(CompletionRules rules, RoslynCompletionItem item, string textTypedSoFar)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/38250

When committing items, we perform a comparison `IsFilterCharacter `and call `StartsWith `there.
StartsWith ignores `\0` at the end of the argument string `"abc".StartsWith("ab\0")` is true in VS Mac and Mono. 

The fix immediately returns `false `in `IsFilterCharacter `for standard commit characters.