### PR TITLE
Avoid warning assigning to readonly property marked [AllowNull]

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -6017,10 +6017,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static FlowAnalysisAnnotations getFieldAnnotations(FieldSymbol field)
             {
-                var property = field.AssociatedSymbol as PropertySymbol;
-                return property is null ?
-                    field.FlowAnalysisAnnotations :
-                    getSetterAnnotations(property);
+                return field.AssociatedSymbol is PropertySymbol property ?
+                    getSetterAnnotations(property) :
+                    field.FlowAnalysisAnnotations;
             }
 
             static FlowAnalysisAnnotations getSetterAnnotations(PropertySymbol property)


### PR DESCRIPTION
Fixes #39926