### PR TITLE
Don't use the C#_LSP language service for Razor secondary buffers

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/Client/Debugging/CSharpLspLanguageService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Debugging/CSharpLspLanguageService.cs
@@ -15,8 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Debugging
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2302:FlagServiceProviders")]
     internal class CSharpLspLanguageService : AbstractLanguageService<CSharpLspPackage, CSharpLspLanguageService>
     {
-        public static readonly Guid LanguageServiceGuid = new Guid(StringConstants.CSharpLspLanguageServiceGuidString);
-
         internal CSharpLspLanguageService(CSharpLspPackage package)
             : base(package)
         {
@@ -26,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Debugging
 
         protected override Guid DebuggerLanguageId { get; } = new Guid(StringConstants.CSharpLspDebuggerLanguageGuidString);
 
-        public override Guid LanguageServiceId { get; } = LanguageServiceGuid;
+        public override Guid LanguageServiceId { get; } = new Guid(StringConstants.CSharpLspLanguageServiceGuidString);
 
         protected override string ContentTypeName => StringConstants.CSharpLspContentTypeName;
 

--- a/src/VisualStudio/LiveShare/Impl/Client/Razor/CSharpLspContainedLanguageProvider.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Razor/CSharpLspContainedLanguageProvider.cs
@@ -4,11 +4,14 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
-using Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Debugging;
 using Microsoft.VisualStudio.LiveShare.WebEditors.ContainedLanguage;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 
@@ -33,6 +36,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Razor
 
         public IContentType GetContentType(string filePath)
         {
+            return GetContentType();
+        }
+
+        private IContentType GetContentType()
+        {
             return _contentTypeRegistry.GetContentType(StringConstants.CSharpLspContentTypeName);
         }
 
@@ -41,14 +49,34 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Razor
             var componentModel = (IComponentModel)_serviceProvider.GetService(typeof(SComponentModel));
             var projectId = _razorProjectFactory.GetProject(filePath);
 
-            return new ContainedLanguage(
+            var containedLanguage = new ContainedLanguage(
                 bufferCoordinator,
                 componentModel,
                 _razorProjectFactory.Workspace,
                 projectId,
                 project: null,
                 filePath,
-                CSharpLspLanguageService.LanguageServiceGuid);
+                Guids.CSharpLanguageServiceId);
+
+            // Our buffer starts out as the regular CSharp content type. We want it to be C#_LSP. We can change it now, but
+            // ASP.NET ultimately calls IVsContainedLanguage.GetLanguageServiceID to get our ID (which points to regular CSharp),
+            // and switches the buffer back to that. By changing our content type now and then hooking up a buffer change watcher
+            // we can change it back underneath ASP.NET.
+            containedLanguage.SubjectBuffer.ChangeContentType(GetContentType(), editTag: nameof(CSharpLspContainedLanguageProvider) + "." + nameof(GetLanguage));
+            containedLanguage.SubjectBuffer.ContentTypeChanged += SubjectBuffer_ContentTypeChanged;
+
+            return containedLanguage;
+        }
+
+        private void SubjectBuffer_ContentTypeChanged(object sender, Text.ContentTypeChangedEventArgs e)
+        {
+            if (e.AfterContentType.TypeName == ContentTypeNames.CSharpContentType)
+            {
+                var buffer = (ITextBuffer)sender;
+                buffer.ChangeContentType(GetContentType(), editTag: nameof(CSharpLspContainedLanguageProvider) + "." + nameof(SubjectBuffer_ContentTypeChanged));
+
+                buffer.ContentTypeChanged -= SubjectBuffer_ContentTypeChanged;
+            }
         }
     }
 }


### PR DESCRIPTION
This removes one of the remaining uses of the language service.