### PR TITLE
Cleanup hoisted locals at async state machine end (#34239)

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -143,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // [body]
                         rewrittenBody
                     ),
-                    F.CatchBlocks(GenerateExceptionHandling(exceptionLocal)))
+                    F.CatchBlocks(GenerateExceptionHandling(exceptionLocal, rootScopeHoistedLocals)))
                 );
 
             // ReturnLabel (for the rewritten return expressions in the user's method body)
@@ -163,6 +164,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bodyBuilder.Add(F.HiddenSequencePoint());
                 // The remaining code is hidden to hide the fact that it can run concurrently with the task's continuation
             }
+
+            bodyBuilder.Add(GenerateHoistedLocalsCleanup(rootScopeHoistedLocals));
 
             bodyBuilder.Add(GenerateSetResultCall());
 
@@ -207,11 +210,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                         : ImmutableArray<BoundExpression>.Empty));
         }
 
-        protected BoundCatchBlock GenerateExceptionHandling(LocalSymbol exceptionLocal)
+        protected BoundCatchBlock GenerateExceptionHandling(LocalSymbol exceptionLocal, ImmutableArray<StateMachineFieldSymbol> hoistedLocals)
         {
             // catch (Exception ex)
             // {
             //     _state = finishedState;
+            //
+            //     for each hoisted local:
+            //     <>x__y = default
+            //
             //     builder.SetException(ex);  OR  if (this.combinedTokens != null) this.combinedTokens.Dispose(); _promiseOfValueOrEnd.SetException(ex); /* for async-iterator method */
             //     return;
             // }
@@ -231,9 +238,29 @@ namespace Microsoft.CodeAnalysis.CSharp
                 exceptionFilterOpt: null,
                 body: F.Block(
                     assignFinishedState, // _state = finishedState;
+                    GenerateHoistedLocalsCleanup(hoistedLocals),
                     callSetException, // builder.SetException(ex);  OR  _promiseOfValueOrEnd.SetException(ex);
                     GenerateReturn(false)), // return;
                 isSynthesizedAsyncCatchAll: true);
+        }
+
+        protected BoundStatement GenerateHoistedLocalsCleanup(ImmutableArray<StateMachineFieldSymbol> hoistedLocals)
+        {
+            var builder = ArrayBuilder<BoundStatement>.GetInstance();
+
+            // Cleanup all hoisted local variables
+            // so that they can be collected by GC if needed
+            foreach (var hoistedLocal in hoistedLocals)
+            {
+                if (!hoistedLocal.Type.IsManagedType)
+                {
+                    continue;
+                }
+
+                builder.Add(F.Assignment(F.Field(F.This(), hoistedLocal), F.NullOrDefault(hoistedLocal.Type)));
+            }
+
+            return F.Block(builder.ToImmutableAndFree());
         }
 
         protected virtual BoundStatement GenerateSetExceptionCall(LocalSymbol exceptionLocal)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -4041,7 +4041,7 @@ class Test
 
             v.VerifyIL("Test.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      224 (0xe0)
+  // Code size      241 (0xf1)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -4056,7 +4056,7 @@ class Test
    ~IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_006d
+    IL_000c:  br.s       IL_0070
    -IL_000e:  nop
    -IL_000f:  ldarg.0
     IL_0010:  ldc.i4.s   10
@@ -4076,7 +4076,7 @@ class Test
     IL_003f:  stloc.2
    ~IL_0040:  ldloca.s   V_2
     IL_0042:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0047:  brtrue.s   IL_0089
+    IL_0047:  brtrue.s   IL_008c
     IL_0049:  ldarg.0
     IL_004a:  ldc.i4.0
     IL_004b:  dup
@@ -4093,54 +4093,60 @@ class Test
     IL_0063:  ldloca.s   V_3
     IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
     IL_006a:  nop
-    IL_006b:  leave.s    IL_00df
-   >IL_006d:  ldarg.0
-    IL_006e:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_0073:  stloc.2
-    IL_0074:  ldarg.0
-    IL_0075:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_007a:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0080:  ldarg.0
-    IL_0081:  ldc.i4.m1
-    IL_0082:  dup
-    IL_0083:  stloc.0
-    IL_0084:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_0089:  ldarg.0
-    IL_008a:  ldloca.s   V_2
-    IL_008c:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0091:  stfld      ""int Test.<F>d__2.<>s__2""
-    IL_0096:  ldarg.0
-    IL_0097:  ldfld      ""S[] Test.<F>d__2.<>s__3""
-    IL_009c:  ldc.i4.1
-    IL_009d:  ldelema    ""S""
-    IL_00a2:  ldarg.0
-    IL_00a3:  ldfld      ""int Test.<F>d__2.<>s__2""
-    IL_00a8:  call       ""int S.Mutate(int)""
-    IL_00ad:  stloc.1
-    IL_00ae:  leave.s    IL_00ca
+    IL_006b:  leave      IL_00f0
+   >IL_0070:  ldarg.0
+    IL_0071:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_0076:  stloc.2
+    IL_0077:  ldarg.0
+    IL_0078:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_007d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0083:  ldarg.0
+    IL_0084:  ldc.i4.m1
+    IL_0085:  dup
+    IL_0086:  stloc.0
+    IL_0087:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_008c:  ldarg.0
+    IL_008d:  ldloca.s   V_2
+    IL_008f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0094:  stfld      ""int Test.<F>d__2.<>s__2""
+    IL_0099:  ldarg.0
+    IL_009a:  ldfld      ""S[] Test.<F>d__2.<>s__3""
+    IL_009f:  ldc.i4.1
+    IL_00a0:  ldelema    ""S""
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldfld      ""int Test.<F>d__2.<>s__2""
+    IL_00ab:  call       ""int S.Mutate(int)""
+    IL_00b0:  stloc.1
+    IL_00b1:  leave.s    IL_00d4
   }
   catch System.Exception
   {
-   ~IL_00b0:  stloc.s    V_4
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldc.i4.s   -2
-    IL_00b5:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_00ba:  ldarg.0
-    IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_00c0:  ldloc.s    V_4
-    IL_00c2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00c7:  nop
-    IL_00c8:  leave.s    IL_00df
+   ~IL_00b3:  stloc.s    V_4
+    IL_00b5:  ldarg.0
+    IL_00b6:  ldc.i4.s   -2
+    IL_00b8:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_00bd:  ldarg.0
+    IL_00be:  ldnull
+    IL_00bf:  stfld      ""S[] Test.<F>d__2.<array>5__1""
+    IL_00c4:  ldarg.0
+    IL_00c5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_00ca:  ldloc.s    V_4
+    IL_00cc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00d1:  nop
+    IL_00d2:  leave.s    IL_00f0
   }
- -IL_00ca:  ldarg.0
-  IL_00cb:  ldc.i4.s   -2
-  IL_00cd:  stfld      ""int Test.<F>d__2.<>1__state""
- ~IL_00d2:  ldarg.0
-  IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-  IL_00d8:  ldloc.1
-  IL_00d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00de:  nop
-  IL_00df:  ret
+ -IL_00d4:  ldarg.0
+  IL_00d5:  ldc.i4.s   -2
+  IL_00d7:  stfld      ""int Test.<F>d__2.<>1__state""
+ ~IL_00dc:  ldarg.0
+  IL_00dd:  ldnull
+  IL_00de:  stfld      ""S[] Test.<F>d__2.<array>5__1""
+  IL_00e3:  ldarg.0
+  IL_00e4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+  IL_00e9:  ldloc.1
+  IL_00ea:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00ef:  nop
+  IL_00f0:  ret
 }",
             sequencePoints: "Test+<F>d__2.MoveNext");
         }
@@ -5115,7 +5121,7 @@ namespace Test
                 VerifyIL("Test.Program.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
                 @"
 {
-  // Code size      301 (0x12d)
+  // Code size      315 (0x13b)
   .maxstack  4
   .locals init (int V_0,
                 int V_1, //bytesRead
@@ -5162,7 +5168,7 @@ namespace Test
     IL_005b:  ldloca.s   V_2
     IL_005d:  ldarg.0
     IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Test.Program.<M>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Test.Program.<M>d__1)""
-    IL_0063:  leave      IL_012c
+    IL_0063:  leave      IL_013a
     IL_0068:  ldarg.0
     IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Test.Program.<M>d__1.<>u__1""
     IL_006e:  stloc.2
@@ -5204,7 +5210,7 @@ namespace Test
     IL_00ca:  ldloca.s   V_3
     IL_00cc:  ldarg.0
     IL_00cd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.Program.<M>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.Program.<M>d__1)""
-    IL_00d2:  leave.s    IL_012c
+    IL_00d2:  leave.s    IL_013a
     IL_00d4:  ldarg.0
     IL_00d5:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.Program.<M>d__1.<>u__2""
     IL_00da:  stloc.3
@@ -5221,7 +5227,7 @@ namespace Test
     IL_00f7:  dup
     IL_00f8:  stloc.1
     IL_00f9:  brtrue     IL_0023
-    IL_00fe:  leave.s    IL_0119
+    IL_00fe:  leave.s    IL_0120
   }
   catch System.Exception
   {
@@ -5230,18 +5236,24 @@ namespace Test
     IL_0103:  ldc.i4.s   -2
     IL_0105:  stfld      ""int Test.Program.<M>d__1.<>1__state""
     IL_010a:  ldarg.0
-    IL_010b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.Program.<M>d__1.<>t__builder""
-    IL_0110:  ldloc.s    V_4
-    IL_0112:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0117:  leave.s    IL_012c
+    IL_010b:  ldnull
+    IL_010c:  stfld      ""byte[] Test.Program.<M>d__1.<buffer>5__2""
+    IL_0111:  ldarg.0
+    IL_0112:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.Program.<M>d__1.<>t__builder""
+    IL_0117:  ldloc.s    V_4
+    IL_0119:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_011e:  leave.s    IL_013a
   }
-  IL_0119:  ldarg.0
-  IL_011a:  ldc.i4.s   -2
-  IL_011c:  stfld      ""int Test.Program.<M>d__1.<>1__state""
-  IL_0121:  ldarg.0
-  IL_0122:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.Program.<M>d__1.<>t__builder""
-  IL_0127:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_012c:  ret
+  IL_0120:  ldarg.0
+  IL_0121:  ldc.i4.s   -2
+  IL_0123:  stfld      ""int Test.Program.<M>d__1.<>1__state""
+  IL_0128:  ldarg.0
+  IL_0129:  ldnull
+  IL_012a:  stfld      ""byte[] Test.Program.<M>d__1.<buffer>5__2""
+  IL_012f:  ldarg.0
+  IL_0130:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.Program.<M>d__1.<>t__builder""
+  IL_0135:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_013a:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAwaitForeachTests.cs
@@ -4185,7 +4185,7 @@ class C
 
             verifier.VerifyIL("C.<Main>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      258 (0x102)
+  // Code size      272 (0x110)
   .maxstack  3
   .locals init (int V_0,
                 System.Threading.CancellationToken V_1,
@@ -4263,7 +4263,7 @@ class C
     IL_008c:  ldloca.s   V_3
     IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<Main>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<Main>d__0)""
     IL_0093:  nop
-    IL_0094:  leave.s    IL_0101
+    IL_0094:  leave.s    IL_010f
     // async: resume
     IL_0096:  ldarg.0
     IL_0097:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<Main>d__0.<>u__1""
@@ -4286,7 +4286,7 @@ class C
     IL_00ca:  ldarg.0
     IL_00cb:  ldnull
     IL_00cc:  stfld      ""IMyAsyncEnumerator<int> C.<Main>d__0.<>s__2""
-    IL_00d1:  leave.s    IL_00ed
+    IL_00d1:  leave.s    IL_00f4
   }
   catch System.Exception
   {
@@ -4296,22 +4296,28 @@ class C
     IL_00d6:  ldc.i4.s   -2
     IL_00d8:  stfld      ""int C.<Main>d__0.<>1__state""
     IL_00dd:  ldarg.0
-    IL_00de:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-    IL_00e3:  ldloc.s    V_4
-    IL_00e5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00ea:  nop
-    IL_00eb:  leave.s    IL_0101
+    IL_00de:  ldnull
+    IL_00df:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+    IL_00e4:  ldarg.0
+    IL_00e5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+    IL_00ea:  ldloc.s    V_4
+    IL_00ec:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00f1:  nop
+    IL_00f2:  leave.s    IL_010f
   }
   // sequence point: }
-  IL_00ed:  ldarg.0
-  IL_00ee:  ldc.i4.s   -2
-  IL_00f0:  stfld      ""int C.<Main>d__0.<>1__state""
+  IL_00f4:  ldarg.0
+  IL_00f5:  ldc.i4.s   -2
+  IL_00f7:  stfld      ""int C.<Main>d__0.<>1__state""
   // sequence point: <hidden>
-  IL_00f5:  ldarg.0
-  IL_00f6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
-  IL_00fb:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0100:  nop
-  IL_0101:  ret
+  IL_00fc:  ldarg.0
+  IL_00fd:  ldnull
+  IL_00fe:  stfld      ""ICollection<int> C.<Main>d__0.<c>5__1""
+  IL_0103:  ldarg.0
+  IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<Main>d__0.<>t__builder""
+  IL_0109:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_010e:  nop
+  IL_010f:  ret
 }", sequencePoints: "C+<Main>d__0.MoveNext", source: source);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
@@ -1485,7 +1485,7 @@ public class Program
 		{
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext()
 			// Method begins at RVA 0x20d4
-			// Code size 388 (0x184)
+			// Code size 416 (0x1a0)
 			.maxstack 4
 			.locals init (
 				[0] int32,
@@ -1571,7 +1571,7 @@ public class Program
 				IL_00e6: ldloca.s 3
 				IL_00e8: ldarg.0
 				IL_00e9: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<bool>, valuetype Program/'<M>d__0'>(!!0&, !!1&)
-				IL_00ee: leave IL_0183
+				IL_00ee: leave IL_019f
 				IL_00f3: ldarg.0
 				IL_00f4: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter`1<bool> Program/'<M>d__0'::'<>u__1'
 				IL_00f9: stloc.3
@@ -1604,7 +1604,7 @@ public class Program
 				IL_014a: ldc.i4.2
 				IL_014b: callvirt instance !0 class [mscorlib]System.Collections.Generic.List`1<class [mscorlib]System.Action>::get_Item(int32)
 				IL_0150: callvirt instance void [mscorlib]System.Action::Invoke()
-				IL_0155: leave.s IL_0170
+				IL_0155: leave.s IL_017e
 			} // end .try
 			catch [mscorlib]System.Exception
 			{
@@ -1613,18 +1613,30 @@ public class Program
 				IL_015a: ldc.i4.s -2
 				IL_015c: stfld int32 Program/'<M>d__0'::'<>1__state'
 				IL_0161: ldarg.0
-				IL_0162: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
-				IL_0167: ldloc.s 4
-				IL_0169: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::SetException(class [mscorlib]System.Exception)
-				IL_016e: leave.s IL_0183
+				IL_0162: ldnull
+				IL_0163: stfld class Program/'<>c__DisplayClass0_0' Program/'<M>d__0'::'<>8__1'
+				IL_0168: ldarg.0
+				IL_0169: ldnull
+				IL_016a: stfld class [mscorlib]System.Collections.Generic.List`1<class [mscorlib]System.Action> Program/'<M>d__0'::'<actions>5__2'
+				IL_016f: ldarg.0
+				IL_0170: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
+				IL_0175: ldloc.s 4
+				IL_0177: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::SetException(class [mscorlib]System.Exception)
+				IL_017c: leave.s IL_019f
 			} // end handler
-			IL_0170: ldarg.0
-			IL_0171: ldc.i4.s -2
-			IL_0173: stfld int32 Program/'<M>d__0'::'<>1__state'
-			IL_0178: ldarg.0
-			IL_0179: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
-			IL_017e: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::SetResult()
-			IL_0183: ret
+			IL_017e: ldarg.0
+			IL_017f: ldc.i4.s -2
+			IL_0181: stfld int32 Program/'<M>d__0'::'<>1__state'
+			IL_0186: ldarg.0
+			IL_0187: ldnull
+			IL_0188: stfld class Program/'<>c__DisplayClass0_0' Program/'<M>d__0'::'<>8__1'
+			IL_018d: ldarg.0
+			IL_018e: ldnull
+			IL_018f: stfld class [mscorlib]System.Collections.Generic.List`1<class [mscorlib]System.Action> Program/'<M>d__0'::'<actions>5__2'
+			IL_0194: ldarg.0
+			IL_0195: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
+			IL_019a: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::SetResult()
+			IL_019f: ret
 		} // end of method '<M>d__0'::MoveNext
 		.method private final hidebysig newslot virtual 
 			instance void SetStateMachine (
@@ -1635,7 +1647,7 @@ public class Program
 				01 00 00 00
 			)
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
-			// Method begins at RVA 0x2280
+			// Method begins at RVA 0x229c
 			// Code size 13 (0xd)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -8140,7 +8152,7 @@ public class C {
 		{
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext()
 			// Method begins at RVA 0x20cc
-			// Code size 785 (0x311)
+			// Code size 792 (0x318)
 			.maxstack 3
 			.locals init (
 				[0] int32,
@@ -8181,7 +8193,7 @@ public class C {
 				IL_006b: ldloca.s 1
 				IL_006d: ldarg.0
 				IL_006e: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter, valuetype C/'<M>d__0'>(!!0&, !!1&)
-				IL_0073: leave IL_0310
+				IL_0073: leave IL_0317
 				IL_0078: ldarg.0
 				IL_0079: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter C/'<M>d__0'::'<>u__1'
 				IL_007e: stloc.1
@@ -8223,7 +8235,7 @@ public class C {
 				IL_00e2: ldloca.s 1
 				IL_00e4: ldarg.0
 				IL_00e5: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter, valuetype C/'<M>d__0'>(!!0&, !!1&)
-				IL_00ea: leave IL_0310
+				IL_00ea: leave IL_0317
 				IL_00ef: ldarg.0
 				IL_00f0: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter C/'<M>d__0'::'<>u__1'
 				IL_00f5: stloc.1
@@ -8261,7 +8273,7 @@ public class C {
 				IL_0149: ldloca.s 1
 				IL_014b: ldarg.0
 				IL_014c: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter, valuetype C/'<M>d__0'>(!!0&, !!1&)
-				IL_0151: leave IL_0310
+				IL_0151: leave IL_0317
 				IL_0156: ldarg.0
 				IL_0157: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter C/'<M>d__0'::'<>u__1'
 				IL_015c: stloc.1
@@ -8295,7 +8307,7 @@ public class C {
 				IL_01a4: ldloca.s 1
 				IL_01a6: ldarg.0
 				IL_01a7: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter, valuetype C/'<M>d__0'>(!!0&, !!1&)
-				IL_01ac: leave IL_0310
+				IL_01ac: leave IL_0317
 				IL_01b1: ldarg.0
 				IL_01b2: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter C/'<M>d__0'::'<>u__1'
 				IL_01b7: stloc.1
@@ -8333,7 +8345,7 @@ public class C {
 				IL_020b: ldloca.s 1
 				IL_020d: ldarg.0
 				IL_020e: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter, valuetype C/'<M>d__0'>(!!0&, !!1&)
-				IL_0213: leave IL_0310
+				IL_0213: leave IL_0317
 				IL_0218: ldarg.0
 				IL_0219: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter C/'<M>d__0'::'<>u__1'
 				IL_021e: stloc.1
@@ -8375,7 +8387,7 @@ public class C {
 				IL_0282: ldloca.s 1
 				IL_0284: ldarg.0
 				IL_0285: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::AwaitUnsafeOnCompleted<valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter, valuetype C/'<M>d__0'>(!!0&, !!1&)
-				IL_028a: leave IL_0310
+				IL_028a: leave IL_0317
 				IL_028f: ldarg.0
 				IL_0290: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.TaskAwaiter C/'<M>d__0'::'<>u__1'
 				IL_0295: stloc.1
@@ -8422,12 +8434,15 @@ public class C {
 				IL_02fb: ldc.i4.s -2
 				IL_02fd: stfld int32 C/'<M>d__0'::'<>1__state'
 				IL_0302: ldarg.0
-				IL_0303: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
-				IL_0308: ldloc.2
-				IL_0309: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [mscorlib]System.Exception)
-				IL_030e: leave.s IL_0310
+				IL_0303: ldnull
+				IL_0304: stfld class C/'<>c__DisplayClass0_0' C/'<M>d__0'::'<>8__1'
+				IL_0309: ldarg.0
+				IL_030a: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
+				IL_030f: ldloc.2
+				IL_0310: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [mscorlib]System.Exception)
+				IL_0315: leave.s IL_0317
 			} // end handler
-			IL_0310: ret
+			IL_0317: ret
 		} // end of method '<M>d__0'::MoveNext
 		.method private final hidebysig newslot virtual 
 			instance void SetStateMachine (
@@ -8438,7 +8453,7 @@ public class C {
 				01 00 00 00
 			)
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
-			// Method begins at RVA 0x2408
+			// Method begins at RVA 0x240c
 			// Code size 13 (0xd)
 			.maxstack 8
 			IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -2085,7 +2085,7 @@ class C
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      183 (0xb7)
+  // Code size      207 (0xcf)
   .maxstack  3
   .locals init (int V_0,
                 T V_1,
@@ -2127,7 +2127,7 @@ class C
     IL_004e:  ldloca.s   V_2
     IL_0050:  ldarg.0
     IL_0051:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1<T>>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1<T>)""
-    IL_0056:  leave.s    IL_00b6
+    IL_0056:  leave.s    IL_00ce
     IL_0058:  ldarg.0
     IL_0059:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1<T>.<>u__1""
     IL_005e:  stloc.2
@@ -2145,7 +2145,7 @@ class C
     IL_007c:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__2""
     IL_0081:  ldfld      ""T System.ValueTuple<T, T>.Item1""
     IL_0086:  stloc.1
-    IL_0087:  leave.s    IL_00a2
+    IL_0087:  leave.s    IL_00ae
   }
   catch System.Exception
   {
@@ -2154,19 +2154,25 @@ class C
     IL_008c:  ldc.i4.s   -2
     IL_008e:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0093:  ldarg.0
-    IL_0094:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-    IL_0099:  ldloc.s    V_4
-    IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
-    IL_00a0:  leave.s    IL_00b6
+    IL_0094:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__2""
+    IL_0099:  initobj    ""System.ValueTuple<T, T>""
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+    IL_00a5:  ldloc.s    V_4
+    IL_00a7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
+    IL_00ac:  leave.s    IL_00ce
   }
-  IL_00a2:  ldarg.0
-  IL_00a3:  ldc.i4.s   -2
-  IL_00a5:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-  IL_00aa:  ldarg.0
-  IL_00ab:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-  IL_00b0:  ldloc.1
-  IL_00b1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
-  IL_00b6:  ret
+  IL_00ae:  ldarg.0
+  IL_00af:  ldc.i4.s   -2
+  IL_00b1:  stfld      ""int C.<Test>d__1<T>.<>1__state""
+  IL_00b6:  ldarg.0
+  IL_00b7:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__2""
+  IL_00bc:  initobj    ""System.ValueTuple<T, T>""
+  IL_00c2:  ldarg.0
+  IL_00c3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+  IL_00c8:  ldloc.1
+  IL_00c9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
+  IL_00ce:  ret
 }
 ");
         }
@@ -2199,7 +2205,7 @@ class C
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      189 (0xbd)
+  // Code size      213 (0xd5)
   .maxstack  3
   .locals init (int V_0,
                 string V_1,
@@ -2241,7 +2247,7 @@ class C
     IL_004e:  ldloca.s   V_2
     IL_0050:  ldarg.0
     IL_0051:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1<T>>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1<T>)""
-    IL_0056:  leave.s    IL_00bc
+    IL_0056:  leave.s    IL_00d4
     IL_0058:  ldarg.0
     IL_0059:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1<T>.<>u__1""
     IL_005e:  stloc.2
@@ -2260,7 +2266,7 @@ class C
     IL_0081:  constrained. ""System.ValueTuple<T, T>""
     IL_0087:  callvirt   ""string object.ToString()""
     IL_008c:  stloc.1
-    IL_008d:  leave.s    IL_00a8
+    IL_008d:  leave.s    IL_00b4
   }
   catch System.Exception
   {
@@ -2269,19 +2275,25 @@ class C
     IL_0092:  ldc.i4.s   -2
     IL_0094:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0099:  ldarg.0
-    IL_009a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
-    IL_009f:  ldloc.s    V_4
-    IL_00a1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetException(System.Exception)""
-    IL_00a6:  leave.s    IL_00bc
+    IL_009a:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__2""
+    IL_009f:  initobj    ""System.ValueTuple<T, T>""
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
+    IL_00ab:  ldloc.s    V_4
+    IL_00ad:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetException(System.Exception)""
+    IL_00b2:  leave.s    IL_00d4
   }
-  IL_00a8:  ldarg.0
-  IL_00a9:  ldc.i4.s   -2
-  IL_00ab:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-  IL_00b0:  ldarg.0
-  IL_00b1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
-  IL_00b6:  ldloc.1
-  IL_00b7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetResult(string)""
-  IL_00bc:  ret
+  IL_00b4:  ldarg.0
+  IL_00b5:  ldc.i4.s   -2
+  IL_00b7:  stfld      ""int C.<Test>d__1<T>.<>1__state""
+  IL_00bc:  ldarg.0
+  IL_00bd:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__2""
+  IL_00c2:  initobj    ""System.ValueTuple<T, T>""
+  IL_00c8:  ldarg.0
+  IL_00c9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
+  IL_00ce:  ldloc.1
+  IL_00cf:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetResult(string)""
+  IL_00d4:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -1877,7 +1877,7 @@ class C
 
             diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      178 (0xb2)
+  // Code size      192 (0xc0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1923,7 +1923,7 @@ class C
     IL_0050:  ldloca.s   V_3
     IL_0052:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
     IL_0057:  nop
-    IL_0058:  leave.s    IL_00b1
+    IL_0058:  leave.s    IL_00bf
     IL_005a:  ldarg.0
     IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0060:  stloc.2
@@ -1940,7 +1940,7 @@ class C
     IL_007d:  nop
     IL_007e:  ldc.i4.1
     IL_007f:  stloc.1
-    IL_0080:  leave.s    IL_009c
+    IL_0080:  leave.s    IL_00a3
   }
   catch System.Exception
   {
@@ -1949,21 +1949,27 @@ class C
     IL_0085:  ldc.i4.s   -2
     IL_0087:  stfld      ""int C.<F>d__0.<>1__state""
     IL_008c:  ldarg.0
-    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0092:  ldloc.s    V_4
-    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0099:  nop
-    IL_009a:  leave.s    IL_00b1
+    IL_008d:  ldnull
+    IL_008e:  stfld      ""C C.<F>d__0.<a1>5__3""
+    IL_0093:  ldarg.0
+    IL_0094:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0099:  ldloc.s    V_4
+    IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00a0:  nop
+    IL_00a1:  leave.s    IL_00bf
   }
-  IL_009c:  ldarg.0
-  IL_009d:  ldc.i4.s   -2
-  IL_009f:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00a4:  ldarg.0
-  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00aa:  ldloc.1
-  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00b0:  nop
-  IL_00b1:  ret
+  IL_00a3:  ldarg.0
+  IL_00a4:  ldc.i4.s   -2
+  IL_00a6:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00ab:  ldarg.0
+  IL_00ac:  ldnull
+  IL_00ad:  stfld      ""C C.<F>d__0.<a1>5__3""
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00b8:  ldloc.1
+  IL_00b9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00be:  nop
+  IL_00bf:  ret
 }");
             // 2 field defs added (both variables a1 and a2 of F changed their types) & 2 methods updated
             CheckEncLogDefinitions(md2.Reader,
@@ -1980,7 +1986,7 @@ class C
 
             diff2.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      178 (0xb2)
+  // Code size      192 (0xc0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2026,7 +2032,7 @@ class C
     IL_0050:  ldloca.s   V_3
     IL_0052:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
     IL_0057:  nop
-    IL_0058:  leave.s    IL_00b1
+    IL_0058:  leave.s    IL_00bf
     IL_005a:  ldarg.0
     IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0060:  stloc.2
@@ -2043,7 +2049,7 @@ class C
     IL_007d:  nop
     IL_007e:  ldc.i4.1
     IL_007f:  stloc.1
-    IL_0080:  leave.s    IL_009c
+    IL_0080:  leave.s    IL_00a3
   }
   catch System.Exception
   {
@@ -2052,21 +2058,27 @@ class C
     IL_0085:  ldc.i4.s   -2
     IL_0087:  stfld      ""int C.<F>d__0.<>1__state""
     IL_008c:  ldarg.0
-    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0092:  ldloc.s    V_4
-    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0099:  nop
-    IL_009a:  leave.s    IL_00b1
+    IL_008d:  ldnull
+    IL_008e:  stfld      ""C C.<F>d__0.<a2>5__5""
+    IL_0093:  ldarg.0
+    IL_0094:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0099:  ldloc.s    V_4
+    IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00a0:  nop
+    IL_00a1:  leave.s    IL_00bf
   }
-  IL_009c:  ldarg.0
-  IL_009d:  ldc.i4.s   -2
-  IL_009f:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00a4:  ldarg.0
-  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00aa:  ldloc.1
-  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00b0:  nop
-  IL_00b1:  ret
+  IL_00a3:  ldarg.0
+  IL_00a4:  ldc.i4.s   -2
+  IL_00a6:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00ab:  ldarg.0
+  IL_00ac:  ldnull
+  IL_00ad:  stfld      ""C C.<F>d__0.<a2>5__5""
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00b8:  ldloc.1
+  IL_00b9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00be:  nop
+  IL_00bf:  ret
 }");
             // 2 field defs added - variables of G and H changed their types; 4 methods updated: G, H kickoff and MoveNext
             CheckEncLogDefinitions(md3.Reader,

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -63,7 +63,7 @@ class Driver
 
             v.VerifyIL("TestCase.<Run>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      289 (0x121)
+  // Code size      303 (0x12f)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
@@ -121,7 +121,7 @@ class Driver
     IL_007e:  ldloca.s   V_2
     IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, TestCase.<Run>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref TestCase.<Run>d__1)""
     IL_0085:  nop
-    IL_0086:  leave      IL_0120
+    IL_0086:  leave      IL_012e
    >IL_008b:  ldarg.0
     IL_008c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
     IL_0091:  stloc.1
@@ -159,7 +159,7 @@ class Driver
    -IL_00e5:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
     IL_00ea:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
     IL_00ef:  pop
-    IL_00f0:  leave.s    IL_010c
+    IL_00f0:  leave.s    IL_0113
   }
   catch System.Exception
   {
@@ -168,20 +168,26 @@ class Driver
     IL_00f5:  ldc.i4.s   -2
     IL_00f7:  stfld      ""int TestCase.<Run>d__1.<>1__state""
     IL_00fc:  ldarg.0
-    IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-    IL_0102:  ldloc.s    V_4
-    IL_0104:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_0109:  nop
-    IL_010a:  leave.s    IL_0120
+    IL_00fd:  ldnull
+    IL_00fe:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+    IL_0103:  ldarg.0
+    IL_0104:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+    IL_0109:  ldloc.s    V_4
+    IL_010b:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
+    IL_0110:  nop
+    IL_0111:  leave.s    IL_012e
   }
- -IL_010c:  ldarg.0
-  IL_010d:  ldc.i4.s   -2
-  IL_010f:  stfld      ""int TestCase.<Run>d__1.<>1__state""
- ~IL_0114:  ldarg.0
-  IL_0115:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-  IL_011a:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_011f:  nop
-  IL_0120:  ret
+ -IL_0113:  ldarg.0
+  IL_0114:  ldc.i4.s   -2
+  IL_0116:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+ ~IL_011b:  ldarg.0
+  IL_011c:  ldnull
+  IL_011d:  stfld      ""DynamicMembers TestCase.<Run>d__1.<dc2>5__1""
+  IL_0122:  ldarg.0
+  IL_0123:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+  IL_0128:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
+  IL_012d:  nop
+  IL_012e:  ret
 }",
 sequencePoints: "TestCase+<Run>d__1.MoveNext");
 
@@ -268,8 +274,8 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <customDebugInfo>
         <forward declaringType=""TestCase"" methodName="".cctor"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x121"" />
-          <slot startOffset=""0x0"" endOffset=""0x121"" />
+          <slot startOffset=""0x0"" endOffset=""0x12f"" />
+          <slot startOffset=""0x0"" endOffset=""0x12f"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -293,8 +299,8 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" document=""1"" />
         <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" document=""1"" />
         <entry offset=""0xf2"" hidden=""true"" document=""1"" />
-        <entry offset=""0x10c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x114"" hidden=""true"" document=""1"" />
+        <entry offset=""0x113"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x11b"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <catchHandler offset=""0xf2"" />
@@ -465,7 +471,7 @@ namespace ConsoleApplication1
       <customDebugInfo>
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x144"" />
+          <slot startOffset=""0x0"" endOffset=""0x152"" />
           <slot />
           <slot />
           <slot startOffset=""0x41"" endOffset=""0xe3"" />
@@ -497,8 +503,8 @@ namespace ConsoleApplication1
         <entry offset=""0xf1"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" document=""1"" />
         <entry offset=""0x10b"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" document=""1"" />
         <entry offset=""0x114"" hidden=""true"" document=""1"" />
-        <entry offset=""0x12e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x136"" hidden=""true"" document=""1"" />
+        <entry offset=""0x135"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x13d"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""ZBar"" />
@@ -848,7 +854,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x106"" />
+          <slot startOffset=""0x0"" endOffset=""0x114"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -869,8 +875,8 @@ class C
         <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" document=""1"" />
         <entry offset=""0x86"" hidden=""true"" document=""1"" />
         <entry offset=""0xd9"" hidden=""true"" document=""1"" />
-        <entry offset=""0xf1"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf9"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf8"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x100"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -949,7 +955,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0xe4"" />
+          <slot startOffset=""0x0"" endOffset=""0xf2"" />
         </hoistedLocalScopes>
       </customDebugInfo>
       <sequencePoints>
@@ -964,8 +970,8 @@ class C
         <entry offset=""0x5b"" hidden=""true"" document=""1"" />
         <entry offset=""0xa7"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""1"" />
         <entry offset=""0xb9"" hidden=""true"" document=""1"" />
-        <entry offset=""0xd0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xd8"" hidden=""true"" document=""1"" />
+        <entry offset=""0xd7"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xdf"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -1037,7 +1043,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0xf5"" />
+          <slot startOffset=""0x0"" endOffset=""0x103"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1059,8 +1065,8 @@ class C
         <entry offset=""0x64"" hidden=""true"" document=""1"" />
         <entry offset=""0xb5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" document=""1"" />
         <entry offset=""0xc8"" hidden=""true"" document=""1"" />
-        <entry offset=""0xe0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xe8"" hidden=""true"" document=""1"" />
+        <entry offset=""0xe7"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xef"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -1364,7 +1370,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x102"" />
+          <slot startOffset=""0x0"" endOffset=""0x110"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1382,10 +1388,10 @@ class C
         <entry offset=""0x27"" hidden=""true"" document=""1"" />
         <entry offset=""0x7b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" document=""1"" />
         <entry offset=""0xd5"" hidden=""true"" document=""1"" />
-        <entry offset=""0xed"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf5"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf4"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xfc"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x102"">
+      <scope startOffset=""0x0"" endOffset=""0x110"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
@@ -1543,7 +1549,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x102"" />
+          <slot startOffset=""0x0"" endOffset=""0x110"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1561,10 +1567,10 @@ class C
         <entry offset=""0x76"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" document=""1"" />
         <entry offset=""0x82"" hidden=""true"" document=""1"" />
         <entry offset=""0xd5"" hidden=""true"" document=""1"" />
-        <entry offset=""0xed"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
-        <entry offset=""0xf5"" hidden=""true"" document=""1"" />
+        <entry offset=""0xf4"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" document=""1"" />
+        <entry offset=""0xfc"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x102"">
+      <scope startOffset=""0x0"" endOffset=""0x110"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
@@ -2072,7 +2078,7 @@ class C
           <namespace usingCount=""2"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x5a"" />
+          <slot startOffset=""0x0"" endOffset=""0x68"" />
           <slot startOffset=""0x13"" endOffset=""0x2b"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
@@ -2092,10 +2098,10 @@ class C
         <entry offset=""0x28"" hidden=""true"" document=""1"" />
         <entry offset=""0x2b"" hidden=""true"" document=""1"" />
         <entry offset=""0x2d"" hidden=""true"" document=""1"" />
-        <entry offset=""0x45"" hidden=""true"" document=""1"" />
-        <entry offset=""0x4d"" hidden=""true"" document=""1"" />
+        <entry offset=""0x4c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x54"" hidden=""true"" document=""1"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x5a"">
+      <scope startOffset=""0x0"" endOffset=""0x68"">
         <namespace name=""System"" />
         <namespace name=""System.Threading.Tasks"" />
       </scope>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -7711,7 +7711,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c"" methodName=""&lt;F&gt;b__0_0"" parameterNames=""i"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x79"" />
+          <slot startOffset=""0x0"" endOffset=""0x87"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -7724,8 +7724,8 @@ class C
         <entry offset=""0x8"" startLine=""7"" startColumn=""9"" endLine=""7"" endColumn=""35"" document=""1"" />
         <entry offset=""0x1f"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""26"" document=""1"" />
         <entry offset=""0x4c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x64"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
-        <entry offset=""0x6c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6b"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" document=""1"" />
+        <entry offset=""0x73"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""F"" />
@@ -7779,7 +7779,7 @@ class C
       <customDebugInfo>
         <forward declaringType=""C"" methodName=""M"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x79"" />
+          <slot startOffset=""0x0"" endOffset=""0x87"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""50"" />
@@ -7792,8 +7792,8 @@ class C
         <entry offset=""0x8"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""39"" document=""1"" />
         <entry offset=""0x1f"" startLine=""9"" startColumn=""13"" endLine=""9"" endColumn=""30"" document=""1"" />
         <entry offset=""0x4c"" hidden=""true"" document=""1"" />
-        <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
-        <entry offset=""0x6c"" hidden=""true"" document=""1"" />
+        <entry offset=""0x6b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" document=""1"" />
+        <entry offset=""0x73"" hidden=""true"" document=""1"" />
       </sequencePoints>
       <asyncInfo>
         <catchHandler offset=""0x4c"" />


### PR DESCRIPTION
Make async state machine cleanup hoisted locals before calling SetResult to prevent excess GC roots