### PR TITLE
Ensure that work coordinator sees change to "RunAnalyzers" project pr…

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -575,7 +575,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     !object.Equals(oldProject.AnalyzerOptions, newProject.AnalyzerOptions) ||
                     !object.Equals(oldProject.DefaultNamespace, newProject.DefaultNamespace) ||
                     !object.Equals(oldProject.OutputFilePath, newProject.OutputFilePath) ||
-                    !object.Equals(oldProject.OutputRefFilePath, newProject.OutputRefFilePath))
+                    !object.Equals(oldProject.OutputRefFilePath, newProject.OutputRefFilePath) ||
+                    !object.Equals(oldProject.State.RunAnalyzers, newProject.State.RunAnalyzers))
                 {
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectConfigurationChanged);
                 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -576,7 +576,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     !object.Equals(oldProject.DefaultNamespace, newProject.DefaultNamespace) ||
                     !object.Equals(oldProject.OutputFilePath, newProject.OutputFilePath) ||
                     !object.Equals(oldProject.OutputRefFilePath, newProject.OutputRefFilePath) ||
-                    !object.Equals(oldProject.State.RunAnalyzers, newProject.State.RunAnalyzers))
+                    oldProject.State.RunAnalyzers != newProject.State.RunAnalyzers)
                 {
                     projectConfigurationChange = projectConfigurationChange.With(InvocationReasons.ProjectConfigurationChanged);
                 }


### PR DESCRIPTION
…operty as a configuration change that needs to kick off re-analysis.

Verified that added unit tests fail before the fix.