### PR TITLE
Stop using global nuget cache

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -40,7 +40,7 @@ param (
   [switch]$skipAnalyzers,
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
-  [switch]$useGlobalNuGetCache = $true,
+  [switch]$useGlobalNuGetCache = $false,
   [switch]$warnAsError = $false,
   [switch]$sourceBuild = $false,
 


### PR DESCRIPTION
Workaround for https://github.com/dotnet/roslyn/issues/19882, https://github.com/NuGet/Home/issues/5438

NuGet cache got corrupted again on CI machines causing failures in restore:
```
System.Xml.XmlException: '.', hexadecimal value 0x00, is an invalid character. Line 1, position 1
```