### PR TITLE
Re-add ServiceFeatureOnOffOptions.ClosedFileDiagnostic to fix the bre…

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public async Task TestHasSuccessfullyLoadedBeingFalseFSAOn()
         {
             var workspace = new AdhocWorkspace();
-            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution);
+            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
             var document = GetDocumentFromIncompleteProject(workspace);
 
             // open document
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public async Task TestHasSuccessfullyLoadedBeingFalseWithCompilerAnalyzerFSAOn()
         {
             var workspace = new AdhocWorkspace();
-            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution);
+            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
             var document = GetDocumentFromIncompleteProject(workspace);
 
             await TestAnalyzerAsync(workspace, document, new CSharpCompilerDiagnosticAnalyzer(), CompilerAnalyzerResultSetter, expectedSyntax: true, expectedSemantic: false);
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                                       loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class A {}"), VersionStamp.Create(), filePath: "test.cs")),
                                       filePath: "test.cs")}));
 
-            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution);
+            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
 
             // create listener/service/analyzer
             var listener = new AsynchronousOperationListener();

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -389,12 +389,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             MakeFirstDocumentActive(workspace.CurrentSolution.Projects.First());
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options));
+            Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.ActiveFile;
-            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, newAnalysisScope));
+            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
 
-            Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options));
+            Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
             Assert.Equal(1, worker.SyntaxDocumentIds.Count);
             Assert.Equal(1, worker.DocumentIds.Count);
             Assert.Equal(1, worker.ProjectIds.Count);
@@ -408,12 +408,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             workspace.OnSolutionAdded(solutionInfo);
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options));
+            Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.FullSolution;
-            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, newAnalysisScope));
+            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
 
-            Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options));
+            Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
             Assert.Equal(10, worker.SyntaxDocumentIds.Count);
             Assert.Equal(10, worker.DocumentIds.Count);
             Assert.Equal(2, worker.ProjectIds.Count);
@@ -1391,7 +1391,7 @@ End Class";
             public static WorkCoordinatorWorkspace CreateWithAnalysisScope(BackgroundAnalysisScope analysisScope, string workspaceKind = null, bool disablePartialSolutions = true)
             {
                 var workspace = new WorkCoordinatorWorkspace(workspaceKind, disablePartialSolutions);
-                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, analysisScope);
+                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, analysisScope);
                 return workspace;
             }
 

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -280,7 +280,8 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 If Not enabled Then
                     workspace.Options = workspace.Options _
                                                   .WithChangedOption(ServiceComponentOnOffOptions.DiagnosticProvider, False) _
-                                                  .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.Default)
+                                                  .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.Default) _
+                                                  .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.Default)
                 End If
 
                 Dim registrationService = workspace.Services.GetService(Of ISolutionCrawlerRegistrationService)()

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -1984,7 +1984,7 @@ class MyClass
                        </Workspace>
 
             Using workspace = TestWorkspace.CreateWorkspace(test)
-                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution)
+                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
 
                 Dim project = workspace.CurrentSolution.Projects.Single()
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -84,7 +84,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             return e.Option.Feature == nameof(SimplificationOptions) ||
                    e.Option.Feature == nameof(CodeStyleOptions) ||
-                   e.Option == SolutionCrawlerOptions.BackgroundAnalysisScopeOption;
+                   e.Option == SolutionCrawlerOptions.BackgroundAnalysisScopeOption ||
+#pragma warning disable CS0618 // Type or member is obsolete - TypeScript and F# are still on the older ClosedFileDiagnostic option.
+                   e.Option == ServiceFeatureOnOffOptions.ClosedFileDiagnostic;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private void OnProjectAnalyzerReferenceChanged(object sender, ProjectAnalyzerReferenceChangedEventArgs e)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     Contract.ThrowIfNull(item.DocumentId);
 
                     var options = _registration.Workspace.Options;
-                    var analysisScope = SolutionCrawlerOptions.GetBackgroundAnalysisScope(options);
+                    var analysisScope = SolutionCrawlerOptions.GetBackgroundAnalysisScope(options, item.Language);
 
                     if (ShouldEnqueueForAllQueues(item, analysisScope))
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -212,8 +212,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 var solution = _registration.Workspace.CurrentSolution;
 
                 // Check if we are only performing backgroung analysis for active file.
-                if (SolutionCrawlerOptions.GetBackgroundAnalysisScope(solution.Options) == BackgroundAnalysisScope.ActiveFile &&
-                    activeDocumentId != null)
+                if (activeDocumentId != null)
                 {
                     // Change to active document needs to trigger following events in active file analysis scope:
                     //  1. Request analysis for newly active file, similar to a newly opened file.
@@ -223,7 +222,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     // As soon as user switches to a source document, we will perform the appropriate analysis callbacks
                     // on the next active document changed event.
                     var activeDocument = solution.GetDocument(activeDocumentId);
-                    if (activeDocument != null)
+                    if (activeDocument != null &&
+                        SolutionCrawlerOptions.GetBackgroundAnalysisScope(activeDocument.Project) == BackgroundAnalysisScope.ActiveFile)
                     {
                         lock (_gate)
                         {

--- a/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
@@ -38,7 +38,8 @@ namespace AnalyzerRunner
 
             workspace.Options = workspace.Options
                 .WithChangedOption(StorageOptions.SolutionSizeThreshold, _options.UsePersistentStorage ? 0 : int.MaxValue)
-                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, _options.AnalysisScope);
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, _options.AnalysisScope)
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, _options.AnalysisScope);
 
             if (!string.IsNullOrEmpty(_options.ProfileRoot))
             {

--- a/src/Tools/ExternalAccess/FSharp/Shared/Options/FSharpServiceFeatureOnOffOptions.cs
+++ b/src/Tools/ExternalAccess/FSharp/Shared/Options/FSharpServiceFeatureOnOffOptions.cs
@@ -13,9 +13,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Shared.Options
         /// this option doesn't mean we will show all diagnostics that belong to opened files when turned off,
         /// rather it means we will only show diagnostics that are cheap to calculate for small scope such as opened files.
         /// </summary>
-        [Obsolete("Use the new option FSharpServiceFeatureOnOffOptions.BackgroundAnalysisScope'")]
-        public static PerLanguageOption<bool?> ClosedFileDiagnostic => new PerLanguageOption<bool?>("FSharpServiceFeatureOnOffOptions", "Closed File Diagnostic", defaultValue: null);
-
-        public static Option<BackgroundAnalysisScope> BackgroundAnalysisScope => SolutionCrawlerOptions.BackgroundAnalysisScopeOption;
+        [Obsolete("Use the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
+        public static PerLanguageOption<bool?> ClosedFileDiagnostic => Microsoft.CodeAnalysis.Shared.Options.ServiceFeatureOnOffOptions.ClosedFileDiagnostic;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml.cs
@@ -23,9 +23,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             InitializeComponent();
 
-            BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile);
-            BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects);
-            BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution);
+            BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile, LanguageNames.CSharp);
+            BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.CSharp);
+            BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.CSharp);
             BindToOption(Enable_navigation_to_decompiled_sources, FeatureOnOffOptions.NavigateToDecompiledSources);
             BindToOption(Use_editorconfig_compatibility_mode, EditorConfigDocumentOptionsProviderFactory.UseLegacyEditorConfigSupport);
 

--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             // 3. Background analysis memory monitor is on (user can set it off using registry to prevent turning off background analysis)
 
             return availableMemory < MemoryThreshold &&
-                SolutionCrawlerOptions.GetBackgroundAnalysisScope(_workspace.Options) != BackgroundAnalysisScope.Minimal &&
+                !SolutionCrawlerOptions.LowMemoryForcedMinimalBackgroundAnalysis &&
                 _workspace.Options.GetOption(InternalFeatureOnOffOptions.BackgroundAnalysisMemoryMonitor);
         }
 

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -120,21 +120,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             _bindingExpressions.Add(bindingExpression);
         }
 
-        protected void BindToOption<T>(RadioButton radiobutton, Option<T> optionKey, T optionValue)
-        {
-            var binding = new Binding()
-            {
-                Source = new OptionBinding<T>(OptionStore, optionKey),
-                Path = new PropertyPath("Value"),
-                UpdateSourceTrigger = UpdateSourceTrigger.Default,
-                Converter = new RadioButtonCheckedConverter(),
-                ConverterParameter = optionValue
-            };
-
-            var bindingExpression = radiobutton.SetBinding(RadioButton.IsCheckedProperty, binding);
-            _bindingExpressions.Add(bindingExpression);
-        }
-
         protected void BindToOption<T>(RadioButton radiobutton, PerLanguageOption<T> optionKey, T optionValue, string languageName)
         {
             var binding = new Binding()

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -235,7 +235,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         {
             workspace = workspace ?? new AdhocWorkspace(TestHostServices.CreateHostServices());
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
-                                                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution);
+                                                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
+                                                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.FullSolution);
 
             var analyzerService = GetDiagnosticAnalyzerService(hostAnalyzerReferences ?? SpecializedCollections.EmptyEnumerable<AnalyzerReference>());
 

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -271,7 +271,8 @@ End Class";
                 TestWorkspace.CreateVisualBasic(code, parseOptions: options, exportProvider: TestHostServices.CreateExportProvider());
 
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
-                                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution);
+                                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
+                                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.FullSolution);
 
             return workspace;
         }

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim waiter = New AsynchronousOperationListener()
 
                 ' turn on FSA
-                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution)
+                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
 
                 Dim project = workspace.CurrentSolution.Projects.First()
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs
@@ -73,9 +73,16 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void SetFullSolutionAnalysis(bool value)
         {
-            SetOption(
+            SetPerLanguageOption(
                 optionName: SolutionCrawlerOptions.BackgroundAnalysisScopeOption.Name,
                 feature: SolutionCrawlerOptions.BackgroundAnalysisScopeOption.Feature,
+                language: LanguageNames.CSharp,
+                value: value ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default);
+
+            SetPerLanguageOption(
+                optionName: SolutionCrawlerOptions.BackgroundAnalysisScopeOption.Name,
+                feature: SolutionCrawlerOptions.BackgroundAnalysisScopeOption.Feature,
+                language: LanguageNames.VisualBasic,
                 value: value ? BackgroundAnalysisScope.FullSolution : BackgroundAnalysisScope.Default);
         }
 

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml.vb
@@ -22,9 +22,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
             InitializeComponent()
 
-            BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile)
-            BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects)
-            BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution)
+            BindToOption(Background_analysis_scope_active_file, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.ActiveFile, LanguageNames.VisualBasic)
+            BindToOption(Background_analysis_scope_open_files, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.OpenFilesAndProjects, LanguageNames.VisualBasic)
+            BindToOption(Background_analysis_scope_full_solution, SolutionCrawlerOptions.BackgroundAnalysisScopeOption, BackgroundAnalysisScope.FullSolution, LanguageNames.VisualBasic)
             BindToOption(Use_editorconfig_compatibility_mode, EditorConfigDocumentOptionsProviderFactory.UseLegacyEditorConfigSupport)
 
             BindToOption(PlaceSystemNamespaceFirst, GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.VisualBasic)

--- a/src/Workspaces/Core/Portable/SolutionCrawler/ServiceFeatureOnOffOptions.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/ServiceFeatureOnOffOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.Shared.Options
+{
+    internal static class ServiceFeatureOnOffOptions
+    {
+        /// <summary>
+        /// This option is used by TypeScript.
+        /// </summary>
+        [Obsolete("Use the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
+        public static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = new PerLanguageOption<bool?>(
+            "ServiceFeaturesOnOff", "Closed File Diagnostic", defaultValue: null,
+            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Closed File Diagnostic"));
+    }
+}

--- a/src/Workspaces/Core/Portable/SolutionCrawler/ServiceFeatureOnOffOptions.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/ServiceFeatureOnOffOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Shared.Options
         /// <summary>
         /// This option is used by TypeScript.
         /// </summary>
-        [Obsolete("Use the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
+        [Obsolete("Currently used by TypeScript - should move to the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
         public static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = new PerLanguageOption<bool?>(
             "ServiceFeaturesOnOff", "Closed File Diagnostic", defaultValue: null,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Closed File Diagnostic"));

--- a/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Options;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
@@ -9,9 +10,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         /// <summary>
         /// Option to turn configure background analysis scope.
         /// </summary>
-        public static readonly Option<BackgroundAnalysisScope> BackgroundAnalysisScopeOption = new Option<BackgroundAnalysisScope>(
+        public static readonly PerLanguageOption<BackgroundAnalysisScope> BackgroundAnalysisScopeOption = new PerLanguageOption<BackgroundAnalysisScope>(
             nameof(SolutionCrawlerOptions), nameof(BackgroundAnalysisScopeOption), defaultValue: BackgroundAnalysisScope.Default,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.BackgroundAnalysisScopeOption"));
+            storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.BackgroundAnalysisScopeOption"));
 
         /// <summary>
         /// Enables forced <see cref="BackgroundAnalysisScope.Minimal"/> scope when low VM is detected to improve performance.
@@ -19,16 +20,34 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public static bool LowMemoryForcedMinimalBackgroundAnalysis = false;
 
         public static BackgroundAnalysisScope GetBackgroundAnalysisScope(Project project)
-            => GetBackgroundAnalysisScope(project.Solution.Options);
+            => GetBackgroundAnalysisScope(project.Solution.Options, project.Language);
 
-        public static BackgroundAnalysisScope GetBackgroundAnalysisScope(OptionSet options)
+        public static BackgroundAnalysisScope GetBackgroundAnalysisScope(OptionSet options, string language)
         {
             if (LowMemoryForcedMinimalBackgroundAnalysis)
             {
                 return BackgroundAnalysisScope.Minimal;
             }
 
-            return options.GetOption(BackgroundAnalysisScopeOption);
+            switch (language)
+            {
+                case LanguageNames.CSharp:
+                case LanguageNames.VisualBasic:
+                    return options.GetOption(BackgroundAnalysisScopeOption, language);
+
+                default:
+#pragma warning disable CS0618 // Type or member is obsolete - TypeScript and F# are still on the older ClosedFileDiagnostic option.
+                    var option = options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                    // Note that the default value for this option is 'true' for these languages.
+                    if (!option.HasValue || option.Value)
+                    {
+                        return BackgroundAnalysisScope.FullSolution;
+                    }
+
+                    return BackgroundAnalysisScope.Default;
+            }
         }
     }
 }


### PR DESCRIPTION
…ak for TS and F#

Recent PR #39699 introduced a breaking API and functionality change for TypeScript and F# as they are using our internal option `ClosedFileDiagnostic` for controlling their full solution analysis experience. This PR restores this option and functionality for non-C#/VB languages. Additionally, the newly added option `SolutionCrawlerOptions.BackgroundAnalysisScope` has been made a per-language option so that all languages can have different UI/setting for this option.