### PR TITLE
Prefer user-defined conversion over a switch expression conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -109,13 +109,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            conversion = GetSwitchExpressionConversion(sourceExpression, destination, ref useSiteDiagnostics);
+            conversion = GetImplicitUserDefinedConversion(sourceExpression, sourceType, destination, ref useSiteDiagnostics);
             if (conversion.Exists)
             {
                 return conversion;
             }
 
-            return GetImplicitUserDefinedConversion(sourceExpression, sourceType, destination, ref useSiteDiagnostics);
+            // The switch expression conversion is "lowest priority", so that if there is a conversion from the expression's
+            // type it will be preferred over the switch expression conversion.  Technically, we would want the language
+            // specification to say that the switch expression conversion only "exists" if there is no implicit conversion
+            // from the type, and we accomplish that by making it lowest priority.
+            return GetSwitchExpressionConversion(sourceExpression, destination, ref useSiteDiagnostics);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -3805,8 +3805,8 @@ class Program
 }
 class A
 {
-    public static implicit operator int(A a) => (a == null) ? throw null : 4;
-    public static implicit operator B(A a) => throw null;
+    public static implicit operator int(A a) => throw null;
+    public static implicit operator B(A a) => new B();
 }
 class B
 {
@@ -3815,7 +3815,7 @@ class B
 ";
             var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             compilation.VerifyDiagnostics();
-            var expectedOutput = @"42";
+            var expectedOutput = @"22";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
 
@@ -3838,8 +3838,8 @@ class Program
 }
 class A
 {
-    public static implicit operator int(A a) => (a == null) ? throw null : 4;
-    public static implicit operator B(A a) => throw null;
+    public static implicit operator int(A a) => throw null;
+    public static implicit operator B(A a) => new B();
 }
 class B
 {
@@ -3848,7 +3848,7 @@ class B
 ";
             var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             compilation.VerifyDiagnostics();
-            var expectedOutput = @"42";
+            var expectedOutput = @"22";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
 
@@ -3874,12 +3874,12 @@ class Program
 }
 class A : Exception
 {
-    public static implicit operator int(A a) => (a == null) ? throw null : 4;
+    public static implicit operator int(A a) => throw null;
     public static implicit operator B(A a) => throw null;
 }
 class B : Exception
 {
-    public static implicit operator int(B b) => (b == null) ? throw null : 2;
+    public static implicit operator int(B b) => throw null;
 }
 ";
             var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
@@ -3912,8 +3912,8 @@ class Program
 }
 class A : Exception
 {
-    public static implicit operator int(A a) => (a == null) ? throw null : 4;
-    public static implicit operator B(A a) => throw null;
+    public static implicit operator int(A a) => throw null;
+    public static implicit operator B(A a) => new B();
 }
 class B : Exception
 {
@@ -3922,7 +3922,7 @@ class B : Exception
 ";
             var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             compilation.VerifyDiagnostics();
-            var expectedOutput = @"42";
+            var expectedOutput = @"22";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -1593,5 +1593,50 @@ public static class C {
                 Diagnostic(ErrorCode.ERR_BadRetType, "M").WithArguments("C.M(int)", "void").WithLocation(5, 55)
                 );
         }
+
+        [Fact, WorkItem(39767, "https://github.com/dotnet/roslyn/issues/39767")]
+        public void PreferUserDefinedConversionOverSwitchExpressionConversion()
+        {
+            var source = @"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var s1 = new Source1(""Source1"");
+        var s2 = new Source2();
+        foreach (var b in new bool[] { false, true })
+        {
+            Target t = b switch { false => s1, true => s2 };
+            Console.Write(t + "" "");
+        }
+    }
+}
+class Target
+{
+    private readonly string Value;
+    public Target(string value) => Value = value;
+    public override string ToString() => Value;
+}
+class Source1
+{
+    private readonly string Value;
+    public Source1(string value) => Value = value;
+    public override string ToString() => Value;
+    public static implicit operator Target(Source1 self) => new Target(self.Value+""->Target"");
+}
+class Source2
+{
+    public static implicit operator Source1(Source2 self) => new Source1(""Source2->Source1"");
+    public static implicit operator Target(Source2 self) => new Target(""Source2->Target"");
+}
+";
+            var expectedOutput = "Source1->Target Source2->Source1->Target ";
+            var compilation = CreateCompilation(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics(
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+        }
     }
 }


### PR DESCRIPTION
Fixes #39767

This is intentionally being treated as a bug fix for C# 8.0.
