### PR TITLE
Move the ClosedFileDiagnostic option used by TS back to Features layer

### DIFF
--- a/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.SolutionCrawler;
 
 namespace Microsoft.CodeAnalysis.Shared.Options
 {
@@ -9,8 +10,6 @@ namespace Microsoft.CodeAnalysis.Shared.Options
         /// This option is used by TypeScript.
         /// </summary>
         [Obsolete("Currently used by TypeScript - should move to the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
-        public static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = new PerLanguageOption<bool?>(
-            "ServiceFeaturesOnOff", "Closed File Diagnostic", defaultValue: null,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Closed File Diagnostic"));
+        public static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = SolutionCrawlerOptions.ClosedFileDiagnostic;
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Shared/Options/FSharpServiceFeatureOnOffOptions.cs
+++ b/src/Tools/ExternalAccess/FSharp/Shared/Options/FSharpServiceFeatureOnOffOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Shared.Options
         /// this option doesn't mean we will show all diagnostics that belong to opened files when turned off,
         /// rather it means we will only show diagnostics that are cheap to calculate for small scope such as opened files.
         /// </summary>
-        [Obsolete("Use the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
-        public static PerLanguageOption<bool?> ClosedFileDiagnostic => Microsoft.CodeAnalysis.Shared.Options.ServiceFeatureOnOffOptions.ClosedFileDiagnostic;
+        [Obsolete("Currently used by F# - should move to the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
+        public static PerLanguageOption<bool?> ClosedFileDiagnostic => SolutionCrawlerOptions.ClosedFileDiagnostic;
     }
 }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/SolutionCrawlerOptions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Options;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
@@ -13,6 +13,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public static readonly PerLanguageOption<BackgroundAnalysisScope> BackgroundAnalysisScopeOption = new PerLanguageOption<BackgroundAnalysisScope>(
             nameof(SolutionCrawlerOptions), nameof(BackgroundAnalysisScopeOption), defaultValue: BackgroundAnalysisScope.Default,
             storageLocations: new RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.BackgroundAnalysisScopeOption"));
+
+        /// <summary>
+        /// This option is used by TypeScript and F#.
+        /// </summary>
+        [Obsolete("Currently used by TypeScript and F# - should move to the new option SolutionCrawlerOptions.BackgroundAnalysisScopeOption")]
+        internal static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = new PerLanguageOption<bool?>(
+            "ServiceFeaturesOnOff", "Closed File Diagnostic", defaultValue: null,
+            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.Closed File Diagnostic"));
 
         /// <summary>
         /// Enables forced <see cref="BackgroundAnalysisScope.Minimal"/> scope when low VM is detected to improve performance.
@@ -37,7 +45,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 default:
 #pragma warning disable CS0618 // Type or member is obsolete - TypeScript and F# are still on the older ClosedFileDiagnostic option.
-                    var option = options.GetOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, language);
+                    var option = options.GetOption(ClosedFileDiagnostic, language);
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     // Note that the default value for this option is 'true' for these languages.


### PR DESCRIPTION
#39955 re-added the option back to Workspaces instead of Features, its original location. This PR fixes it.