### PR TITLE
Use selected culture when printing diagnostics in interactive host

### DIFF
--- a/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Host/Interactive/Core/InteractiveHost.Service.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             private MetadataShadowCopyProvider _metadataFileProvider;
             private ReplServiceProvider _replServiceProvider;
             private InteractiveScriptGlobals _globals;
+            private CultureInfo _culture;
 
             // Session is not thread-safe by itself, and the compilation
             // and execution of scripts are asynchronous operations.
@@ -155,11 +156,13 @@ namespace Microsoft.CodeAnalysis.Interactive
                 Debug.Assert(_assemblyLoader == null);
                 Debug.Assert(_replServiceProvider == null);
 
+                _culture = new CultureInfo(cultureName);
+
                 // TODO (tomat): we should share the copied files with the host
                 _metadataFileProvider = new MetadataShadowCopyProvider(
                     Path.Combine(Path.GetTempPath(), "InteractiveHostShadow"),
                     noShadowCopyDirectories: s_systemNoShadowCopyDirectories,
-                    documentationCommentsCulture: new CultureInfo(cultureName));
+                    documentationCommentsCulture: _culture);
 
                 _assemblyLoader = new InteractiveAssemblyLoader(_metadataFileProvider);
 
@@ -843,7 +846,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
                 foreach (var diagnostic in displayedDiagnostics)
                 {
-                    output.WriteLine(formatter.Format(diagnostic, output.FormatProvider as CultureInfo));
+                    output.WriteLine(formatter.Format(diagnostic, _culture));
                 }
 
                 if (diagnostics.Length > MaxErrorCount)

--- a/src/Interactive/HostTest/InteractiveHostTests.cs
+++ b/src/Interactive/HostTest/InteractiveHostTests.cs
@@ -937,7 +937,7 @@ OK
             Execute("new Process()");
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-{initFile.Path}(1,3): error CS1002: { CSharpResources.ERR_SemicolonExpected }
+{initFile.Path}(1,3): error CS1002: { ErrorFacts.GetMessage(ErrorCode.ERR_SemicolonExpected, CultureInfo.InvariantCulture) }
 ", ReadErrorOutputToEnd());
 
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
@@ -994,8 +994,25 @@ WriteLine(new Complex(2, 6).Real);
         {
             Execute("nameof(Microsoft.Missing)");
             AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-(1,8): error CS0234: { string.Format(CSharpResources.ERR_DottedTypeNameNotFoundInNS, "Missing", "Microsoft") }",
+(1,8): error CS0234: { string.Format(ErrorFacts.GetMessage(ErrorCode.ERR_DottedTypeNameNotFoundInNS, CultureInfo.InvariantCulture), "Missing", "Microsoft") }",
     ReadErrorOutputToEnd());
+
+            Assert.Equal("", ReadOutputToEnd());
+        }
+
+        [Theory]
+        [InlineData("fr-FR")]
+        [InlineData("es-ES")]
+        public void LocalizedDiagnostics(string cultureName)
+        {
+            var culture = CultureInfo.GetCultureInfo(cultureName);
+            _host.ResetAsync(new InteractiveHostOptions(GetInteractiveHostDirectory(), initializationFile: null, culture: culture)).Wait();
+
+            Execute("nameof(Microsoft.Missing)");
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
+(1,8): error CS0234: { string.Format(ErrorFacts.GetMessage(ErrorCode.ERR_DottedTypeNameNotFoundInNS, culture), "Missing", "Microsoft") }",
+                ReadErrorOutputToEnd());
 
             Assert.Equal("", ReadOutputToEnd());
         }


### PR DESCRIPTION
I noticed that InteractiveHost unit tests failed on my machine. This PR fixes that by using the selected culture for diagnostics output.

Fixes #37899
