### PR TITLE
Unskip and fix test for local function parsing with `await`

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -510,67 +510,287 @@ class c
             Assert.Equal(SyntaxKind.NumericLiteralExpression, s2.Expression.Kind());
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/10388")]
+        [Fact]
         public void LocalFunctionsWithAwait()
         {
-            var file = ParseFile(@"class c
+            UsingTree(@"
+class c
 {
     void m1() { await await() => new await(); }
     void m2() { await () => new await(); }
     async void m3() { await () => new await(); }
     void m4() { async await() => new await(); }
+    async void m5() { await async () => new await(); }
 }");
 
-            Assert.NotNull(file);
-            var c = (ClassDeclarationSyntax)file.Members.Single();
-            Assert.Equal(4, c.Members.Count);
-
+            N(SyntaxKind.CompilationUnit);
             {
-                Assert.Equal(SyntaxKind.MethodDeclaration, c.Members[0].Kind());
-                var m1 = (MethodDeclarationSyntax)c.Members[0];
-                Assert.Equal(0, m1.Modifiers.Count);
-                Assert.Equal(1, m1.Body.Statements.Count);
-                Assert.Equal(SyntaxKind.LocalFunctionStatement, m1.Body.Statements[0].Kind());
-                var s1 = (LocalFunctionStatementSyntax)m1.Body.Statements[0];
-                Assert.False(s1.HasErrors);
-                Assert.Equal(0, s1.Modifiers.Count);
-                Assert.Equal("await", s1.ReturnType.ToString());
-                Assert.Equal("await", s1.Identifier.ToString());
-                Assert.Null(s1.TypeParameterList);
-                Assert.Equal(0, s1.ParameterList.ParameterCount);
-                Assert.Null(s1.Body);
-                Assert.NotNull(s1.ExpressionBody);
+                N(SyntaxKind.ClassDeclaration);
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "c");
+                N(SyntaxKind.OpenBraceToken);
+                {
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "m1");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        N(SyntaxKind.OpenBraceToken);
+                        {
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "await");
+                                }
+                                N(SyntaxKind.IdentifierToken, "await");
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.ArrowExpressionClause);
+                                {
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.ObjectCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "await");
+                                            N(SyntaxKind.ArgumentList);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                N(SyntaxKind.CloseParenToken);
+                                            }
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "m2");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        N(SyntaxKind.OpenBraceToken);
+                        {
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.InvocationExpression);
+                                N(SyntaxKind.IdentifierName, "await");
+                                {
+                                    N(SyntaxKind.IdentifierToken, "await");
+                                }
+                                N(SyntaxKind.ArgumentList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                                N(SyntaxKind.ExpressionStatement);
+                                {
+                                    N(SyntaxKind.ObjectCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "await");
+                                            N(SyntaxKind.ArgumentList);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                N(SyntaxKind.CloseParenToken);
+                                            }
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "m3");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        N(SyntaxKind.OpenBraceToken);
+                        {
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.AwaitExpression);
+                                {
+                                    N(SyntaxKind.AwaitKeyword);
+                                    N(SyntaxKind.ParenthesizedExpression);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        M(SyntaxKind.IdentifierName);
+                                        {
+                                            M(SyntaxKind.IdentifierToken);
+                                        }
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.ObjectCreationExpression);
+                                {
+                                    N(SyntaxKind.NewKeyword);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "await");
+                                        N(SyntaxKind.ArgumentList);
+                                        {
+                                            N(SyntaxKind.OpenParenToken);
+                                            N(SyntaxKind.CloseParenToken);
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "m4");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        N(SyntaxKind.OpenBraceToken);
+                        {
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "async");
+                                }
+                                N(SyntaxKind.IdentifierToken, "await");
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.ArrowExpressionClause);
+                                {
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.ObjectCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "await");
+                                            N(SyntaxKind.ArgumentList);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                N(SyntaxKind.CloseParenToken);
+                                            }
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "m5");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        N(SyntaxKind.OpenBraceToken);
+                        {
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.AwaitExpression);
+                                {
+                                    N(SyntaxKind.AwaitKeyword);
+                                    N(SyntaxKind.InvocationExpression);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "async");
+                                        }
+                                        N(SyntaxKind.ArgumentList);
+                                        {
+                                            N(SyntaxKind.OpenParenToken);
+                                            N(SyntaxKind.CloseParenToken);
+                                        }
+                                    }
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.ObjectCreationExpression);
+                                {
+                                    N(SyntaxKind.NewKeyword);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "await");
+                                        N(SyntaxKind.ArgumentList);
+                                        {
+                                            N(SyntaxKind.OpenParenToken);
+                                            N(SyntaxKind.CloseParenToken);
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
             }
-
-            {
-                Assert.Equal(SyntaxKind.MethodDeclaration, c.Members[1].Kind());
-                var m2 = (MethodDeclarationSyntax)c.Members[1];
-                Assert.Equal(0, m2.Modifiers.Count);
-                Assert.Equal(2, m2.Body.Statements.Count);
-                Assert.Equal(SyntaxKind.ExpressionStatement, m2.Body.Statements[0].Kind());
-                var s1 = (ExpressionStatementSyntax)m2.Body.Statements[0];
-                Assert.Equal(SyntaxKind.InvocationExpression, s1.Expression.Kind());
-                var e1 = (InvocationExpressionSyntax)s1.Expression;
-                Assert.Equal("await", e1.Expression.ToString());
-                Assert.Equal(0, e1.ArgumentList.Arguments.Count);
-                Assert.True(s1.SemicolonToken.IsMissing);
-                Assert.Equal("=> ", s1.GetTrailingTrivia().ToFullString());
-            }
-
-            {
-                Assert.Equal(SyntaxKind.MethodDeclaration, c.Members[2].Kind());
-                var m3 = (MethodDeclarationSyntax)c.Members[2];
-                Assert.Equal(1, m3.Modifiers.Count);
-                Assert.Equal("async", m3.Modifiers.Single().ToString());
-                Assert.Equal(2, m3.Body.Statements.Count);
-                Assert.Equal(SyntaxKind.ExpressionStatement, m3.Body.Statements[0].Kind());
-                var s1 = (ExpressionStatementSyntax)m3.Body.Statements[0];
-                Assert.Equal(SyntaxKind.AwaitExpression, s1.Expression.Kind());
-                var e1 = (AwaitExpressionSyntax)s1.Expression;
-                Assert.Equal(SyntaxKind.SimpleLambdaExpression, e1.Expression.Kind());
-                Assert.True(s1.SemicolonToken.IsMissing);
-                Assert.Equal("=> ", s1.GetTrailingTrivia().ToFullString());
-            }
+            N(SyntaxKind.EndOfFileToken);
+            EOF();
         }
 
         [WorkItem(13090, "https://github.com/dotnet/roslyn/issues/13090")]


### PR DESCRIPTION
This test explores potential ambiguity between lambdas and local
functions where the start of the local function or lambda is `await`.
This turns out not to be a problem because await is followed by an
expression with unary precedence, which is higher than lambda
precedence.

Fixes #10388