### PR TITLE
In var foreach, use return type of the Current enumerator prop…

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6918,13 +6918,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else if (node.Syntax is ForEachStatementSyntax { Type: { IsVar: true } })
                         {
-                            result = sourceState;
+                            // foreach (var variable in collection)
                             _variableTypes[iterationVariable] = sourceState.ToTypeWithAnnotations();
                         }
                         else
                         {
                             // foreach (DestinationType variable in collection)
-                            // foreach (var variable in collection)
                             // and asynchronous variants
                             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                             Conversion conversion = node.ElementConversion.Kind == ConversionKind.UnsetConversionKind

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6916,6 +6916,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 ReportNullabilityMismatchInAssignment(foreachSyntax.Type, sourceType, destinationType);
                             }
                         }
+                        else if (node.Syntax is ForEachStatementSyntax { Type: { IsVar: true } })
+                        {
+                            result = sourceState;
+                            _variableTypes[iterationVariable] = sourceState.ToTypeWithAnnotations();
+                        }
                         else
                         {
                             // foreach (DestinationType variable in collection)
@@ -6943,12 +6948,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // In non-error cases we'll only run this loop a single time. In error cases we'll set the nullability of the VariableType multiple times, but at least end up with something
                         SetAnalyzedNullability(node.IterationVariableType, new VisitResult(result, destinationType), isLvalue: true);
                         state = result.State;
-
-                        // If we inferred the type of this variable, then record the inferred type of the variable for later use by the SemanticModel.
-                        if (node.Syntax is ForEachStatementSyntax { Type: { IsVar: true } })
-                        {
-                            _variableTypes[iterationVariable] = result.ToTypeWithAnnotations();
-                        }
                     }
 
                     int slot = GetOrCreateSlot(iterationVariable);


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/roslyn/issues/39736. The deconstruction case is unhandled, and I'm going to leave it off until @jcouv gets back from vacation. It will require diving in to the tuple type, pulling it apart, and using the original type where appropriate. It would likely need to be rewritten after his changes, so we'll wait on doing it.