### PR TITLE
Temporarily publish to only one channel, with Shipping packages only

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -55,11 +55,11 @@
       "vsMajorVersion": 16
     },
     "release/dev16.4-vs-deps": {
-      "nugetKind": ["Shipping", "NonShipping"],
+      "nugetKind": ["Shipping"],
       "version": "3.4.*",
       "nuget": [ "https://dotnet.myget.org/F/roslyn/api/v2/package" ],
       "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
-      "channels": [ "dev16.4p3", "dev16.4" ],
+      "channels": [ "dev16.4" ],
       "vsBranch": "rel/d16.4",
       "vsMajorVersion": 16
     },


### PR DESCRIPTION
This is causing a race where we try to submit multiple changes to the dotnet/versions repository one after the other. The changes need to be fast-forward, but if you submit changes very quickly, you could get the HEAD of the old build right after submitting, meaning that the commit would be based on the old content. The failure to commit a fast-forward merge is failing the build.

https://github.com/dotnet/arcade/pull/4320 addresses the need to retry if a fast-forward fails.