### PR TITLE
Don't try to use UIContexts if we are in a command line build

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage.cs
@@ -10,8 +10,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
     {
         protected async Task LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(CancellationToken cancellationToken)
         {
-            await KnownUIContexts.SolutionExistsAndFullyLoadedContext;
-            await LoadComponentsAsync(cancellationToken).ConfigureAwait(false);
+            // UIContexts can be "zombied" if UIContexts aren't supported because we're in a command line build or in other scenarios.
+            // Trying to await them will throw.
+            if (!KnownUIContexts.SolutionExistsAndFullyLoadedContext.IsZombie)
+            {
+                await KnownUIContexts.SolutionExistsAndFullyLoadedContext;
+                await LoadComponentsAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         protected abstract Task LoadComponentsAsync(CancellationToken cancellationToken);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1953,7 +1953,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         language,
                         l => Services.GetLanguageServices(l).GetService<IProjectExistsUIContextProviderLanguageService>()?.GetUIContext());
 
-                if (uiContext != null)
+                // UIContexts can be "zombied" if UIContexts aren't supported because we're in a command line build or in other scenarios.
+                if (uiContext != null && !uiContext.IsZombie)
                 {
                     uiContext.IsActive = CurrentSolution.Projects.Any(p => p.Language == language);
                 }


### PR DESCRIPTION
This code isn't new, but the use inside VisualStudioWorkspaceImpl.cs meant that we'd throw an exception when a project was added. This would get caught by the project system and converted back to an HRESULT.

Customer reports claim this is a regression in newer builds, and I can't disagree with that but can't explain it. We have integration tests that test this, and on our CI right now they are passing. I similarly saw passing tests locally when I previously investigated this but am now seeing failing tests on newer dogfood builds. I also saw it fail once with a different error code or simply no error code; it leads me to believe that something environmental can cause either the HRESULT to be converted differently (as this is using IErrorInfo which is often the cause of spooky-action-at-a-distance) or something the project system is doing is swallowing the exception. It's unclear but the fix seems the same no matter what.

Fixes https://developercommunity.visualstudio.com/content/problem/806929/command-line-builds-using-devenv-no-longer-work-fo.html