### PR TITLE
Implement Initializer expression wrappers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
@@ -90,5 +90,69 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 }"
 );
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestShortInitializerExpressionRefactorings()
+        {
+            await TestAllWrappingCasesAsync(
+@"class C {
+    void Bar() {
+        var test = new[]
+        [||]{
+            1,
+            2
+        };
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] { 1, 2 };
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[]
+        {
+            1, 2
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestLongIntializerExpressionRefactorings()
+        {
+            await TestAllWrappingCasesAsync(
+@"class C {
+    void Bar() {
+        var test = new[]
+        [||]{
+            ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""
+        };
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[]
+        {
+            ""the"",
+            ""quick"",
+            ""brown"",
+            ""fox"",
+            ""jumps"",
+            ""over"",
+            ""the"",
+            ""lazy"",
+            ""dog""
+        };
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] { ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog"" };
+     }
+}"
+);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 }",
 @"class C {
     void Bar() {
-        var test = new[] 
+        var test = new[]
         {
             1,
             2
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 }",
 @"class C {
     void Bar() {
-        var test = new[] 
+        var test = new[]
         {
             ""the"",
             ""quick"",
@@ -68,15 +68,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
             ""over"",
             ""the"",
             ""lazy"",
-            ""dog""};
-        }
+            ""dog""
+        };
+     }
 }",
 @"class C {
     void Bar() {
-        var test = new[] 
+        var test = new[]
         {
-            ""the"",""quick"",""brown"",""fox"",""jumps"",""over"",""the"",""lazy"",""dog""};
-        }
+            ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""
+        };
+     }
 }"
 );
         }

--- a/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Wrapping;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
+{
+    public class IntializerExpressionWrappingTests : AbstractWrappingTests
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpWrappingCodeRefactoringProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestNoWrappingSuggestions()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ 1 };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestWrappingShortInitializerExpression()
+        {
+            await TestAllWrappingCasesAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ 1, 2 };
+    }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] 
+        {
+            1,
+            2
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)]
+        public async Task TestWrappingLongIntializerExpression()
+        {
+            await TestAllWrappingCasesAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog"" };
+     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] 
+        {
+            ""the"",
+            ""quick"",
+            ""brown"",
+            ""fox"",
+            ""jumps"",
+            ""over"",
+            ""the"",
+            ""lazy"",
+            ""dog""};
+        }
+}",
+@"class C {
+    void Bar() {
+        var test = new[] 
+        {
+            ""the"",""quick"",""brown"",""fox"",""jumps"",""over"",""the"",""lazy"",""dog""};
+        }
+}"
+);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
@@ -44,6 +44,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
             2
         };
     }
+}",
+@"class C {
+    void Bar() {
+        var test = new[]
+        {
+            1, 2
+        };
+    }
 }");
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/InitializerExpressionWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/InitializerExpressionWrappingTests.vb
@@ -1,0 +1,127 @@
+﻿Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.VisualBasic.Wrapping
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Wrapping
+    Public Class InitializerExpressionWrappingTests
+        Inherits AbstractWrappingTests
+
+        Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
+            Return New VisualBasicWrappingCodeRefactoringProvider()
+        End Function
+
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)>
+        Public Async Function TestNoWrappingSuggestions() As Task
+            Await TestMissingAsync(
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() [||]{1}
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)>
+        Public Async Function TestWrappingShortInitializerExpression() As Task
+            Await TestAllWrappingCasesAsync(
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() [||]{1, 2}
+    End Sub
+End Class",
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() {
+            1,
+            2
+        }
+    End Sub
+End Class", "Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() {
+            1, 2
+        }
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)>
+        Public Async Function TestWrappingLongIntializerExpression() As Task
+            Await TestAllWrappingCasesAsync("Class C
+    Public Sub Bar()
+        Dim test() As String = New String() [||]{""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""}
+    End Sub
+}", "Class C
+    Public Sub Bar()
+        Dim test() As String = New String() {
+            ""the"",
+            ""quick"",
+            ""brown"",
+            ""fox"",
+            ""jumps"",
+            ""over"",
+            ""the"",
+            ""lazy"",
+            ""dog""
+        }
+    End Sub
+}", "Class C
+    Public Sub Bar()
+        Dim test() As String = New String() {
+            ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""
+        }
+    End Sub
+}")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)>
+        Public Async Function TestShortInitializerExpressionRefactorings() As Task
+            Await TestAllWrappingCasesAsync("Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() [||]{
+            1,
+            2
+        }
+    End Sub
+End Class", "Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() {1, 2}
+    End Sub
+End Class", "Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() {
+            1, 2
+        }
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsWrapping)>
+        Public Async Function TestLongIntializerExpressionRefactorings() As Task
+            Await TestAllWrappingCasesAsync("Class C
+    Public Sub Bar()
+        Dim test() As String = New String() [||]{
+            ""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""
+        }
+     End Sub
+End Class", "Class C
+    Public Sub Bar()
+        Dim test() As String = New String() {
+            ""the"",
+            ""quick"",
+            ""brown"",
+            ""fox"",
+            ""jumps"",
+            ""over"",
+            ""the"",
+            ""lazy"",
+            ""dog""
+        }
+     End Sub
+End Class", "Class C
+    Public Sub Bar()
+        Dim test() As String = New String() {""the"", ""quick"", ""brown"", ""fox"", ""jumps"", ""over"", ""the"", ""lazy"", ""dog""}
+     End Sub
+End Class")
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/Wrapping/CSharpWrappingCodeRefactoringProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList;
 using Microsoft.CodeAnalysis.CSharp.Wrapping.BinaryExpression;
 using Microsoft.CodeAnalysis.CSharp.Wrapping.ChainedExpression;
 using Microsoft.CodeAnalysis.Wrapping;
+using Microsoft.CodeAnalysis.CSharp.Wrapping.InitializerExpression;
 
 namespace Microsoft.CodeAnalysis.CSharp.Wrapping
 {
@@ -18,7 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping
                 new CSharpArgumentWrapper(),
                 new CSharpParameterWrapper(),
                 new CSharpBinaryExpressionWrapper(),
-                new CSharpChainedExpressionWrapper());
+                new CSharpChainedExpressionWrapper(),
+                new CSharpInitializerExpression());
 
         [ImportingConstructor]
         public CSharpWrappingCodeRefactoringProvider()

--- a/src/Features/CSharp/Portable/Wrapping/InitializerExpression/AbstractCSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/InitializerExpression/AbstractCSharpInitializerExpressionWrapper.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.InitializerExpression
         protected override string Unwrap_list => FeaturesResources.Unwrap_element_list;
         protected override string Wrap_every_item => FeaturesResources.Wrap_every_element;
         protected override string Wrap_long_list => FeaturesResources.Wrap_long_element_list;
+        protected override bool DoWrapInitializerOpenBrace => true;
 
         protected AbstractCSharpInitializerExpressionWrapper() : base(CSharpIndentationService.Instance)
         {

--- a/src/Features/CSharp/Portable/Wrapping/InitializerExpression/AbstractCSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/InitializerExpression/AbstractCSharpInitializerExpressionWrapper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Indentation;
+using Microsoft.CodeAnalysis.Indentation;
+using Microsoft.CodeAnalysis.Wrapping.InitializerExpression;
+
+namespace Microsoft.CodeAnalysis.CSharp.Wrapping.InitializerExpression
+{
+    internal abstract class AbstractCSharpInitializerExpressionWrapper<TListSyntax, TListItemSyntax>
+        : AbstractInitializerExpression<TListSyntax, TListItemSyntax>
+        where TListSyntax : SyntaxNode
+        where TListItemSyntax : SyntaxNode
+    {
+        protected override string Indent_all_items => FeaturesResources.Indent_all_arguments;
+        protected override string Unwrap_all_items => FeaturesResources.Unwrap_all_arguments;
+        protected override string Unwrap_list => FeaturesResources.Unwrap_element_list;
+        protected override string Wrap_every_item => FeaturesResources.Wrap_every_element;
+        protected override string Wrap_long_list => FeaturesResources.Wrap_long_element_list;
+
+        protected AbstractCSharpInitializerExpressionWrapper() : base(CSharpIndentationService.Instance)
+        {
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Wrapping/InitializerExpression/CSharpInitializerExpression.cs
+++ b/src/Features/CSharp/Portable/Wrapping/InitializerExpression/CSharpInitializerExpression.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.Wrapping.InitializerExpression
+{
+    internal partial class CSharpInitializerExpression : AbstractCSharpInitializerExpressionWrapper<InitializerExpressionSyntax, ExpressionSyntax>
+    {
+        protected override SeparatedSyntaxList<ExpressionSyntax> GetListItems(InitializerExpressionSyntax listSyntax)
+        {
+            return listSyntax.Expressions;
+        }
+
+        protected override bool PositionIsApplicable(SyntaxNode root, int position, SyntaxNode declaration, InitializerExpressionSyntax listSyntax)
+        {
+            var startToken = listSyntax.GetFirstToken();
+
+            var token = root.FindToken(position);
+            if (token.Parent.Ancestors().Contains(listSyntax))
+            {
+                var current = token.Parent;
+                while (current != listSyntax)
+                {
+                    if (CSharpSyntaxFactsService.Instance.IsAnonymousFunction(current))
+                    {
+                        return false;
+                    }
+
+                    current = current.Parent;
+                }
+            }
+
+            return true;
+        }
+
+        protected override InitializerExpressionSyntax TryGetApplicableList(SyntaxNode node)
+        {
+            return node as InitializerExpressionSyntax;
+        }
+    }
+}

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -4048,6 +4048,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unwrap element list.
+        /// </summary>
+        internal static string Unwrap_element_list {
+            get {
+                return ResourceManager.GetString("Unwrap_element_list", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unwrap expression.
         /// </summary>
         internal static string Unwrap_expression {
@@ -4636,7 +4645,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a &apos;using&apos; statement or a &apos;using&apos; declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the &apos;finally&apos; region, say &apos;x?.Dispose()&apos;. If the object is explicitly disposed within the try region or the dispose ownership is transferred to another object  [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Use recommended dispose pattern to ensure that locally scoped disposable objects are disposed on all paths. If possible, wrap the creation within a &apos;using&apos; statement or a &apos;using&apos; declaration. Otherwise, use a try-finally pattern, with a dedicated local variable declared before the try region and an unconditional Dispose invocation on non-null value in the &apos;finally&apos; region, say &apos;x?.Dispose()&apos;. If the object is explicitly disposed within the try region or the dispose ownership is transferred to another object [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string UseRecommendedDisposePatternDescription {
             get {
@@ -4790,6 +4799,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Wrap every element.
+        /// </summary>
+        internal static string Wrap_every_element {
+            get {
+                return ResourceManager.GetString("Wrap_every_element", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Wrap every parameter.
         /// </summary>
         internal static string Wrap_every_parameter {
@@ -4822,6 +4840,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Wrap_long_call_chain {
             get {
                 return ResourceManager.GetString("Wrap_long_call_chain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wrap long element list.
+        /// </summary>
+        internal static string Wrap_long_element_list {
+            get {
+                return ResourceManager.GetString("Wrap_long_element_list", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1711,4 +1711,13 @@ This version used in: {2}</value>
   <data name="Add_null_checks_for_all_parameters" xml:space="preserve">
     <value>Add null checks for all parameters</value>
   </data>
+  <data name="Unwrap_element_list" xml:space="preserve">
+    <value>Unwrap element list</value>
+  </data>
+  <data name="Wrap_every_element" xml:space="preserve">
+    <value>Wrap every element</value>
+  </data>
+  <data name="Wrap_long_element_list" xml:space="preserve">
+    <value>Wrap long element list</value>
+  </data>
 </root>

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/AbstractInitializerExpression.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/AbstractInitializerExpression.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
         protected abstract string Wrap_every_item { get; }
         protected abstract string Indent_all_items { get; }
 
+        protected abstract bool DoWrapInitializerOpenBrace { get; }
+
         protected AbstractInitializerExpression(IIndentationService indentationService)
             : base(indentationService)
         {
@@ -65,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             return new InitializerExpressionCodeActionComputer(
-                this, document, sourceText, options, listSyntax, listItems, cancellationToken);
+                this, document, sourceText, options, listSyntax, listItems, DoWrapInitializerOpenBrace, cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/AbstractInitializerExpression.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/AbstractInitializerExpression.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Indentation;
+
+namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
+{
+    internal abstract partial class AbstractInitializerExpression<
+        TListSyntax,
+        TListItemSyntax>
+        : AbstractSyntaxWrapper
+        where TListSyntax : SyntaxNode
+        where TListItemSyntax : SyntaxNode
+    {
+        protected abstract string Unwrap_list { get; }
+        protected abstract string Wrap_long_list { get; }
+        protected abstract string Unwrap_all_items { get; }
+        protected abstract string Wrap_every_item { get; }
+        protected abstract string Indent_all_items { get; }
+
+        protected AbstractInitializerExpression(IIndentationService indentationService)
+            : base(indentationService)
+        {
+        }
+
+        protected abstract TListSyntax TryGetApplicableList(SyntaxNode node);
+        protected abstract SeparatedSyntaxList<TListItemSyntax> GetListItems(TListSyntax listSyntax);
+        protected abstract bool PositionIsApplicable(
+            SyntaxNode root, int position, SyntaxNode declaration, TListSyntax listSyntax);
+
+        public override async Task<ICodeActionComputer> TryCreateComputerAsync(
+            Document document, int position, SyntaxNode declaration, CancellationToken cancellationToken)
+        {
+            var listSyntax = TryGetApplicableList(declaration);
+            if (listSyntax == null)
+            {
+                return null;
+            }
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (!PositionIsApplicable(root, position, declaration, listSyntax))
+            {
+                return null;
+            }
+
+            var listItems = GetListItems(listSyntax);
+            if (listItems.Count <= 1)
+            {
+                // nothing to do with 0-1 items.  Simple enough for users to just edit
+                // themselves, and this prevents constant clutter with formatting that isn't
+                // really that useful.
+                return null;
+            }
+
+            var containsUnformattableContent = await ContainsUnformattableContentAsync(
+                document, listItems.GetWithSeparators(), cancellationToken).ConfigureAwait(false);
+
+            if (containsUnformattableContent)
+            {
+                return null;
+            }
+
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            return new InitializerExpressionCodeActionComputer(
+                this, document, sourceText, options, listSyntax, listItems, cancellationToken);
+        }
+    }
+}

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
@@ -151,8 +151,9 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
 
                 if (DoWrapInitializerOpenBrace)
                 {
-                    var position = _listSyntax.GetFirstToken().SpanStart;
-                    var token = _listSyntax.Parent.FindToken(position - 1);
+                    int position = FindEndOfParentPosition();
+
+                    var token = _listSyntax.Parent.FindToken(position);
                     result.Add(Edit.UpdateBetween(token, NewLineTrivia, _braceIndentationTrivia, _listSyntax.GetFirstToken()));
                 }
 
@@ -178,6 +179,22 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
                 result.Add(Edit.UpdateBetween(_listItems.Last(), NewLineTrivia, _braceIndentationTrivia, _listSyntax.GetLastToken()));
 
                 return result.ToImmutableAndFree();
+            }
+
+            private int FindEndOfParentPosition()
+            {
+                var position = _listSyntax.GetFirstToken().SpanStart;
+                var endOfParent = 1;
+                var syntaxTriviaList = _listSyntax.GetLeadingTrivia();
+                if (_listSyntax != null)
+                {
+                    foreach (var syntax in syntaxTriviaList)
+                    {
+                        endOfParent += syntax.Width();
+                    }
+                }
+
+                return position - endOfParent;
             }
 
             private void AddTextChangeBetweenOpenAndFirstItem(
@@ -213,6 +230,13 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             private ImmutableArray<Edit> GetUnwrapAllEdits(WrappingStyle wrappingStyle)
             {
                 var result = ArrayBuilder<Edit>.GetInstance();
+
+                if (DoWrapInitializerOpenBrace)
+                {
+                    var position = FindEndOfParentPosition();
+                    var token = _listSyntax.Parent.FindToken(position);
+                    result.Add(Edit.DeleteBetween(token, _listSyntax.GetFirstToken()));
+                }
 
                 AddTextChangeBetweenOpenAndFirstItem(wrappingStyle, result);
 
@@ -259,8 +283,8 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
 
                 if (DoWrapInitializerOpenBrace)
                 {
-                    var position = _listSyntax.GetFirstToken().SpanStart;
-                    var token = _listSyntax.Parent.FindToken(position - 1);
+                    var position = FindEndOfParentPosition();
+                    var token = _listSyntax.Parent.FindToken(position);
                     result.Add(Edit.UpdateBetween(token, NewLineTrivia, _braceIndentationTrivia, _listSyntax.GetFirstToken()));
                 }
 

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Wrapping;
+using Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
+{
+    internal abstract partial class AbstractInitializerExpression<TListSyntax, TListItemSyntax>
+    {
+        private class InitializerExpressionCodeActionComputer : AbstractCodeActionComputer<AbstractInitializerExpression<TListSyntax, TListItemSyntax>>
+        {
+            private readonly TListSyntax _listSyntax;
+            private readonly SeparatedSyntaxList<TListItemSyntax> _listItems;
+
+            /// <summary>
+            /// The indentation string necessary to indent an item in a list such that the start of
+            /// that item will exact start at the end of the open-token for the containing list. i.e.
+            /// 
+            ///     void Goobar(
+            ///                 ^
+            ///                 |
+            /// 
+            /// This is the indentation we want when we're aligning wrapped items with the first item 
+            /// in the list.
+            /// </summary>
+            private readonly SyntaxTrivia _afterOpenTokenIndentationTrivia;
+
+            /// <summary>
+            /// Indentation amount for any items that have been wrapped to a new line.  Valid if we're
+            /// not aligning with the first item. i.e.
+            /// 
+            ///     void Goobar(
+            ///         ^
+            ///         |
+            /// </summary>
+            private readonly SyntaxTrivia _singleIndentationTrivia;
+
+            public InitializerExpressionCodeActionComputer(
+                AbstractInitializerExpression<TListSyntax, TListItemSyntax> service,
+                Document document, SourceText sourceText, DocumentOptionSet options,
+                TListSyntax listSyntax, SeparatedSyntaxList<TListItemSyntax> listItems,
+                CancellationToken cancellationToken)
+                : base(service, document, sourceText, options, cancellationToken)
+            {
+                _listSyntax = listSyntax;
+                _listItems = listItems;
+
+                var generator = SyntaxGenerator.GetGenerator(this.OriginalDocument);
+
+                _afterOpenTokenIndentationTrivia = generator.Whitespace(GetAfterOpenTokenIdentation());
+                _singleIndentationTrivia = generator.Whitespace(GetSingleIdentation());
+            }
+
+            private string GetAfterOpenTokenIdentation()
+            {
+                var openToken = _listSyntax.GetFirstToken();
+                var afterOpenTokenOffset = OriginalSourceText.GetOffset(openToken.Span.End);
+
+                var indentString = afterOpenTokenOffset.CreateIndentationString(UseTabs, TabSize);
+                return indentString;
+            }
+
+            private string GetSingleIdentation()
+            {
+                // Insert a newline after the open token of the list.  Then ask the
+                // ISynchronousIndentationService where it thinks that the next line should be
+                // indented.
+                var openToken = _listSyntax.GetFirstToken();
+
+                return GetSmartIndentationAfter(openToken);
+            }
+
+            protected override async Task<ImmutableArray<WrappingGroup>> ComputeWrappingGroupsAsync()
+            {
+                var result = ArrayBuilder<WrappingGroup>.GetInstance();
+                await AddWrappingGroups(result).ConfigureAwait(false);
+                return result.ToImmutableAndFree();
+            }
+
+            private async Task AddWrappingGroups(ArrayBuilder<WrappingGroup> result)
+            {
+                result.Add(await GetWrapEveryGroupAsync().ConfigureAwait(false));
+                //result.Add(await GetUnwrapGroupAsync().ConfigureAwait(false));
+                //result.Add(await GetWrapLongGroupAsync().ConfigureAwait(false));
+            }
+
+            private async Task<WrappingGroup> GetWrapEveryGroupAsync()
+            {
+                var parentTitle = Wrapper.Wrap_every_item;
+
+                var codeActions = ArrayBuilder<WrapItemsAction>.GetInstance();
+
+                codeActions.Add(await GetWrapEveryNestedCodeActionAsync(
+                    parentTitle, WrappingStyle.WrapFirst_IndentRest).ConfigureAwait(false));
+
+                // See comment in GetWrapLongTopLevelCodeActionAsync for explanation of why we're
+                // not inlinable.
+                return new WrappingGroup(isInlinable: false, codeActions.ToImmutableAndFree());
+            }
+
+            private async Task<WrapItemsAction> GetWrapEveryNestedCodeActionAsync(
+                string parentTitle, WrappingStyle wrappingStyle)
+            {
+                var indentationTrivia = GetIndentationTrivia(wrappingStyle);
+
+                var edits = GetWrapEachEdits(wrappingStyle, indentationTrivia);
+                var title = GetNestedCodeActionTitle(wrappingStyle);
+
+                return await TryCreateCodeActionAsync(edits, parentTitle, title).ConfigureAwait(false);
+            }
+
+            private SyntaxTrivia GetIndentationTrivia(WrappingStyle wrappingStyle)
+            {
+                return wrappingStyle == WrappingStyle.UnwrapFirst_AlignRest
+                    ? _afterOpenTokenIndentationTrivia
+                    : _singleIndentationTrivia;
+            }
+
+            private string GetNestedCodeActionTitle(WrappingStyle wrappingStyle)
+                => wrappingStyle switch
+                {
+                    WrappingStyle.WrapFirst_IndentRest => Wrapper.Indent_all_items,
+                    _ => throw ExceptionUtilities.UnexpectedValue(wrappingStyle),
+                };
+
+            private ImmutableArray<Edit> GetWrapEachEdits(
+                WrappingStyle wrappingStyle, SyntaxTrivia indentationTrivia)
+            {
+                var result = ArrayBuilder<Edit>.GetInstance();
+
+                AddTextChangeBetweenOpenAndFirstItem(wrappingStyle, result);
+
+                var itemsAndSeparators = _listItems.GetWithSeparators();
+
+                for (var i = 0; i < itemsAndSeparators.Count; i += 2)
+                {
+                    var item = itemsAndSeparators[i].AsNode();
+                    if (i < itemsAndSeparators.Count - 1)
+                    {
+                        // intermediary item
+                        var comma = itemsAndSeparators[i + 1].AsToken();
+                        result.Add(Edit.DeleteBetween(item, comma));
+
+                        // Always wrap between this comma and the next item.
+                        result.Add(Edit.UpdateBetween(
+                            comma, NewLineTrivia, indentationTrivia, itemsAndSeparators[i + 2]));
+                    }
+                }
+
+                // last item.  Delete whatever is between it and the close token of the list.
+                result.Add(Edit.DeleteBetween(_listItems.Last(), _listSyntax.GetLastToken()));
+
+                return result.ToImmutableAndFree();
+            }
+
+            private void AddTextChangeBetweenOpenAndFirstItem(
+                WrappingStyle wrappingStyle, ArrayBuilder<Edit> result)
+            {
+                result.Add(wrappingStyle == WrappingStyle.WrapFirst_IndentRest
+                    ? Edit.UpdateBetween(_listSyntax.GetFirstToken(), NewLineTrivia, _singleIndentationTrivia, _listItems[0])
+                    : Edit.DeleteBetween(_listSyntax.GetFirstToken(), _listItems[0]));
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Wrapping;
 using Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList;
 using Roslyn.Utilities;
 
@@ -25,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             private readonly SyntaxTrivia _afterOpenTokenIndentationTrivia;
             private readonly SyntaxTrivia _singleIndentationTrivia;
             private readonly SyntaxTrivia _braceIndentationTrivia;
-            private readonly bool DoWrapInitializerOpenBrace;
+            private readonly bool _doWrapInitializerOpenBrace;
 
             public InitializerExpressionCodeActionComputer(
                 AbstractInitializerExpression<TListSyntax, TListItemSyntax> service,
@@ -43,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
                 _singleIndentationTrivia = generator.Whitespace(GetSingleIdentation());
                 _braceIndentationTrivia = generator.Whitespace(GetBraceTokenIndentation());
 
-                DoWrapInitializerOpenBrace = doWrapInitializerOpenBrace;
+                _doWrapInitializerOpenBrace = doWrapInitializerOpenBrace;
             }
 
             private string GetAfterOpenTokenIdentation()
@@ -149,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             {
                 var result = ArrayBuilder<Edit>.GetInstance();
 
-                if (DoWrapInitializerOpenBrace)
+                if (_doWrapInitializerOpenBrace)
                 {
                     int position = FindEndOfParentPosition();
 
@@ -210,8 +209,6 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
                 var unwrapActions = ArrayBuilder<WrapItemsAction>.GetInstance();
 
                 var parentTitle = Wrapper.Unwrap_list;
-
-                // MethodName(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j)
                 unwrapActions.Add(await GetUnwrapAllCodeActionAsync(parentTitle, WrappingStyle.UnwrapFirst_IndentRest).ConfigureAwait(false));
 
                 // The 'unwrap' title strings are unique and do not collide with any other code
@@ -231,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             {
                 var result = ArrayBuilder<Edit>.GetInstance();
 
-                if (DoWrapInitializerOpenBrace)
+                if (_doWrapInitializerOpenBrace)
                 {
                     var position = FindEndOfParentPosition();
                     var token = _listSyntax.Parent.FindToken(position);
@@ -255,12 +252,8 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
                 var parentTitle = Wrapper.Wrap_long_list;
                 var codeActions = ArrayBuilder<WrapItemsAction>.GetInstance();
 
-                // MethodName(
-                //     int a, int b, int c, int d, int e,
-                //     int f, int g, int h, int i, int j)
                 codeActions.Add(await GetWrapLongLineCodeActionAsync(
                     parentTitle, WrappingStyle.WrapFirst_IndentRest).ConfigureAwait(false));
-
 
                 return new WrappingGroup(isInlinable: false, codeActions.ToImmutableAndFree());
             }
@@ -281,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             {
                 var result = ArrayBuilder<Edit>.GetInstance();
 
-                if (DoWrapInitializerOpenBrace)
+                if (_doWrapInitializerOpenBrace)
                 {
                     var position = FindEndOfParentPosition();
                     var token = _listSyntax.Parent.FindToken(position);
@@ -325,7 +318,6 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
                     //// comma or close token).
                     var nextToken = item.GetLastToken().GetNextToken();
 
-                    //result.Add(Edit.DeleteBetween(item, nextToken));
                     currentOffset += nextToken.Span.Length;
                 }
 

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
@@ -79,8 +79,25 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
 
             private string GetCloseTokenIndentation()
             {
-                var initialStatement = _listSyntax.Parent.Parent.Parent.Parent;
-                var afterInitialStatementOffset = OriginalSourceText.GetOffset(initialStatement.SpanStart);
+                var generator = SyntaxGenerator.GetGenerator(this.OriginalDocument);
+                var initialStatement = generator.GetDeclaration(_listSyntax);
+
+                if (initialStatement == null)
+                {
+                    return string.Empty;
+                }
+
+                var initialStatementOffset = initialStatement.SpanStart;
+                if (generator.GetDeclarationKind(initialStatement) == DeclarationKind.Method)
+                {
+                    // If we didn't find some form of declaration and are in a method body
+                    // the initializer must be in a return statement. Therefore, add a tab
+                    // to align the end brace with the return keyword
+                    initialStatementOffset += TabSize;
+                }
+
+
+                var afterInitialStatementOffset = OriginalSourceText.GetOffset(initialStatementOffset);
 
                 var indentString = afterInitialStatementOffset.CreateIndentationString(UseTabs, TabSize);
                 return indentString;

--- a/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
+++ b/src/Features/Core/Portable/Wrapping/InitializerExpression/InitializerExpressionCodeActionComputer.cs
@@ -46,6 +46,8 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
             /// </summary>
             private readonly SyntaxTrivia _singleIndentationTrivia;
 
+            private readonly SyntaxTrivia _elasticTrivia;
+
             public InitializerExpressionCodeActionComputer(
                 AbstractInitializerExpression<TListSyntax, TListItemSyntax> service,
                 Document document, SourceText sourceText, DocumentOptionSet options,
@@ -60,6 +62,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
 
                 _afterOpenTokenIndentationTrivia = generator.Whitespace(GetAfterOpenTokenIdentation());
                 _singleIndentationTrivia = generator.Whitespace(GetSingleIdentation());
+                _elasticTrivia = generator.ElasticCarriageReturnLineFeed;
             }
 
             private string GetAfterOpenTokenIdentation()
@@ -158,8 +161,7 @@ namespace Microsoft.CodeAnalysis.Wrapping.InitializerExpression
                     }
                 }
 
-                // last item.  Delete whatever is between it and the close token of the list.
-                result.Add(Edit.DeleteBetween(_listItems.Last(), _listSyntax.GetLastToken()));
+                result.Add(Edit.UpdateBetween(_listItems.Last(), NewLineTrivia, _afterOpenTokenIndentationTrivia , _listSyntax.GetLastToken()));
 
                 return result.ToImmutableAndFree();
             }

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Nezalamovat posloupnost volání</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Zrušit zalomení výrazu</target>
@@ -642,6 +647,11 @@
         <target state="translated">Zalomit každý argument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Zalomit každý parametr</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Zalomit dlouhou posloupnost volání</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Zeilenumbruch für Aufrufkette aufheben</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Ausdruck umschließen</target>
@@ -642,6 +647,11 @@
         <target state="translated">Jedes Argument umschließen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Alle Parameter umschließen</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Lange Aufrufkette umbrechen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Desencapsular la cadena de llamada</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Desajustar la expresión</target>
@@ -642,6 +647,11 @@
         <target state="translated">Ajustar todos los argumentos</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Ajustar todos los parámetros</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Encapsular la cadena de llamada larga</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Ne pas effectuer le retour à la ligne d'une chaîne d'appels</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Exclure l'expression du wrapper</target>
@@ -642,6 +647,11 @@
         <target state="translated">Inclure dans un wrapper chaque argument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Wrapper chaque paramètre</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Effectuer le retour à la ligne d'une longue chaîne d'appels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Annulla ritorno a capo per la catena di chiamate</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Annulla ritorno a capo per l'espressione</target>
@@ -642,6 +647,11 @@
         <target state="translated">Imposta ritorno a capo per ogni argomento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Imposta ritorno a capo per ogni parametro</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Applica ritorno a capo alla catena di chiamate lunga</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -522,6 +522,11 @@
         <target state="translated">呼び出しチェーンのラップ解除</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">式の折り返しを解除</target>
@@ -642,6 +647,11 @@
         <target state="translated">すべての引数を折り返します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">すべてのパラメーターを折り返します</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">長い呼び出しチェーンのラップ</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -522,6 +522,11 @@
         <target state="translated">호출 체인 래핑 해제</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">식 줄 바꿈 조정</target>
@@ -642,6 +647,11 @@
         <target state="translated">모든 인수 줄 바꿈</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">모든 매개 변수 줄 바꿈</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">긴 호출 체인 래핑</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Cofnij zawijanie łańcucha wywołań</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Odpakuj wyrażenie</target>
@@ -642,6 +647,11 @@
         <target state="translated">Opakuj każdy argument</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Opakuj każdy parametr</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Zawijaj długi łańcuch wywołań</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Desencapsular cadeia de chamadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Desencapsular a expressão</target>
@@ -642,6 +647,11 @@
         <target state="translated">Encapsular cada argumento</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Encapsular cada parâmetro</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Encapsular cadeia longa de chamadas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Развернуть цепочку вызовов</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">Развернуть выражение</target>
@@ -642,6 +647,11 @@
         <target state="translated">Свернуть каждый аргумент</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Свернуть каждый параметр</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Свернуть длинную цепочку вызовов</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -522,6 +522,11 @@
         <target state="translated">Çağrı zincirinin sarmalamasını kaldır</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">İfadenin sarmalamasını kaldır</target>
@@ -642,6 +647,11 @@
         <target state="translated">Her bağımsız değişkeni sarmala</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">Her parametreyi sarmala</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">Uzun çağrı zincirini sarmala</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -522,6 +522,11 @@
         <target state="translated">对调用链解包</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">展开表达式</target>
@@ -642,6 +647,11 @@
         <target state="translated">包装每个参数</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">包装每个参数</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">包装长调用链</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -522,6 +522,11 @@
         <target state="translated">將呼叫鏈結取消包裝</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unwrap_element_list">
+        <source>Unwrap element list</source>
+        <target state="new">Unwrap element list</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unwrap_expression">
         <source>Unwrap expression</source>
         <target state="translated">將運算式取消換行</target>
@@ -642,6 +647,11 @@
         <target state="translated">包裝每個引數</target>
         <note />
       </trans-unit>
+      <trans-unit id="Wrap_every_element">
+        <source>Wrap every element</source>
+        <target state="new">Wrap every element</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Wrap_every_parameter">
         <source>Wrap every parameter</source>
         <target state="translated">將每個參數換行</target>
@@ -660,6 +670,11 @@
       <trans-unit id="Wrap_long_call_chain">
         <source>Wrap long call chain</source>
         <target state="translated">包裝長呼叫鏈結</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Wrap_long_element_list">
+        <source>Wrap long element list</source>
+        <target state="new">Wrap long element list</target>
         <note />
       </trans-unit>
       <trans-unit id="Wrap_long_parameter_list">

--- a/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/AbstractVisualBasicInitializerExpression.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/AbstractVisualBasicInitializerExpression.vb
@@ -1,0 +1,18 @@
+﻿Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.VisualBasic.Indentation
+Imports Microsoft.CodeAnalysis.Wrapping.InitializerExpression
+
+Friend MustInherit Class AbstractVisualBasicInitializerExpression(
+    Of TListSyntax As SyntaxNode, TListItemSyntax As SyntaxNode)
+    Inherits AbstractInitializerExpression(Of TListSyntax, TListItemSyntax)
+
+    Protected Overrides ReadOnly Property Indent_all_items As String = FeaturesResources.Indent_all_arguments
+    Protected Overrides ReadOnly Property Unwrap_all_items As String = FeaturesResources.Unwrap_all_arguments
+    Protected Overrides ReadOnly Property Unwrap_list As String = FeaturesResources.Unwrap_argument_list
+    Protected Overrides ReadOnly Property Wrap_every_item As String = FeaturesResources.Wrap_every_argument
+    Protected Overrides ReadOnly Property Wrap_long_list As String = FeaturesResources.Wrap_long_argument_list
+
+    Protected Sub New()
+        MyBase.New(VisualBasicIndentationService.WithoutParameterAlignmentInstance)
+    End Sub
+End Class

--- a/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/AbstractVisualBasicInitializerExpression.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/AbstractVisualBasicInitializerExpression.vb
@@ -8,9 +8,9 @@ Friend MustInherit Class AbstractVisualBasicInitializerExpression(
 
     Protected Overrides ReadOnly Property Indent_all_items As String = FeaturesResources.Indent_all_arguments
     Protected Overrides ReadOnly Property Unwrap_all_items As String = FeaturesResources.Unwrap_all_arguments
-    Protected Overrides ReadOnly Property Unwrap_list As String = FeaturesResources.Unwrap_argument_list
-    Protected Overrides ReadOnly Property Wrap_every_item As String = FeaturesResources.Wrap_every_argument
-    Protected Overrides ReadOnly Property Wrap_long_list As String = FeaturesResources.Wrap_long_argument_list
+    Protected Overrides ReadOnly Property Unwrap_list As String = FeaturesResources.Unwrap_element_list
+    Protected Overrides ReadOnly Property Wrap_every_item As String = FeaturesResources.Wrap_every_element
+    Protected Overrides ReadOnly Property Wrap_long_list As String = FeaturesResources.Wrap_long_element_list
 
     Protected Sub New()
         MyBase.New(VisualBasicIndentationService.WithoutParameterAlignmentInstance)

--- a/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/AbstractVisualBasicInitializerExpression.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/AbstractVisualBasicInitializerExpression.vb
@@ -11,6 +11,7 @@ Friend MustInherit Class AbstractVisualBasicInitializerExpression(
     Protected Overrides ReadOnly Property Unwrap_list As String = FeaturesResources.Unwrap_element_list
     Protected Overrides ReadOnly Property Wrap_every_item As String = FeaturesResources.Wrap_every_element
     Protected Overrides ReadOnly Property Wrap_long_list As String = FeaturesResources.Wrap_long_element_list
+    Protected Overrides ReadOnly Property DoWrapInitializerOpenBrace As Boolean = False
 
     Protected Sub New()
         MyBase.New(VisualBasicIndentationService.WithoutParameterAlignmentInstance)

--- a/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/VisualBasicCollectionCreationExpression.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/InitializerExpression/VisualBasicCollectionCreationExpression.vb
@@ -1,0 +1,39 @@
+﻿Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Friend Class VisualBasicCollectionCreationExpression
+    Inherits AbstractVisualBasicInitializerExpression(Of CollectionInitializerSyntax, ExpressionSyntax)
+
+    Protected Overrides Function GetListItems(listSyntax As CollectionInitializerSyntax) As SeparatedSyntaxList(Of ExpressionSyntax)
+        Return listSyntax.Initializers
+    End Function
+
+    Protected Overrides Function TryGetApplicableList(node As SyntaxNode) As CollectionInitializerSyntax
+        Return If(TryCast(node, ArrayCreationExpressionSyntax)?.Initializer,
+                  TryCast(node, ObjectCollectionInitializerSyntax)?.Initializer)
+    End Function
+
+    Protected Overrides Function PositionIsApplicable(
+            root As SyntaxNode, position As Integer,
+            declaration As SyntaxNode, listSyntax As CollectionInitializerSyntax) As Boolean
+
+        Dim startToken = listSyntax.GetFirstToken()
+
+        ' allow anywhere in the arg list, as long we don't end up walking through something
+        ' complex Like a lambda/anonymous function.
+        Dim token = root.FindToken(position)
+        If token.Parent.Ancestors().Contains(listSyntax) Then
+            Dim current = token.Parent
+            While current IsNot listSyntax
+                If VisualBasicSyntaxFactsService.Instance.IsAnonymousFunction(current) Then
+                    Return False
+                End If
+
+                current = current.Parent
+            End While
+        End If
+
+        Return True
+    End Function
+End Class

--- a/src/Features/VisualBasic/Portable/Wrapping/VisualBasicWrappingCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/VisualBasicWrappingCodeRefactoringProvider.vb
@@ -18,7 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping
                 New VisualBasicArgumentWrapper(),
                 New VisualBasicParameterWrapper(),
                 New VisualBasicBinaryExpressionWrapper(),
-                New VisualBasicChainedExpressionWrapper())
+                New VisualBasicChainedExpressionWrapper(),
+                New VisualBasicCollectionCreationExpression())
 
         <ImportingConstructor>
         Public Sub New()


### PR DESCRIPTION
Users will now be offered refactoring options for collection initializers. The implementation was modelled after the AbstractSeparatedSyntaxList implementation. This applies to visual basic and c#. 

There are 3 choices for users:

1. Wrap every element
```CSharp
// Before
var example = new[] { 1, 2 };

// After
var example = new[] 
{
    1,
    2
};
```

2. Unwrap every element
```CSharp
// Before
var example = new[] 
{
    1,
    2
};

// After
var example = new[] { 1, 2 };
```

3. Wrap long
```CSharp
// Before
var example = new[] { 1, 2 };

// After
var example = new[]
{
    1, 2
};
```

This PR is in response to #39148 

