### PR TITLE
Address a number of variance safety issues with code in interfaces.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -10753,6 +10753,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enums, classes, and structures cannot be declared in an interface that has an &apos;in&apos; or &apos;out&apos; type parameter..
+        /// </summary>
+        internal static string ERR_VarianceInterfaceNesting {
+            get {
+                return ResourceManager.GetString("ERR_VarianceInterfaceNesting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The syntax &apos;var (...)&apos; as an lvalue is reserved..
         /// </summary>
         internal static string ERR_VarInvocationLvalueReserved {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5951,4 +5951,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureAsyncUsing" xml:space="preserve">
     <value>asynchronous using</value>
   </data>
+  <data name="ERR_VarianceInterfaceNesting" xml:space="preserve">
+    <value>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -592,6 +592,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        bool Cci.ITypeDefinition.IsDelegate
+        {
+            get
+            {
+                CheckDefinitionInvariant();
+                return this.IsDelegateType();
+            }
+        }
+
         bool Cci.ITypeDefinition.IsRuntimeSpecial
         {
             get

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -154,6 +154,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             }
         }
 
+        protected override bool IsDelegate
+        {
+            get
+            {
+                return UnderlyingNamedType.IsDelegateType();
+            }
+        }
+
         protected override bool IsSerializable
         {
             get

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1735,6 +1735,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion diagnostics introduced for C# 8.0
 
         ERR_InternalError = 8751,
+        ERR_VarianceInterfaceNesting = 8752,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1604,6 +1604,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UnconsumedEnumeratorCancellationAttributeUsage = 8424,
         WRN_UndecoratedCancellationTokenParameter = 8425,
         ERR_MultipleEnumeratorCancellationAttributes = 8426,
+        ERR_VarianceInterfaceNesting = 8427,
         // available range
 
         #region diagnostics introduced for recursive patterns
@@ -1735,7 +1736,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion diagnostics introduced for C# 8.0
 
         ERR_InternalError = 8751,
-        ERR_VarianceInterfaceNesting = 8752,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
                 // If we are in a variant interface, runtime might not consider the 
-                // method synthesized directly within the interface as viriant safe.
+                // method synthesized directly within the interface as variant safe.
                 // For simplicity we do not perform precise analysis whether this would
                 // definitely be the case. If we are in a variant interface, we always force
                 // creation of a display class.
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // or a class.
 
                     // If we are in a variant interface, runtime might not consider the 
-                    // method synthesized directly within the interface as viriant safe.
+                    // method synthesized directly within the interface as variant safe.
                     // For simplicity we do not perform precise analysis whether this would
                     // definitely be the case. If we are in a variant interface, we always force
                     // creation of a display class.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -246,7 +246,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         RemoveEnv();
                     }
                 }
-                else
+                // If we are in a variant interface, runtime might not consider the 
+                // method synthesized directly within the interface as viriant safe.
+                // For simplicity we do not perform precise analysis whether this would
+                // definitely be the case. If we are in a variant interface, we always force
+                // creation of a display class.
+                else if (VarianceSafety.GetEnclosingVariantInterface(_topLevelMethod) is null)
                 {
                     // Class-based 'this' closures can move member functions to
                     // the top-level type and environments which capture the 'this'
@@ -299,7 +304,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // functions that capture those variables, so multiple passes may
                     // be needed. This will also decide if the environment is a struct
                     // or a class.
-                    bool isStruct = true;
+
+                    // If we are in a variant interface, runtime might not consider the 
+                    // method synthesized directly within the interface as viriant safe.
+                    // For simplicity we do not perform precise analysis whether this would
+                    // definitely be the case. If we are in a variant interface, we always force
+                    // creation of a display class.
+                    bool isStruct = VarianceSafety.GetEnclosingVariantInterface(_topLevelMethod) is null;
                     var closures = new SetWithInsertionOrder<Closure>();
                     bool addedItem;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                           originalMethod.MethodKind == MethodKind.LambdaMethod &&
                           _analysis.MethodsConvertedToDelegates.Contains(originalMethod)) ||
                          // If we are in a variant interface, runtime might not consider the 
-                         // method synthesized directly within the interface as viriant safe.
+                         // method synthesized directly within the interface as variant safe.
                          // For simplicity we do not perform precise analysis whether this would
                          // definitely be the case. If we are in a variant interface, we always force
                          // creation of a display class.

--- a/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
@@ -91,31 +91,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static NamedTypeSymbol GetEnclosingVariantInterface(Symbol member)
         {
-            var container = member.ContainingType;
-
-            do
+            for (var container = member.ContainingType; container is object; container = container.ContainingType)
             {
                 if (!container.IsInterfaceType())
                 {
                     Debug.Assert(!container.IsDelegateType());
                     // The same validation will be performed for the container and 
                     // there is no reason to duplicate the same errors, if any, on this type.
-                    container = null;
                     break;
                 }
 
                 if (container.TypeParameters.Any(tp => tp.Variance != VarianceKind.None))
                 {
                     // We are inside of a variant interface
-                    break;
+                    return container;
                 }
 
                 // This interface isn't variant, but its containing interface might be.
-                container = container.ContainingType;
             }
-            while (container is object);
 
-            return container;
+            return null;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
@@ -52,8 +54,68 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case SymbolKind.Event:
                         CheckEventVarianceSafety((EventSymbol)member, diagnostics);
                         break;
+                    case SymbolKind.NamedType:
+                        CheckNestedTypeVarianceSafety((NamedTypeSymbol)member, diagnostics);
+                        break;
                 }
             }
+        }
+
+        /// <summary>
+        /// Check for illegal nesting into a variant interface.
+        /// </summary>
+        private static void CheckNestedTypeVarianceSafety(NamedTypeSymbol member, DiagnosticBag diagnostics)
+        {
+            switch (member.TypeKind)
+            {
+                case TypeKind.Class:
+                case TypeKind.Struct:
+                case TypeKind.Enum:
+                    break;
+                case TypeKind.Interface:
+                case TypeKind.Delegate:
+                    return;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(member.TypeKind);
+            }
+
+            NamedTypeSymbol container = GetEnclosingVariantInterface(member);
+
+            if (container is object)
+            {
+                Debug.Assert(container.IsInterfaceType());
+                Debug.Assert(container.TypeParameters.Any(tp => tp.Variance != VarianceKind.None));
+                diagnostics.Add(ErrorCode.ERR_VarianceInterfaceNesting, member.Locations[0]);
+            }
+        }
+
+        internal static NamedTypeSymbol GetEnclosingVariantInterface(Symbol member)
+        {
+            var container = member.ContainingType;
+
+            do
+            {
+                if (!container.IsInterfaceType())
+                {
+                    Debug.Assert(!container.IsDelegateType());
+                    // The same validation will be performed for the container and 
+                    // there is no reason to duplicate the same errors, if any, on this type.
+                    container = null;
+                    break;
+                }
+
+                if (container.TypeParameters.Any(tp => tp.Variance != VarianceKind.None))
+                {
+                    // We are inside of a variant interface
+                    break;
+                }
+
+                // This interface isn't variant, but its containing interface might be.
+                container = container.ContainingType;
+            }
+            while (container is object);
+
+            return container;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -472,6 +472,11 @@
         <target state="translated">U syntaxe var pro vzor se nepovoluje odkazování na typ, ale {0} je tady v rámci rozsahu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">Přiřazení k řazené kolekci členů typu {0} vyžaduje dílčí vzory {1}, ale k dispozici jsou dílčí vzory {2}.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -472,6 +472,11 @@
         <target state="translated">Die Syntax "var" für ein Muster darf nicht zum Verweis auf einen Typen verwendet werden, "{0}" ist jedoch im Bereich enthalten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">Für den Abgleich von Tupeltyp "{0}" sind {1} Teilmuster erforderlich, aber es sind {2} Teilmuster vorhanden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -472,6 +472,11 @@
         <target state="translated">La sintaxis "var" de un patrón no puede hacer referencia a un tipo, pero "{0}" está dentro del ámbito aquí.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">La coincidencia del tipo de tupla "{0}" requiere subpatrones "{1}", pero hay subpatrones "{2}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -472,6 +472,11 @@
         <target state="translated">La syntaxe 'var' d'un modèle n'est pas autorisée à faire référence à un type, mais '{0}' est dans l'étendue ici.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">La correspondance avec le type de tuple '{0}' nécessite des sous-modèles '{1}', mais des sous-modèles '{2}' sont présents.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -472,6 +472,11 @@
         <target state="translated">Per fare riferimento a un tipo, non è consentito usare la sintassi 'var' per un criterio, ma in questo '{0}' è incluso nell'ambito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">Per la corrispondenza del tipo di tupla '{0}' sono richiesti '{1}' criteri secondari, ma ne sono presenti '{2}'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -472,6 +472,11 @@
         <target state="translated">型を参照するためにパターンに構文 'var' を使用することは許可されていませんが、ここでは '{0}' がスコープ内にあります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">タプル型 '{0}' のマッチングには '{1}' サブパターンが必要ですが、'{2}' サブパターンが指定されています。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -472,6 +472,11 @@
         <target state="translated">패턴의 'var' 구문은 형식 참조가 허용되지 않지만 '{0}'은(는) 여기서 범위 내에 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">튜플 형식 '{0}'을(를) 일치시키려면 '{1}' 하위 패턴이 필요하지만 '{2}' 하위 패턴이 있습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -472,6 +472,11 @@
         <target state="translated">Składnia „var” dla wzorca nie może odwoływać się do typu, ale element „{0}” należy tutaj do zakresu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">Dopasowanie typu krotki „{0}” wymaga „{1}” wzorców podrzędnych, ale istnieje następująca liczba wzorców podrzędnych: „{2}”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -472,6 +472,11 @@
         <target state="translated">A sintaxe 'var' de um padrão não pode referenciar um tipo, mas '{0}' está no escopo aqui.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">A correspondência ao tipo de tupla '{0}' requer '{1}' subpadrões, mas '{2}' subpadrões estão presentes.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -472,6 +472,11 @@
         <target state="translated">Синтаксису "var" для шаблона запрещено ссылаться на тип, но "{0}" здесь входит в область.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">Для сопоставления типа кортежа "{0}" требуются вложенные шаблоны "{1}", но сейчас есть вложенные шаблоны "{2}".</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -472,6 +472,11 @@
         <target state="translated">Bir desene yönelik 'var' söz diziminin bir türe başvurmasına izin verilmez, ancak burada '{0}' kapsam dahilinde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">'{0}' demet türünün eşleştirilmesi '{1}' alt desenlerini gerektirir, ancak '{2}' alt desenleri var.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -472,6 +472,11 @@
         <target state="translated">模式的语法 "var" 不允许引用类型，但“{0}”在此范围内。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">匹配元组类型“{0}”需要“{1}”子模式，但存在“{2}”子模式。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -472,6 +472,11 @@
         <target state="translated">不允許模式的語法 'var' 參考類型，但 '{0}' 在此處的範圍中。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_VarianceInterfaceNesting">
+        <source>Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</source>
+        <target state="new">Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_WrongNumberOfSubpatterns">
         <source>Matching the tuple type '{0}' requires '{1}' subpatterns, but '{2}' subpatterns are present.</source>
         <target state="translated">需要 '{1}' 子模式才能比對元組類型 '{0}'，但此處為 '{2}' 子模式。</target>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -58605,5 +58605,578 @@ class C3 : C1
 
             CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr).VerifyDiagnostics();
         }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_01()
+        {
+            var source1 =
+@"
+interface I1<out T1, in T2, T3>
+{
+    delegate void D11(T1 x);
+    delegate T2 D12();
+    delegate T3 D13(T3 x);
+
+    void M1(T1 x);
+    T2 M2();
+    T3 M3(T3 x);
+
+    interface I2
+    {
+        void M21(T1 x);
+        T2 M22();
+        T3 M23(T3 x);
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (4,23): error CS1961: Invalid variance: The type parameter 'T1' must be contravariantly valid on 'I1<T1, T2, T3>.D11.Invoke(T1)'. 'T1' is covariant.
+                //     delegate void D11(T1 x);
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T1").WithArguments("I1<T1, T2, T3>.D11.Invoke(T1)", "T1", "covariant", "contravariantly").WithLocation(4, 23),
+                // (5,14): error CS1961: Invalid variance: The type parameter 'T2' must be covariantly valid on 'I1<T1, T2, T3>.D12.Invoke()'. 'T2' is contravariant.
+                //     delegate T2 D12();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T2").WithArguments("I1<T1, T2, T3>.D12.Invoke()", "T2", "contravariant", "covariantly").WithLocation(5, 14),
+                // (8,13): error CS1961: Invalid variance: The type parameter 'T1' must be contravariantly valid on 'I1<T1, T2, T3>.M1(T1)'. 'T1' is covariant.
+                //     void M1(T1 x);
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T1").WithArguments("I1<T1, T2, T3>.M1(T1)", "T1", "covariant", "contravariantly").WithLocation(8, 13),
+                // (9,5): error CS1961: Invalid variance: The type parameter 'T2' must be covariantly valid on 'I1<T1, T2, T3>.M2()'. 'T2' is contravariant.
+                //     T2 M2();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T2").WithArguments("I1<T1, T2, T3>.M2()", "T2", "contravariant", "covariantly").WithLocation(9, 5),
+                // (14,18): error CS1961: Invalid variance: The type parameter 'T1' must be contravariantly valid on 'I1<T1, T2, T3>.I2.M21(T1)'. 'T1' is covariant.
+                //         void M21(T1 x);
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T1").WithArguments("I1<T1, T2, T3>.I2.M21(T1)", "T1", "covariant", "contravariantly").WithLocation(14, 18),
+                // (15,9): error CS1961: Invalid variance: The type parameter 'T2' must be covariantly valid on 'I1<T1, T2, T3>.I2.M22()'. 'T2' is contravariant.
+                //         T2 M22();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T2").WithArguments("I1<T1, T2, T3>.I2.M22()", "T2", "contravariant", "covariantly").WithLocation(15, 9)
+                );
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_02()
+        {
+            var source1 =
+@"
+interface I2<in T1, out T2>
+{
+    delegate void D21(T1 x);
+    delegate T2 D22();
+
+    void M1(T1 x);
+    T2 M2();
+
+    interface I2
+    {
+        void M21(T1 x);
+        T2 M22();
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_03()
+        {
+            var source1 =
+@"
+interface I1<out T1, in T2, T3>
+{
+    interface I2
+    {
+        delegate void D11(T1 x);
+        delegate T2 D12();
+        delegate T3 D13(T3 x);
+
+        interface I3
+        {
+            void M31(T1 x);
+            T2 M32();
+            T3 M33(T3 x);
+        }
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (6,27): error CS1961: Invalid variance: The type parameter 'T1' must be contravariantly valid on 'I1<T1, T2, T3>.I2.D11.Invoke(T1)'. 'T1' is covariant.
+                //         delegate void D11(T1 x);
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T1").WithArguments("I1<T1, T2, T3>.I2.D11.Invoke(T1)", "T1", "covariant", "contravariantly").WithLocation(6, 27),
+                // (7,18): error CS1961: Invalid variance: The type parameter 'T2' must be covariantly valid on 'I1<T1, T2, T3>.I2.D12.Invoke()'. 'T2' is contravariant.
+                //         delegate T2 D12();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T2").WithArguments("I1<T1, T2, T3>.I2.D12.Invoke()", "T2", "contravariant", "covariantly").WithLocation(7, 18),
+                // (12,22): error CS1961: Invalid variance: The type parameter 'T1' must be contravariantly valid on 'I1<T1, T2, T3>.I2.I3.M31(T1)'. 'T1' is covariant.
+                //             void M31(T1 x);
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T1").WithArguments("I1<T1, T2, T3>.I2.I3.M31(T1)", "T1", "covariant", "contravariantly").WithLocation(12, 22),
+                // (13,13): error CS1961: Invalid variance: The type parameter 'T2' must be covariantly valid on 'I1<T1, T2, T3>.I2.I3.M32()'. 'T2' is contravariant.
+                //             T2 M32();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T2").WithArguments("I1<T1, T2, T3>.I2.I3.M32()", "T2", "contravariant", "covariantly").WithLocation(13, 13)
+                );
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_04()
+        {
+            var source1 =
+@"
+interface I2<in T1, out T2>
+{
+    interface I2
+    {
+        delegate void D21(T1 x);
+        delegate T2 D22();
+
+        interface I3
+        {
+            void M31(T1 x);
+            T2 M32();
+        }
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_05()
+        {
+            var source1 =
+@"
+interface I1<out T1>
+{
+    class C1
+    {
+        void MC1(T1 x) {}
+        class C {}
+        struct S {}
+        enum E {}
+    }
+    struct S1
+    {
+        void MS1(T1 x) {}
+        class C {}
+        struct S {}
+        enum E {}
+    }
+    enum E1 {}
+}
+
+interface I2<in T2>
+{
+    class C2
+    {
+        T2 MC2() => default;
+        class C {}
+        struct S {}
+        enum E {}
+    }
+    struct S2
+    {
+        T2 MS2() => default;
+        class C {}
+        struct S {}
+        enum E {}
+    }
+    enum E2 {}
+}
+
+interface I3<T3>
+{
+    class C3
+    {
+        T3 MC3(T3 x) => default;
+        class C {}
+        struct S {}
+        enum E {}
+    }
+    struct S3
+    {
+        T3 MS3(T3 x) => default;
+        class C {}
+        struct S {}
+        enum E {}
+    }
+    enum E3 {}
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (4,11): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //     class C1
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C1").WithLocation(4, 11),
+                // (11,12): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //     struct S1
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S1").WithLocation(11, 12),
+                // (18,10): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //     enum E1 {}
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E1").WithLocation(18, 10),
+                // (23,11): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //     class C2
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C2").WithLocation(23, 11),
+                // (30,12): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //     struct S2
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S2").WithLocation(30, 12),
+                // (37,10): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //     enum E2 {}
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E2").WithLocation(37, 10)
+                );
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_06()
+        {
+            var source1 =
+@"
+interface I1<out T1>
+{
+    interface I0
+    {
+        class C1
+        {
+            interface I
+            {
+                class C {}
+                struct S {}
+                enum E {}
+            }
+        }
+        struct S1
+        {
+            interface I
+            {
+                class C {}
+                struct S {}
+                enum E {}
+            }
+        }
+        enum E1 {}
+    }
+}
+
+interface I2<in T2>
+{
+    interface I0
+    {
+        class C2
+        {
+            interface I
+            {
+                class C {}
+                struct S {}
+                enum E {}
+            }
+        }
+        struct S2
+        {
+            interface I
+            {
+                class C {}
+                struct S {}
+                enum E {}
+            }
+        }
+        enum E2 {}
+    }
+}
+
+interface I3<T3>
+{
+    interface I0
+    {
+        class C3
+        {
+            interface I
+            {
+                class C {}
+                struct S {}
+                enum E {}
+            }
+        }
+        struct S3
+        {
+            interface I
+            {
+                class C {}
+                struct S {}
+                enum E {}
+            }
+        }
+        enum E3 {}
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (6,15): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //         class C1
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C1").WithLocation(6, 15),
+                // (15,16): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //         struct S1
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S1").WithLocation(15, 16),
+                // (24,14): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //         enum E1 {}
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E1").WithLocation(24, 14),
+                // (32,15): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //         class C2
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C2").WithLocation(32, 15),
+                // (41,16): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //         struct S2
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S2").WithLocation(41, 16),
+                // (50,14): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                //         enum E2 {}
+                Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E2").WithLocation(50, 14)
+                );
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_07()
+        {
+            var source1 =
+@"
+public interface I1<out T1, in T2, T3>
+{
+    void M1()
+    {
+        T1 x = local(default, default);
+
+        T1 local(T1 x, I2 y)
+        {
+            System.Console.WriteLine(""M1"");
+            return x;
+        }
+    }
+
+    void M2()
+    {
+        T2 x = local(default, default);
+
+        T2 local(T2 x, I2.I3 y)
+        {
+            System.Console.WriteLine(""M2"");
+            return x;
+        }
+    }
+
+    void M3()
+    {
+        T3 x = local(default);
+
+        T3 local(T3 x)
+        {
+            System.Console.WriteLine(""M3"");
+            return x;
+        }
+    }
+
+    interface I2
+    {
+        void M4()
+        {
+            System.Console.WriteLine(""M4"");
+        }
+
+        interface I3
+        {
+        }
+    }
+
+    delegate T1 D1(T2 x);
+    delegate T3 D3(T3 x);
+}
+";
+            var source2 =
+@"
+class C1 : I1<C1, C1, C1>, I1<C1, object, C1>.I2
+{
+    static void Main()
+    {
+        I1<C1, C1, C1> x = new C1();
+        x.M1();
+        x.M2();
+        x.M3();
+
+        var y = (I1<C1, object, C1>.I2)x;
+        I1<object, C1, C1>.I2 z = y;
+        z.M4();
+
+        I1<C1, object, C1>.D1 d1 = M5;
+        I1<object, C1, C1>.D1 d2 = d1;
+        _ = d2(new C1());
+    }
+
+    static C1 M5(object x)
+    {
+        System.Console.WriteLine(""M5"");
+        return (C1)x;
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            foreach (var reference in new[] { compilation1.ToMetadataReference(), compilation1.EmitToImageReference() })
+            {
+                var compilation2 = CreateCompilation(source2, new[] { reference }, options: TestOptions.DebugExe,
+                                                     parseOptions: TestOptions.Regular,
+                                                     targetFramework: TargetFramework.NetStandardLatest);
+
+                CompileAndVerify(compilation2, verify: VerifyOnMonoOrCoreClr, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null :
+@"M1
+M2
+M3
+M4
+M5");
+            }
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_08()
+        {
+            var source1 =
+@"
+public interface I1<out T1, in T2>
+{
+    void M1()
+    {
+        System.Func<T1, T1> d = (T1 x) =>
+                                {
+                                    System.Console.WriteLine(""M1"");
+                                    return x;
+                                };
+        d(default);
+    }
+
+    void M2()
+    {
+        System.Func<T2, T2> d = (T2 x) =>
+                                {
+                                    System.Console.WriteLine(""M2"");
+                                    return x;
+                                };
+        d(default);
+    }
+}
+
+class C1 : I1<C1, C1>
+{
+    static void Main()
+    {
+        I1<C1, C1> x = new C1();
+        x.M1();
+        x.M2();
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugExe,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null :
+@"M1
+M2");
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_09()
+        {
+            var source1 =
+@"
+using System.Collections.Generic;
+
+class Program : I2<int>
+{
+    static void Main()
+    {
+        ((I2<int>)new Program()).M2().GetEnumerator().MoveNext();
+    }
+}
+
+interface I2<out T>
+{
+    IEnumerable<int> M2()
+    {
+        System.Console.WriteLine(""M2"");
+        yield break;
+    }
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugExe,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null : @"M2");
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_10()
+        {
+            var source1 =
+@"
+class Program
+{
+    static void Main()
+    {
+        I2<string, string>.F1 = ""a"";
+        I2<string, string>.F2 = ""b"";
+        System.Console.WriteLine(I2<string, string>.F1);
+        System.Console.WriteLine(I2<string, string>.F2);
+    }
+}
+
+interface I2<out T1, in T2>
+{
+    static T1 F1 = default;
+    static T2 F2 = default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugExe,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            CompileAndVerify(compilation1, verify: VerifyOnMonoOrCoreClr, expectedOutput: !ExecutionConditionUtil.IsMonoOrCoreClr ? null :
+@"a
+b");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -58828,22 +58828,22 @@ interface I3<T3>
                                                  targetFramework: TargetFramework.NetStandardLatest);
 
             compilation1.VerifyDiagnostics(
-                // (4,11): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (4,11): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //     class C1
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C1").WithLocation(4, 11),
-                // (11,12): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (11,12): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //     struct S1
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S1").WithLocation(11, 12),
-                // (18,10): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (18,10): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //     enum E1 {}
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E1").WithLocation(18, 10),
-                // (23,11): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (23,11): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //     class C2
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C2").WithLocation(23, 11),
-                // (30,12): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (30,12): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //     struct S2
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S2").WithLocation(30, 12),
-                // (37,10): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (37,10): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //     enum E2 {}
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E2").WithLocation(37, 10)
                 );
@@ -58939,22 +58939,22 @@ interface I3<T3>
                                                  targetFramework: TargetFramework.NetStandardLatest);
 
             compilation1.VerifyDiagnostics(
-                // (6,15): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (6,15): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //         class C1
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C1").WithLocation(6, 15),
-                // (15,16): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (15,16): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //         struct S1
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S1").WithLocation(15, 16),
-                // (24,14): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (24,14): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //         enum E1 {}
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E1").WithLocation(24, 14),
-                // (32,15): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (32,15): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //         class C2
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "C2").WithLocation(32, 15),
-                // (41,16): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (41,16): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //         struct S2
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "S2").WithLocation(41, 16),
-                // (50,14): error CS8752: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
+                // (50,14): error CS8427: Enums, classes, and structures cannot be declared in an interface that has an 'in' or 'out' type parameter.
                 //         enum E2 {}
                 Diagnostic(ErrorCode.ERR_VarianceInterfaceNesting, "E2").WithLocation(50, 14)
                 );
@@ -59239,6 +59239,33 @@ class C1 : I1<C1, C1>
 @"M1
 M2");
             }
+        }
+
+        [Fact]
+        [WorkItem(39731, "https://github.com/dotnet/roslyn/issues/39731")]
+        public void VarianceSafety_12()
+        {
+            var source1 =
+@"
+interface I1<out T1, in T2>
+{
+    private void M1(T1 x) {}
+    private T2 M2() => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (4,21): error CS1961: Invalid variance: The type parameter 'T1' must be contravariantly valid on 'I1<T1, T2>.M1(T1)'. 'T1' is covariant.
+                //     private void M1(T1 x) {}
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T1").WithArguments("I1<T1, T2>.M1(T1)", "T1", "covariant", "contravariantly").WithLocation(4, 21),
+                // (5,13): error CS1961: Invalid variance: The type parameter 'T2' must be covariantly valid on 'I1<T1, T2>.M2()'. 'T2' is contravariant.
+                //     private T2 M2() => default;
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "T2").WithArguments("I1<T1, T2>.M2()", "T2", "contravariant", "covariantly").WithLocation(5, 13)
+                );
         }
     }
 }

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -504,6 +504,8 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public bool IsInterface => false;
 
+        public bool IsDelegate => false;
+
         public bool IsRuntimeSpecial => false;
 
         public bool IsSerializable => false;

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             protected abstract bool IsBeforeFieldInit { get; }
             protected abstract bool IsComImport { get; }
             protected abstract bool IsInterface { get; }
+            protected abstract bool IsDelegate { get; }
             protected abstract bool IsSerializable { get; }
             protected abstract bool IsSpecialName { get; }
             protected abstract bool IsWindowsRuntimeImport { get; }
@@ -354,6 +355,14 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 get
                 {
                     return IsInterface;
+                }
+            }
+
+            bool Cci.ITypeDefinition.IsDelegate
+            {
+                get
+                {
+                    return IsDelegate;
                 }
             }
 

--- a/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Cci
 
         public TypeParameterVariance Variance
         {
-            get { return _parentParameter.Variance; }
+            get { return _inheritingType.IsInterface || _inheritingType.IsDelegate ? _parentParameter.Variance : TypeParameterVariance.NonVariant; }
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
@@ -101,6 +101,11 @@ namespace Microsoft.Cci
             get { return false; }
         }
 
+        public bool IsDelegate
+        {
+            get { return false; }
+        }
+
         public bool IsRuntimeSpecial
         {
             get { return false; }

--- a/src/Compilers/Core/Portable/PEWriter/Types.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Types.cs
@@ -504,6 +504,11 @@ namespace Microsoft.Cci
         bool IsInterface { get; }
 
         /// <summary>
+        /// True if the type is a delegate.
+        /// </summary>
+        bool IsDelegate { get; }
+
+        /// <summary>
         /// True if this type gets special treatment from the runtime.
         /// </summary>
         bool IsRuntimeSpecial { get; }

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -568,6 +568,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property ITypeDefinitionIsDelegate As Boolean Implements ITypeDefinition.IsDelegate
+            Get
+                Debug.Assert(Not Me.IsAnonymousType)
+
+                ' can't be generic instantiation
+                ' must be declared in the module we are building
+                CheckDefinitionInvariant()
+
+                Return Me.IsDelegateType()
+            End Get
+        End Property
+
         Private ReadOnly Property ITypeDefinitionIsRuntimeSpecial As Boolean Implements ITypeDefinition.IsRuntimeSpecial
             Get
                 Debug.Assert(Not Me.IsAnonymousType)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -120,6 +120,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             End Get
         End Property
 
+        Protected Overrides ReadOnly Property IsDelegate As Boolean
+            Get
+                Return UnderlyingNamedType.IsDelegateType()
+            End Get
+        End Property
+
         Protected Overrides ReadOnly Property IsSerializable As Boolean
             Get
                 Return UnderlyingNamedType.IsSerializable

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NamespaceTypeDefinitionNoBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NamespaceTypeDefinitionNoBase.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
         bool ITypeDefinition.IsInterface => UnderlyingType.IsInterface;
 
+        bool ITypeDefinition.IsDelegate => UnderlyingType.IsDelegate;
+
         bool INamespaceTypeDefinition.IsPublic => UnderlyingType.IsPublic;
 
         bool ITypeDefinition.IsRuntimeSpecial => UnderlyingType.IsRuntimeSpecial;


### PR DESCRIPTION
Fixes #39731.

- Declaration of classes, structures and enums within variant interfaces is disallowed.
- Nested classes synthesized by the compiler don't have variant emitted type parameters.
- Local functions and lambdas used within a variant interface always have display class.
