### PR TITLE
Change to telemetry logger

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis
             // For type import completion
             SessionWithTypeImportCompletionEnabled,
             CommitWithTypeImportCompletionEnabled,
-            CommitsOfTypeImportCompletionItem,
 
             // For targeted type completion
             SessionHasTargetTypeFilterEnabled,
@@ -35,9 +34,6 @@ namespace Microsoft.CodeAnalysis
 
         internal static void LogCommitWithTypeImportCompletionEnabled() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.CommitWithTypeImportCompletionEnabled);
-
-        internal static void LogCommitOfTypeImportCompletionItem() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfTypeImportCompletionItem);
 
         internal static void LogCommitWithTargetTypeCompletionExperimentEnabled() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.CommitWithTargetTypeCompletionExperimentEnabled);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -143,11 +143,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             if (session.TextView.Properties.TryGetProperty(CompletionSource.TypeImportCompletionEnabled, out bool isTyperImportCompletionEnabled) && isTyperImportCompletionEnabled)
             {
                 AsyncCompletionLogger.LogCommitWithTypeImportCompletionEnabled();
-
-                if (roslynItem.Flags.IsCached())
-                {
-                    AsyncCompletionLogger.LogCommitOfTypeImportCompletionItem();
-                }
             }
 
             if (session.TextView.Properties.TryGetProperty(CompletionSource.TargetTypeFilterExperimentEnabled, out bool isExperimentEnabled) && isExperimentEnabled)

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             TypeImportCompletionItemCount,
             TypeImportCompletionReferenceCount,
             TypeImportCompletionCacheMissCount,
+            CommitsOfTypeImportCompletionItem,
 
             TargetTypeCompletionTicks,
 
@@ -34,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             ExtensionMethodCompletionGetSymbolTicks,
             ExtensionMethodCompletionTypesChecked,
             ExtensionMethodCompletionMethodsChecked,
+            CommitsOfExtensionMethodImportCompletionItem,
         }
 
         internal static void LogTypeImportCompletionTicksDataPoint(int count)
@@ -50,6 +52,9 @@ namespace Microsoft.CodeAnalysis.Completion.Log
 
         internal static void LogTypeImportCompletionCacheMiss() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionCacheMissCount);
+
+        internal static void LogCommitOfTypeImportCompletionItem() =>
+            s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfTypeImportCompletionItem);
 
         internal static void LogTargetTypeCompletionTicksDataPoint(int count) =>
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TargetTypeCompletionTicks, count);
@@ -79,6 +84,8 @@ namespace Microsoft.CodeAnalysis.Completion.Log
         internal static void LogExtensionMethodCompletionMethodsCheckedDataPoint(int count) =>
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionMethodsChecked, count);
 
+        internal static void LogCommitOfExtensionMethodImportCompletionItem() =>
+            s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfExtensionMethodImportCompletionItem);
 
         internal static void ReportTelemetry()
         {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Log;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -20,6 +21,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         protected override bool ShouldProvideCompletion(Document document, SyntaxContext syntaxContext)
             => syntaxContext.IsRightOfNameSeparator && IsAddingImportsSupported(document);
+
+        protected override void LogCommit()
+            => CompletionProvidersLogger.LogCommitOfExtensionMethodImportCompletionItem();
 
         protected async override Task AddCompletionItemsAsync(
             CompletionContext completionContext,

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -27,6 +27,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected abstract bool ShouldProvideCompletion(Document document, SyntaxContext syntaxContext);
         protected abstract Task AddCompletionItemsAsync(CompletionContext completionContext, SyntaxContext syntaxContext, HashSet<string> namespacesInScope, bool isExpandedCompletion, CancellationToken cancellationToken);
 
+        // For telemetry reporting
+        protected abstract void LogCommit();
+
         internal override bool IsExpandItemProvider => true;
 
         private bool? _isImportCompletionExperimentEnabled = null;
@@ -99,6 +102,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         internal override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem completionItem, TextSpan completionListSpan, char? commitKey, CancellationToken cancellationToken)
         {
+            LogCommit();
             var containingNamespace = ImportCompletionItem.GetContainingNamespace(completionItem);
 
             if (await ShouldCompleteWithFullyQualifyTypeName().ConfigureAwait(false))

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
@@ -20,6 +20,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected override bool ShouldProvideCompletion(Document document, SyntaxContext syntaxContext)
             => syntaxContext.IsTypeContext;
 
+        protected override void LogCommit()
+            => CompletionProvidersLogger.LogCommitOfTypeImportCompletionItem();
+
         protected override async Task AddCompletionItemsAsync(CompletionContext completionContext, SyntaxContext syntaxContext, HashSet<string> namespacesInScope, bool isExpandedCompletion, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Completion_TypeImportCompletionProvider_GetCompletionItemsAsync, cancellationToken))

--- a/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
@@ -1,53 +1,95 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
     /// <summary>
     /// Defines a log aggregator to create a histogram
     /// </summary>
-    internal class HistogramLogAggregator : AbstractLogAggregator<LogAggregator.Counter>
+    internal sealed class HistogramLogAggregator : AbstractLogAggregator<HistogramLogAggregator.HistogramCounter>
     {
         private readonly int _bucketSize;
         private readonly int _maxBucketValue;
+        private readonly int _bucketCount;
 
         public HistogramLogAggregator(int bucketSize, int maxBucketValue)
         {
+            if (bucketSize <= 0 || maxBucketValue <= 0 || maxBucketValue % bucketSize != 0)
+            {
+                throw new ArgumentException();
+            }
+
             _bucketSize = bucketSize;
             _maxBucketValue = maxBucketValue;
+            _bucketCount = maxBucketValue / bucketSize + 1;
         }
 
-        public void IncreaseCount(decimal value)
+        protected override HistogramCounter CreateCounter()
         {
-            var counter = GetCounter(GetBucket(value));
-            counter.IncreaseCount();
+            return new HistogramCounter(_bucketSize, _maxBucketValue, _bucketCount);
         }
 
-        public int GetCount(decimal value)
+        public void IncreaseCount(object key, decimal value)
         {
-            if (TryGetCounter(GetBucket(value), out var counter))
+            var counter = GetCounter(key);
+            counter.IncreaseCount(value);
+        }
+
+        internal sealed class HistogramCounter
+        {
+            private readonly int[] _buckets;
+
+            public int BucketCount { get; }
+            public int BucketSize { get; }
+            public int MaxBucketValue { get; }
+
+            public HistogramCounter(int bucketSize, int maxBucketValue, int bucketCount)
             {
-                return counter.GetCount();
+                Debug.Assert(bucketSize > 0 && maxBucketValue > 0 && bucketCount > 0);
+
+                BucketSize = bucketSize;
+                MaxBucketValue = maxBucketValue;
+                BucketCount = bucketCount;
+                _buckets = new int[BucketCount];
             }
 
-            return 0;
-        }
-
-        protected override LogAggregator.Counter CreateCounter()
-        {
-            return new LogAggregator.Counter();
-        }
-
-        private int GetBucket(decimal value)
-        {
-            var bucket = (int)Math.Floor(value / _bucketSize) * _bucketSize;
-            if (bucket > _maxBucketValue)
+            public void IncreaseCount(decimal value)
             {
-                bucket = _maxBucketValue;
+                var bucket = GetBucket(value);
+                _buckets[bucket]++;
             }
 
-            return bucket;
+            public string GetBucketsAsString()
+            {
+                var pooledStringBuilder = PooledStringBuilder.GetInstance();
+                var builder = pooledStringBuilder.Builder;
+
+                builder.Append('[');
+                builder.Append(_buckets[0]);
+
+                for (var i = 1; i < _buckets.Length; ++i)
+                {
+                    builder.Append(',');
+                    builder.Append(_buckets[i]);
+                }
+
+                builder.Append(']');
+                return pooledStringBuilder.ToStringAndFree();
+            }
+
+            private int GetBucket(decimal value)
+            {
+                var bucket = (int)Math.Floor(value / BucketSize);
+                if (bucket >= BucketCount)
+                {
+                    bucket = BucketCount - 1;
+                }
+
+                return bucket;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Log/SyntacticLspLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/SyntacticLspLogger.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
     internal sealed class SyntacticLspLogger
     {
-        private static readonly HistogramLogAggregator s_lexicalClassificationsLogAggregator = new HistogramLogAggregator(bucketSize: 100, maxBucketValue: 5000);
-        private static readonly HistogramLogAggregator s_syntacticClassificationsRemoteAggregator = new HistogramLogAggregator(bucketSize: 100, maxBucketValue: 5000);
-        private static readonly HistogramLogAggregator s_syntacticTaggerRemoteAggregator = new HistogramLogAggregator(bucketSize: 100, maxBucketValue: 5000);
+        private static readonly HistogramLogAggregator s_histogramLogAggregator = new HistogramLogAggregator(bucketSize: 100, maxBucketValue: 5000);
 
         internal enum RequestType
         {
@@ -19,38 +15,40 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         internal static void LogRequestLatency(RequestType requestType, decimal latency)
         {
-            switch (requestType)
-            {
-                case RequestType.LexicalClassifications:
-                    s_lexicalClassificationsLogAggregator.IncreaseCount(latency);
-                    break;
-                case RequestType.SyntacticClassifications:
-                    s_syntacticClassificationsRemoteAggregator.IncreaseCount(latency);
-                    break;
-                case RequestType.SyntacticTagger:
-                    s_syntacticTaggerRemoteAggregator.IncreaseCount(latency);
-                    break;
-                default:
-                    break;
-
-            }
+            s_histogramLogAggregator.IncreaseCount(requestType, latency);
         }
 
         internal static void ReportTelemetry()
         {
-            ReportTelemetry(FunctionId.Liveshare_LexicalClassifications, RequestType.LexicalClassifications.ToString(), s_lexicalClassificationsLogAggregator);
-            ReportTelemetry(FunctionId.Liveshare_SyntacticClassifications, RequestType.SyntacticClassifications.ToString(), s_syntacticClassificationsRemoteAggregator);
-            ReportTelemetry(FunctionId.Liveshare_SyntacticTagger, RequestType.SyntacticTagger.ToString(), s_syntacticTaggerRemoteAggregator);
 
-            static void ReportTelemetry(FunctionId functionId, string typeName, HistogramLogAggregator aggregator)
+            foreach (var kv in s_histogramLogAggregator)
             {
+                Report((RequestType)kv.Key, kv.Value);
+            }
+
+            static void Report(RequestType requestType, HistogramLogAggregator.HistogramCounter counter)
+            {
+                FunctionId functionId;
+                switch (requestType)
+                {
+                    case RequestType.LexicalClassifications:
+                        functionId = FunctionId.Liveshare_LexicalClassifications;
+                        break;
+                    case RequestType.SyntacticClassifications:
+                        functionId = FunctionId.Liveshare_SyntacticClassifications;
+                        break;
+                    case RequestType.SyntacticTagger:
+                        functionId = FunctionId.Liveshare_SyntacticTagger;
+                        break;
+                    default:
+                        return;
+                }
+
                 Logger.Log(functionId, KeyValueLogMessage.Create(m =>
                 {
-                    foreach (var kv in aggregator)
-                    {
-                        var info = $"{typeName}.{kv.Key}";
-                        m[info] = kv.Value.GetCount();
-                    }
+                    m[$"{requestType.ToString()}.BucketSize"] = counter.BucketSize;
+                    m[$"{requestType.ToString()}.MaxBucketValue"] = counter.MaxBucketValue;
+                    m[$"{requestType.ToString()}.Buckets"] = counter.GetBucketsAsString();
                 }));
             }
         }


### PR DESCRIPTION
This PR contains following changes to telemetry reporting:

1. Make it easier to query results reported by `HistogramLogAggregator`, i.e. represent the buckets as an array instead of a collection of individual properties.

![image](https://user-images.githubusercontent.com/788783/69466849-9064a280-0d3a-11ea-8423-4d4cef9f5537.png)

2. Additional usage data for import completion