### PR TITLE
EnC: Fix document out-of-sync checks when module is not loaded when d…

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -147,19 +147,33 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         private void LoadLibraryToDebuggee(DebuggeeModuleInfo debuggeeModuleInfo)
             => _mockDebugeeModuleMetadataProvider.TryGetBaselineModuleInfo = mvid => debuggeeModuleInfo;
 
-        private (DebuggeeModuleInfo, Guid) EmitLibrary(string source, ProjectId projectId, string assemblyName = "", string sourceFilePath = "test1.cs")
+        private (DebuggeeModuleInfo, Guid) EmitLibrary(string source, ProjectId projectId, string assemblyName = "", string sourceFilePath = "test1.cs", DebugInformationFormat pdbFormat = DebugInformationFormat.PortablePdb)
         {
             var sourceText = SourceText.From(new MemoryStream(Encoding.UTF8.GetBytes(source)), encoding: Encoding.UTF8, checksumAlgorithm: SourceHashAlgorithm.Sha256);
             var tree = SyntaxFactory.ParseSyntaxTree(sourceText, TestOptions.RegularPreview, sourceFilePath);
             var compilation = CSharpTestBase.CreateCompilationWithMscorlib40(tree, options: TestOptions.DebugDll, assemblyName: assemblyName);
-            var (peImage, symReader) = SymReaderTestHelpers.EmitAndOpenDummySymReader(compilation, DebugInformationFormat.PortablePdb);
+
+            var (peImage, pdbImage) = compilation.EmitToArrays(new EmitOptions(debugInformationFormat: pdbFormat));
+            var symReader = SymReaderTestHelpers.OpenDummySymReader(pdbImage);
 
             var moduleMetadata = ModuleMetadata.CreateFromImage(peImage);
             var moduleId = moduleMetadata.GetModuleVersionId();
             var debuggeeModuleInfo = new DebuggeeModuleInfo(moduleMetadata, symReader);
 
             // associate the binaries with the project
-            _mockCompilationOutputsService.Outputs.Add(projectId, new MockCompilationOutputs(moduleId));
+            _mockCompilationOutputsService.Outputs.Add(projectId, new MockCompilationOutputs(moduleId)
+            {
+                OpenPdbStreamImpl = () =>
+                {
+                    var pdbStream = new MemoryStream();
+                    pdbImage.WriteToStream(pdbStream);
+                    pdbStream.Position = 0;
+                    return pdbStream;
+                }
+            });
+
+            // library not loaded yet:
+            _mockDebugeeModuleMetadataProvider.TryGetBaselineModuleInfo = mvid => null;
 
             return (debuggeeModuleInfo, moduleId);
         }
@@ -583,15 +597,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             Assert.Empty(deltas);
         }
 
-        [Fact]
-        public async Task BreakMode_DesignTimeOnlyDocument_Wpf()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task BreakMode_DesignTimeOnlyDocument_Wpf(bool delayLoad)
         {
             var sourceA = "class A { public void M() { } }";
             var sourceB = "class B { public void M() { } }";
             var sourceC = "class C { public void M() { } }";
 
             var dir = Temp.CreateDirectory();
-            var sourceFile = dir.CreateFile("a.cs").WriteAllText(sourceA);
+            var sourceFileA = dir.CreateFile("a.cs").WriteAllText(sourceA);
 
             using var workspace = new TestWorkspace();
 
@@ -599,7 +615,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             var documentA = workspace.CurrentSolution.
                 AddProject("test", "test", LanguageNames.CSharp).
                 AddMetadataReferences(TargetFrameworkUtil.GetReferences(TargetFramework.Mscorlib40)).
-                AddDocument("a.cs", SourceText.From(sourceA, Encoding.UTF8), filePath: sourceFile.Path);
+                AddDocument("a.cs", SourceText.From(sourceA, Encoding.UTF8), filePath: sourceFileA.Path);
 
             var documentB = documentA.Project.
                 AddDocument("b.g.i.cs", SourceText.From(sourceB, Encoding.UTF8), filePath: "b.g.i.cs");
@@ -610,7 +626,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             workspace.ChangeSolution(documentC.Project.Solution);
 
             // only compile A; B and C are design-time-only:
-            var (_, moduleId) = EmitAndLoadLibraryToDebuggee(sourceA, documentA.Project.Id, sourceFilePath: sourceFile.Path);
+            var (moduleInfo, moduleId) = EmitLibrary(sourceA, documentA.Project.Id, sourceFilePath: sourceFileA.Path);
+
+            if (!delayLoad)
+            {
+                LoadLibraryToDebuggee(moduleInfo);
+            }
 
             var service = CreateEditAndContinueService(workspace);
 
@@ -635,6 +656,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             var (solutionStatusEmit, deltas) = await service.EmitSolutionUpdateAsync(CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(SolutionUpdateStatus.None, solutionStatusEmit);
             Assert.Empty(_emitDiagnosticsUpdated);
+
+            if (delayLoad)
+            {
+                LoadLibraryToDebuggee(moduleInfo);
+
+                // validate solution update status and emit:
+                solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+                Assert.Equal(SolutionUpdateStatus.None, solutionStatus);
+
+                (solutionStatusEmit, deltas) = await service.EmitSolutionUpdateAsync(CancellationToken.None).ConfigureAwait(false);
+                Assert.Equal(SolutionUpdateStatus.None, solutionStatusEmit);
+                Assert.Empty(_emitDiagnosticsUpdated);
+            }
 
             service.EndEditSession();
             service.EndDebuggingSession();
@@ -1483,8 +1517,10 @@ class C1
             service.EndDebuggingSession();
         }
 
-        [Fact]
-        public async Task BreakMode_ValidSignificantChange_DocumentOutOfSync2()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task BreakMode_ValidSignificantChange_DocumentOutOfSync(bool delayLoad)
         {
             var sourceOnDisk = "class C1 { void M() { System.Console.WriteLine(1); } }";
 
@@ -1502,11 +1538,16 @@ class C1
             var project = document1.Project;
             workspace.ChangeSolution(project.Solution);
 
-            var (_, moduleId) = EmitAndLoadLibraryToDebuggee(sourceOnDisk, project.Id, sourceFilePath: sourceFile.Path);
+            var (moduleInfo, moduleId) = EmitLibrary(sourceOnDisk, project.Id, sourceFilePath: sourceFile.Path);
+
+            if (!delayLoad)
+            {
+                LoadLibraryToDebuggee(moduleInfo);
+            }
 
             var service = CreateEditAndContinueService(workspace);
 
-            var debuggingSession = StartDebuggingSession(service, initialState: CommittedSolution.DocumentState.None);
+            StartDebuggingSession(service, initialState: CommittedSolution.DocumentState.None);
 
             service.StartEditSession();
             VerifyReanalyzeInvocation(workspace, null, ImmutableArray<DocumentId>.Empty, false);
@@ -1528,15 +1569,15 @@ class C1
             workspace.ChangeDocument(document1.Id, SourceText.From(sourceOnDisk, Encoding.UTF8));
             var document3 = workspace.CurrentSolution.Projects.Single().Documents.Single();
 
-            var diagnostics2 = await service.GetDocumentDiagnosticsAsync(document3, CancellationToken.None).ConfigureAwait(false);
-            Assert.Empty(diagnostics2);
+            var diagnostics = await service.GetDocumentDiagnosticsAsync(document3, CancellationToken.None).ConfigureAwait(false);
+            Assert.Empty(diagnostics);
 
             // the content of the file is now exactly the same as the compiled document, so there is no change to be applied:
-            var solutionStatus2 = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(SolutionUpdateStatus.None, solutionStatus2);
+            solutionStatus = await service.GetSolutionUpdateStatusAsync(sourceFilePath: null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatus);
 
-            var (solutionStatusEmit2, deltas2) = await service.EmitSolutionUpdateAsync(CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal(SolutionUpdateStatus.None, solutionStatusEmit2);
+            (solutionStatusEmit, _) = await service.EmitSolutionUpdateAsync(CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(SolutionUpdateStatus.None, solutionStatusEmit);
 
             service.EndEditSession();
 
@@ -1815,7 +1856,8 @@ class C1
             var compilationA = CSharpTestBase.CreateCompilationWithMscorlib40(source1, options: TestOptions.DebugDll, assemblyName: "A");
             var compilationB = CSharpTestBase.CreateCompilationWithMscorlib45(source1, options: TestOptions.DebugDll, assemblyName: "B");
 
-            var (peImageA, symReaderA) = SymReaderTestHelpers.EmitAndOpenDummySymReader(compilationA, DebugInformationFormat.PortablePdb);
+            var (peImageA, pdbImageA) = compilationA.EmitToArrays(new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb));
+            var symReaderA = SymReaderTestHelpers.OpenDummySymReader(pdbImageA);
 
             var moduleMetadataA = ModuleMetadata.CreateFromImage(peImageA);
             var moduleFileA = Temp.CreateFile("A.dll").WriteAllBytes(peImageA);

--- a/src/EditorFeatures/Test/EditAndContinue/Helpers/SymReaderTestHelpers.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/Helpers/SymReaderTestHelpers.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -30,32 +31,32 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 => throw new NotImplementedException();
         }
 
-        public static (ImmutableArray<byte> PEImage, ISymUnmanagedReader5 SymReader) EmitAndOpenDummySymReader(Compilation compilation, DebugInformationFormat pdbFormat)
+        public static (ImmutableArray<byte> PEImage, ImmutableArray<byte> PdbImage) EmitToArrays(this Compilation compilation, EmitOptions options)
+        {
+            var pdbStream = new MemoryStream();
+            var peImage = compilation.EmitToArray(options, pdbStream: pdbStream);
+            return (peImage, pdbStream.ToImmutable());
+        }
+
+        public static ISymUnmanagedReader5 OpenDummySymReader(ImmutableArray<byte> pdbImage)
         {
             var symBinder = new SymBinder();
             var metadataImportProvider = new DummyMetadataImportProvider();
 
             var pdbStream = new MemoryStream();
-            var peImage = compilation.EmitToArray(new EmitOptions(debugInformationFormat: pdbFormat), pdbStream: pdbStream);
-            pdbStream.Position = 0;
+            pdbImage.WriteToStream(pdbStream);
 
             var pdbStreamCom = SymUnmanagedStreamFactory.CreateStream(pdbStream);
-
-            ISymUnmanagedReader5 symReader5;
-            if (pdbFormat == DebugInformationFormat.PortablePdb)
+            if (pdbImage.Length > 4 && pdbImage[0] == 'B' && pdbImage[1] == 'S' && pdbImage[2] == 'J' && pdbImage[3] == 'B')
             {
                 int hr = symBinder.GetReaderFromPdbStream(metadataImportProvider, pdbStreamCom, out var symReader);
                 Assert.Equal(0, hr);
-                symReader5 = (ISymUnmanagedReader5)symReader;
+                return (ISymUnmanagedReader5)symReader;
             }
             else
             {
-                symReader5 = SymUnmanagedReaderFactory.CreateReader<ISymUnmanagedReader5>(pdbStream, new DummySymReaderMetadataProvider());
+                return SymUnmanagedReaderFactory.CreateReader<ISymUnmanagedReader5>(pdbStream, new DummySymReaderMetadataProvider());
             }
-
-            return (peImage, symReader5);
         }
-
-
     }
 }

--- a/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
+++ b/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;

--- a/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
+++ b/src/Features/Core/Portable/Debugging/DebugInformationReaderProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             /// The document content is matched with the build output instead of the loaded module
             ///  since the module hasn't been loaded yet.
             ///
-            /// This document state may change to to <see cref="OutOfSync"/>, <see cref="MatchesDebuggee"/>, 
+            /// This document state may change to <see cref="OutOfSync"/>, <see cref="MatchesDebuggee"/>, 
             /// or <see cref="DesignTimeOnly"/> or once the module has been loaded.
             /// </summary>
             MatchesBuildOutput = 1,

--- a/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
+++ b/src/Features/Core/Portable/EditAndContinue/CommittedSolution.cs
@@ -38,8 +38,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             /// The document content is matched with the build output instead of the loaded module
             ///  since the module hasn't been loaded yet.
             ///
-            /// This document state may change to to <see cref="OutOfSync"/> or <see cref="MatchesDebuggee"/> 
-            /// or once the module has been loaded.
+            /// This document state may change to to <see cref="OutOfSync"/>, <see cref="MatchesDebuggee"/>, 
+            /// or <see cref="DesignTimeOnly"/> or once the module has been loaded.
             /// </summary>
             MatchesBuildOutput = 1,
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -350,6 +350,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         continue;
 
                     default:
+                        // Include the document regardless of whether the module it was built into has been loaded or not.
+                        // If the module has been built it might get loaded later during the debugging session,
+                        // at which point we apply all changes that have been made to the project so far.
                         changedDocuments.Add((oldDocument, document));
                         break;
                 }

--- a/src/Features/Core/Portable/EditAndContinue/IDebuggeeModuleMetadataProvider.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IDebuggeeModuleMetadataProvider.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Shall only be called while in debug mode.
         /// Shall only be called on MTA thread.
         /// </summary>
+        /// <returns>Null, if the module with the specified MVID is not loaded.</returns>
         DebuggeeModuleInfo? TryGetBaselineModuleInfo(Guid mvid);
 
         /// <summary>


### PR DESCRIPTION
…ebugging session starts

Previous change https://github.com/dotnet/roslyn/pull/39295 allowed us to rely on PDB source file checksums when distinguishing between design-time-only documents that should be ignored when applying changes and documents whose changes must be applied to the debuggee. The change did not handle the case when the PDB isn't loaded yet when this check is being performed. This bug resulted in changes not being applied correctly and documents getting out-of-sync in scenarios where the modules were not loaded to the debuggee fast enough.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1013242