### PR TITLE
Use global properties to iterate over TFMs in MSBuildWorkspace

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
@@ -59,6 +59,9 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 var targetFrameworks = targetFrameworksValue.Split(';');
                 var results = ImmutableArray.CreateBuilder<ProjectFileInfo>(targetFrameworks.Length);
 
+                if (!_loadedProject.GlobalProperties.TryGetValue(PropertyNames.TargetFramework, out var initialGlobalTargetFrameworkValue))
+                    initialGlobalTargetFrameworkValue = null;
+
                 foreach (var targetFramework in targetFrameworks)
                 {
                     _loadedProject.SetGlobalProperty(PropertyNames.TargetFramework, targetFramework);
@@ -69,7 +72,15 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     results.Add(projectFileInfo);
                 }
 
-                _loadedProject.RemoveGlobalProperty(PropertyNames.TargetFramework);
+                if (initialGlobalTargetFrameworkValue is null)
+                {
+                    _loadedProject.RemoveGlobalProperty(PropertyNames.TargetFramework);
+                }
+                else
+                {
+                    _loadedProject.SetGlobalProperty(PropertyNames.TargetFramework, initialGlobalTargetFrameworkValue);
+                }
+
                 _loadedProject.ReevaluateIfNecessary();
 
                 return results.ToImmutable();

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectFile/ProjectFile.cs
@@ -56,13 +56,12 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 // In this case, we need to iterate through the <TargetFrameworks>, set <TargetFramework> with
                 // each value, and build the project.
 
-                var hasTargetFrameworkProp = _loadedProject.GetProperty(PropertyNames.TargetFramework) != null;
                 var targetFrameworks = targetFrameworksValue.Split(';');
                 var results = ImmutableArray.CreateBuilder<ProjectFileInfo>(targetFrameworks.Length);
 
                 foreach (var targetFramework in targetFrameworks)
                 {
-                    _loadedProject.SetProperty(PropertyNames.TargetFramework, targetFramework);
+                    _loadedProject.SetGlobalProperty(PropertyNames.TargetFramework, targetFramework);
                     _loadedProject.ReevaluateIfNecessary();
 
                     var projectFileInfo = await BuildProjectFileInfoAsync(cancellationToken).ConfigureAwait(false);
@@ -70,18 +69,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                     results.Add(projectFileInfo);
                 }
 
-                // Remove the <TargetFramework> property if it didn't exist in the file before we set it.
-                // Otherwise, set it back to it's original value.
-                if (!hasTargetFrameworkProp)
-                {
-                    var targetFrameworkProp = _loadedProject.GetProperty(PropertyNames.TargetFramework);
-                    _loadedProject.RemoveProperty(targetFrameworkProp);
-                }
-                else
-                {
-                    _loadedProject.SetProperty(PropertyNames.TargetFramework, targetFrameworkValue);
-                }
-
+                _loadedProject.RemoveGlobalProperty(PropertyNames.TargetFramework);
                 _loadedProject.ReevaluateIfNecessary();
 
                 return results.ToImmutable();

--- a/src/Workspaces/MSBuildTest/Resources/NetCoreMultiTFM_ExtensionWithConditionOnTFM/Project.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/NetCoreMultiTFM_ExtensionWithConditionOnTFM/Project.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workspaces/MSBuildTest/Resources/NetCoreMultiTFM_ExtensionWithConditionOnTFM/Project.csproj.test.props
+++ b/src/Workspaces/MSBuildTest/Resources/NetCoreMultiTFM_ExtensionWithConditionOnTFM/Project.csproj.test.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <RootNamespace Condition="'$(TargetFramework)' == 'netcoreapp2.1'">Project.NetCore</RootNamespace>
+    <RootNamespace Condition="'$(TargetFramework)' == 'netstandard2.0'">Project.NetStandard</RootNamespace>
+    <RootNamespace Condition="'$(TargetFramework)' == 'net461'">Project.NetFramework</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -138,6 +138,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
                 public static string NetCoreApp2AndTwoLibraries_Library1 => GetText("NetCoreApp2AndTwoLibraries.Library1.csproj");
                 public static string NetCoreApp2AndTwoLibraries_Library2 => GetText("NetCoreApp2AndTwoLibraries.Library2.csproj");
                 public static string NetCoreMultiTFM_Project => GetText("NetCoreMultiTFM.Project.csproj");
+                public static string NetCoreMultiTFM_ExtensionWithConditionOnTFM_Project => GetText("NetCoreMultiTFM_ExtensionWithConditionOnTFM.Project.csproj");
+                public static string NetCoreMultiTFM_ExtensionWithConditionOnTFM_ProjectTestProps => GetText("NetCoreMultiTFM_ExtensionWithConditionOnTFM.Project.csproj.test.props");
                 public static string NetCoreMultiTFM_ProjectReference_Library => GetText("NetCoreMultiTFM_ProjectReference.Library.csproj");
                 public static string NetCoreMultiTFM_ProjectReference_Project => GetText("NetCoreMultiTFM_ProjectReference.Project.csproj");
                 public static string NetCoreMultiTFM_ProjectReferenceToFSharp_CSharpLib = GetText("NetCoreMultiTFM_ProjectReferenceToFSharp.csharplib.csharplib.csproj");

--- a/src/Workspaces/MSBuildTest/WorkspaceTestBase.cs
+++ b/src/Workspaces/MSBuildTest/WorkspaceTestBase.cs
@@ -153,6 +153,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 (@"Program.cs", Resources.SourceFiles.CSharp.NetCoreApp2_Program));
         }
 
+        protected FileSet GetNetCoreMultiTFMFiles_ExtensionWithConditionOnTFM()
+        {
+            return new FileSet(
+                (@"NuGet.Config", Resources.NuGet_Config),
+                (@"Directory.Build.props", Resources.Directory_Build_props),
+                (@"Directory.Build.targets", Resources.Directory_Build_targets),
+                (@"Project.csproj", Resources.ProjectFiles.CSharp.NetCoreMultiTFM_ExtensionWithConditionOnTFM_Project),
+                (@"obj\Project.csproj.test.props", Resources.ProjectFiles.CSharp.NetCoreMultiTFM_ExtensionWithConditionOnTFM_ProjectTestProps));
+        }
+
         protected FileSet GetNetCoreMultiTFMFiles_ProjectReference()
         {
             return new FileSet(


### PR DESCRIPTION
This ensures that conditions based on the TFM work correctly in MSBuild files which are included early, like in NuGet props files for instance.

Fixes #39724 - the issue is explained in more detail there.