### PR TITLE
Beginning of work on "Used Assembly References" feature.

### DIFF
--- a/docs/features/UsedAssemblyReferences.md
+++ b/docs/features/UsedAssemblyReferences.md
@@ -2,7 +2,7 @@ Used Assembly References
 =========================
 
 The *Used Assembly References* feature provides a ```GetUsedAssemblyReferences``` API on a ```Compilation``` to obtain a set
-of metadata assembly references that are considered as used by the compilation. For example, if a type declared in a
-referenced assembly is referenced in source code within the compilation, the reference is considered as used. Etc.
+of metadata assembly references that are considered to be used by the compilation. For example, if a type declared in a
+referenced assembly is referenced in source code within the compilation, the reference is considered to be used. Etc.
 
 See https://github.com/dotnet/roslyn/issues/37768 for more information.

--- a/docs/features/UsedAssemblyReferences.md
+++ b/docs/features/UsedAssemblyReferences.md
@@ -1,0 +1,8 @@
+Used Assembly References
+=========================
+
+The *Used Assembly References* feature provides a ```GetUsedAssemblyReferences``` API on a ```Compilation``` to obtain a set
+of metadata assembly references that are considered as used by the compilation. For example, if a type declared in a
+referenced assembly is referenced in source code within the compilation, the reference is considered as used. Etc.
+
+See https://github.com/dotnet/roslyn/issues/37768 for more information.

--- a/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BinderFlags.cs
@@ -88,25 +88,30 @@ namespace Microsoft.CodeAnalysis.CSharp
         IgnoreCorLibraryDuplicatedTypes = 1 << 26,
 
         /// <summary>
+        /// Set for a binder used to bind a using directive target
+        /// </summary>
+        InUsing = 1 << 27,
+
+        /// <summary>
         /// When binding imports in scripts/submissions, using aliases (other than from the current submission)
         /// are considered but other imports are not.
         /// </summary>
-        InScriptUsing = 1 << 27,
+        InScriptUsing = 1 << 28,
 
         /// <summary>
         /// In a file that has been included in the compilation via #load.
         /// </summary>
-        InLoadedSyntaxTree = 1 << 28,
+        InLoadedSyntaxTree = 1 << 29,
 
         /// <summary>
         /// This is a <see cref="ContextualAttributeBinder"/>, or has <see cref="ContextualAttributeBinder"/> as its parent.
         /// </summary>
-        InContextualAttributeBinder = 1 << 29,
+        InContextualAttributeBinder = 1 << 30,
 
         /// <summary>
         /// Are we binding for the purpose of an Expression Evaluator
         /// </summary>
-        InEEMethodBinder = 1 << 30,
+        InEEMethodBinder = 1U << 31,
 
         // Groups
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -194,6 +194,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)attributeType != null);
 
             NullableWalker.AnalyzeIfNeeded(this, boundAttribute, diagnostics);
+            if (!IsSemanticModelBinder)
+            {
+                UsedAssembliesRecorder.RecordUsedAssemblies(Compilation, boundAttribute, diagnostics);
+            }
 
             bool hasErrors = boundAttribute.HasAnyErrors;
 
@@ -431,7 +435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             this.LookupMembersWithFallback(result, attributeType, name, 0, ref useSiteDiagnostics);
             diagnostics.Add(identifierName, useSiteDiagnostics);
-            Symbol resultSymbol = this.ResultSymbol(result, name, 0, identifierName, diagnostics, false, out wasError);
+            Symbol resultSymbol = this.ResultSymbol(result, name, 0, identifierName, diagnostics, false, out wasError, qualifierOpt: null);
             resultKind = result.Kind;
             result.Free();
             return resultSymbol;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -747,7 +747,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or it might not; if it is not then we do not want to report an error. If it is, then
             // we want to treat the declaration as an explicitly typed declaration.
 
-            TypeWithAnnotations declType = BindTypeWithAnnotationsOrVarKeyword(typeSyntax.SkipRef(out _), diagnostics, out isVar, out alias);
+            TypeWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax.SkipRef(out _), diagnostics, out isVar, out alias);
             Debug.Assert(declType.HasType || isVar);
 
             if (isVar)
@@ -2430,7 +2430,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             AliasSymbol alias;
             bool isVar;
-            TypeWithAnnotations declType = BindTypeWithAnnotationsOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
+            TypeWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
 
             Debug.Assert(declType.HasType || isVar);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1536,16 +1536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (shouldRecordUsedAssemblyReferences() && qualifierOpt?.IsType != true)
                     {
-                        NamedTypeSymbol container = symbol.ContainingType;
-
-                        if (container is null)
-                        {
-                            Compilation.AddUsedAssembly(symbol.ContainingAssembly);
-                        }
-                        else
-                        {
-                            Compilation.AddAssembliesUsedByTypeReference(container);
-                        }
+                        Compilation.AddAssembliesUsedByTypeReference((NamedTypeSymbol)symbol);
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         bool isVar;
                         AliasSymbol alias;
-                        TypeWithAnnotations declType = BindTypeWithAnnotationsOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
+                        TypeWithAnnotations declType = BindTypeOrVarKeyword(typeSyntax, diagnostics, out isVar, out alias);
 
                         if (isVar)
                         {

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2096,14 +2096,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void ReportUnusedImports(SyntaxTree filterTree, DiagnosticBag diagnostics, CancellationToken cancellationToken)
         {
-            if (_lazyImportInfos != null && filterTree?.Options.DocumentationMode != DocumentationMode.None)
+            if (_lazyImportInfos != null && (filterTree is null || ReportUnusedImportsInTree(filterTree)))
             {
                 foreach (ImportInfo info in _lazyImportInfos)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
                     SyntaxTree infoTree = info.Tree;
-                    if ((filterTree == null || filterTree == infoTree) && infoTree.Options.DocumentationMode != DocumentationMode.None)
+                    if ((filterTree == null || filterTree == infoTree) && ReportUnusedImportsInTree(infoTree))
                     {
                         TextSpan infoSpan = info.Span;
                         if (!this.IsImportDirectiveUsed(infoTree, infoSpan.Start))

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -961,6 +961,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 symbol = ((AliasSymbol)symbol).GetAliasTarget(basesBeingResolved: null);
             }
 
+            if (symbol is TypeSymbol type)
+            {
+                binder.Compilation.AddAssembliesUsedByTypeReference(type);
+            }
+            else if (symbol is NamespaceSymbol ns)
+            {
+                Debug.Assert(!ns.IsGlobalNamespace);
+                binder.Compilation.AddAssembliesUsedByNamespaceReference(ns);
+            }
+            else
+            {
+                binder.Compilation.AddAssembliesUsedByTypeReference(symbol.ContainingType);
+            }
+
             return symbol.OriginalDefinition.GetDocumentationCommentId();
         }
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -970,6 +970,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var unusedDiagnostics = DiagnosticBag.GetInstance();
                     DefiniteAssignmentPass.Analyze(_compilation, methodSymbol, initializerStatements, unusedDiagnostics, requireOutParamsAssigned: false);
                     DiagnosticsPass.IssueDiagnostics(_compilation, initializerStatements, unusedDiagnostics, methodSymbol);
+                    UsedAssembliesRecorder.RecordUsedAssemblies(_compilation, initializerStatements, unusedDiagnostics);
                     unusedDiagnostics.Free();
                 }
                 else
@@ -1019,6 +1020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // Control flow analysis and implicit return insertion are unnecessary.
                             DefiniteAssignmentPass.Analyze(_compilation, methodSymbol, analyzedInitializers, diagsForCurrentMethod, requireOutParamsAssigned: false);
                             DiagnosticsPass.IssueDiagnostics(_compilation, analyzedInitializers, diagsForCurrentMethod, methodSymbol);
+                            UsedAssembliesRecorder.RecordUsedAssemblies(_compilation, analyzedInitializers, diagsForCurrentMethod);
                         }
                     }
                 }
@@ -1045,6 +1047,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (body != null)
                 {
                     DiagnosticsPass.IssueDiagnostics(_compilation, body, diagsForCurrentMethod, methodSymbol);
+                    UsedAssembliesRecorder.RecordUsedAssemblies(_compilation, body, diagsForCurrentMethod);
                 }
 
                 BoundBlock flowAnalyzedBody = null;

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_UsedAssemblies.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_UsedAssemblies.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    public partial class CSharpCompilation
+    {
+        private ConcurrentSet<AssemblySymbol> _lazyUsedAssemblyReferences;
+        private bool _usedAssemblyReferencesFrozen;
+
+        internal override ImmutableArray<MetadataReference> GetUsedAssemblyReferences(CancellationToken cancellationToken = default)
+        {
+            ConcurrentSet<AssemblySymbol> usedAssemblies = GetCompleteSetOfUsedAssemblies(cancellationToken);
+
+            if (usedAssemblies is null)
+            {
+                return ImmutableArray<MetadataReference>.Empty;
+            }
+
+            var builder = ArrayBuilder<MetadataReference>.GetInstance(usedAssemblies.Count);
+
+            foreach (var reference in References)
+            {
+                if (reference.Properties.Kind == MetadataImageKind.Assembly &&
+                    usedAssemblies.Contains((AssemblySymbol)GetAssemblyOrModuleSymbol(reference)))
+                {
+                    builder.Add(reference);
+                }
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        private ConcurrentSet<AssemblySymbol> GetCompleteSetOfUsedAssemblies(CancellationToken cancellationToken)
+        {
+            if (!_usedAssemblyReferencesFrozen && !Volatile.Read(ref _usedAssemblyReferencesFrozen))
+            {
+                // PROTOTYPE(UsedAssemblyReferences): Try to optimize scenarios when GetDiagnostics was called before
+                //                                    and we either already encountered errors, or have done all the work 
+                //                                    to record usage.
+                var diagnostics = DiagnosticBag.GetInstance();
+                GetDiagnostics(CompilationStage.Compile, includeEarlierStages: true, diagnostics, cancellationToken);
+
+                completeTheSetOfUsedAssemblies(diagnostics, cancellationToken);
+
+                diagnostics.Free();
+            }
+
+            return _lazyUsedAssemblyReferences;
+
+            void addUsedAssembly(AssemblySymbol dependency, ArrayBuilder<AssemblySymbol> stack)
+            {
+                if (AddUsedAssembly(dependency))
+                {
+                    stack.Push(dependency);
+                }
+            }
+
+            void addReferencedAssemblies(AssemblySymbol assembly, bool includeMainModule, ArrayBuilder<AssemblySymbol> stack)
+            {
+                for (int i = (includeMainModule ? 0 : 1); i < assembly.Modules.Length; i++)
+                {
+                    foreach (var dependency in assembly.Modules[i].ReferencedAssemblySymbols)
+                    {
+                        addUsedAssembly(dependency, stack);
+                    }
+                }
+            }
+
+            void completeTheSetOfUsedAssemblies(DiagnosticBag diagnostics, CancellationToken cancellationToken)
+            {
+                if (_usedAssemblyReferencesFrozen || Volatile.Read(ref _usedAssemblyReferencesFrozen))
+                {
+                    return;
+                }
+
+                if (diagnostics.HasAnyErrors())
+                {
+                    // Add all referenced assemblies
+                    foreach (var assembly in SourceModule.ReferencedAssemblySymbols)
+                    {
+                        AddUsedAssembly(assembly);
+                    }
+                }
+                else
+                {
+                    // Assume that all assemblies used by the added modules are also used
+                    for (int i = 1; i < SourceAssembly.Modules.Length; i++)
+                    {
+                        foreach (var dependency in SourceAssembly.Modules[i].ReferencedAssemblySymbols)
+                        {
+                            AddUsedAssembly(dependency);
+                        }
+                    }
+
+                    // Assume that all assemblies used by the used assemblies are also used
+                    if (_lazyUsedAssemblyReferences is object)
+                    {
+                        lock (_lazyUsedAssemblyReferences)
+                        {
+                            if (_usedAssemblyReferencesFrozen || Volatile.Read(ref _usedAssemblyReferencesFrozen))
+                            {
+                                return;
+                            }
+
+                            var stack = ArrayBuilder<AssemblySymbol>.GetInstance(_lazyUsedAssemblyReferences.Count);
+                            stack.AddRange(_lazyUsedAssemblyReferences);
+
+                            while (stack.Count != 0)
+                            {
+                                AssemblySymbol current = stack.Pop();
+                                ConcurrentSet<AssemblySymbol> usedAssemblies;
+
+                                switch (current)
+                                {
+                                    case SourceAssemblySymbol sourceAssembly:
+                                        // PROTOTYPE(UsedAssemblyReferences): The set of assemblies used by the referenced compilation feels like
+                                        //                                    a reasonable approximation to the set of assembly references that would
+                                        //                                    be emitted into the resulting binary for that compilation. An alternative
+                                        //                                    would be to attempt to emit and get the exact set of emitted references
+                                        //                                    in case of success. This might be too slow though.
+                                        usedAssemblies = sourceAssembly.DeclaringCompilation.GetCompleteSetOfUsedAssemblies(cancellationToken);
+                                        if (usedAssemblies is object)
+                                        {
+                                            foreach (AssemblySymbol dependency in usedAssemblies)
+                                            {
+                                                Debug.Assert(!dependency.IsLinked);
+                                                addUsedAssembly(dependency, stack);
+                                            }
+                                        }
+                                        break;
+
+                                    case RetargetingAssemblySymbol retargetingAssembly:
+                                        usedAssemblies = retargetingAssembly.UnderlyingAssembly.DeclaringCompilation.GetCompleteSetOfUsedAssemblies(cancellationToken);
+                                        if (usedAssemblies is object)
+                                        {
+                                            foreach (AssemblySymbol underlyingDependency in retargetingAssembly.UnderlyingAssembly.SourceModule.ReferencedAssemblySymbols)
+                                            {
+                                                if (!underlyingDependency.IsLinked && usedAssemblies.Contains(underlyingDependency))
+                                                {
+                                                    AssemblySymbol dependency;
+
+                                                    if (!((RetargetingModuleSymbol)retargetingAssembly.Modules[0]).RetargetingDefinitions(underlyingDependency, out dependency))
+                                                    {
+                                                        Debug.Assert(retargetingAssembly.Modules[0].ReferencedAssemblySymbols.Contains(underlyingDependency));
+                                                        dependency = underlyingDependency;
+                                                    }
+
+                                                    addUsedAssembly(dependency, stack);
+                                                }
+                                            }
+                                        }
+
+                                        addReferencedAssemblies(retargetingAssembly, includeMainModule: false, stack);
+                                        break;
+                                    default:
+                                        addReferencedAssemblies(current, includeMainModule: true, stack);
+                                        break;
+                                }
+                            }
+
+                            stack.Free();
+                        }
+                    }
+
+                    if (SourceAssembly.CorLibrary is object)
+                    {
+                        // Add core library
+                        AddUsedAssembly(SourceAssembly.CorLibrary);
+                    }
+                }
+
+                _usedAssemblyReferencesFrozen = true;
+            }
+        }
+
+        internal bool AddUsedAssembly(AssemblySymbol assembly)
+        {
+            if (assembly is null || assembly == SourceAssembly || assembly.IsMissing)
+            {
+                return false;
+            }
+
+            _lazyUsedAssemblyReferences ??= new ConcurrentSet<AssemblySymbol>();
+
+#if DEBUG
+            bool wasFrozen = _usedAssemblyReferencesFrozen;
+#endif
+            bool result = _lazyUsedAssemblyReferences.Add(assembly);
+
+#if DEBUG
+            Debug.Assert(!result || !wasFrozen);
+#endif
+            return result;
+        }
+
+        internal void AddAssembliesUsedByTypeReference(TypeSymbol typeOpt)
+        {
+            while (true)
+            {
+                switch (typeOpt)
+                {
+                    case null:
+                    case TypeParameterSymbol _:
+                    case DynamicTypeSymbol _:
+                        return;
+                    case PointerTypeSymbol pointer:
+                        typeOpt = pointer.PointedAtTypeWithAnnotations.DefaultType;
+                        break;
+                    case ArrayTypeSymbol array:
+                        typeOpt = array.ElementTypeWithAnnotations.DefaultType;
+                        break;
+                    case NamedTypeSymbol named:
+                        named = named.TupleUnderlyingTypeOrSelf();
+                        AddUsedAssembly(named.ContainingAssembly);
+                        do
+                        {
+                            foreach (var typeArgument in named.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics)
+                            {
+                                AddAssembliesUsedByTypeReference(typeArgument.DefaultType);
+                            }
+
+                            named = named.ContainingType;
+                        }
+                        while (named is object);
+                        return;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(typeOpt.TypeKind);
+                }
+            }
+        }
+
+        internal void AddAssembliesUsedByNamespaceReference(NamespaceSymbol ns)
+        {
+            // Treat all assemblies contributing to this namespace symbol as used
+            if (ns.Extent.Kind == NamespaceKind.Compilation)
+            {
+                foreach (var constituent in ns.ConstituentNamespaces)
+                {
+                    AddAssembliesUsedByNamespaceReference(constituent);
+                }
+            }
+            else
+            {
+                AddUsedAssembly(ns.ContainingAssembly);
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_UsedAssemblies.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_UsedAssemblies.cs
@@ -189,7 +189,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            _lazyUsedAssemblyReferences ??= new ConcurrentSet<AssemblySymbol>();
+            if (_lazyUsedAssemblyReferences is null)
+            {
+                Interlocked.CompareExchange(ref _lazyUsedAssemblyReferences, new ConcurrentSet<AssemblySymbol>(), null);
+            }
 
 #if DEBUG
             bool wasFrozen = _usedAssemblyReferencesFrozen;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -124,10 +124,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         }
 
         /// <summary>
-        /// The underlying AssemblySymbol.
-        /// This cannot be an instance of RetargetingAssemblySymbol.
+        /// The underlying <see cref="SourceAssemblySymbol"/>.
         /// </summary>
-        public AssemblySymbol UnderlyingAssembly
+        public SourceAssemblySymbol UnderlyingAssembly
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -234,6 +234,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 #endif
         }
 
+        internal bool RetargetingDefinitions(AssemblySymbol from, out AssemblySymbol to)
+        {
+            DestinationData destination;
+
+            if (!_retargetingAssemblyMap.TryGetValue(from, out destination))
+            {
+                to = null;
+                return false;
+            }
+
+            to = destination.To;
+            return true;
+        }
+
         internal override ICollection<string> TypeNames
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -149,6 +149,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.TupleUnderlyingType ?? type;
         }
 
+        public static NamedTypeSymbol TupleUnderlyingTypeOrSelf(this NamedTypeSymbol type)
+        {
+            return type.TupleUnderlyingType ?? type;
+        }
+
         public static TypeSymbol EnumUnderlyingTypeOrSelf(this TypeSymbol type)
         {
             return type.IsEnumType() ? type.GetEnumUnderlyingType() : type;

--- a/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed class UsedAssembliesRecorder : BoundTreeWalkerWithStackGuard
+    {
+        private readonly CSharpCompilation _compilation;
+
+        public static void RecordUsedAssemblies(CSharpCompilation compilation, BoundNode node, DiagnosticBag diagnostics)
+        {
+            Debug.Assert(node != null);
+
+            try
+            {
+                var visitor = new UsedAssembliesRecorder(compilation);
+                visitor.Visit(node);
+            }
+            catch (CancelledByStackGuardException ex)
+            {
+                // PROTOTYPE(UsedAssemblyReferences): This error might not be cached, but its presence might affect cached full set of used assemblies. 
+                //                                    We would report all assemblies as used, even though no one will ever see this error and under
+                //                                    different environment state the pass could succeed causing us to return different set of used assemblies
+                //                                    with now apparent reason for the difference from the consumer's point of view. 
+                ex.AddAnError(diagnostics);
+            }
+        }
+
+        private UsedAssembliesRecorder(CSharpCompilation compilation)
+        {
+            _compilation = compilation;
+        }
+
+        private void AddAssembliesUsedBySymbolReference(BoundExpression receiverOpt, Symbol symbol)
+        {
+            if (symbol.IsStatic && receiverOpt?.Kind != BoundKind.TypeExpression)
+            {
+                _compilation.AddAssembliesUsedByTypeReference(symbol.ContainingType);
+            }
+        }
+
+        public override BoundNode VisitFieldAccess(BoundFieldAccess node)
+        {
+            AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.FieldSymbol);
+            return base.VisitFieldAccess(node);
+        }
+
+        public override BoundNode VisitCall(BoundCall node)
+        {
+            AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.Method);
+            return base.VisitCall(node);
+        }
+
+        public override BoundNode VisitNameOfOperator(BoundNameOfOperator node)
+        {
+            if (node.Argument is BoundNamespaceExpression nsExpr)
+            {
+                Debug.Assert(!nsExpr.NamespaceSymbol.IsGlobalNamespace);
+                _compilation.AddAssembliesUsedByNamespaceReference(nsExpr.NamespaceSymbol);
+            }
+
+            return base.VisitNameOfOperator(node);
+        }
+
+        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        {
+            // It is very common for bound trees to be left-heavy binary operators, eg,
+            // a + b + c + d + ...
+            // To avoid blowing the stack, do not recurse down the left hand side.
+
+            // In order to avoid blowing the stack, we end up visiting right children
+            // before left children; this should not be a problem
+
+            BoundBinaryOperator current = node;
+            while (true)
+            {
+                Visit(current.Right);
+                if (current.Left.Kind == BoundKind.BinaryOperator)
+                {
+                    current = (BoundBinaryOperator)current.Left;
+                }
+                else
+                {
+                    Visit(current.Left);
+                    break;
+                }
+            }
+
+            return null;
+        }
+
+        public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
+        {
+            // In order to avoid blowing the stack, we end up visiting right children
+            // before left children; this should not be a problem
+
+            BoundUserDefinedConditionalLogicalOperator current = node;
+            while (true)
+            {
+                Visit(current.Right);
+                if (current.Left.Kind == BoundKind.UserDefinedConditionalLogicalOperator)
+                {
+                    current = (BoundUserDefinedConditionalLogicalOperator)current.Left;
+                }
+                else
+                {
+                    Visit(current.Left);
+                    break;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //                                    We would report all assemblies as used, even though no one will ever see this error and under
                 //                                    different environment state the pass could succeed causing us to return different set of used assemblies
                 //                                    with no apparent reason for the difference from the consumer's point of view. 
+                //                                    We will have the same problem with any BoundTreeWalker invoked under umbrella of GetUsedAssemblyReferences API.
+                //                                    Including flow analysis, lowering, etc.
                 ex.AddAnError(diagnostics);
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -23,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // PROTOTYPE(UsedAssemblyReferences): This error might not be cached, but its presence might affect cached full set of used assemblies. 
                 //                                    We would report all assemblies as used, even though no one will ever see this error and under
                 //                                    different environment state the pass could succeed causing us to return different set of used assemblies
-                //                                    with now apparent reason for the difference from the consumer's point of view. 
+                //                                    with no apparent reason for the difference from the consumer's point of view. 
                 ex.AddAnError(diagnostics);
             }
         }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
@@ -1,0 +1,2727 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using ICSharpCode.Decompiler.IL;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class UsedAssembliesTests : CSharpTestBase
+    {
+
+        [Fact]
+        public void NoReferences_01()
+        {
+            var source =
+@"
+interface I1
+{
+    public I1 M();
+}
+";
+            var comp1 = CreateEmptyCompilation(source);
+            CompileAndVerify(comp1);
+
+            Assert.Empty(comp1.GetUsedAssemblyReferences());
+
+            var comp2 = CreateCompilation(source);
+            CompileAndVerify(comp2);
+
+            AssertUsedAssemblyReferences(comp2);
+        }
+
+        [Fact]
+        public void NoReferences_02()
+        {
+            var source =
+@"
+public interface I1
+{
+    public I1 M();
+}
+";
+            var comp1 = CreateEmptyCompilation(source);
+            CompileAndVerify(comp1);
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main(I1 x)
+    {
+        x.M();
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp1.EmitToImageReference());
+            verify<RetargetingAssemblySymbol>(source2, comp1.ToMetadataReference());
+            Assert.Empty(comp1.GetUsedAssemblyReferences());
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = AssertUsedAssemblyReferences(source2, reference);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference));
+            }
+        }
+
+        private static void AssertUsedAssemblyReferences(Compilation comp, MetadataReference[] expected, DiagnosticDescription[] before, DiagnosticDescription[] after)
+        {
+            comp.VerifyDiagnostics(before);
+
+            bool hasCoreLibraryRef = !comp.ObjectType.IsErrorType();
+            Assert.True(comp.References.Count() > expected.Length + (hasCoreLibraryRef ? 1 : 0));
+
+            var used = comp.GetUsedAssemblyReferences();
+
+            if (hasCoreLibraryRef)
+            {
+                Assert.Same(comp.ObjectType.ContainingAssembly, comp.GetAssemblyOrModuleSymbol(used[0]));
+                AssertEx.Equal(expected, used.Skip(1));
+            }
+            else
+            {
+                AssertEx.Equal(expected, used);
+            }
+
+            Assert.Empty(used.Where(r => r.Properties.Kind == MetadataImageKind.Module));
+
+            comp.RemoveAllReferences().AddReferences(used.Concat(comp.References.Where(r => r.Properties.Kind == MetadataImageKind.Module))).VerifyDiagnostics(after);
+        }
+
+        private static void AssertUsedAssemblyReferences(Compilation comp, params MetadataReference[] expected)
+        {
+            AssertUsedAssemblyReferences(comp, expected, new DiagnosticDescription[] { }, new DiagnosticDescription[] { });
+        }
+
+        private static Compilation AssertUsedAssemblyReferences(string source, MetadataReference[] references, params MetadataReference[] expected)
+        {
+            Compilation comp = CreateCompilation(source, references: references);
+            AssertUsedAssemblyReferences(comp, expected);
+            return comp;
+        }
+
+        private static Compilation AssertUsedAssemblyReferences(string source, params MetadataReference[] references)
+        {
+            return AssertUsedAssemblyReferences(source, references, references);
+        }
+
+        [Fact]
+        public void NoReferences_03()
+        {
+            var source =
+@"
+namespace System
+{
+    public class Object {}
+    public class ValueType {}
+    public struct Void {}
+}
+
+public interface I1
+{
+    public I1 M();
+}
+";
+            var comp1 = CreateEmptyCompilation(source);
+            comp1.VerifyEmitDiagnostics(
+                // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
+                Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1)
+                );
+
+            var source2 =
+@"
+public class C2
+{
+    public static object Main(I1 x)
+    {
+        x.M();
+        return null;
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp1.EmitToImageReference());
+            verify<SourceAssemblySymbol>(source2, comp1.ToMetadataReference());
+            Assert.Empty(comp1.GetUsedAssemblyReferences());
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = CreateEmptyCompilation(source2, references: new[] { reference, SystemCoreRef, SystemDrawingRef });
+                AssertUsedAssemblyReferences(comp2);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference));
+            }
+        }
+
+        [Fact]
+        public void NoReferences_04()
+        {
+            var source =
+@"
+public interface I1
+{
+    public I1 M1();
+}
+";
+            var comp1 = CreateEmptyCompilation(source);
+            CompileAndVerify(comp1);
+
+            var source2 =
+@"
+public interface I2
+{
+    public I1 M2();
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp1.EmitToImageReference());
+            verify<RetargetingAssemblySymbol>(source2, comp1.ToMetadataReference());
+            Assert.Empty(comp1.GetUsedAssemblyReferences());
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = CreateEmptyCompilation(source2, references: new[] { reference, SystemCoreRef, SystemDrawingRef });
+                AssertUsedAssemblyReferences(comp2, reference);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference));
+            }
+        }
+
+        [Fact]
+        public void FieldReference_01()
+        {
+            var source1 =
+@"
+public class C1
+{
+    public static int F1 = 0;
+    public int F2 = 0;
+}
+";
+            var comp1 = CreateCompilation(source1);
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1.F1;
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp1ImageRef);
+            verify<SourceAssemblySymbol>(source2, comp1Ref);
+
+            var source3 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        C1 x = null;
+        _ = x.F2;
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source3, comp1ImageRef);
+            verify<SourceAssemblySymbol>(source3, comp1Ref);
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = AssertUsedAssemblyReferences(source2, reference);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference));
+            }
+        }
+
+        [Fact]
+        public void FieldReference_02()
+        {
+            var source0 =
+@"
+public class C0
+{
+    public static C0 F0 = new C0();
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference();
+            var comp0ImageRef = comp0.EmitToImageReference();
+
+            var source1 =
+@"
+public class C1
+{
+    public static C0 F0 = C0.F0;
+    public static int F1 = 0;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            comp1.VerifyDiagnostics();
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1.F1;
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp0ImageRef, comp1ImageRef);
+            verify<PEAssemblySymbol>(source2, comp0Ref, comp1ImageRef);
+            verify<SourceAssemblySymbol>(source2, comp0Ref, comp1Ref);
+            verify<RetargetingAssemblySymbol>(source2, comp0ImageRef, comp1Ref);
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference0, MetadataReference reference1) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = AssertUsedAssemblyReferences(source2, reference0, reference1);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference1));
+            }
+        }
+
+        [Fact]
+        public void FieldReference_03()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference();
+            var comp0ImageRef = comp0.EmitToImageReference();
+
+            var source1 =
+@"
+class C1
+{
+    static C0 F0 = new C0();
+    public static C1 F1 = new C1();
+}
+";
+
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref }, options: TestOptions.DebugModule);
+            comp1.VerifyDiagnostics();
+
+            var comp1Ref = comp1.EmitToImageReference();
+
+            var source2 =
+@"
+public class C2
+{
+    static C1 F1 = C1.F1;
+    public static int F2 = 0;
+}
+";
+            var comp2 = verify2<SourceAssemblySymbol>(source2, comp0Ref, comp1Ref);
+
+            var comp2Ref = comp2.ToMetadataReference();
+            var comp2ImageRef = comp2.EmitToImageReference();
+
+            var source3 =
+@"
+public class C3
+{
+    public static void Main()
+    {
+        _ = C2.F2;
+    }
+}
+";
+
+            verify3<PEAssemblySymbol>(source3, comp0ImageRef, comp2ImageRef);
+            verify3<PEAssemblySymbol>(source3, comp0Ref, comp2ImageRef);
+            verify3<SourceAssemblySymbol>(source3, comp0Ref, comp2Ref);
+            verify3<RetargetingAssemblySymbol>(source3, comp0ImageRef, comp2Ref);
+            verify3<PEAssemblySymbol>(source3, comp2ImageRef);
+            verify3<RetargetingAssemblySymbol>(source3, comp2Ref);
+
+            comp2 = verify2<PEAssemblySymbol>(source2, comp0ImageRef, comp1Ref);
+            comp2Ref = comp2.ToMetadataReference();
+            comp2ImageRef = comp2.EmitToImageReference();
+
+            verify3<PEAssemblySymbol>(source3, comp0ImageRef, comp2ImageRef);
+            verify3<PEAssemblySymbol>(source3, comp0Ref, comp2ImageRef);
+            verify3<RetargetingAssemblySymbol>(source3, comp0Ref, comp2Ref);
+            verify3<SourceAssemblySymbol>(source3, comp0ImageRef, comp2Ref);
+            verify3<PEAssemblySymbol>(source3, comp2ImageRef);
+            verify3<RetargetingAssemblySymbol>(source3, comp2Ref);
+
+            comp2 = CreateCompilation(source2, references: new[] { comp1Ref });
+            comp2.VerifyDiagnostics();
+
+            Assert.True(comp2.References.Count() > 1);
+
+            var used = comp2.GetUsedAssemblyReferences();
+
+            Assert.Equal(1, used.Length);
+            Assert.Same(comp2.ObjectType.ContainingAssembly, comp2.GetAssemblyOrModuleSymbol(used[0]));
+
+            comp2Ref = comp2.ToMetadataReference();
+            comp2ImageRef = comp2.EmitToImageReference();
+
+            verify3<PEAssemblySymbol>(source3, comp0ImageRef, comp2ImageRef);
+            verify3<PEAssemblySymbol>(source3, comp0Ref, comp2ImageRef);
+            verify3<RetargetingAssemblySymbol>(source3, comp0Ref, comp2Ref);
+            verify3<RetargetingAssemblySymbol>(source3, comp0ImageRef, comp2Ref);
+            verify3<PEAssemblySymbol>(source3, comp2ImageRef);
+            verify3<SourceAssemblySymbol>(source3, comp2Ref);
+
+            static Compilation verify2<TAssemblySymbol>(string source2, MetadataReference reference0, MetadataReference reference1) where TAssemblySymbol : AssemblySymbol
+            {
+                var comp2 = AssertUsedAssemblyReferences(source2, new[] { reference0, reference1 }, reference0);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference0));
+                return comp2;
+            }
+
+            static void verify3<TAssemblySymbol>(string source3, params MetadataReference[] references) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp3 = AssertUsedAssemblyReferences(source3, references: references);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp3).GetAssemblyOrModuleSymbol(references.Last()));
+            }
+        }
+
+        [Fact]
+        public void FieldReference_04()
+        {
+            var source1 =
+@"
+namespace N1
+{
+    public enum E1
+    {
+        F1 = 0
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+
+            var comp1Ref = comp1.ToMetadataReference();
+            verify(comp1Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = N1.E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp1Ref,
+@"
+using N1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp1Ref,
+@"
+using static N1.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = F1 + 1;
+    }
+}
+");
+
+            verify(comp1Ref,
+@"
+using alias = N1.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.F1 + 1;
+    }
+}
+");
+
+            static void verify(MetadataReference reference, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference);
+            }
+        }
+
+        [Fact]
+        public void FieldReference_05()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+        F1 = 0
+    }
+
+    public class C3
+    {
+        public int F3 = 0;
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1<C0>.E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1<C0>.E1.F1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(E1.F1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(F1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias.F1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias.E1.F1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1<C0>.C3.F3);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C3.F3);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.C3;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias.F3);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias.C3.F3);
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void FieldReference_06()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+        F1 = 0
+    }
+
+    public class C3
+    {
+        public int F3;
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+class C2
+{
+    /// <summary>
+    /// <see cref=""C1{C0}.E1.F1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                hasTypeReferensesInUsing: false);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""E1.F1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>.E1;
+class C2
+{
+    /// <summary>
+    /// <see cref=""F1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.F1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.E1.F1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+class C2
+{
+    /// <summary>
+    /// <see cref=""C1{C0}.C3.F3""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                hasTypeReferensesInUsing: false);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""C3.F3""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.C3;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.F3""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.C3.F3""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source, bool hasTypeReferensesInUsing = true)
+            {
+                var references = new[] { reference0, reference1 };
+                Compilation comp2 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None));
+                AssertUsedAssemblyReferences(comp2, hasTypeReferensesInUsing ? references : new MetadataReference[] { });
+
+                var expected = hasTypeReferensesInUsing ? references : new[] { reference1 };
+
+                Compilation comp3 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse));
+                AssertUsedAssemblyReferences(comp3, expected);
+
+                Compilation comp4 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Diagnose));
+                AssertUsedAssemblyReferences(comp4, expected);
+            }
+        }
+
+        [Fact]
+        public void FieldReference_07()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+        F1 = 0
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var attribute =
+@"
+class TestAttribute : System.Attribute
+{
+    public TestAttribute()
+    { }
+    public TestAttribute(int value)
+    { }
+    public int Value = 0;
+}
+";
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    [Test((int)C1<C0>.E1.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    [Test((int)E1.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>.E1;
+public class C2
+{
+    [Test((int)F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+public class C2
+{
+    [Test((int)alias.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    [Test((int)alias.E1.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    [Test(Value = (int)C1<C0>.E1.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    [Test(Value = (int)E1.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>.E1;
+public class C2
+{
+    [Test(Value = (int)F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+public class C2
+{
+    [Test(Value = (int)alias.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    [Test(Value = (int)alias.E1.F1 + 1)]
+    public static void Main()
+    {
+    }
+}
+" + attribute);
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void FieldReference_08()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+        F1 = 0
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    public static void Main(int p = (int)C1<C0>.E1.F1 + 1)
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    public static void Main(int p = (int)E1.F1 + 1)
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>.E1;
+public class C2
+{
+    public static void Main(int p = (int)F1 + 1)
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+public class C2
+{
+    public static void Main(int p = (int)alias.F1 + 1)
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    public static void Main(int p = (int)alias.E1.F1 + 1)
+    {
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void MethodReference_01()
+        {
+            var source1 =
+@"
+public class C1
+{
+    public static void M1(){}
+}
+";
+            var comp1 = CreateCompilation(source1);
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        C1.M1();
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp1.EmitToImageReference());
+            verify<SourceAssemblySymbol>(source2, comp1.ToMetadataReference());
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = AssertUsedAssemblyReferences(source2, reference);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference));
+            }
+        }
+
+        [Fact]
+        public void MethodReference_02()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var source1 =
+@"
+public class C1
+{
+    public static void M1<T>(){}
+}
+
+public class C2<T> {}
+
+public class C3<T>
+{
+    public class C4 {}
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+
+            var reference0 = comp0.ToMetadataReference();
+            var reference1 = comp1.ToMetadataReference();
+
+            verify(reference0, reference1,
+@"
+public class C5
+{
+    public static void Main()
+    {
+        C1.M1<C0>();
+    }
+}
+");
+
+            verify(reference0, reference1,
+@"
+public class C5
+{
+    public static void Main()
+    {
+        C1.M1<C2<C0>>();
+    }
+}
+");
+
+            verify(reference1, reference0,
+@"
+public class C5
+{
+    public static void Main()
+    {
+        C1.M1<C3<C0>.C4>();
+    }
+}
+");
+
+            void verify(MetadataReference reference0, MetadataReference reference1, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void MethodReference_03()
+        {
+            var source0 =
+@"
+public static class C0
+{
+    public static void M1(this string x, int y) { }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public static class C1
+{
+    public static void M1(this string x, string y) { }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        var x = ""a"";
+        x.M1(""b"");
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source2, references: new[] { comp0Ref, comp1Ref }, comp1Ref);
+        }
+
+        [Fact]
+        public void MethodReference_04()
+        {
+            var source0 =
+@"
+public static class C0
+{
+    public static void M1(this string x, string y) { }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public static class C1
+{
+    public static void M1(this string x, string y) { }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        var x = ""a"";
+        x.M1(""b"");
+    }
+}
+";
+
+            Compilation comp2 = CreateCompilation(source2, references: new[] { comp0Ref, comp1Ref });
+            comp2.VerifyDiagnostics(
+                // (7,11): error CS0121: The call is ambiguous between the following methods or properties: 'C0.M1(string, string)' and 'C1.M1(string, string)'
+                //         x.M1("b");
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M1").WithArguments("C0.M1(string, string)", "C1.M1(string, string)").WithLocation(7, 11)
+                );
+
+            var used = comp2.GetUsedAssemblyReferences();
+            foreach (var reference in comp2.References)
+            {
+                Assert.Contains(reference, used);
+            }
+        }
+
+        [Fact]
+        public void FieldDeclaration_01()
+        {
+            var source1 =
+@"
+namespace N1
+{
+    public class C1
+    {
+        public class C11
+        {
+        }
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+
+            var comp1Ref = comp1.ToMetadataReference();
+            verify(comp1Ref,
+@"
+public class C2
+{
+    public static N1.C1.C11 F1 = null;
+}
+");
+            verify(comp1Ref,
+@"
+using N2 = N1;
+public class C2
+{
+    public static N2.C1.C11 F1 = null;
+}
+");
+            verify(comp1Ref,
+@"
+using N1;
+public class C2
+{
+    public static C1.C11 F1 = null;
+}
+");
+            verify(comp1Ref,
+@"
+using static N1.C1;
+public class C2
+{
+    public static C11 F1 = null;
+}
+");
+            verify(comp1Ref,
+@"
+using C111 = N1.C1.C11;
+public class C2
+{
+    public static C111 F1 = null;
+}
+");
+
+            static void verify(MetadataReference reference, string source2)
+            {
+                AssertUsedAssemblyReferences(source2, reference);
+            }
+        }
+
+        [Fact]
+        public void UnusedUsings_01()
+        {
+            var source1 =
+@"
+namespace N1
+{
+    public static class C1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify1(comp1Ref,
+@"
+using N1;
+
+public class C2
+{
+}
+",
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using N1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref,
+@"
+using static N1.C1;
+
+public class C2
+{
+}
+",
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static N1.C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static N1.C1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref,
+@"
+using alias = N1.C1;
+
+public class C2
+{
+}
+",
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using alias = N1.C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using alias = N1.C1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref.WithAliases(new[] { "N1C1" }),
+@"
+extern alias N1C1;
+
+public class C2
+{
+}
+",
+                // (2,1): hidden CS8020: Unused extern alias.
+                // extern alias N1C1;
+                Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias N1C1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref,
+@"namespace N2 {
+using N1;
+
+public class C2
+{
+}
+}",
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using N1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref,
+@"namespace N2 {
+using static N1.C1;
+
+public class C2
+{
+}
+}",
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static N1.C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static N1.C1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref,
+@"namespace N2 {
+using alias = N1.C1;
+
+public class C2
+{
+}
+}",
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using alias = N1.C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using alias = N1.C1;").WithLocation(2, 1)
+                );
+
+            verify1(comp1Ref.WithAliases(new[] { "N1C1" }),
+@"namespace N2 {
+extern alias N1C1;
+
+public class C2
+{
+}
+}",
+                // (2,1): hidden CS8020: Unused extern alias.
+                // extern alias N1C1;
+                Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias N1C1;").WithLocation(2, 1)
+                );
+
+            verify2(comp1Ref,
+@"
+public class C2
+{
+}
+",
+                "N1");
+
+            verify2(comp1Ref,
+@"
+public class C2
+{
+}
+",
+                "N1.C1");
+
+            static void verify1(MetadataReference reference, string source, params DiagnosticDescription[] expected)
+            {
+                Compilation comp = CreateCompilation(source, references: new[] { reference });
+                comp.VerifyDiagnostics(expected);
+
+                Assert.True(comp.References.Count() > 1);
+
+                var used = comp.GetUsedAssemblyReferences();
+
+                Assert.Equal(1, used.Length);
+                Assert.Same(comp.ObjectType.ContainingAssembly, comp.GetAssemblyOrModuleSymbol(used[0]));
+            }
+
+            static void verify2(MetadataReference reference, string source, string @using)
+            {
+                AssertUsedAssemblyReferences(CreateCompilation(Parse(source, options: TestOptions.Script), references: new[] { reference }, options: TestOptions.DebugDll.WithUsings(@using)),
+                                             reference);
+            }
+        }
+
+        [Fact]
+        public void MethodDeclaration_01()
+        {
+            var source1 =
+@"
+namespace N1
+{
+    public class C1
+    {
+        public class C11
+        {
+        }
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+
+            var comp1Ref = comp1.ToMetadataReference();
+            verify(comp1Ref,
+@"
+public class C2
+{
+    public static N1.C1.C11 M1() => null;
+}
+");
+            verify(comp1Ref,
+@"
+using N2 = N1;
+public class C2
+{
+    public static N2.C1.C11 M1() => null;
+}
+");
+            verify(comp1Ref,
+@"
+using N1;
+public class C2
+{
+    public static C1.C11 M1() => null;
+}
+");
+            verify(comp1Ref,
+@"
+using static N1.C1;
+public class C2
+{
+    public static C11 M1() => null;
+}
+");
+            verify(comp1Ref,
+@"
+using C111 = N1.C1.C11;
+public class C2
+{
+    public static C111 M1() => null;
+}
+");
+
+            static void verify(MetadataReference reference, string source2)
+            {
+                AssertUsedAssemblyReferences(source2, reference);
+            }
+        }
+
+        [Fact]
+        public void NoPia_01()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1
+{
+    public static ITest33 F0 = null;
+    public static int F1 = 0;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1.F1;
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp0ImageRef, comp1ImageRef);
+            verify<PEAssemblySymbol>(source2, comp0Ref, comp1ImageRef);
+            verify<RetargetingAssemblySymbol>(source2, comp0Ref, comp1Ref);
+            verify<RetargetingAssemblySymbol>(source2, comp0ImageRef, comp1Ref);
+
+            static void verify<TAssemblySymbol>(string source2, MetadataReference reference0, MetadataReference reference1) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = AssertUsedAssemblyReferences(source2, new[] { reference0, reference1 }, reference1);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference1));
+            }
+        }
+
+        [Fact]
+        public void ArraysAndPointers_01()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+        F1 = 0
+    }
+}
+
+public struct S<T>
+{ }
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1<S<C0>*[]>.E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<S<C0>*[]>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = E1.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<S<C0>*[]>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<S<C0>*[]>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.F1 + 1;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<S<C0>*[]>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.E1.F1 + 1;
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void TypeReference_01()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1<C0>.E1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(E1);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias.E1);
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source)
+            {
+                AssertUsedAssemblyReferences(source, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void TypeReference_02()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+class C2
+{
+    /// <summary>
+    /// <see cref=""C1{C0}.E1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                hasTypeReferensesInUsing: false);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""E1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.E1""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            var source2 =
+@"
+class C2
+{
+    static void Main1()
+    {
+    }
+}
+";
+
+            var references = new[] { comp0Ref, comp1Ref };
+            AssertUsedAssemblyReferences(CreateCompilation(source2, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.None),
+                                                           options: TestOptions.DebugDll.WithUsings("C0")),
+                                         comp0Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source2, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.Parse),
+                                                           options: TestOptions.DebugDll.WithUsings("C0")),
+                                         comp0Ref);
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source, bool hasTypeReferensesInUsing = true)
+            {
+                var references = new[] { reference0, reference1 };
+                Compilation comp2 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None));
+                AssertUsedAssemblyReferences(comp2, hasTypeReferensesInUsing ? references : new MetadataReference[] { });
+
+                var expected = hasTypeReferensesInUsing ? references : new[] { reference1 };
+
+                Compilation comp3 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse));
+                AssertUsedAssemblyReferences(comp3, expected);
+
+                Compilation comp4 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Diagnose));
+                AssertUsedAssemblyReferences(comp4, expected);
+            }
+        }
+
+        [Fact]
+        public void TypeReference_03()
+        {
+            var source0 =
+@"
+public class C0 {}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1<T>
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref,
+@"
+class C2
+{
+    /// <summary>
+    /// <see cref=""M(C1{C0}.E1)""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+
+    void M(int x) {}
+}
+",
+                hasTypeReferensesInUsing: false);
+
+            verify(comp0Ref, comp1Ref,
+@"
+using static C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""M(E1)""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+
+    void M(int x) {}
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>.E1;
+class C2
+{
+    /// <summary>
+    /// <see cref=""M(alias)""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+
+    void M(int x) {}
+}
+");
+
+            verify(comp0Ref, comp1Ref,
+@"
+using alias = C1<C0>;
+class C2
+{
+    /// <summary>
+    /// <see cref=""M(alias.E1)""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+
+    void M(int x) {}
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, string source, bool hasTypeReferensesInUsing = true)
+            {
+                var references = new[] { reference0, reference1 };
+                Compilation comp2 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None));
+                AssertUsedAssemblyReferences(comp2, hasTypeReferensesInUsing ? references : new MetadataReference[] { });
+
+                Compilation comp3 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse));
+                AssertUsedAssemblyReferences(comp3, references);
+            }
+        }
+
+        [Fact]
+        public void NamespaceReference_01()
+        {
+            var source0 =
+@"
+namespace N1.N2
+{
+    public enum E0
+    {
+    }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+namespace N1.N2
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+namespace N1
+{
+    public enum E2
+    {
+    }
+}
+";
+            var comp2 = CreateCompilation(source2);
+            comp2.VerifyDiagnostics();
+            var comp2Ref = comp2.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(N1.N2);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1.N2;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias);
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(alias.N2);
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, MetadataReference reference2, string source)
+            {
+                AssertUsedAssemblyReferences(source, new[] { reference0, reference1, reference2 }, reference0, reference1);
+            }
+        }
+
+        [Fact]
+        public void NamespaceReference_02()
+        {
+            var source0 =
+@"
+namespace N1.N2
+{
+    public enum E0
+    {
+        F0
+    }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+namespace N1.N2
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+namespace N1
+{
+    public enum E2
+    {
+    }
+}
+";
+            var comp2 = CreateCompilation(source2);
+            comp2.VerifyDiagnostics();
+            var comp2Ref = comp2.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = N1.N2.E0.F0;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1.N2.E0;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.F0;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using static N1.N2.E0;
+public class C2
+{
+    public static void Main()
+    {
+        _ = F0;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1.N2;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.E0.F0;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using N1.N2;
+public class C2
+{
+    public static void Main()
+    {
+        _ = E0.F0;
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1;
+public class C2
+{
+    public static void Main()
+    {
+        _ = alias.N2.E0.F0;
+    }
+}
+");
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, MetadataReference reference2, string source)
+            {
+                AssertUsedAssemblyReferences(source, new[] { reference0, reference1, reference2 }, reference0);
+            }
+        }
+
+        [Fact]
+        public void NamespaceReference_03()
+        {
+            var source0 =
+@"
+namespace N1.N2
+{
+    public enum E0
+    {
+    }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+namespace N1.N2
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+namespace N1
+{
+    public enum E2
+    {
+    }
+}
+";
+            var comp2 = CreateCompilation(source2);
+            comp2.VerifyDiagnostics();
+            var comp2Ref = comp2.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+class C2
+{
+    /// <summary>
+    /// <see cref=""N1.N2""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1.N2;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                namespaceOrdinalReferencedInUsings: 2
+                );
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.N2""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                namespaceOrdinalReferencedInUsings: 1
+                );
+
+            var source3 =
+@"
+using N1.N2;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            var references = new[] { comp0Ref, comp1Ref, comp2Ref };
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)),
+                                         comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse)),
+                                         new MetadataReference[] { },
+                                         new[] {
+                                             // (2,1): hidden CS8019: Unnecessary using directive.
+                                             // using N1.N2;
+                                             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N1.N2;").WithLocation(2, 1)
+                                         },
+                                         new[] {
+                                             // (2,1): hidden CS8019: Unnecessary using directive.
+                                             // using N1.N2;
+                                             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N1.N2;").WithLocation(2, 1),
+                                             // (2,7): error CS0246: The type or namespace name 'N1' could not be found (are you missing a using directive or an assembly reference?)
+                                             // using N1.N2;
+                                             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "N1").WithArguments("N1").WithLocation(2, 7)
+                                         });
+
+            var source4 =
+@"
+using N1;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(CreateCompilation(source4, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)),
+                                         references);
+            AssertUsedAssemblyReferences(CreateCompilation(source4, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse)),
+                                         new MetadataReference[] { },
+                                         new[] {
+                                             // (2,1): hidden CS8019: Unnecessary using directive.
+                                             // using N1;
+                                             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N1;").WithLocation(2, 1)
+                                         },
+                                         new[] {
+                                             // (2,1): hidden CS8019: Unnecessary using directive.
+                                             // using N1;
+                                             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using N1;").WithLocation(2, 1),
+                                             // (2,7): error CS0246: The type or namespace name 'N1' could not be found (are you missing a
+                                             // using N1;
+                                             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "N1").WithArguments("N1").WithLocation(2, 7)
+                                         });
+
+            var source5 =
+@"
+class C2
+{
+    static void Main1()
+    {
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(CreateCompilation(source5, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.None),
+                                                           options: TestOptions.DebugDll.WithUsings("N1.N2")),
+                                         comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source5, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.Parse),
+                                                           options: TestOptions.DebugDll.WithUsings("N1.N2")),
+                                         comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source5, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.None),
+                                                           options: TestOptions.DebugDll.WithUsings("N1")),
+                                         references);
+            AssertUsedAssemblyReferences(CreateCompilation(source5, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.Parse),
+                                                           options: TestOptions.DebugDll.WithUsings("N1")),
+                                         references);
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, MetadataReference reference2, string source, int namespaceOrdinalReferencedInUsings = 0)
+            {
+                var references = new[] { reference0, reference1, reference2 };
+                var expected = new[] { reference0, reference1 };
+                Compilation comp2 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None));
+                AssertUsedAssemblyReferences(comp2, namespaceOrdinalReferencedInUsings switch { 1 => references, 2 => expected, _ => new MetadataReference[] { } });
+
+                Compilation comp3 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse));
+                AssertUsedAssemblyReferences(comp3, expected);
+
+                Compilation comp4 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Diagnose));
+                AssertUsedAssemblyReferences(comp4, expected);
+            }
+        }
+
+        [Fact]
+        public void NamespaceReference_04()
+        {
+            var source0 =
+@"
+namespace N1.N2
+{
+    public enum E0
+    {
+        F0
+    }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+namespace N1.N2
+{
+    public enum E1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+namespace N1
+{
+    public enum E2
+    {
+    }
+}
+";
+            var comp2 = CreateCompilation(source2);
+            comp2.VerifyDiagnostics();
+            var comp2Ref = comp2.ToMetadataReference();
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+class C2
+{
+    /// <summary>
+    /// <see cref=""N1.N2.E0""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+");
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1.N2;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.E0""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                namespaceOrdinalReferencedInUsings: 2
+                );
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1.N2.E0;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                namespaceOrdinalReferencedInUsings: 3
+                );
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using static N1.N2.E0;
+class C2
+{
+    /// <summary>
+    /// <see cref=""F0""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                namespaceOrdinalReferencedInUsings: 3
+                );
+
+            verify(comp0Ref, comp1Ref, comp2Ref,
+@"
+using alias = N1;
+class C2
+{
+    /// <summary>
+    /// <see cref=""alias.N2.E0""/>
+    /// </summary>
+    static void Main()
+    {
+    }
+}
+",
+                namespaceOrdinalReferencedInUsings: 1
+                );
+
+            var source3 =
+@"
+using static N1.N2.E0;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            var references = new[] { comp0Ref, comp1Ref, comp2Ref };
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)),
+                                         comp0Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse)),
+                                         new MetadataReference[] { },
+                                         new[] {
+                                             // (2,1): hidden CS8019: Unnecessary using directive.
+                                             // using static N1.N2.E0;
+                                             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static N1.N2.E0;").WithLocation(2, 1)
+                                         },
+                                         new[] {
+                                             // (2,1): hidden CS8019: Unnecessary using directive.
+                                             // using static N1.N2.E0;
+                                             Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static N1.N2.E0;").WithLocation(2, 1),
+                                             // (2,14): error CS0246: The type or namespace name 'N1' could not be found (are you missing a using directive or an assembly reference?)
+                                             // using static N1.N2.E0;
+                                             Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "N1").WithArguments("N1").WithLocation(2, 14)
+                                         });
+
+            var source5 =
+@"
+class C2
+{
+    static void Main1()
+    {
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(CreateCompilation(source5, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.None),
+                                                           options: TestOptions.DebugDll.WithUsings("N1.N2.E0")),
+                                         comp0Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source5, references: references,
+                                                           parseOptions: TestOptions.Script.WithDocumentationMode(DocumentationMode.Parse),
+                                                           options: TestOptions.DebugDll.WithUsings("N1.N2.E0")),
+                                         comp0Ref);
+
+            static void verify(MetadataReference reference0, MetadataReference reference1, MetadataReference reference2, string source, int namespaceOrdinalReferencedInUsings = 0)
+            {
+                var references = new[] { reference0, reference1, reference2 };
+                Compilation comp2 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None));
+                AssertUsedAssemblyReferences(comp2, namespaceOrdinalReferencedInUsings switch { 1 => references, 2 => new[] { reference0, reference1 }, 3 => new[] { reference0 }, _ => new MetadataReference[] { } });
+
+                Compilation comp3 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse));
+                AssertUsedAssemblyReferences(comp3, reference0);
+
+                Compilation comp4 = CreateCompilation(source, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Diagnose));
+                AssertUsedAssemblyReferences(comp4, reference0);
+            }
+        }
+
+        [Fact]
+        public void NamespaceReference_05()
+        {
+            var source1 =
+@"
+using global;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            CreateCompilation(source1, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)).VerifyDiagnostics(
+                // (2,7): error CS0246: The type or namespace name 'global' could not be found (are you missing a using directive or an assembly reference?)
+                // using global;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "global").WithArguments("global").WithLocation(2, 7)
+                );
+
+            var source2 =
+@"
+using alias = global;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            CreateCompilation(source2, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)).VerifyDiagnostics(
+                // (2,15): error CS0246: The type or namespace name 'global' could not be found (are you missing a using directive or an assembly reference?)
+                // using alias = global;
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "global").WithArguments("global").WithLocation(2, 15)
+                );
+        }
+
+        [Fact]
+        public void NamespaceReference_06()
+        {
+            var source1 =
+@"
+using global::;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            CreateCompilation(source1, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)).VerifyDiagnostics(
+                // (2,15): error CS1001: Identifier expected
+                // using global::;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(2, 15)
+                );
+
+            var source2 =
+@"
+using alias = global::;
+class C2
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            CreateCompilation(source2, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)).VerifyDiagnostics(
+                // (2,23): error CS1001: Identifier expected
+                // using alias = global::;
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(2, 23)
+                );
+        }
+
+        [Fact]
+        public void ExternAlias_01()
+        {
+            var source1 =
+@"
+namespace N1
+{
+    public static class C1
+    {
+    }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            var comp1Ref = comp1.ToMetadataReference().WithAliases(new[] { "N1C1" });
+
+            var source2 =
+@"
+namespace N1
+{
+    public static class C2
+    {
+    }
+}
+";
+            var comp2 = CreateCompilation(source2);
+            var comp2Ref = comp2.ToMetadataReference();
+
+            var source3 =
+@"
+extern alias N1C1;
+
+public class C2
+{
+}
+";
+            var references = new[] { comp1Ref, comp2Ref };
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)),
+                                         comp1Ref);
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse)),
+                                         new MetadataReference[] { },
+                                         new[] {
+                                             // (2,1): hidden CS8020: Unused extern alias.
+                                             // extern alias N1C1;
+                                             Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias N1C1;").WithLocation(2, 1)
+                                         },
+                                         new[] {
+                                             // (2,1): hidden CS8020: Unused extern alias.
+                                             // extern alias N1C1;
+                                             Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias N1C1;").WithLocation(2, 1),
+                                             // (2,14): error CS0430: The extern alias 'N1C1' was not specified in a /reference option
+                                             // extern alias N1C1;
+                                             Diagnostic(ErrorCode.ERR_BadExternAlias, "N1C1").WithArguments("N1C1").WithLocation(2, 14)
+                                         });
+
+            comp2Ref = comp2.ToMetadataReference().WithAliases(new[] { "N1C1" });
+            references = new[] { comp1Ref, comp2Ref };
+
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.None)),
+                                         references);
+            AssertUsedAssemblyReferences(CreateCompilation(source3, references: references, parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Parse)),
+                                         new MetadataReference[] { },
+                                         new[] {
+                                             // (2,1): hidden CS8020: Unused extern alias.
+                                             // extern alias N1C1;
+                                             Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias N1C1;").WithLocation(2, 1)
+                                         },
+                                         new[] {
+                                             // (2,1): hidden CS8020: Unused extern alias.
+                                             // extern alias N1C1;
+                                             Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias N1C1;").WithLocation(2, 1),
+                                             // (2,14): error CS0430: The extern alias 'N1C1' was not specified in a /reference option
+                                             // extern alias N1C1;
+                                             Diagnostic(ErrorCode.ERR_BadExternAlias, "N1C1").WithArguments("N1C1").WithLocation(2, 14)
+                                         });
+        }
+
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class UsedAssembliesTests : CSharpTestBase
     {
-
         [Fact]
         public void NoReferences_01()
         {

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1398,12 +1398,11 @@ namespace Microsoft.CodeAnalysis
         internal abstract void GetDiagnostics(CompilationStage stage, bool includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Unique metadata assembly references that are considered as used by this compilation.
+        /// Unique metadata assembly references that are considered to be used by this compilation.
         /// For example, if a type declared in a referenced assembly is referenced in source code 
         /// within this compilation, the reference is considered to be used. Etc.
         /// The returned set is a subset of references returned by <see cref="References"/> API.
-        /// If compilation contains errors, it is valid to consider all assembly references as used for the purpose
-        /// of this API. The actual behavior in this case could be implementation dependent.
+        /// The result is undefined if the compilation contains errors.
         /// </summary>
         internal abstract ImmutableArray<MetadataReference> GetUsedAssemblyReferences(CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1397,6 +1397,16 @@ namespace Microsoft.CodeAnalysis
 
         internal abstract void GetDiagnostics(CompilationStage stage, bool includeEarlierStages, DiagnosticBag diagnostics, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Unique metadata assembly references that are considered as used by this compilation.
+        /// For example, if a type declared in a referenced assembly is referenced in source code 
+        /// within this compilation, the reference is considered to be used. Etc.
+        /// The returned set is a subset of references returned by <see cref="References"/> API.
+        /// If compilation contains errors, it is valid to consider all assembly references as used for the purpose
+        /// of this API. The actual behavior in this case could be implementation dependent.
+        /// </summary>
+        internal abstract ImmutableArray<MetadataReference> GetUsedAssemblyReferences(CancellationToken cancellationToken = default(CancellationToken));
+
         internal void EnsureCompilationEventQueueCompleted()
         {
             Debug.Assert(EventQueue != null);
@@ -2141,6 +2151,11 @@ namespace Microsoft.CodeAnalysis
             SyntaxTree filterTree,
             DiagnosticBag diagnostics,
             CancellationToken cancellationToken);
+
+        internal static bool ReportUnusedImportsInTree(SyntaxTree tree)
+        {
+            return tree.Options.DocumentationMode != DocumentationMode.None;
+        }
 
         /// <summary>
         /// Signals the event queue, if any, that we are done compiling.

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1583,14 +1583,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Friend Overrides Sub ReportUnusedImports(filterTree As SyntaxTree, diagnostics As DiagnosticBag, cancellationToken As CancellationToken)
-            If _lazyImportInfos IsNot Nothing AndAlso (filterTree Is Nothing OrElse filterTree.Options.DocumentationMode <> DocumentationMode.None) Then
+            If _lazyImportInfos IsNot Nothing AndAlso (filterTree Is Nothing OrElse ReportUnusedImportsInTree(filterTree)) Then
                 Dim unusedBuilder As ArrayBuilder(Of TextSpan) = Nothing
 
                 For Each info As ImportInfo In _lazyImportInfos
                     cancellationToken.ThrowIfCancellationRequested()
 
                     Dim infoTree As SyntaxTree = info.Tree
-                    If (filterTree Is Nothing OrElse filterTree Is infoTree) AndAlso infoTree.Options.DocumentationMode <> DocumentationMode.None Then
+                    If (filterTree Is Nothing OrElse filterTree Is infoTree) AndAlso ReportUnusedImportsInTree(infoTree) Then
                         Dim clauseSpans = info.ClauseSpans
                         Dim numClauseSpans = clauseSpans.Length
 
@@ -1921,6 +1921,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return VisualBasic.MessageProvider.Instance
             End Get
         End Property
+
+        Friend Overrides Function GetUsedAssemblyReferences(Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of MetadataReference)
+            Throw New System.NotImplementedException()
+        End Function
 
         ''' <summary>
         ''' Get all diagnostics for the entire compilation. This includes diagnostics from parsing, declarations, and

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1923,6 +1923,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Friend Overrides Function GetUsedAssemblyReferences(Optional cancellationToken As CancellationToken = Nothing) As ImmutableArray(Of MetadataReference)
+            ' PROTOTYPE(UsedAssemblyReferences): Add implementation
             Throw New System.NotImplementedException()
         End Function
 


### PR DESCRIPTION
This is a beginning of work on #37768.

Detect used assembly references from:
- explicit references to types in source;
- explicit references to namespaces in source;
- explicit references to fields in source;
- explicit method invocations in source;

Usings flagged by the compiler as unused shouldn’t contribute to the set of used references.