### PR TITLE
LSP - Never precalculate codeaction results. They will be calculated lazily on preview or invoke.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -46,6 +46,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 // Note that we can pass through the params for this
                 // request (like range, filename) because between getcodeaction and runcodeaction there can be no
                 // changes on the IDE side (it will requery for codeactions if there are changes).
+
+                // Always return the Command instead of a precalculated set of workspace edits. The edits will be
+                // calculated when the code action is either previewed or invoked.
+
                 result.Add(
                     new LSP.Command
                     {

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -8,8 +8,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -48,56 +49,76 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var result = new ArrayBuilder<object>();
             foreach (var codeAction in codeActions)
             {
+                if (!clientSupportsWorkspaceEdits)
+                {
+                    AddCodeActionWithoutIncludingChanges(request, result, codeAction);
+                    continue;
+                }
+
                 // If we have a codeaction with a single applychangesoperation, we want to send the codeaction with the edits.
                 var operations = await codeAction.GetOperationsAsync(cancellationToken).ConfigureAwait(keepThreadContext);
-                if (clientSupportsWorkspaceEdits && operations.Length == 1 && operations.First() is ApplyChangesOperation applyChangesOperation)
+                if (operations.Length == 1 && operations.First() is ApplyChangesOperation applyChangesOperation)
                 {
-                    var workspaceEdit = new LSP.WorkspaceEdit { Changes = new Dictionary<string, LSP.TextEdit[]>() };
-                    var changes = applyChangesOperation.ChangedSolution.GetChanges(solution);
-                    var changedDocuments = changes.GetProjectChanges().SelectMany(pc => pc.GetChangedDocuments());
-
-                    foreach (var docId in changedDocuments)
-                    {
-                        var newDoc = applyChangesOperation.ChangedSolution.GetDocument(docId);
-                        var oldDoc = solution.GetDocument(docId);
-                        var oldText = await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(keepThreadContext);
-                        var textChanges = await newDoc.GetTextChangesAsync(oldDoc).ConfigureAwait(keepThreadContext);
-
-                        var edits = textChanges.Select(tc => new LSP.TextEdit
-                        {
-                            NewText = tc.NewText,
-                            Range = ProtocolConversions.TextSpanToRange(tc.Span, oldText)
-                        });
-
-                        workspaceEdit.Changes.Add(newDoc.FilePath, edits.ToArray());
-                    }
-
-                    result.Add(new LSP.CodeAction { Title = codeAction.Title, Edit = workspaceEdit });
+                    await AddCodeActionIncludingChangesAsync(
+                        codeAction, applyChangesOperation, solution, result,
+                        keepThreadContext, cancellationToken).ConfigureAwait(keepThreadContext);
                 }
-                // Otherwise, send the original request to be executed on the host.
                 else
                 {
-                    // Note that we can pass through the params for this
-                    // request (like range, filename) because between getcodeaction and runcodeaction there can be no
-                    // changes on the IDE side (it will requery for codeactions if there are changes).
-                    result.Add(
-                        new LSP.Command
-                        {
-                            CommandIdentifier = RunCodeActionCommandName,
-                            Title = codeAction.Title,
-                            Arguments = new object[]
-                            {
+                    // Otherwise, send the original request to be executed on the host.
+                    AddCodeActionWithoutIncludingChanges(request, result, codeAction);
+                }
+            }
+
+            return result.ToArrayAndFree();
+        }
+
+        private static async Task AddCodeActionIncludingChangesAsync(
+            CodeActions.CodeAction codeAction, ApplyChangesOperation applyChangesOperation, Solution solution,
+            ArrayBuilder<object> result, bool keepThreadContext, CancellationToken cancellationToken)
+        {
+            var workspaceEdit = new LSP.WorkspaceEdit { Changes = new Dictionary<string, LSP.TextEdit[]>() };
+            var changes = applyChangesOperation.ChangedSolution.GetChanges(solution);
+            var changedDocuments = changes.GetProjectChanges().SelectMany(pc => pc.GetChangedDocuments());
+
+            foreach (var docId in changedDocuments)
+            {
+                var newDoc = applyChangesOperation.ChangedSolution.GetDocument(docId);
+                var oldDoc = solution.GetDocument(docId);
+                var oldText = await oldDoc.GetTextAsync(cancellationToken).ConfigureAwait(keepThreadContext);
+                var textChanges = await newDoc.GetTextChangesAsync(oldDoc).ConfigureAwait(keepThreadContext);
+
+                var edits = textChanges.Select(tc => new LSP.TextEdit
+                {
+                    NewText = tc.NewText,
+                    Range = ProtocolConversions.TextSpanToRange(tc.Span, oldText)
+                });
+
+                workspaceEdit.Changes.Add(newDoc.FilePath, edits.ToArray());
+            }
+
+            result.Add(new LSP.CodeAction { Title = codeAction.Title, Edit = workspaceEdit });
+        }
+
+        private static void AddCodeActionWithoutIncludingChanges(CodeActionParams request, ArrayBuilder<object> result, CodeActions.CodeAction codeAction)
+        {
+            // Note that we can pass through the params for this
+            // request (like range, filename) because between getcodeaction and runcodeaction there can be no
+            // changes on the IDE side (it will requery for codeactions if there are changes).
+            result.Add(
+                new LSP.Command
+                {
+                    CommandIdentifier = RunCodeActionCommandName,
+                    Title = codeAction.Title,
+                    Arguments = new object[]
+                    {
                                 new RunCodeActionParams
                                 {
                                     CodeActionParams = request,
                                     Title = codeAction.Title
                                 }
-                            }
-                        });
-                }
-            }
-
-            return result.ToArrayAndFree();
+                    }
+                });
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -10,8 +9,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.LanguageServer.CustomProtocol;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Newtonsoft.Json.Linq;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
 
                 // If we have a codeaction with a single applychangesoperation, we want to send the codeaction with the edits.
                 var operations = await codeAction.GetOperationsAsync(cancellationToken).ConfigureAwait(keepThreadContext);
-                if (operations.Length == 1 && operations.First() is ApplyChangesOperation applyChangesOperation)
+                if (operations.Length == 1 && operations.Single() is ApplyChangesOperation applyChangesOperation)
                 {
                     await AddCodeActionIncludingChangesAsync(
                         codeAction, applyChangesOperation, solution, result,

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -40,12 +40,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var result = new ArrayBuilder<object>();
             foreach (var codeAction in codeActions)
             {
-                // Note that we can pass through the params for this
-                // request (like range, filename) because between getcodeaction and runcodeaction there can be no
-                // changes on the IDE side (it will requery for codeactions if there are changes).
+                // Always return the Command instead of a precalculated set of workspace edits. 
+                // The edits will be calculated when the code action is either previewed or 
+                // invoked.
 
-                // Always return the Command instead of a precalculated set of workspace edits. The edits will be
-                // calculated when the code action is either previewed or invoked.
+                // It's safe for the client to pass back the range/filename in the command to run
+                // on the server because the client will always re-issue a get code actions request
+                // before invoking a preview or running the command on the server.
 
                 result.Add(
                     new LSP.Command


### PR DESCRIPTION
Related to https://github.com/dotnet/roslyn/issues/40043 in that it prevents the preemptive immediate crash in the LSP case
Related to https://github.com/dotnet/roslyn/issues/40086 in that it improves performance of gathering the code actions, but makes seeing previews slower after that point.