### PR TITLE
Don't store pooled object in cache

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerConfigTests.cs
@@ -1460,6 +1460,7 @@ dotnet_diagnostic.cs000.severity = warning", "/.editorconfig"));
                 new[] { "/a.cs", "/b.cs", "/c.cs" },
                 configs);
             configs.Free();
+            Assert.Equal(KeyValuePair.Create("cs000", ReportDiagnostic.Warn), options[0].TreeOptions.Single());
 
             Assert.Same(options[0].TreeOptions, options[1].TreeOptions);
             Assert.Same(options[0].AnalyzerOptions, options[1].AnalyzerOptions);

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -193,7 +193,7 @@ namespace Microsoft.CodeAnalysis
                     treeOptionsBuilder.Count > 0 ? treeOptionsBuilder.ToImmutable() : SyntaxTree.EmptyDiagnosticOptions,
                     analyzerOptionsBuilder.Count > 0 ? analyzerOptionsBuilder.ToImmutable() : AnalyzerConfigOptions.EmptyDictionary,
                     diagnosticBuilder.ToImmutableAndFree());
-                _optionsCache.TryAdd(sectionKey, result);
+                _optionsCache.TryAdd(new List<Section>(sectionKey), result);
             }
 
             sectionKey.Clear();

--- a/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
+++ b/src/Compilers/Core/Portable/CommandLine/AnalyzerConfigSet.cs
@@ -193,17 +193,33 @@ namespace Microsoft.CodeAnalysis
                     treeOptionsBuilder.Count > 0 ? treeOptionsBuilder.ToImmutable() : SyntaxTree.EmptyDiagnosticOptions,
                     analyzerOptionsBuilder.Count > 0 ? analyzerOptionsBuilder.ToImmutable() : AnalyzerConfigOptions.EmptyDictionary,
                     diagnosticBuilder.ToImmutableAndFree());
-                _optionsCache.TryAdd(new List<Section>(sectionKey), result);
+                if (_optionsCache.TryAdd(sectionKey, result))
+                {
+                    // Release the pooled object to be used as a key
+                    _sectionKeyPool.ForgetTrackedObject(sectionKey);
+                }
+                else
+                {
+                    freeKey(sectionKey, _sectionKeyPool);
+                }
+            }
+            else
+            {
+                freeKey(sectionKey, _sectionKeyPool);
             }
 
-            sectionKey.Clear();
             treeOptionsBuilder.Clear();
             analyzerOptionsBuilder.Clear();
-            _sectionKeyPool.Free(sectionKey);
             _treeOptionsPool.Free(treeOptionsBuilder);
             _analyzerOptionsPool.Free(analyzerOptionsBuilder);
 
             return result;
+
+            static void freeKey(List<Section> sectionKey, ObjectPool<List<Section>> pool)
+            {
+                sectionKey.Clear();
+                pool.Free(sectionKey);
+            }
 
             static void addOptions(
                 AnalyzerConfig.Section section,


### PR DESCRIPTION
The AnalyzerConfigSet had a race where we were storing the pooled object
in the cache. It turns out that this often works, due to hash codes mapping
different sets to different buckets, but is wildly unsafe and can produce
almost any result.

This change allocates a new list for the cache when adding.

Fixes #39599