### PR TITLE
Improve performance of the 'introduce variable' code action.

### DIFF
--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService.cs
@@ -136,11 +136,6 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             return expression.GetAncestorsOrThis<BlockSyntax>();
         }
 
-        protected override IList<bool> GetInsertionIndices(TypeDeclarationSyntax destination, CancellationToken cancellationToken)
-        {
-            return destination.GetInsertionIndices(cancellationToken);
-        }
-
         protected override bool CanReplace(ExpressionSyntax expression)
         {
             return true;

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceField.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
 {
     internal partial class CSharpIntroduceVariableService
     {
-        protected override Task<Tuple<Document, SyntaxNode, int>> IntroduceFieldAsync(
+        protected override Task<Document> IntroduceFieldAsync(
             SemanticDocument document,
             ExpressionSyntax expression,
             bool allOccurrences,
@@ -57,9 +57,8 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
 
                 var finalTypeDeclaration = InsertMember(newTypeDeclaration, newFieldDeclaration, insertionIndex);
 
-                SyntaxNode destination = oldTypeDeclaration;
                 var newRoot = document.Root.ReplaceNode(oldTypeDeclaration, finalTypeDeclaration);
-                return Task.FromResult(Tuple.Create(document.Document.WithSyntaxRoot(newRoot), destination, insertionIndex));
+                return Task.FromResult(document.Document.WithSyntaxRoot(newRoot));
             }
             else
             {
@@ -71,9 +70,8 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                     DetermineConstantInsertPosition(oldCompilationUnit.Members, newCompilationUnit.Members) :
                     DetermineFieldInsertPosition(oldCompilationUnit.Members, newCompilationUnit.Members);
 
-                SyntaxNode destination = oldCompilationUnit;
                 var newRoot = newCompilationUnit.WithMembers(newCompilationUnit.Members.Insert(insertionIndex, newFieldDeclaration));
-                return Task.FromResult(Tuple.Create(document.Document.WithSyntaxRoot(newRoot), destination, insertionIndex));
+                return Task.FromResult(document.Document.WithSyntaxRoot(newRoot));
             }
         }
 

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs
@@ -64,11 +64,8 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 }
             }
 
-            private async Task<Document> IntroduceFieldAsync(CancellationToken cancellationToken)
-            {
-                var result = await _service.IntroduceFieldAsync(_semanticDocument, _expression, _allOccurrences, _isConstant, cancellationToken).ConfigureAwait(false);
-                return result.Item1;
-            }
+            private Task<Document> IntroduceFieldAsync(CancellationToken cancellationToken)
+                => _service.IntroduceFieldAsync(_semanticDocument, _expression, _allOccurrences, _isConstant, cancellationToken);
 
             private string CreateDisplayText(TExpressionSyntax expression)
             {

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -186,10 +186,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 if (CanGenerateIntoContainer(state, cancellationToken))
                 {
                     actions.Add(CreateAction(state, allOccurrences: false, isConstant: true, isLocal: false, isQueryLocal: false));
-                }
-
-                if (CanGenerateIntoContainer(state, cancellationToken))
-                {
                     actions.Add(CreateAction(state, allOccurrences: true, isConstant: true, isLocal: false, isQueryLocal: false));
                 }
             }

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -182,21 +182,19 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 // If something is a constant, and it doesn't access any other locals constants,
                 // then we prefer to offer to generate a constant field instead of a constant
                 // local.
-                var action1 = CreateAction(state, allOccurrences: false, isConstant: true, isLocal: false, isQueryLocal: false);
-                if (await CanGenerateIntoContainerAsync(state, action1, cancellationToken).ConfigureAwait(false))
+                if (await CanGenerateIntoContainerAsync(state, cancellationToken).ConfigureAwait(false))
                 {
-                    actions.Add(action1);
+                    actions.Add(CreateAction(state, allOccurrences: false, isConstant: true, isLocal: false, isQueryLocal: false));
                 }
 
-                var action2 = CreateAction(state, allOccurrences: true, isConstant: true, isLocal: false, isQueryLocal: false);
-                if (await CanGenerateIntoContainerAsync(state, action2, cancellationToken).ConfigureAwait(false))
+                if (await CanGenerateIntoContainerAsync(state, cancellationToken).ConfigureAwait(false))
                 {
-                    actions.Add(action2);
+                    actions.Add(CreateAction(state, allOccurrences: true, isConstant: true, isLocal: false, isQueryLocal: false));
                 }
             }
         }
 
-        private async Task<bool> CanGenerateIntoContainerAsync(State state, CodeAction action, CancellationToken cancellationToken)
+        private async Task<bool> CanGenerateIntoContainerAsync(State state, CancellationToken cancellationToken)
         {
             var result = await IntroduceFieldAsync(
                 state.Document, state.Expression,

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService.vb
@@ -21,10 +21,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
             Return expression.GetContainingExecutableBlocks()
         End Function
 
-        Protected Overrides Function GetInsertionIndices(destination As TypeBlockSyntax, cancellationToken As CancellationToken) As IList(Of Boolean)
-            Return destination.GetInsertionIndices(cancellationToken)
-        End Function
-
         Protected Overrides Function IsInAttributeArgumentInitializer(expression As ExpressionSyntax) As Boolean
             If expression.GetAncestorOrThis(Of ArgumentSyntax)() Is Nothing Then
                 Return False

--- a/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceField.vb
+++ b/src/Features/VisualBasic/Portable/IntroduceVariable/VisualBasicIntroduceVariableService_IntroduceField.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                 expression As ExpressionSyntax,
                 allOccurrences As Boolean,
                 isConstant As Boolean,
-                cancellationToken As CancellationToken) As Task(Of Tuple(Of Document, SyntaxNode, Integer))
+                cancellationToken As CancellationToken) As Task(Of Document)
 
             Dim oldTypeDeclaration = expression.GetAncestorOrThis(Of TypeBlockSyntax)()
             Dim oldType = If(oldTypeDeclaration IsNot Nothing,
@@ -42,12 +42,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                     document, oldTypeDeclaration, newNameToken, expression, allOccurrences, isConstant, cancellationToken)
 
                 Dim insertionIndex = If(isConstant, DetermineConstantInsertPosition(oldCompilationUnit.Members, newCompilationUnit.Members), DetermineFieldInsertPosition(oldCompilationUnit.Members, newCompilationUnit.Members))
-                Dim destination As SyntaxNode = oldCompilationUnit
 
                 Dim newRoot = newCompilationUnit.WithMembers(
                     newCompilationUnit.Members.Insert(insertionIndex, newFieldDeclaration))
 
-                Return Tuple.Create(document.Document.WithSyntaxRoot(newRoot), destination, insertionIndex)
+                Return document.Document.WithSyntaxRoot(newRoot)
             End If
         End Function
 
@@ -60,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                 newNameToken As SyntaxToken,
                 allOccurrences As Boolean,
                 isConstant As Boolean,
-                cancellationToken As CancellationToken) As Task(Of Tuple(Of Document, SyntaxNode, Integer))
+                cancellationToken As CancellationToken) As Task(Of Document)
 
             Dim oldToNewTypeBlockMap = New Dictionary(Of TypeBlockSyntax, TypeBlockSyntax)
 
@@ -101,7 +100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.IntroduceVariable
                 updatedDocument = updatedDocument.Project.Solution.GetDocument(currentDocument.Id).WithSyntaxRoot(newRoot)
             Next
 
-            Return Tuple.Create(updatedDocument, destination, insertionIndex)
+            Return updatedDocument
         End Function
 
         Protected Shared Function DetermineConstantInsertPosition(oldMembers As SyntaxList(Of StatementSyntax),


### PR DESCRIPTION
More mitigations for https://github.com/dotnet/roslyn/issues/24548

This PR changes the logic for 'intro var' slightly in a way that shoudl not negatively impact users, but which should speed up the work it does a lot. 

More explanation in the code change itself.  

Tagging @jinujoseph @sharwell 