### PR TITLE
Follow-up to "Local function attributes emit"

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedClosureMethod.cs
@@ -160,6 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => ImmutableArray<TypeSymbol>.CastUp(_structEnvironments);
         internal int ExtraSynthesizedParameterCount => this._structEnvironments.IsDefault ? 0 : this._structEnvironments.Length;
 
+        internal override bool InheritsBaseMethodAttributes => BaseMethod is LocalFunctionSymbol;
         internal override bool GenerateDebugInfo => !this.IsAsync;
         internal override bool IsExpressionBodied => false;
         internal MethodSymbol TopLevelMethod => _topLevelMethod;

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             int ordinal = 0;
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance();
             var parameters = this.BaseMethodParameters;
-            var inheritAttributes = this.BaseMethod.SynthesizedMethodsInheritAttributes;
+            var inheritAttributes = InheritsBaseMethodAttributes;
             foreach (var p in parameters)
             {
                 builder.Add(SynthesizedParameterSymbol.Create(
@@ -137,10 +137,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return builder.ToImmutableAndFree();
         }
 
+        /// <summary>
+        /// Indicates that this method inherits attributes from the base method, its parameters, return type, and type parameters.
+        /// </summary>
+        internal virtual bool InheritsBaseMethodAttributes => false;
+
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             Debug.Assert(base.GetAttributes().IsEmpty);
-            return BaseMethod.SynthesizedMethodsInheritAttributes
+            return InheritsBaseMethodAttributes
                 ? BaseMethod.GetAttributes()
                 : ImmutableArray<CSharpAttributeData>.Empty;
         }
@@ -148,7 +153,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override ImmutableArray<CSharpAttributeData> GetReturnTypeAttributes()
         {
             Debug.Assert(base.GetReturnTypeAttributes().IsEmpty);
-            return BaseMethod.SynthesizedMethodsInheritAttributes ? BaseMethod.GetReturnTypeAttributes() : ImmutableArray<CSharpAttributeData>.Empty;
+            return InheritsBaseMethodAttributes ? BaseMethod.GetReturnTypeAttributes() : ImmutableArray<CSharpAttributeData>.Empty;
         }
 
         public sealed override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal virtual bool InheritsBaseMethodAttributes => false;
 
-        public override ImmutableArray<CSharpAttributeData> GetAttributes()
+        public sealed override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
             Debug.Assert(base.GetAttributes().IsEmpty);
             return InheritsBaseMethodAttributes
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 : ImmutableArray<CSharpAttributeData>.Empty;
         }
 
-        public override ImmutableArray<CSharpAttributeData> GetReturnTypeAttributes()
+        public sealed override ImmutableArray<CSharpAttributeData> GetReturnTypeAttributes()
         {
             Debug.Assert(base.GetReturnTypeAttributes().IsEmpty);
             return InheritsBaseMethodAttributes ? BaseMethod.GetReturnTypeAttributes() : ImmutableArray<CSharpAttributeData>.Empty;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7154,7 +7154,7 @@ done:;
                 case SyntaxKind.ProtectedKeyword:
                 case SyntaxKind.PrivateKeyword:
                 // could be a local function with attributes
-                case SyntaxKind.OpenBracketToken:  // PROTOTYPE reuse this or always allow the OpenBracketToken?
+                case SyntaxKind.OpenBracketToken:  // PROTOTYPE(local-function-attributes): reuse this or always allow the OpenBracketToken?
                     return acceptAccessibilityMods;
                 default:
                     return IsPredefinedType(tk)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -330,11 +330,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected bool IsValidReadOnlyTarget => !IsStatic && ContainingType.IsStructType() && MethodKind != MethodKind.Constructor;
 
         /// <summary>
-        /// Indicates whether synthesized methods derived from this method should inherit the attributes of this method, its parameters, return type, and type parameters.
-        /// </summary>
-        internal virtual bool SynthesizedMethodsInheritAttributes => false;
-
-        /// <summary>
         /// Returns interface methods explicitly implemented by this method.
         /// </summary>
         /// <remarks>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -383,8 +383,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsDeclaredReadOnly => false;
 
-        internal override bool SynthesizedMethodsInheritAttributes => true;
-
         IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner => this;
 
         AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations => AttributeLocation.Method | AttributeLocation.Return;

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -92,16 +92,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public sealed override ImmutableArray<CSharpAttributeData> GetAttributes()
-        {
-            if (_container is SynthesizedMethodBaseSymbol { InheritsBaseMethodAttributes: true })
-            {
-                return _underlyingTypeParameter.GetAttributes();
-            }
-
-            return ImmutableArray<CSharpAttributeData>.Empty;
-        }
-
         internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress)
         {
             var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedTypeParameterSymbol.cs
@@ -92,9 +92,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ImmutableArray<CSharpAttributeData> GetAttributes()
+        public sealed override ImmutableArray<CSharpAttributeData> GetAttributes()
         {
-            return _underlyingTypeParameter.GetAttributes();
+            if (_container is SynthesizedMethodBaseSymbol { InheritsBaseMethodAttributes: true })
+            {
+                return _underlyingTypeParameter.GetAttributes();
+            }
+
+            return ImmutableArray<CSharpAttributeData>.Empty;
         }
 
         internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedSubstitutedTypeParameterSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -28,6 +29,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeIsUnmanagedAttribute(this));
             }
+        }
+
+        public override ImmutableArray<CSharpAttributeData> GetAttributes()
+        {
+            if (ContainingSymbol is SynthesizedMethodBaseSymbol { InheritsBaseMethodAttributes: true })
+            {
+                return _underlyingTypeParameter.GetAttributes();
+            }
+
+            return ImmutableArray<CSharpAttributeData>.Empty;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
@@ -146,5 +146,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _underlyingTypeParameter.EnsureAllConstraintsAreResolved();
         }
+
+        public override ImmutableArray<CSharpAttributeData> GetAttributes()
+        {
+            return _underlyingTypeParameter.GetAttributes();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -637,6 +637,26 @@ class B : A
                 Assert.Empty(typeParameter.GetAttributes());
             });
         }
+
+        [Fact]
+        public void SubstitutedTypeParameter_Attributes()
+        {
+            string source = @"
+class Attr : System.Attribute { }
+
+internal class C1<T1>
+{
+    internal class C2<[Attr] T2> { }
+}
+";
+            var comp = CreateCompilation(source);
+            var c1OfInt = comp.GetTypeByMetadataName("C1`1").Construct(comp.GetSpecialType(SpecialType.System_Int32));
+
+            var c2 = c1OfInt.GetTypeMember("C2");
+            var typeParam = c2.TypeParameters.Single();
+            Assert.Equal(new[] { "Attr" }, GetAttributeNames(typeParam.GetAttributes()));
+        }
+
         #endregion
 
         #region CompilationRelaxationsAttribute, RuntimeCompatibilityAttribute, DebuggableAttribute

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -3117,7 +3117,7 @@ class C
 }", sequencePoints: "C+<M>d__0.MoveNext", source: source);
         }
 
-        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop, AlwaysSkip = "PROTOTYPE")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.NativePdbRequiresDesktop, AlwaysSkip = "PROTOTYPE(local-function-attributes)")]
         public void AsyncIteratorWithAwaitCompletedAndYield_WithEnumeratorCancellation_LocalFunction()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncIteratorTests.cs
@@ -3142,7 +3142,7 @@ class C
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp);
 
-            // PROTOTYPE: EnumeratorCancellation attribute should produce a combinedTokens field and modify codegen
+            // PROTOTYPE(local-function-attributes): EnumeratorCancellation attribute should produce a combinedTokens field and modify codegen
             var expectedFields = new[] {
                 "FieldDefinition:Int32 <>1__state",
                 "FieldDefinition:System.Runtime.CompilerServices.AsyncIteratorMethodBuilder <>t__builder",

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -5355,7 +5355,7 @@ class C
                 var attrs1 = localFn1.GetAttributes();
                 Assert.Equal("CompilerGeneratedAttribute", attrs1.Single().AttributeClass.Name);
 
-                // PROTOTYPE: consider preventing the lowered local function from containing DynamicAttribute
+                // PROTOTYPE(local-function-attributes): consider preventing the lowered local function from containing DynamicAttribute
                 Assert.Equal("DynamicAttribute", localFn1.GetReturnTypeAttributes().Single().AttributeClass.Name);
 
                 var param = localFn1.Parameters.Single();
@@ -5363,7 +5363,7 @@ class C
             }
         }
 
-        [Fact(Skip = "PROTOTYPE")]
+        [Fact(Skip = "PROTOTYPE(local-function-attributes)")]
         public void LocalFunctionConditionalAttribute()
         {
             var source = @"
@@ -5391,7 +5391,7 @@ class C
                 symbolValidator: validate,
                 expectedOutput: "hello");
 
-            // PROTOTYPE: local functions with conditional attribute should not run in release mode
+            // PROTOTYPE(local-function-attributes): local functions with conditional attribute should not run in release mode
             CompileAndVerify(
                 source,
                 options: TestOptions.ReleaseExe.WithMetadataImportOptions(MetadataImportOptions.All),

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Synthesized.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Synthesized.vb
@@ -279,7 +279,7 @@ End Class
                                                                                {"CompilerGeneratedAttribute", "CompilerGeneratedAttribute", "DebuggerHiddenAttribute"})
 
                                                         AssertEx.SetEqual(expectedNames, GetAttributeNames(baseWrapper.GetAttributes()))
-                                                        AssertEx.SetEqual({}, GetAttributeNames(baseWrapper.GetReturnTypeAttributes()))
+                                                        Assert.Empty(baseWrapper.GetReturnTypeAttributes())
                                                     End Sub)
         End Sub
 
@@ -335,9 +335,9 @@ End Class
                                                                                {"CompilerGeneratedAttribute", "CompilerGeneratedAttribute", "DebuggerHiddenAttribute"})
 
                                                         AssertEx.SetEqual(expectedNames, GetAttributeNames(baseWrapper.GetAttributes()))
-                                                        AssertEx.SetEqual({}, GetAttributeNames(baseWrapper.GetReturnTypeAttributes()))
-                                                        AssertEx.SetEqual({}, GetAttributeNames(baseWrapper.Parameters.Single().GetAttributes()))
-                                                        AssertEx.SetEqual({}, GetAttributeNames(baseWrapper.TypeParameters.Single().GetAttributes()))
+                                                        Assert.Empty(baseWrapper.GetReturnTypeAttributes())
+                                                        Assert.Empty(baseWrapper.Parameters.Single().GetAttributes())
+                                                        Assert.Empty(baseWrapper.TypeParameters.Single().GetAttributes())
                                                     End Sub)
         End Sub
 


### PR DESCRIPTION
Follow up to #39226

I merged before all of @AlekseyTs's comments were addressed. This PR is meant to address those comments.

I think emitting local function type parameters is actually working at least in some scenarios:
https://github.com/dotnet/roslyn/blob/6af59607ed36afae9a2969b2063d3f20d68d9fb0/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs#L5212

I'll take another look over the tests and try to remember where I thought the gap was. (Edit: it was that all synthesized methods were inheriting type parameter attributes from their base method. This PR corrects that so the type parameter attributes are only inherited when expected.)