### PR TITLE
Emit CS8370 instead of CS1674 for ref struct disposable

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -699,12 +699,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(expr.Type is object);
             Debug.Assert(expr.Type.IsRefLikeType || hasAwait); // pattern dispose lookup is only valid on ref structs or asynchronous usings
 
-            // Don't try and lookup if we're not enabled
-            if (MessageID.IDS_FeatureUsingDeclarations.RequiredVersion() > Compilation.LanguageVersion)
-            {
-                return null;
-            }
-
             var result = PerformPatternMethodLookup(expr,
                                                     hasAwait ? WellKnownMemberNames.DisposeAsyncMethodName : WellKnownMemberNames.DisposeMethodName,
                                                     syntaxNode,

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -860,7 +860,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 builder.NeedsDisposal = true;
             }
-            else if (Compilation.LanguageVersion >= MessageID.IDS_FeatureUsingDeclarations.RequiredVersion() &&
+            else if (Compilation.IsFeatureEnabled(MessageID.IDS_FeatureUsingDeclarations) &&
                     (enumeratorType.IsRefLikeType || isAsync))
             {
                 // if it wasn't directly convertable to IDisposable, see if it is pattern-disposable

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -860,7 +860,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 builder.NeedsDisposal = true;
             }
-            else if (enumeratorType.IsRefLikeType || isAsync)
+            else if (Compilation.LanguageVersion >= MessageID.IDS_FeatureUsingDeclarations.RequiredVersion() &&
+                    (enumeratorType.IsRefLikeType || isAsync))
             {
                 // if it wasn't directly convertable to IDisposable, see if it is pattern-disposable
                 // again, we throw away any binding diagnostics, and assume it's not disposable if we encounter errors

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -201,6 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     disposeMethodOpt = originalBinder.TryFindDisposePatternMethod(receiver, syntax, hasAwait, diagnostics);
                     if (disposeMethodOpt is object)
                     {
+                        MessageID.IDS_FeatureUsingDeclarations.CheckFeatureAvailability(diagnostics, originalBinder.Compilation, syntax.Location);
                         if (hasAwait)
                         {
                             awaitableTypeOpt = disposeMethodOpt.ReturnType;

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -198,7 +198,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                ? expressionOpt
                                                : new BoundLocal(syntax, declarationsOpt[0].LocalSymbol, null, type) { WasCompilerGenerated = true };
 
-                    disposeMethodOpt = originalBinder.TryFindDisposePatternMethod(receiver, syntax, hasAwait, diagnostics);
+                    DiagnosticBag patternDiagnostics = originalBinder.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureUsingDeclarations)
+                                                       ? diagnostics
+                                                       : new DiagnosticBag();
+                    disposeMethodOpt = originalBinder.TryFindDisposePatternMethod(receiver, syntax, hasAwait, patternDiagnostics);
                     if (disposeMethodOpt is object)
                     {
                         MessageID.IDS_FeatureUsingDeclarations.CheckFeatureAvailability(diagnostics, originalBinder.Compilation, syntax.Location);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1133,6 +1133,38 @@ class C2
         }
 
         [Fact]
+        [WorkItem(32728, "https://github.com/dotnet/roslyn/issues/32728")]
+        public void UsingPatternWithLangVer7_3()
+        {
+            var source = @"
+ref struct S1
+{
+    public void Dispose() { }
+}
+
+class C2
+{
+    static void Main()
+    {
+        using (S1 s = new S1())
+        {
+        }
+    }
+}
+";
+            var expected = new[]
+            {
+                // (11,16): error CS8370: The feature 'using declarations' is not available in C# 7.3. Please use language version 8.0 or greater.
+                //         using (S1 s = new S1())
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "S1 s = new S1()").WithArguments("using declarations", "8.0").WithLocation(11, 16)
+            };
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(expected);
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular8).VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Lambda()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingStatementTests.cs
@@ -1152,14 +1152,12 @@ class C2
     }
 }
 ";
-            var expected = new[]
-            {
+
+            CreateCompilation(source, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(
                 // (11,16): error CS8370: The feature 'using declarations' is not available in C# 7.3. Please use language version 8.0 or greater.
                 //         using (S1 s = new S1())
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, "S1 s = new S1()").WithArguments("using declarations", "8.0").WithLocation(11, 16)
-            };
-
-            CreateCompilation(source, parseOptions: TestOptions.Regular7_3).VerifyDiagnostics(expected);
+            );
 
             CreateCompilation(source, parseOptions: TestOptions.Regular8).VerifyDiagnostics();
         }


### PR DESCRIPTION
Small change to fix https://github.com/dotnet/roslyn/issues/32728

Changes 'Must implement IDisposable' error to a 'needs lang ver > 8' error if you try and dispose a ref struct via pattern in 7.3