### PR TITLE
Diagnostics refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.UnitTests.Diagnostics;
@@ -150,7 +151,7 @@ class C
 
         private class ThrowingDoNotCatchDiagnosticAnalyzer<TLanguageKindEnum> : ThrowingDiagnosticAnalyzer<TLanguageKindEnum>, IBuiltInAnalyzer where TLanguageKindEnum : struct
         {
-            public bool OpenFileOnly(Workspace workspace) => false;
+            public bool OpenFileOnly(OptionSet options) => false;
 
             public DiagnosticAnalyzerCategory GetAnalyzerCategory()
             {

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -680,7 +680,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     // diagnostic from things like build shouldn't reach here since we don't support LB for those diagnostics
                     Debug.Assert(diag.Item1.HasTextSpan);
                     var category = GetFixCategory(diag.Item1.Severity);
-                    sets.Add(new SuggestedActionSet(category, group, priority: priority, applicableToSpan: diag.Item1.TextSpan.ToSpan()));
+                    sets.Add(new SuggestedActionSet(category, group, priority: priority, applicableToSpan: diag.Item1.GetTextSpan().ToSpan()));
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             foreach (var diagnostic in severityGroup)
             {
-                if (!range.IntersectsWith(diagnostic.TextSpan))
+                if (!range.IntersectsWith(diagnostic.GetTextSpan()))
                 {
                     continue;
                 }
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 cancellationToken.ThrowIfCancellationRequested();
 
                 aggregatedDiagnostics ??= new Dictionary<TextSpan, List<DiagnosticData>>();
-                aggregatedDiagnostics.GetOrAdd(diagnostic.TextSpan, _ => new List<DiagnosticData>()).Add(diagnostic);
+                aggregatedDiagnostics.GetOrAdd(diagnostic.GetTextSpan(), _ => new List<DiagnosticData>()).Add(diagnostic);
             }
 
             if (aggregatedDiagnostics == null)

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 workspace,
                 ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>>.Empty.Add(
                     document.Project.Id,
-                    ImmutableArray.Create(DiagnosticData.Create(document, Diagnostic.Create(NoNameAnalyzer.s_syntaxRule, location)))));
+                    ImmutableArray.Create(DiagnosticData.Create(Diagnostic.Create(NoNameAnalyzer.s_syntaxRule, location), document.Project))));
 
             // wait for all events to raised
             await listener.CreateExpeditedWaitTask().ConfigureAwait(false);

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -230,14 +230,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             };
 
             // cause analysis
+            var location = Location.Create(document.FilePath, textSpan: default, lineSpan: default);
+
             await service.SynchronizeWithBuildAsync(
                 workspace,
                 ImmutableDictionary<ProjectId, ImmutableArray<DiagnosticData>>.Empty.Add(
                     document.Project.Id,
-                    ImmutableArray.Create(
-                        Diagnostic.Create(
-                            NoNameAnalyzer.s_syntaxRule,
-                            Location.Create(document.FilePath, TextSpan.FromBounds(0, 0), new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 0)))).ToDiagnosticData(project))));
+                    ImmutableArray.Create(DiagnosticData.Create(document, Diagnostic.Create(NoNameAnalyzer.s_syntaxRule, location)))));
 
             // wait for all events to raised
             await listener.CreateExpeditedWaitTask().ConfigureAwait(false);
@@ -434,7 +433,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 return DiagnosticAnalyzerCategory.SyntaxTreeWithoutSemanticsAnalysis;
             }
 
-            public bool OpenFileOnly(Workspace workspace)
+            public bool OpenFileOnly(CodeAnalysis.Options.OptionSet options)
             {
                 return true;
             }

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
@@ -91,10 +91,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var version = VersionStamp.Create(utcTime.AddDays(1));
 
             var key = "document";
+
+            var persistentService = workspace.Services.GetRequiredService<IPersistentStorageService>();
             var serializer = new CodeAnalysis.Workspaces.Diagnostics.DiagnosticDataSerializer(analyzerVersion, version);
 
-            Assert.True(await serializer.SerializeAsync(document, key, diagnostics, CancellationToken.None).ConfigureAwait(false));
-            var recovered = await serializer.DeserializeAsync(document, key, CancellationToken.None);
+            Assert.True(await serializer.SerializeAsync(persistentService, document.Project, document, key, diagnostics, CancellationToken.None).ConfigureAwait(false));
+
+            var recovered = await serializer.DeserializeAsync(persistentService, document.Project, document, key, CancellationToken.None);
 
             AssertDiagnostics(diagnostics, recovered.Value);
         }
@@ -158,10 +161,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             var version = VersionStamp.Create(utcTime.AddDays(1));
 
             var key = "project";
+            var persistentService = workspace.Services.GetRequiredService<IPersistentStorageService>();
             var serializer = new CodeAnalysis.Workspaces.Diagnostics.DiagnosticDataSerializer(analyzerVersion, version);
 
-            Assert.True(await serializer.SerializeAsync(document, key, diagnostics, CancellationToken.None).ConfigureAwait(false));
-            var recovered = await serializer.DeserializeAsync(document, key, CancellationToken.None);
+            Assert.True(await serializer.SerializeAsync(persistentService, document.Project, document, key, diagnostics, CancellationToken.None).ConfigureAwait(false));
+            var recovered = await serializer.DeserializeAsync(persistentService, document.Project, document, key, CancellationToken.None);
 
             AssertDiagnostics(diagnostics, recovered.Value);
         }

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Assert.Equal(item1.HasTextSpan, item2.HasTextSpan);
             if (item1.HasTextSpan)
             {
-                Assert.Equal(item1.TextSpan, item2.TextSpan);
+                Assert.Equal(item1.GetTextSpan(), item2.GetTextSpan());
             }
 
             Assert.Equal(item1.DataLocation?.MappedFilePath, item2.DataLocation?.MappedFilePath);

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
             var recovered = await serializer.DeserializeAsync(persistentService, document.Project, document, key, CancellationToken.None);
 
-            AssertDiagnostics(diagnostics, recovered.Value);
+            AssertDiagnostics(diagnostics, recovered);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             Assert.True(await serializer.SerializeAsync(persistentService, document.Project, document, key, diagnostics, CancellationToken.None).ConfigureAwait(false));
             var recovered = await serializer.DeserializeAsync(persistentService, document.Project, document, key, CancellationToken.None);
 
-            AssertDiagnostics(diagnostics, recovered.Value);
+            AssertDiagnostics(diagnostics, recovered);
         }
 
         [WorkItem(6104, "https://github.com/dotnet/roslyn/issues/6104")]

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -222,9 +222,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             internal void CreateDiagnosticAndFireEvents(Location location)
             {
                 var document = _workspace.CurrentSolution.Projects.Single().Documents.Single();
-                _diagnostic = DiagnosticData.Create(document,
-                    Diagnostic.Create(DiagnosticId, "MockCategory", "MockMessage", DiagnosticSeverity.Error, DiagnosticSeverity.Error, isEnabledByDefault: true, warningLevel: 0,
-                    location: location));
+                _diagnostic = DiagnosticData.Create(Diagnostic.Create(DiagnosticId, "MockCategory", "MockMessage", DiagnosticSeverity.Error, DiagnosticSeverity.Error, isEnabledByDefault: true, warningLevel: 0,
+                    location: location),
+                    document);
 
                 DiagnosticsUpdated?.Invoke(this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
                     this, _workspace, _workspace.CurrentSolution,

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -502,12 +502,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim exceptionDiagnosticsSource = New TestHostDiagnosticUpdateSource(workspace)
 
                 ' check reporting diagnostic to a project that doesn't exist
-                exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, workspace, ProjectId.CreateFromSerialized(Guid.NewGuid(), "dummy"))
+                exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, ProjectId.CreateFromSerialized(Guid.NewGuid(), "dummy"))
                 Dim diagnostics = exceptionDiagnosticsSource.GetTestAccessor().GetReportedDiagnostics(analyzer)
                 Assert.Equal(0, diagnostics.Count())
 
                 ' check workspace diagnostic reporting
-                exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, workspace, Nothing)
+                exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, projectId:=Nothing)
                 diagnostics = exceptionDiagnosticsSource.GetTestAccessor().GetReportedDiagnostics(analyzer)
 
                 Assert.Equal(1, diagnostics.Count())

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -1072,7 +1072,7 @@ public class B
 
                 Dim diagnostics = diagnosticService.GetDiagnosticsForSpanAsync(document, fullSpan).
                     WaitAndGetResult(CancellationToken.None).
-                    OrderBy(Function(d) d.TextSpan.Start).ToArray
+                    OrderBy(Function(d) d.GetTextSpan().Start).ToArray
 
                 Assert.Equal(3, diagnostics.Count)
                 Assert.True(diagnostics.All(Function(d) d.Id = MethodSymbolAnalyzer.Descriptor.Id))
@@ -1184,7 +1184,7 @@ public class B
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
                 Dim diagnostics = diagnosticService.GetDiagnosticsForSpanAsync(document, fullSpan).
                     WaitAndGetResult(CancellationToken.None).
-                    OrderBy(Function(d) d.TextSpan.Start).
+                    OrderBy(Function(d) d.GetTextSpan().Start).
                     ToArray()
                 Assert.Equal(4, diagnostics.Length)
                 Assert.Equal(4, diagnostics.Where(Function(d) d.Id = FieldDeclarationAnalyzer.Descriptor1.Id).Count)
@@ -1230,7 +1230,7 @@ public class B
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
                 Dim diagnostics = diagnosticService.GetDiagnosticsForSpanAsync(document, fullSpan).
                     WaitAndGetResult(CancellationToken.None).
-                    OrderBy(Function(d) d.TextSpan.Start).
+                    OrderBy(Function(d) d.GetTextSpan().Start).
                     ToArray()
 
                 For Each diagnostic In diagnostics

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractSuppressionAllCodeTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             private readonly DiagnosticDescriptor _descriptor =
                     new DiagnosticDescriptor("TestId", "Test", "Test", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
-            public bool OpenFileOnly(Workspace workspace) => false;
+            public bool OpenFileOnly(CodeAnalysis.Options.OptionSet options) => false;
 
             public ImmutableArray<SyntaxNode> AllNodes { get; set; }
 

--- a/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerDriver.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/TestDiagnosticAnalyzerDriver.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             if (getDocumentDiagnostics)
             {
                 var dxs = await _diagnosticAnalyzerService.GetDiagnosticsAsync(project.Solution, project.Id, document.Id, _includeSuppressedDiagnostics);
-                documentDiagnostics = await CodeAnalysis.Diagnostics.Extensions.ToDiagnosticsAsync(dxs.Where(d => d.HasTextSpan && d.TextSpan.IntersectsWith(span)), project, CancellationToken.None);
+                documentDiagnostics = await CodeAnalysis.Diagnostics.Extensions.ToDiagnosticsAsync(dxs.Where(d => d.HasTextSpan && d.GetTextSpan().IntersectsWith(span)), project, CancellationToken.None);
             }
 
             if (getProjectDiagnostics)

--- a/src/Features/CSharp/Portable/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
                     .Add(Constants.ShouldRemoveNextStatementKey, shouldRemoveNextStatement.ToString(CultureInfo.InvariantCulture))));
         }
 
-        public override bool OpenFileOnly(Workspace workspace)
+        public override bool OpenFileOnly(OptionSet options)
             => false;
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -27,11 +27,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
-        public override bool OpenFileOnly(Workspace workspace)
+        public override bool OpenFileOnly(OptionSet options)
         {
-            var forIntrinsicTypesOption = workspace.Options.GetOption(CSharpCodeStyleOptions.VarForBuiltInTypes).Notification;
-            var whereApparentOption = workspace.Options.GetOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent).Notification;
-            var wherePossibleOption = workspace.Options.GetOption(CSharpCodeStyleOptions.VarElsewhere).Notification;
+            var forIntrinsicTypesOption = options.GetOption(CSharpCodeStyleOptions.VarForBuiltInTypes).Notification;
+            var whereApparentOption = options.GetOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent).Notification;
+            var wherePossibleOption = options.GetOption(CSharpCodeStyleOptions.VarElsewhere).Notification;
 
             return !(forIntrinsicTypesOption == NotificationOption.Warning || forIntrinsicTypesOption == NotificationOption.Error ||
                      whereApparentOption == NotificationOption.Warning || whereApparentOption == NotificationOption.Error ||

--- a/src/Features/Core/Portable/CodeQuality/AbstractCodeQualityDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/CodeQuality/AbstractCodeQualityDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.CodeQuality
 {
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CodeQuality
 
         public abstract DiagnosticAnalyzerCategory GetAnalyzerCategory();
 
-        public bool OpenFileOnly(Workspace workspace)
+        public bool OpenFileOnly(OptionSet options)
             => false;
 
         protected static DiagnosticDescriptor CreateDescriptor(

--- a/src/Features/Core/Portable/CodeStyle/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/CodeStyle/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         public abstract DiagnosticAnalyzerCategory GetAnalyzerCategory();
 
-        public virtual bool OpenFileOnly(Workspace workspace)
+        public virtual bool OpenFileOnly(OptionSet options)
             => false;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -50,7 +50,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            var diagnosticData = DiagnosticData.Create(diagnostic, project, Workspace.Options);
+            var diagnosticData = (project != null) ?
+                DiagnosticData.Create(diagnostic, project) :
+                DiagnosticData.Create(diagnostic, Workspace.Options);
+
             ReportAnalyzerDiagnostic(analyzer, diagnosticData, project);
         }
 

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -37,15 +37,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             DiagnosticsUpdated?.Invoke(this, args);
         }
 
-        public void ReportAnalyzerDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, Workspace? workspace, ProjectId? projectId)
+        public void ReportAnalyzerDiagnostic(DiagnosticAnalyzer analyzer, Diagnostic diagnostic, ProjectId? projectId)
         {
-            if (workspace != Workspace)
-            {
-                return;
-            }
-
             // check whether we are reporting project specific diagnostic or workspace wide diagnostic
-            var project = (projectId != null) ? workspace.CurrentSolution.GetProject(projectId) : null;
+            var project = (projectId != null) ? Workspace.CurrentSolution.GetProject(projectId) : null;
 
             // check whether project the diagnostic belong to still exist
             if (projectId != null && project == null)
@@ -55,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            var diagnosticData = DiagnosticData.Create(workspace, diagnostic, project?.Id);
+            var diagnosticData = DiagnosticData.Create(diagnostic, project, Workspace.Options);
             ReportAnalyzerDiagnostic(analyzer, diagnosticData, project);
         }
 

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -608,7 +608,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
-                    yield return DiagnosticData.Create(targetDocument, diagnostic);
+                    yield return DiagnosticData.Create(diagnostic, targetDocument);
                 }
             }
 
@@ -629,7 +629,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
-                    yield return DiagnosticData.Create(document, diagnostic);
+                    yield return DiagnosticData.Create(diagnostic, document);
                 }
             }
         }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -50,24 +50,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private const string AnalyzerExceptionDiagnosticCategory = "Intellisense";
 
         public static bool IsWorkspaceDiagnosticAnalyzer(this DiagnosticAnalyzer analyzer)
-        {
-            return analyzer is DocumentDiagnosticAnalyzer || analyzer is ProjectDiagnosticAnalyzer;
-        }
+            => analyzer is DocumentDiagnosticAnalyzer || analyzer is ProjectDiagnosticAnalyzer;
 
         public static bool IsBuiltInAnalyzer(this DiagnosticAnalyzer analyzer)
-        {
-            return analyzer is IBuiltInAnalyzer || analyzer.IsWorkspaceDiagnosticAnalyzer() || analyzer.IsCompilerAnalyzer();
-        }
+            => analyzer is IBuiltInAnalyzer || analyzer.IsWorkspaceDiagnosticAnalyzer() || analyzer.IsCompilerAnalyzer();
 
-        public static bool IsOpenFileOnly(this DiagnosticAnalyzer analyzer, Workspace workspace)
-        {
-            if (analyzer is IBuiltInAnalyzer builtInAnalyzer)
-            {
-                return builtInAnalyzer.OpenFileOnly(workspace);
-            }
-
-            return false;
-        }
+        public static bool IsOpenFileOnly(this DiagnosticAnalyzer analyzer, OptionSet options)
+            => analyzer is IBuiltInAnalyzer builtInAnalyzer && builtInAnalyzer.OpenFileOnly(options);
 
         public static ReportDiagnostic GetEffectiveSeverity(this DiagnosticDescriptor descriptor, CompilationOptions options)
         {
@@ -123,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (diagnostic != null)
             {
-                hostDiagnosticUpdateSource?.ReportAnalyzerDiagnostic(analyzer, diagnostic, hostDiagnosticUpdateSource?.Workspace, projectId);
+                hostDiagnosticUpdateSource?.ReportAnalyzerDiagnostic(analyzer, diagnostic, projectId);
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/EditAndContinueDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/EditAndContinueDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         public DiagnosticAnalyzerCategory GetAnalyzerCategory()
             => DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
 
-        public bool OpenFileOnly(Workspace workspace)
+        public bool OpenFileOnly(OptionSet options)
             => false;
 
         // No syntax diagnostics produced by the EnC engine.  

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyleDiagnosticAnalyzerBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.NamingStyles;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
         // see https://github.com/dotnet/roslyn/issues/14061
         protected abstract ImmutableArray<TLanguageKindEnum> SupportedSyntaxKinds { get; }
 
-        public override bool OpenFileOnly(Workspace workspace) => true;
+        public override bool OpenFileOnly(OptionSet options) => true;
 
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterCompilationStartAction(CompilationStartAction);

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
         protected abstract bool IsNameOf(SyntaxNode node);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptor, DiagnosticDescriptor2);
-        public bool OpenFileOnly(Workspace workspace) => false;
+        public bool OpenFileOnly(OptionSet options) => false;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_BuildSynchronization.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (_map.TryGetValue(workspace, out var analyzer))
             {
-                return analyzer.SynchronizeWithBuildAsync(workspace, diagnostics);
+                return analyzer.SynchronizeWithBuildAsync(diagnostics);
             }
 
             return Task.CompletedTask;

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.Host;
@@ -15,50 +16,44 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal static class DiagnosticResultSerializer
     {
-        public static (int diagnostics, int telemetry, int exceptions) Serialize(
+        public static (int diagnostics, int telemetry, int exceptions) WriteDiagnosticAnalysisResults(
             ObjectWriter writer, DiagnosticAnalysisResultMap<string, DiagnosticAnalysisResultBuilder> result, CancellationToken cancellationToken)
         {
             var diagnosticCount = 0;
             var diagnosticSerializer = new DiagnosticDataSerializer(VersionStamp.Default, VersionStamp.Default);
 
-            var analysisResult = result.AnalysisResult;
-
-            writer.WriteInt32(analysisResult.Count);
-            foreach (var kv in analysisResult)
+            writer.WriteInt32(result.AnalysisResult.Count);
+            foreach (var (analyzerId, analyzerResults) in result.AnalysisResult)
             {
-                writer.WriteString(kv.Key);
+                writer.WriteString(analyzerId);
 
-                diagnosticCount += Serialize(writer, diagnosticSerializer, kv.Value.SyntaxLocals, cancellationToken);
-                diagnosticCount += Serialize(writer, diagnosticSerializer, kv.Value.SemanticLocals, cancellationToken);
-                diagnosticCount += Serialize(writer, diagnosticSerializer, kv.Value.NonLocals, cancellationToken);
+                diagnosticCount += WriteDiagnosticDataMap(writer, diagnosticSerializer, analyzerResults.SyntaxLocals, cancellationToken);
+                diagnosticCount += WriteDiagnosticDataMap(writer, diagnosticSerializer, analyzerResults.SemanticLocals, cancellationToken);
+                diagnosticCount += WriteDiagnosticDataMap(writer, diagnosticSerializer, analyzerResults.NonLocals, cancellationToken);
 
-                diagnosticSerializer.WriteTo(writer, kv.Value.Others, cancellationToken);
-                diagnosticCount += kv.Value.Others.Length;
+                diagnosticSerializer.WriteDiagnosticData(writer, analyzerResults.Others, cancellationToken);
+                diagnosticCount += analyzerResults.Others.Length;
             }
 
-            var telemetryInfo = result.TelemetryInfo;
-
-            writer.WriteInt32(telemetryInfo.Count);
-            foreach (var kv in telemetryInfo)
+            writer.WriteInt32(result.TelemetryInfo.Count);
+            foreach (var (analyzerId, analyzerTelemetry) in result.TelemetryInfo)
             {
-                writer.WriteString(kv.Key);
-                Serialize(writer, kv.Value, cancellationToken);
+                writer.WriteString(analyzerId);
+                WriteTelemetry(writer, analyzerTelemetry, cancellationToken);
             }
 
-            var exceptions = result.Exceptions;
-
-            writer.WriteInt32(exceptions.Count);
-            foreach (var kv in exceptions)
+            writer.WriteInt32(result.Exceptions.Count);
+            foreach (var (analyzerId, analyzerExceptions) in result.Exceptions)
             {
-                writer.WriteString(kv.Key);
-                diagnosticSerializer.WriteTo(writer, kv.Value, cancellationToken);
+                writer.WriteString(analyzerId);
+                diagnosticSerializer.WriteDiagnosticData(writer, analyzerExceptions, cancellationToken);
             }
 
             // report how many data has been sent
-            return (diagnosticCount, telemetryInfo.Count, exceptions.Count);
+            return (diagnosticCount, result.TelemetryInfo.Count, result.Exceptions.Count);
         }
 
-        public static DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult> Deserialize(
+        public static DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult> ReadDiagnosticAnalysisResults(
             ObjectReader reader, IDictionary<string, DiagnosticAnalyzer> analyzerMap, Project project, VersionStamp version, CancellationToken cancellationToken)
         {
             var diagnosticDataSerializer = new DiagnosticDataSerializer(VersionStamp.Default, VersionStamp.Default);
@@ -70,11 +65,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 var analyzer = analyzerMap[reader.ReadString()];
 
-                var syntaxLocalMap = Deserialize(reader, diagnosticDataSerializer, project, cancellationToken);
-                var semanticLocalMap = Deserialize(reader, diagnosticDataSerializer, project, cancellationToken);
-                var nonLocalMap = Deserialize(reader, diagnosticDataSerializer, project, cancellationToken);
+                var syntaxLocalMap = ReadDiagnosticDataMap(reader, diagnosticDataSerializer, project, cancellationToken);
+                var semanticLocalMap = ReadDiagnosticDataMap(reader, diagnosticDataSerializer, project, cancellationToken);
+                var nonLocalMap = ReadDiagnosticDataMap(reader, diagnosticDataSerializer, project, cancellationToken);
 
-                var others = diagnosticDataSerializer.ReadFrom(reader, project, cancellationToken);
+                var others = diagnosticDataSerializer.ReadDiagnosticData(reader, project, document: null, cancellationToken);
 
                 var analysisResult = DiagnosticAnalysisResult.CreateFromSerialization(
                     project,
@@ -82,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     syntaxLocalMap,
                     semanticLocalMap,
                     nonLocalMap,
-                    GetOrDefault(others),
+                    others,
                     documentIds: null);
 
                 analysisMap.Add(analyzer, analysisResult);
@@ -94,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             for (var i = 0; i < telemetryCount; i++)
             {
                 var analyzer = analyzerMap[reader.ReadString()];
-                var telemetryInfo = Deserialize(reader, cancellationToken);
+                var telemetryInfo = ReadTelemetry(reader, cancellationToken);
 
                 telemetryMap.Add(analyzer, telemetryInfo);
             }
@@ -105,15 +100,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             for (var i = 0; i < exceptionCount; i++)
             {
                 var analyzer = analyzerMap[reader.ReadString()];
-                var exceptions = diagnosticDataSerializer.ReadFrom(reader, project, cancellationToken);
 
-                exceptionMap.Add(analyzer, GetOrDefault(exceptions));
+                var exceptions = diagnosticDataSerializer.ReadDiagnosticData(reader, project, document: null, cancellationToken);
+                if (!exceptions.IsEmpty)
+                {
+                    exceptionMap.Add(analyzer, exceptions);
+                }
             }
 
             return DiagnosticAnalysisResultMap.Create(analysisMap.ToImmutable(), telemetryMap.ToImmutable(), exceptionMap.ToImmutable());
         }
 
-        private static int Serialize(
+        private static int WriteDiagnosticDataMap(
             ObjectWriter writer,
             DiagnosticDataSerializer serializer,
             ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>> diagnostics,
@@ -122,46 +120,46 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var count = 0;
 
             writer.WriteInt32(diagnostics.Count);
-            foreach (var kv in diagnostics)
+            foreach (var (documentId, data) in diagnostics)
             {
-                kv.Key.WriteTo(writer);
-                serializer.WriteTo(writer, kv.Value, cancellationToken);
+                documentId.WriteTo(writer);
+                serializer.WriteDiagnosticData(writer, data, cancellationToken);
 
-                count += kv.Value.Length;
+                count += data.Length;
             }
 
             return count;
         }
 
-        private static ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>> Deserialize(
+        private static ImmutableDictionary<DocumentId, ImmutableArray<DiagnosticData>> ReadDiagnosticDataMap(
             ObjectReader reader,
             DiagnosticDataSerializer serializer,
             Project project,
             CancellationToken cancellationToken)
         {
             var count = reader.ReadInt32();
+
             var map = ImmutableDictionary.CreateBuilder<DocumentId, ImmutableArray<DiagnosticData>>();
             for (var i = 0; i < count; i++)
             {
                 var documentId = DocumentId.ReadFrom(reader);
                 var document = project.GetDocument(documentId);
 
-                var diagnostics = serializer.ReadFrom(reader, document, cancellationToken);
+                var diagnostics = serializer.ReadDiagnosticData(reader, project, document, cancellationToken);
 
-                if (document?.SupportsDiagnostics() == false)
+                // drop diagnostics for non-null document that doesn't support diagnostics
+                if (diagnostics.IsEmpty || document?.SupportsDiagnostics() == false)
                 {
-                    // drop diagnostics for non-null document that doesn't support
-                    // diagnostics
                     continue;
                 }
 
-                map.Add(documentId, GetOrDefault(diagnostics));
+                map.Add(documentId, diagnostics);
             }
 
             return map.ToImmutable();
         }
 
-        private static void Serialize(ObjectWriter writer, AnalyzerTelemetryInfo telemetryInfo, CancellationToken cancellationToken)
+        private static void WriteTelemetry(ObjectWriter writer, AnalyzerTelemetryInfo telemetryInfo, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -186,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             writer.WriteBoolean(telemetryInfo.Concurrent);
         }
 
-        private static AnalyzerTelemetryInfo Deserialize(ObjectReader reader, CancellationToken cancellationToken)
+        private static AnalyzerTelemetryInfo ReadTelemetry(ObjectReader reader, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -238,11 +236,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 Concurrent = concurrent
             };
-        }
-
-        private static ImmutableArray<T> GetOrDefault<T>(StrongBox<ImmutableArray<T>> items)
-        {
-            return items?.Value ?? default;
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticResultSerializer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     syntaxLocalMap,
                     semanticLocalMap,
                     nonLocalMap,
-                    others,
+                    others.NullToEmpty(),
                     documentIds: null);
 
                 analysisMap.Add(analyzer, analysisResult);
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var analyzer = analyzerMap[reader.ReadString()];
 
                 var exceptions = diagnosticDataSerializer.ReadDiagnosticData(reader, project, document: null, cancellationToken);
-                if (!exceptions.IsEmpty)
+                if (!exceptions.IsDefault)
                 {
                     exceptionMap.Add(analyzer, exceptions);
                 }
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var diagnostics = serializer.ReadDiagnosticData(reader, project, document, cancellationToken);
 
                 // drop diagnostics for non-null document that doesn't support diagnostics
-                if (diagnostics.IsEmpty || document?.SupportsDiagnostics() == false)
+                if (diagnostics.IsDefault || document?.SupportsDiagnostics() == false)
                 {
                     continue;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 using Roslyn.Utilities;
 
@@ -112,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return GetResultOrEmpty(Result, analyzer, ProjectId, Version);
             }
 
-            public static async Task<ProjectAnalysisData> CreateAsync(Project project, IEnumerable<StateSet> stateSets, bool avoidLoadingData, CancellationToken cancellationToken)
+            public static async Task<ProjectAnalysisData> CreateAsync(IPersistentStorageService persistentService, Project project, IEnumerable<StateSet> stateSets, bool avoidLoadingData, CancellationToken cancellationToken)
             {
                 VersionStamp? version = null;
 
@@ -120,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 foreach (var stateSet in stateSets)
                 {
                     var state = stateSet.GetOrCreateProjectState(project.Id);
-                    var result = await state.GetAnalysisDataAsync(project, avoidLoadingData, cancellationToken).ConfigureAwait(false);
+                    var result = await state.GetAnalysisDataAsync(persistentService, project, avoidLoadingData, cancellationToken).ConfigureAwait(false);
                     Contract.ThrowIfFalse(project.Id == result.ProjectId);
 
                     if (!version.HasValue)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     // PERF: We need to flip this to false when we do actual diffing.
                     var avoidLoadingData = true;
                     var version = await GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
-                    var existingData = await ProjectAnalysisData.CreateAsync(project, stateSets, avoidLoadingData, cancellationToken).ConfigureAwait(false);
+                    var existingData = await ProjectAnalysisData.CreateAsync(PersistentStorageService, project, stateSets, avoidLoadingData, cancellationToken).ConfigureAwait(false);
 
                     // We can't return here if we have open file only analyzers since saved data for open file only analyzer
                     // is incomplete -- it only contains info on open files rather than whole project.

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     // We can't return here if we have open file only analyzers since saved data for open file only analyzer
                     // is incomplete -- it only contains info on open files rather than whole project.
-                    if (existingData.Version == version && !CompilationHasOpenFileOnlyAnalyzers(compilation, project.Solution.Workspace))
+                    if (existingData.Version == version && !CompilationHasOpenFileOnlyAnalyzers(compilation, project.Solution.Options))
                     {
                         return existingData;
                     }
@@ -114,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
         }
 
-        private static bool CompilationHasOpenFileOnlyAnalyzers(CompilationWithAnalyzers? compilation, Workspace workspace)
+        private static bool CompilationHasOpenFileOnlyAnalyzers(CompilationWithAnalyzers? compilation, OptionSet options)
         {
             if (compilation == null)
             {
@@ -123,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             foreach (var analyzer in compilation.Analyzers)
             {
-                if (analyzer.IsOpenFileOnly(workspace))
+                if (analyzer.IsOpenFileOnly(options))
                 {
                     return true;
                 }
@@ -265,13 +266,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         {
             analyzers = default;
 
+            var options = project.Solution.Options;
+
             var existingAnalyzers = compilation.Analyzers;
             var builder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
             foreach (var analyzer in existingAnalyzers)
             {
                 if (existing.TryGetValue(analyzer, out var analysisResult) &&
                     analysisResult.Version == version &&
-                    !analyzer.IsOpenFileOnly(project.Solution.Workspace))
+                    !analyzer.IsOpenFileOnly(options))
                 {
                     // we already have up to date result.
                     continue;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 using var pooledObject = SharedPools.Default<Dictionary<string, DiagnosticAnalyzer>>().GetPooledObject();
                 var analyzerMap = pooledObject.Object;
 
-                analyzerMap.AppendAnalyzerMap(analyzerDriver.Analyzers.Where(a => forcedAnalysis || !a.IsOpenFileOnly(solution.Workspace)));
+                analyzerMap.AppendAnalyzerMap(analyzerDriver.Analyzers.Where(a => forcedAnalysis || !a.IsOpenFileOnly(solution.Options)));
                 if (analyzerMap.Count == 0)
                 {
                     return DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -184,10 +184,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var version = await DiagnosticIncrementalAnalyzer.GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
 
                 using var reader = ObjectReader.TryGetReader(stream);
-                Debug.Assert(reader != null,
+                RoslynDebug.Assert(reader != null,
 @"We only ge a reader for data transmitted between live processes.
 This data should always be correct as we're never persisting the data between sessions.");
-                return DiagnosticResultSerializer.Deserialize(reader, analyzerMap, project, version, cancellationToken);
+                return DiagnosticResultSerializer.ReadDiagnosticAnalysisResults(reader, analyzerMap, project, version, cancellationToken);
             }
 
             private void ReportAnalyzerExceptions(Project project, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> exceptions)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // keep from build flag if full analysis is off
                 var fromBuild = fullAnalysis ? false : lastResult.FromBuild;
 
-                var openFileOnlyAnalyzer = _owner.Analyzer.IsOpenFileOnly(document.Project.Solution.Workspace);
+                var openFileOnlyAnalyzer = _owner.Analyzer.IsOpenFileOnly(document.Project.Solution.Options);
 
                 // if it is allowed to keep project state, check versions and if they are same, bail out.
                 // if full solution analysis is off or we are asked to reset document state, we always merge.

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
@@ -23,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private partial class StateManager
         {
             private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
+            private readonly IPersistentStorageService _persistentStorageService;
 
             /// <summary>
             /// Analyzers supplied by the host (IDE). These are built-in to the IDE, the compiler, or from an installed IDE extension (VSIX). 
@@ -40,9 +42,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// </summary>
             public event EventHandler<ProjectAnalyzerReferenceChangedEventArgs>? ProjectAnalyzerReferenceChanged;
 
-            public StateManager(DiagnosticAnalyzerInfoCache analyzerInfoCache)
+            public StateManager(DiagnosticAnalyzerInfoCache analyzerInfoCache, IPersistentStorageService persistentStorageService)
             {
                 _analyzerInfoCache = analyzerInfoCache;
+                _persistentStorageService = persistentStorageService;
 
                 _hostAnalyzerStateMap = ImmutableDictionary<string, HostAnalyzerStateSets>.Empty;
                 _projectAnalyzerStateMap = new ConcurrentDictionary<ProjectId, ProjectAnalyzerStateSets>(concurrencyLevel: 2, capacity: 10);
@@ -211,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var opened = false;
                 foreach (var stateSet in stateSets)
                 {
-                    opened |= await stateSet.OnDocumentOpenedAsync(document).ConfigureAwait(false);
+                    opened |= await stateSet.OnDocumentOpenedAsync(_persistentStorageService, document).ConfigureAwait(false);
                 }
 
                 return opened;
@@ -223,7 +226,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var removed = false;
                 foreach (var stateSet in stateSets)
                 {
-                    removed |= await stateSet.OnDocumentClosedAsync(document).ConfigureAwait(false);
+                    removed |= await stateSet.OnDocumentClosedAsync(_persistentStorageService, document).ConfigureAwait(false);
                 }
 
                 return removed;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
@@ -135,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             public ProjectState GetOrCreateProjectState(ProjectId projectId)
                 => _projectStates.GetOrAdd(projectId, id => new ProjectState(this, id));
 
-            public async Task<bool> OnDocumentOpenedAsync(Document document)
+            public async Task<bool> OnDocumentOpenedAsync(IPersistentStorageService persistentStorageService, Document document)
             {
                 // can not be cancelled
                 if (!TryGetProjectState(document.Project.Id, out var projectState) ||
@@ -145,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return false;
                 }
 
-                var result = await projectState.GetAnalysisDataAsync(document, avoidLoadingData: false, CancellationToken.None).ConfigureAwait(false);
+                var result = await projectState.GetAnalysisDataAsync(persistentStorageService, document, avoidLoadingData: false, CancellationToken.None).ConfigureAwait(false);
 
                 // store analysis result to active file state:
                 var activeFileState = GetOrCreateActiveFileState(document.Id);
@@ -156,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return true;
             }
 
-            public async Task<bool> OnDocumentClosedAsync(Document document)
+            public async Task<bool> OnDocumentClosedAsync(IPersistentStorageService persistentStorageService, Document document)
             {
                 // can not be cancelled
                 // remove active file state and put it in project state
@@ -167,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 // active file exist, put it in the project state
                 var projectState = GetOrCreateProjectState(document.Project.Id);
-                await projectState.MergeAsync(activeFileState, document).ConfigureAwait(false);
+                await projectState.MergeAsync(persistentStorageService, activeFileState, document).ConfigureAwait(false);
                 return true;
             }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Options;
@@ -37,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         internal DiagnosticAnalyzerService AnalyzerService { get; }
         internal Workspace Workspace { get; }
+        internal IPersistentStorageService PersistentStorageService { get; }
         internal AbstractHostDiagnosticUpdateSource HostDiagnosticUpdateSource { get; }
         internal DiagnosticAnalyzerInfoCache DiagnosticAnalyzerInfoCache { get; }
         internal DiagnosticLogAggregator DiagnosticLogAggregator { get; private set; }
@@ -55,10 +57,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             DiagnosticAnalyzerInfoCache = analyzerInfoCache;
             HostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
             DiagnosticLogAggregator = new DiagnosticLogAggregator(analyzerService);
+            PersistentStorageService = workspace.Services.GetRequiredService<IPersistentStorageService>();
 
             _correlationId = correlationId;
 
-            _stateManager = new StateManager(analyzerInfoCache);
+            _stateManager = new StateManager(analyzerInfoCache, PersistentStorageService);
             _stateManager.ProjectAnalyzerReferenceChanged += OnProjectAnalyzerReferenceChanged;
 
             _diagnosticAnalyzerRunner = new InProcOrRemoteHostAnalyzerRunner(AnalyzerService, HostDiagnosticUpdateSource);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -223,12 +223,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         return ImmutableArray<DiagnosticData>.Empty;
                     }
 
-                    var result = await state.GetAnalysisDataAsync(document, avoidLoadingData: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var result = await state.GetAnalysisDataAsync(Owner.PersistentStorageService, document, avoidLoadingData: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                     return result.GetDocumentDiagnostics(documentId, kind);
                 }
 
                 Contract.ThrowIfFalse(kind == AnalysisKind.NonLocal);
-                var nonLocalResult = await state.GetProjectAnalysisDataAsync(project, avoidLoadingData: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var nonLocalResult = await state.GetProjectAnalysisDataAsync(Owner.PersistentStorageService, project, avoidLoadingData: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return nonLocalResult.GetOtherDiagnostics();
             }
         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             {
                                 var avoidLoadingData = true;
                                 var state = stateSet.GetOrCreateProjectState(_project.Id);
-                                var result = await state.GetAnalysisDataAsync(_document, avoidLoadingData, cancellationToken).ConfigureAwait(false);
+                                var result = await state.GetAnalysisDataAsync(_owner.PersistentStorageService, _document, avoidLoadingData, cancellationToken).ConfigureAwait(false);
 
                                 // no previous compilation end diagnostics in this file.
                                 var version = await GetDiagnosticVersionAsync(_project, cancellationToken).ConfigureAwait(false);
@@ -382,7 +383,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var state = stateSet.GetOrCreateProjectState(_document.Project.Id);
 
                 // see whether we can use existing info
-                var result = await state.GetAnalysisDataAsync(_document, avoidLoadingData: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var result = await state.GetAnalysisDataAsync(_owner.PersistentStorageService, _document, avoidLoadingData: true, cancellationToken: cancellationToken).ConfigureAwait(false);
                 var version = await GetDiagnosticVersionAsync(_document.Project, cancellationToken).ConfigureAwait(false);
                 if (result.Version == version)
                 {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private bool ShouldInclude(DiagnosticData diagnostic)
             {
-                return diagnostic.DocumentId == _document.Id && _range.IntersectsWith(diagnostic.TextSpan)
+                return diagnostic.DocumentId == _document.Id && _range.IntersectsWith(diagnostic.GetTextSpan())
                     && (_includeSuppressedDiagnostics || !diagnostic.IsSuppressed)
                     && (_diagnosticId == null || _diagnosticId == diagnostic.Id);
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var state = stateSet.GetOrCreateProjectState(project.Id);
 
-                    await state.SaveAsync(project, result.GetResult(stateSet.Analyzer)).ConfigureAwait(false);
+                    await state.SaveAsync(PersistentStorageService, project, result.GetResult(stateSet.Analyzer)).ConfigureAwait(false);
                     stateSet.ComputeCompilationEndAnalyzer(project, compilation);
                 }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -94,14 +94,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             try
             {
                 var stateSets = GetStateSetsForFullSolutionAnalysis(_stateManager.GetOrUpdateStateSets(project), project).ToList();
+                var options = project.Solution.Options;
 
                 // PERF: get analyzers that are not suppressed and marked as open file only
                 // this is perf optimization. we cache these result since we know the result. (no diagnostics)
                 // REVIEW: IsAnalyzerSuppressed call seems can be quite expensive in certain condition. is there any other way to do this?
                 var activeAnalyzers = stateSets
                                         .Select(s => s.Analyzer)
-                                        .Where(a => !AnalyzerService.IsAnalyzerSuppressed(a, project) &&
-                                                    !a.IsOpenFileOnly(project.Solution.Workspace));
+                                        .Where(a => !AnalyzerService.IsAnalyzerSuppressed(a, project) && !a.IsOpenFileOnly(options));
 
                 // get driver only with active analyzers.
                 var compilationWithAnalyzers = await CreateCompilationWithAnalyzersAsync(project, activeAnalyzers, includeSuppressedDiagnostics: true, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Diagnostics/IBuiltInAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/IBuiltInAnalyzer.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Options;
+
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     /// <summary>
@@ -23,6 +25,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <summary>
         /// This indicates whether this built-in analyzer will only run on opened files.
         /// </summary>
-        bool OpenFileOnly(Workspace workspace);
+        bool OpenFileOnly(OptionSet options);
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -29,8 +31,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
         }
 
-        public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
-        public event EventHandler DiagnosticsCleared;
+        public event EventHandler<DiagnosticsUpdatedArgs>? DiagnosticsUpdated;
+        public event EventHandler? DiagnosticsCleared;
 
         /// <summary>
         /// This implementation reports diagnostics via <see cref="DiagnosticsUpdated"/> event.
@@ -51,9 +53,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Reports given set of diagnostics. 
         /// Categorizes diagnostic into two groups - diagnostics associated with a document and diagnostics associated with a project or solution.
         /// </summary>
-        public void ReportDiagnostics(Solution solution, ProjectId projectIdOpt, IEnumerable<Diagnostic> diagnostics)
+        public void ReportDiagnostics(Solution solution, ProjectId? projectId, IEnumerable<Diagnostic> diagnostics)
         {
-            Debug.Assert(solution != null);
+            RoslynDebug.Assert(solution != null);
 
             var updateEvent = DiagnosticsUpdated;
             if (updateEvent == null)
@@ -64,19 +66,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             var documentDiagnosticData = ArrayBuilder<DiagnosticData>.GetInstance();
             var nonDocumentDiagnosticData = ArrayBuilder<DiagnosticData>.GetInstance();
             var workspace = solution.Workspace;
-            var project = (projectIdOpt != null) ? solution.GetProject(projectIdOpt) : null;
+            var options = solution.Options;
+            var project = (projectId != null) ? solution.GetProject(projectId) : null;
 
             foreach (var diagnostic in diagnostics)
             {
-                var documentOpt = solution.GetDocument(diagnostic.Location.SourceTree);
+                var document = solution.GetDocument(diagnostic.Location.SourceTree);
 
-                if (documentOpt != null)
+                if (document != null)
                 {
-                    documentDiagnosticData.Add(DiagnosticData.Create(documentOpt, diagnostic));
+                    documentDiagnosticData.Add(DiagnosticData.Create(document, diagnostic));
                 }
                 else
                 {
-                    nonDocumentDiagnosticData.Add(DiagnosticData.Create(solution.Workspace, diagnostic, projectIdOpt));
+                    nonDocumentDiagnosticData.Add(DiagnosticData.Create(diagnostic, project, options));
                 }
             }
 
@@ -84,13 +87,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 foreach (var (documentId, diagnosticData) in documentDiagnosticData.ToDictionary(data => data.DocumentId))
                 {
-                    var diagnosticGroupId = (this, documentId, projectIdOpt);
+                    var diagnosticGroupId = (this, documentId, projectId);
 
                     updateEvent(this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
                         diagnosticGroupId,
                         workspace,
                         solution,
-                        projectIdOpt,
+                        projectId,
                         documentId: documentId,
                         diagnostics: diagnosticData));
                 }
@@ -98,13 +101,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             if (nonDocumentDiagnosticData.Count > 0)
             {
-                var diagnosticGroupId = (this, projectIdOpt);
+                var diagnosticGroupId = (this, projectId);
 
                 updateEvent(this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
                     diagnosticGroupId,
                     workspace,
                     solution,
-                    projectIdOpt,
+                    projectId,
                     documentId: null,
                     diagnostics: nonDocumentDiagnosticData.ToImmutable()));
             }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -75,11 +75,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (document != null)
                 {
-                    documentDiagnosticData.Add(DiagnosticData.Create(document, diagnostic));
+                    documentDiagnosticData.Add(DiagnosticData.Create(diagnostic, document));
+                }
+                else if (project != null)
+                {
+                    nonDocumentDiagnosticData.Add(DiagnosticData.Create(diagnostic, project));
                 }
                 else
                 {
-                    nonDocumentDiagnosticData.Add(DiagnosticData.Create(diagnostic, project, options));
+                    nonDocumentDiagnosticData.Add(DiagnosticData.Create(diagnostic, options));
                 }
             }
 

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             _emitDiagnosticsUpdateSource.ReportDiagnostics(
                 _workspace.CurrentSolution,
-                projectIdOpt: null,
+                projectId: null,
                 new[] { Diagnostic.Create(descriptor, Location.None, new[] { message }) });
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
             }
 
-            return new ActiveStatementsMap(byDocument.ToDictionaryAndFree(), byInstruction.ToDictionaryAndFree());
+            return new ActiveStatementsMap(byDocument.ToMultiDictionaryAndFree(), byInstruction.ToDictionaryAndFree());
         }
 
         private LinePositionSpan GetUpToDateSpan(ActiveStatementDebugInfo activeStatementInfo)

--- a/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -27,11 +27,11 @@ namespace Microsoft.CodeAnalysis.PreferFrameworkType
         private static PerLanguageOption<CodeStyleOption<bool>> GetOptionForMemberAccessContext
             => CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess;
 
-        public override bool OpenFileOnly(Workspace workspace)
+        public override bool OpenFileOnly(OptionSet options)
         {
-            var preferTypeKeywordInDeclarationOption = workspace.Options.GetOption(
+            var preferTypeKeywordInDeclarationOption = options.GetOption(
                 CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, GetLanguageName()).Notification;
-            var preferTypeKeywordInMemberAccessOption = workspace.Options.GetOption(
+            var preferTypeKeywordInMemberAccessOption = options.GetOption(
                 CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, GetLanguageName()).Notification;
 
             return !(preferTypeKeywordInDeclarationOption == NotificationOption.Warning || preferTypeKeywordInDeclarationOption == NotificationOption.Error ||

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -26,12 +26,12 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
         {
         }
 
-        public override bool OpenFileOnly(Workspace workspace)
+        public override bool OpenFileOnly(OptionSet options)
         {
-            var qualifyFieldAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyFieldAccess, GetLanguageName()).Notification;
-            var qualifyPropertyAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyPropertyAccess, GetLanguageName()).Notification;
-            var qualifyMethodAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyMethodAccess, GetLanguageName()).Notification;
-            var qualifyEventAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyEventAccess, GetLanguageName()).Notification;
+            var qualifyFieldAccessOption = options.GetOption(CodeStyleOptions.QualifyFieldAccess, GetLanguageName()).Notification;
+            var qualifyPropertyAccessOption = options.GetOption(CodeStyleOptions.QualifyPropertyAccess, GetLanguageName()).Notification;
+            var qualifyMethodAccessOption = options.GetOption(CodeStyleOptions.QualifyMethodAccess, GetLanguageName()).Notification;
+            var qualifyEventAccessOption = options.GetOption(CodeStyleOptions.QualifyEventAccess, GetLanguageName()).Notification;
 
             return !(qualifyFieldAccessOption == NotificationOption.Warning || qualifyFieldAccessOption == NotificationOption.Error ||
                      qualifyPropertyAccessOption == NotificationOption.Warning || qualifyPropertyAccessOption == NotificationOption.Error ||

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Fading;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -94,7 +95,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             }
         }
 
-        public bool OpenFileOnly(Workspace workspace) => false;
+        public bool OpenFileOnly(OptionSet options) => false;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -60,11 +60,11 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             _kindsOfInterest = kindsOfInterest;
         }
 
-        public bool OpenFileOnly(Workspace workspace)
+        public bool OpenFileOnly(OptionSet options)
         {
-            var preferTypeKeywordInDeclarationOption = workspace.Options.GetOption(
+            var preferTypeKeywordInDeclarationOption = options.GetOption(
                 CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, GetLanguageName()).Notification;
-            var preferTypeKeywordInMemberAccessOption = workspace.Options.GetOption(
+            var preferTypeKeywordInMemberAccessOption = options.GetOption(
                 CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, GetLanguageName()).Notification;
 
             return !(preferTypeKeywordInDeclarationOption == NotificationOption.Warning || preferTypeKeywordInDeclarationOption == NotificationOption.Error ||

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDocumentDiagnosticAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpDocumentDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
@@ -88,7 +89,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
 
-        public bool OpenFileOnly(Workspace workspace)
+        public bool OpenFileOnly(OptionSet options)
         {
             return true;
         }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpSimplifyNameDiagnosticAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpSimplifyNameDiagnosticAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
 
-        public bool OpenFileOnly(Workspace workspace)
+        public bool OpenFileOnly(OptionSet options)
         {
             return true;
         }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Diagnostics/FSharpUnusedDeclarationsAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
 {
@@ -68,7 +69,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Diagnostics
             return DiagnosticAnalyzerCategory.SemanticDocumentAnalysis;
         }
 
-        public bool OpenFileOnly(Workspace workspace)
+        public bool OpenFileOnly(OptionSet options)
         {
             return true;
         }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                         analyzerFilePaths.Contains(conflict.AnalyzerFilePath2))
                     {
                         var messageArguments = new string[] { conflict.AnalyzerFilePath1, conflict.AnalyzerFilePath2, conflict.Identity.ToString() };
-                        if (DiagnosticData.TryCreate(s_analyzerDependencyConflictRule, messageArguments, project.Id, solution.Workspace, out var diagnostic))
+                        if (DiagnosticData.TryCreate(s_analyzerDependencyConflictRule, messageArguments, project, out var diagnostic))
                         {
                             builder.Add(diagnostic);
                         }
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     if (analyzerFilePaths.Contains(missingDependency.AnalyzerPath))
                     {
                         var messageArguments = new string[] { missingDependency.AnalyzerPath, missingDependency.DependencyIdentity.ToString() };
-                        if (DiagnosticData.TryCreate(s_missingAnalyzerReferenceRule, messageArguments, project.Id, solution.Workspace, out var diagnostic))
+                        if (DiagnosticData.TryCreate(s_missingAnalyzerReferenceRule, messageArguments, project, out var diagnostic))
                         {
                             builder.Add(diagnostic);
                         }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerFileWatcherService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerFileWatcherService.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -60,7 +62,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private void RaiseAnalyzerChangedWarning(ProjectId projectId, string analyzerPath)
         {
             var messageArguments = new string[] { analyzerPath };
-            if (DiagnosticData.TryCreate(_analyzerChangedRule, messageArguments, projectId, _workspace, out var diagnostic))
+
+            var project = _workspace.CurrentSolution.GetProject(projectId);
+            if (project != null && DiagnosticData.TryCreate(_analyzerChangedRule, messageArguments, project, out var diagnostic))
             {
                 _updateSource.UpdateDiagnosticsForProject(projectId, Tuple.Create(s_analyzerChangedErrorId, analyzerPath), SpecializedCollections.SingletonEnumerable(diagnostic));
             }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IIntellisenseBuildTarget.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IIntellisenseBuildTarget.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 id: IDEDiagnosticIds.IntellisenseBuildFailedDiagnosticId,
                 category: FeaturesResources.Roslyn_HostError,
                 message: ServicesVSResources.Error_encountered_while_loading_the_project_Some_project_features_such_as_full_solution_analysis_for_the_failed_project_and_projects_that_depend_on_it_have_been_disabled,
-                enuMessageForBingSearch: ServicesVSResources.ResourceManager.GetString(nameof(ServicesVSResources.Error_encountered_while_loading_the_project_Some_project_features_such_as_full_solution_analysis_for_the_failed_project_and_projects_that_depend_on_it_have_been_disabled), CodeAnalysis.Diagnostics.Extensions.s_USCultureInfo),
+                enuMessageForBingSearch: ServicesVSResources.ResourceManager.GetString(nameof(ServicesVSResources.Error_encountered_while_loading_the_project_Some_project_features_such_as_full_solution_analysis_for_the_failed_project_and_projects_that_depend_on_it_have_been_disabled), CodeAnalysis.Diagnostics.Extensions.USCultureInfo),
                 severity: DiagnosticSeverity.Warning,
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true,

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -499,16 +499,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
         <Fact>
         Public Async Function TestBingHelpLink_NoCustomType() As Task
             Using workspace = TestWorkspace.CreateCSharp("class A { int 111a; }")
-                Dim diagnostic = (Await workspace.CurrentSolution.Projects.First().GetCompilationAsync()).GetDiagnostics().First(Function(d) d.Id = "CS1519")
+                Dim solution = workspace.CurrentSolution
+                Dim diagnostic = (Await solution.Projects.First().GetCompilationAsync()).GetDiagnostics().First(Function(d) d.Id = "CS1519")
 
-                Dim helpMessage = diagnostic.GetBingHelpMessage(workspace)
+                Dim helpMessage = diagnostic.GetBingHelpMessage(solution.Options)
                 Assert.Equal("Invalid token '111' in class, struct, or interface member declaration", helpMessage)
 
                 ' turn off custom type search
                 Dim optionServices = workspace.Services.GetService(Of IOptionService)()
                 optionServices.SetOptions(optionServices.GetOptions().WithChangedOption(InternalDiagnosticsOptions.PutCustomTypeInBingSearch, False))
 
-                Dim helpMessage2 = diagnostic.GetBingHelpMessage(workspace)
+                Dim helpMessage2 = diagnostic.GetBingHelpMessage(solution.Options)
                 Assert.Equal("Invalid token '{0}' in class, struct, or interface member declaration", helpMessage2)
             End Using
         End Function

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFix.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFix.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CodeFixes
 {
@@ -38,17 +42,41 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         internal CodeFix(Project project, CodeAction action, Diagnostic diagnostic)
         {
-            this.Project = project;
-            this.Action = action;
-            this.Diagnostics = ImmutableArray.Create(diagnostic);
+            Project = project;
+            Action = action;
+            Diagnostics = ImmutableArray.Create(diagnostic);
         }
 
         internal CodeFix(Project project, CodeAction action, ImmutableArray<Diagnostic> diagnostics)
         {
             Debug.Assert(!diagnostics.IsDefault);
-            this.Project = project;
-            this.Action = action;
-            this.Diagnostics = diagnostics;
+            Project = project;
+            Action = action;
+            Diagnostics = diagnostics;
+        }
+
+        internal DiagnosticData GetPrimaryDiagnosticData()
+        {
+            var diagnostic = PrimaryDiagnostic;
+
+            if (diagnostic.Location.IsInSource)
+            {
+                var document = Project.GetDocument(diagnostic.Location.SourceTree);
+                if (document != null)
+                {
+                    return DiagnosticData.Create(document, diagnostic);
+                }
+            }
+            else if (diagnostic.Location.Kind == LocationKind.ExternalFile)
+            {
+                var document = Project.Documents.FirstOrDefault(d => d.FilePath == diagnostic.Location.GetLineSpan().Path);
+                if (document != null)
+                {
+                    return DiagnosticData.Create(document, diagnostic);
+                }
+            }
+
+            return DiagnosticData.Create(diagnostic, Project, Project.Solution.Options);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFix.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFix.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 var document = Project.GetDocument(diagnostic.Location.SourceTree);
                 if (document != null)
                 {
-                    return DiagnosticData.Create(document, diagnostic);
+                    return DiagnosticData.Create(diagnostic, document);
                 }
             }
             else if (diagnostic.Location.Kind == LocationKind.ExternalFile)
@@ -72,11 +72,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 var document = Project.Documents.FirstOrDefault(d => d.FilePath == diagnostic.Location.GetLineSpan().Path);
                 if (document != null)
                 {
-                    return DiagnosticData.Create(document, diagnostic);
+                    return DiagnosticData.Create(diagnostic, document);
                 }
             }
 
-            return DiagnosticData.Create(diagnostic, Project, Project.Solution.Options);
+            return DiagnosticData.Create(diagnostic, Project);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
@@ -65,8 +65,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
         {
             Contract.ThrowIfTrue(Project.SupportsCompilation);
 
-            var options = Project.Solution.Options;
-
             foreach (var diagnostic in diagnostics)
             {
                 // REVIEW: what is our plan for additional locations? 
@@ -88,14 +86,14 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                             else
                             {
                                 // non local diagnostics without location
-                                AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
+                                AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project));
                             }
 
                             break;
                         }
 
                     case LocationKind.None:
-                        AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
+                        AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project));
                         break;
 
                     case LocationKind.SourceFile:
@@ -118,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             }
 
             map ??= new Dictionary<DocumentId, List<DiagnosticData>>();
-            map.GetOrAdd(document.Id, _ => new List<DiagnosticData>()).Add(DiagnosticData.Create(document, diagnostic));
+            map.GetOrAdd(document.Id, _ => new List<DiagnosticData>()).Add(DiagnosticData.Create(diagnostic, document));
 
             _lazyDocumentsWithDiagnostics ??= new HashSet<DocumentId>();
             _lazyDocumentsWithDiagnostics.Add(document.Id);
@@ -152,8 +150,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
         private void AddDiagnostics(
             ref Dictionary<DocumentId, List<DiagnosticData>>? lazyLocals, SyntaxTree? tree, IEnumerable<Diagnostic> diagnostics)
         {
-            var options = Project.Solution.Options;
-
             foreach (var diagnostic in diagnostics)
             {
                 // REVIEW: what is our plan for additional locations? 
@@ -164,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                         break;
 
                     case LocationKind.None:
-                        AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
+                        AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project));
                         break;
 
                     case LocationKind.SourceFile:
@@ -182,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                         else
                         {
                             // non local diagnostics without location
-                            AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
+                            AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project));
                         }
 
                         break;

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultBuilder.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Versions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
@@ -64,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
         {
             Contract.ThrowIfTrue(Project.SupportsCompilation);
 
-            var workspace = Project.Solution.Workspace;
+            var options = Project.Solution.Options;
 
             foreach (var diagnostic in diagnostics)
             {
@@ -87,14 +88,14 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                             else
                             {
                                 // non local diagnostics without location
-                                AddOtherDiagnostic(DiagnosticData.Create(workspace, diagnostic, Project.Id));
+                                AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
                             }
 
                             break;
                         }
 
                     case LocationKind.None:
-                        AddOtherDiagnostic(DiagnosticData.Create(workspace, diagnostic, Project.Id));
+                        AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
                         break;
 
                     case LocationKind.SourceFile:
@@ -151,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
         private void AddDiagnostics(
             ref Dictionary<DocumentId, List<DiagnosticData>>? lazyLocals, SyntaxTree? tree, IEnumerable<Diagnostic> diagnostics)
         {
-            var workspace = Project.Solution.Workspace;
+            var options = Project.Solution.Options;
 
             foreach (var diagnostic in diagnostics)
             {
@@ -163,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                         break;
 
                     case LocationKind.None:
-                        AddOtherDiagnostic(DiagnosticData.Create(workspace, diagnostic, Project.Id));
+                        AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
                         break;
 
                     case LocationKind.SourceFile:
@@ -181,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                         else
                         {
                             // non local diagnostics without location
-                            AddOtherDiagnostic(DiagnosticData.Create(workspace, diagnostic, Project.Id));
+                            AddOtherDiagnostic(DiagnosticData.Create(diagnostic, Project, options));
                         }
 
                         break;

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -100,12 +100,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public bool HasTextSpan => (DataLocation?.SourceSpan).HasValue;
 
         /// <summary>
-        /// return TextSpan if it exists, otherwise it will throw
+        /// Get <see cref="TextSpan"/> if it exists, throws otherwise.
         /// 
-        /// some diagnostic data such as created from build will have original line/column but not text span
-        /// in those cases, use GetTextSpan method instead to calculate one from original line/column
+        /// Some diagnostic data such as those created from build have original line/column but not <see cref="TextSpan"/>.
+        /// In those cases use <see cref="GetTextSpan(DiagnosticDataLocation, SourceText)"/> method instead to calculate span from original line/column.
         /// </summary>
-        public TextSpan TextSpan => (DataLocation?.SourceSpan)!.Value;
+        public TextSpan GetTextSpan()
+        {
+            Contract.ThrowIfFalse(DataLocation != null && DataLocation.SourceSpan.HasValue);
+            return DataLocation.SourceSpan.Value;
+        }
 
         public override bool Equals(object obj)
             => obj is DiagnosticData data && Equals(data);
@@ -162,7 +166,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public TextSpan GetExistingOrCalculatedTextSpan(SourceText text)
-            => HasTextSpan ? EnsureInBounds(TextSpan, text) : GetTextSpan(DataLocation, text);
+            => HasTextSpan ? EnsureInBounds(GetTextSpan(), text) : GetTextSpan(DataLocation, text);
 
         private static TextSpan EnsureInBounds(TextSpan textSpan, SourceText text)
             => TextSpan.FromBounds(

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataLocation.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataLocation.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -7,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal sealed class DiagnosticDataLocation
     {
-        public readonly DocumentId DocumentId;
+        public readonly DocumentId? DocumentId;
 
         // text can be either given or calculated from original line/column
         public readonly TextSpan? SourceSpan;
@@ -17,26 +19,26 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Note that the value might be a relative path. In that case <see cref="OriginalFilePath"/> should be used
         /// as a base path for path resolution.
         /// </summary>
-        public readonly string MappedFilePath;
+        public readonly string? MappedFilePath;
         public readonly int MappedStartLine;
         public readonly int MappedStartColumn;
         public readonly int MappedEndLine;
         public readonly int MappedEndColumn;
-        public readonly string OriginalFilePath;
+        public readonly string? OriginalFilePath;
         public readonly int OriginalStartLine;
         public readonly int OriginalStartColumn;
         public readonly int OriginalEndLine;
         public readonly int OriginalEndColumn;
 
         public DiagnosticDataLocation(
-            DocumentId documentId = null,
+            DocumentId? documentId = null,
             TextSpan? sourceSpan = null,
-            string originalFilePath = null,
+            string? originalFilePath = null,
             int originalStartLine = 0,
             int originalStartColumn = 0,
             int originalEndLine = 0,
             int originalEndColumn = 0,
-            string mappedFilePath = null,
+            string? mappedFilePath = null,
             int mappedStartLine = 0,
             int mappedStartColumn = 0,
             int mappedEndLine = 0,

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             return await writeTask.ConfigureAwait(false);
         }
 
-        public async Task<StrongBox<ImmutableArray<DiagnosticData>>?> DeserializeAsync(IPersistentStorageService persistentService, Project project, Document? document, string key, CancellationToken cancellationToken)
+        public async ValueTask<ImmutableArray<DiagnosticData>> DeserializeAsync(IPersistentStorageService persistentService, Project project, Document? document, string key, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(document == null || document.Project == project);
 
@@ -75,10 +75,10 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
 
             if (reader == null)
             {
-                return null;
+                return default;
             }
 
-            return new StrongBox<ImmutableArray<DiagnosticData>>(ReadDiagnosticData(reader, project, document, cancellationToken));
+            return ReadDiagnosticData(reader, project, document, cancellationToken);
         }
 
         public void WriteDiagnosticData(ObjectWriter writer, ImmutableArray<DiagnosticData> items, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -11,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -19,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
     /// <summary>
     /// DiagnosticData serializer
     /// </summary>
-    internal struct DiagnosticDataSerializer
+    internal readonly struct DiagnosticDataSerializer
     {
         // version of serialized format
         private const int FormatVersion = 1;
@@ -36,30 +40,27 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             Version = version;
         }
 
-        public async Task<bool> SerializeAsync(object documentOrProject, string key, ImmutableArray<DiagnosticData> items, CancellationToken cancellationToken)
+        public async Task<bool> SerializeAsync(IPersistentStorageService persistentService, Project project, Document? document, string key, ImmutableArray<DiagnosticData> items, CancellationToken cancellationToken)
         {
+            Contract.ThrowIfFalse(document == null || document.Project == project);
+
             using var stream = SerializableBytes.CreateWritableStream();
             using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
 
-            WriteTo(writer, items, cancellationToken);
+            WriteDiagnosticData(writer, items, cancellationToken);
 
-            var solution = GetSolution(documentOrProject);
-            var persistService = solution.Workspace.Services.GetService<IPersistentStorageService>();
-
-            using var storage = persistService.GetStorage(solution);
+            using var storage = persistentService.GetStorage(project.Solution);
 
             stream.Position = 0;
-            return await WriteStreamAsync(storage, documentOrProject, key, stream, cancellationToken).ConfigureAwait(false);
+            return await ((document != null) ? storage.WriteStreamAsync(document, key, stream, cancellationToken) : storage.WriteStreamAsync(project, key, stream, cancellationToken)).ConfigureAwait(false);
         }
 
-        public async Task<StrongBox<ImmutableArray<DiagnosticData>>> DeserializeAsync(object documentOrProject, string key, CancellationToken cancellationToken)
+        public async Task<StrongBox<ImmutableArray<DiagnosticData>>?> DeserializeAsync(IPersistentStorageService persistentService, Project project, Document? document, string key, CancellationToken cancellationToken)
         {
-            // we have persisted data
-            var solution = GetSolution(documentOrProject);
-            var persistService = solution.Workspace.Services.GetService<IPersistentStorageService>();
+            Contract.ThrowIfFalse(document == null || document.Project == project);
 
-            using var storage = persistService.GetStorage(solution);
-            using var stream = await ReadStreamAsync(storage, key, documentOrProject, cancellationToken).ConfigureAwait(false);
+            using var storage = persistentService.GetStorage(project.Solution);
+            using var stream = await ((document != null) ? storage.ReadStreamAsync(document, key, cancellationToken) : storage.ReadStreamAsync(project, key, cancellationToken)).ConfigureAwait(false);
             using var reader = ObjectReader.TryGetReader(stream);
 
             if (reader == null)
@@ -67,23 +68,10 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 return null;
             }
 
-            // we return StrongBox rather than ImmutableArray due to task lib's issue with allocations
-            // when returning default(value type)
-            return ReadFrom(reader, documentOrProject, cancellationToken);
+            return new StrongBox<ImmutableArray<DiagnosticData>>(ReadDiagnosticData(reader, project, document, cancellationToken));
         }
 
-        private Task<bool> WriteStreamAsync(IPersistentStorage storage, object documentOrProject, string key, Stream stream, CancellationToken cancellationToken)
-        {
-            if (documentOrProject is Document document)
-            {
-                return storage.WriteStreamAsync(document, key, stream, cancellationToken);
-            }
-
-            var project = (Project)documentOrProject;
-            return storage.WriteStreamAsync(project, key, stream, cancellationToken);
-        }
-
-        public void WriteTo(ObjectWriter writer, ImmutableArray<DiagnosticData> items, CancellationToken cancellationToken)
+        public void WriteDiagnosticData(ObjectWriter writer, ImmutableArray<DiagnosticData> items, CancellationToken cancellationToken)
         {
             writer.WriteInt32(FormatVersion);
 
@@ -110,21 +98,12 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 writer.WriteBoolean(item.IsSuppressed);
                 writer.WriteInt32(item.WarningLevel);
 
-                if (item.HasTextSpan)
-                {
-                    // document state
-                    writer.WriteInt32(item.TextSpan.Start);
-                    writer.WriteInt32(item.TextSpan.Length);
-                }
-                else
-                {
-                    // project state
-                    writer.WriteInt32(0);
-                    writer.WriteInt32(0);
-                }
+                // unused
+                writer.WriteInt32(0);
+                writer.WriteInt32(0);
 
-                WriteTo(writer, item.DataLocation);
-                WriteTo(writer, item.AdditionalLocations, cancellationToken);
+                WriteLocation(writer, item.DataLocation);
+                WriteAdditionalLocations(writer, item.AdditionalLocations, cancellationToken);
 
                 writer.WriteInt32(item.CustomTags.Count);
                 foreach (var tag in item.CustomTags)
@@ -141,30 +120,26 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             }
         }
 
-        private static void WriteTo(ObjectWriter writer, IReadOnlyCollection<DiagnosticDataLocation> additionalLocations, CancellationToken cancellationToken)
+        private static void WriteAdditionalLocations(ObjectWriter writer, IReadOnlyCollection<DiagnosticDataLocation> additionalLocations, CancellationToken cancellationToken)
         {
-            writer.WriteInt32(additionalLocations?.Count ?? 0);
-            if (additionalLocations != null)
+            writer.WriteInt32(additionalLocations.Count);
+
+            foreach (var location in additionalLocations)
             {
-                foreach (var location in additionalLocations)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    WriteTo(writer, location);
-                }
+                cancellationToken.ThrowIfCancellationRequested();
+                WriteLocation(writer, location);
             }
         }
 
-        private static void WriteTo(ObjectWriter writer, DiagnosticDataLocation item)
+        private static void WriteLocation(ObjectWriter writer, DiagnosticDataLocation? item)
         {
             if (item == null)
             {
                 writer.WriteBoolean(false);
                 return;
             }
-            else
-            {
-                writer.WriteBoolean(true);
-            }
+
+            writer.WriteBoolean(true);
 
             if (item.SourceSpan.HasValue)
             {
@@ -190,68 +165,46 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             writer.WriteInt32(item.MappedEndColumn);
         }
 
-        private Task<Stream> ReadStreamAsync(IPersistentStorage storage, string key, object documentOrProject, CancellationToken cancellationToken)
-        {
-            if (documentOrProject is Document document)
-            {
-                return storage.ReadStreamAsync(document, key, cancellationToken);
-            }
-
-            var project = (Project)documentOrProject;
-            return storage.ReadStreamAsync(project, key, cancellationToken);
-        }
-
-        public StrongBox<ImmutableArray<DiagnosticData>> ReadFrom(ObjectReader reader, object documentOrProject, CancellationToken cancellationToken)
-        {
-            if (documentOrProject is Document document)
-            {
-                return ReadFrom(reader, document.Project, document, cancellationToken);
-            }
-
-            var project = (Project)documentOrProject;
-            return ReadFrom(reader, project, null, cancellationToken);
-        }
-
-        private StrongBox<ImmutableArray<DiagnosticData>> ReadFrom(ObjectReader reader, Project project, Document document, CancellationToken cancellationToken)
+        public ImmutableArray<DiagnosticData> ReadDiagnosticData(ObjectReader reader, Project project, Document? document, CancellationToken cancellationToken)
         {
             try
             {
-                using var pooledObject = SharedPools.Default<List<DiagnosticData>>().GetPooledObject();
-
-                var list = pooledObject.Object;
-
                 var format = reader.ReadInt32();
                 if (format != FormatVersion)
                 {
-                    return null;
+                    return ImmutableArray<DiagnosticData>.Empty;
                 }
 
                 // saved data is for same analyzer of different version of dll
                 var analyzerVersion = VersionStamp.ReadFrom(reader);
                 if (analyzerVersion != AnalyzerVersion)
                 {
-                    return null;
+                    return ImmutableArray<DiagnosticData>.Empty;
                 }
 
                 var version = VersionStamp.ReadFrom(reader);
                 if (version != VersionStamp.Default && version != Version)
                 {
-                    return null;
+                    return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                ReadFrom(reader, project, document, list, cancellationToken);
-
-                return new StrongBox<ImmutableArray<DiagnosticData>>(list.ToImmutableArray());
+                return ReadDiagnosticDataArray(reader, project, document, cancellationToken);
             }
             catch (Exception)
             {
-                return null;
+                return ImmutableArray<DiagnosticData>.Empty;
             }
         }
 
-        private static void ReadFrom(ObjectReader reader, Project project, Document document, List<DiagnosticData> list, CancellationToken cancellationToken)
+        private static ImmutableArray<DiagnosticData> ReadDiagnosticDataArray(ObjectReader reader, Project project, Document? document, CancellationToken cancellationToken)
         {
             var count = reader.ReadInt32();
+            if (count == 0)
+            {
+                return ImmutableArray<DiagnosticData>.Empty;
+            }
+
+            var builder = ArrayBuilder<DiagnosticData>.GetInstance(count);
 
             for (var i = 0; i < count; i++)
             {
@@ -271,9 +224,9 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 var isSuppressed = reader.ReadBoolean();
                 var warningLevel = reader.ReadInt32();
 
-                var start = reader.ReadInt32();
-                var length = reader.ReadInt32();
-                var textSpan = new TextSpan(start, length);
+                // these fields are unused - the actual span is read in ReadLocation
+                _ = reader.ReadInt32();
+                _ = reader.ReadInt32();
 
                 var location = ReadLocation(project, reader, document);
                 var additionalLocations = ReadAdditionalLocations(project, reader);
@@ -284,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                 var propertiesCount = reader.ReadInt32();
                 var properties = GetProperties(reader, propertiesCount);
 
-                list.Add(new DiagnosticData(
+                builder.Add(new DiagnosticData(
                     id: id,
                     category: category,
                     message: message,
@@ -304,9 +257,11 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
                     helpLink: helpLink,
                     isSuppressed: isSuppressed));
             }
+
+            return builder.ToImmutableAndFree();
         }
 
-        private static DiagnosticDataLocation ReadLocation(Project project, ObjectReader reader, Document documentOpt)
+        private static DiagnosticDataLocation? ReadLocation(Project project, ObjectReader reader, Document? document)
         {
             var exists = reader.ReadBoolean();
             if (!exists)
@@ -332,8 +287,8 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             var mappedEndLine = reader.ReadInt32();
             var mappedEndColumn = reader.ReadInt32();
 
-            var documentId = documentOpt != null
-                ? documentOpt.Id
+            var documentId = document != null
+                ? document.Id
                 : project.Documents.FirstOrDefault(d => d.FilePath == originalFile)?.Id;
 
             return new DiagnosticDataLocation(documentId, sourceSpan,
@@ -347,7 +302,11 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             var result = new List<DiagnosticDataLocation>();
             for (var i = 0; i < count; i++)
             {
-                result.Add(ReadLocation(project, reader, documentOpt: null));
+                var location = ReadLocation(project, reader, document: null);
+                if (location != null)
+                {
+                    result.Add(location);
+                }
             }
 
             return result;
@@ -383,17 +342,6 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             }
 
             return SpecializedCollections.EmptyReadOnlyList<string>();
-        }
-
-        private static Solution GetSolution(object documentOrProject)
-        {
-            if (documentOrProject is Document document)
-            {
-                return document.Project.Solution;
-            }
-
-            var project = (Project)documentOrProject;
-            return project.Solution;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableDictionaryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableDictionaryExtensions.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableDictionaryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableDictionaryExtensions.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {

--- a/src/Workspaces/Core/Portable/Utilities/IDictionaryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/IDictionaryExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Roslyn.Utilities
 {
@@ -47,6 +48,18 @@ namespace Roslyn.Utilities
             }
 
             collection.Add(value);
+        }
+
+        public static void MultiAdd<TKey, TValue>(this IDictionary<TKey, ArrayBuilder<TValue>> dictionary, TKey key, TValue value)
+            where TKey : notnull
+        {
+            if (!dictionary.TryGetValue(key, out var builder))
+            {
+                builder = ArrayBuilder<TValue>.GetInstance();
+                dictionary.Add(key, builder);
+            }
+
+            builder.Add(value);
         }
 
         public static void MultiAdd<TKey, TValue>(this IDictionary<TKey, ImmutableArray<TValue>> dictionary, TKey key, TValue value, ImmutableArray<TValue> defaultArray)

--- a/src/Workspaces/Core/Portable/Utilities/PooledBuilderExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/PooledBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Roslyn.Utilities
             return dictionary;
         }
 
-        public static Dictionary<K, ImmutableArray<V>> ToDictionaryAndFree<K, V>(this PooledDictionary<K, ArrayBuilder<V>> builders)
+        public static Dictionary<K, ImmutableArray<V>> ToMultiDictionaryAndFree<K, V>(this PooledDictionary<K, ArrayBuilder<V>> builders)
         {
             var dictionary = new Dictionary<K, ImmutableArray<V>>(builders.Count);
 
@@ -35,7 +35,7 @@ namespace Roslyn.Utilities
             return dictionary;
         }
 
-        public static ImmutableDictionary<K, ImmutableArray<V>> ToImmutableDictionaryAndFree<K, V>(this PooledDictionary<K, ArrayBuilder<V>> builders)
+        public static ImmutableDictionary<K, ImmutableArray<V>> ToImmutableMultiDictionaryAndFree<K, V>(this PooledDictionary<K, ArrayBuilder<V>> builders)
         {
             var result = ImmutableDictionary.CreateBuilder<K, ImmutableArray<V>>();
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1267,7 +1267,7 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                // TODO: actually make this a snapshot
+                // TODO: actually make this a snapshot (https://github.com/dotnet/roslyn/issues/19284)
                 return this.Workspace.Options;
             }
         }

--- a/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             lock (_exceptions)
             {
                 var list = _exceptions.GetOrAdd(analyzer, _ => new HashSet<DiagnosticData>());
-                list.Add(DiagnosticData.Create(diagnostic, _project, _project.Solution.Options));
+                list.Add(DiagnosticData.Create(diagnostic, _project));
             }
         }
 

--- a/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             lock (_exceptions)
             {
                 var list = _exceptions.GetOrAdd(analyzer, _ => new HashSet<DiagnosticData>());
-                list.Add(DiagnosticData.Create(_project.Solution.Workspace, diagnostic, _project.Id));
+                list.Add(DiagnosticData.Create(diagnostic, _project, _project.Solution.Options));
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 using (var writer = new ObjectWriter(stream))
                 {
-                    var (diagnostics, telemetry, exceptions) = DiagnosticResultSerializer.Serialize(writer, result, cancellationToken);
+                    var (diagnostics, telemetry, exceptions) = DiagnosticResultSerializer.WriteDiagnosticAnalysisResults(writer, result, cancellationToken);
 
                     // save log for debugging
                     Log(TraceEventType.Information, $"diagnostics: {diagnostics}, telemetry: {telemetry}, exceptions: {exceptions}");


### PR DESCRIPTION
Add nullable annotations.
Remove dependency on `Workspace` from `IBuiltInAnalyzer.OpenFileOnly`.
Remove usages of `Solution.Workspace` from `DiagnosticIncrementalAnalyzer`.
Clean up `DiagnosticData` factories.