### PR TITLE
Record used assembly references for more scenarios.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
             this.LookupMembersWithFallback(result, attributeType, name, 0, ref useSiteDiagnostics);
             diagnostics.Add(identifierName, useSiteDiagnostics);
-            Symbol resultSymbol = this.ResultSymbol(result, name, 0, identifierName, diagnostics, false, out wasError, qualifierOpt: null);
+            Symbol resultSymbol = this.ResultSymbol(result, name, 0, identifierName, diagnostics, false, out wasError, qualifierOpt: null, basesBeingResolved: null);
             resultKind = result.Kind;
             result.Free();
             return resultSymbol;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5811,7 +5811,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (lookupResult.IsMultiViable)
                             {
                                 bool wasError;
-                                Symbol sym = ResultSymbol(lookupResult, rightName, rightArity, node, diagnostics, false, out wasError, ns, options);
+                                Symbol sym = ResultSymbol(lookupResult, rightName, rightArity, node, diagnostics, false, out wasError, ns, basesBeingResolved: null, options);
                                 if (wasError)
                                 {
                                     return new BoundBadExpression(node, LookupResultKind.Ambiguous, lookupResult.Symbols.AsImmutable(), ImmutableArray.Create(boundLeft), CreateErrorType(rightName), hasErrors: true);
@@ -6869,7 +6869,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             methodOrPropertyGroup.Clear();
-            return ResultSymbol(result, plainName, arity, node, diagnostics, false, out wasError, qualifierOpt);
+            return ResultSymbol(result, plainName, arity, node, diagnostics, false, out wasError, qualifierOpt, basesBeingResolved: null);
         }
 
         private static bool IsMethodOrPropertyGroup(ArrayBuilder<Symbol> members)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -232,7 +232,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         diagnostics: resultDiagnostics,
                         suppressUseSiteDiagnostics: false,
                         wasError: out wasError,
-                        qualifierOpt: null);
+                        qualifierOpt: null,
+                        basesBeingResolved: null);
 
                     // Here, we're mimicking behavior of dev10.  If the identifier fails to bind
                     // as a type, even if the reason is (e.g.) a type/alias conflict, then treat
@@ -354,7 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.LookupSymbolsWithFallback(result, plainName, 0, ref useSiteDiagnostics, null, LookupOptions.NamespaceAliasesOnly);
                 diagnostics.Add(node, useSiteDiagnostics);
 
-                Symbol bindingResult = ResultSymbol(result, plainName, 0, node, diagnostics, false, out wasError, qualifierOpt: null, options: LookupOptions.NamespaceAliasesOnly);
+                Symbol bindingResult = ResultSymbol(result, plainName, 0, node, diagnostics, false, out wasError, qualifierOpt: null, basesBeingResolved: null, options: LookupOptions.NamespaceAliasesOnly);
                 result.Free();
 
                 return bindingResult;
@@ -831,7 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 bool wasError;
 
-                bindingResult = ResultSymbol(result, identifierValueText, 0, node, diagnostics, suppressUseSiteDiagnostics, out wasError, qualifierOpt, options);
+                bindingResult = ResultSymbol(result, identifierValueText, 0, node, diagnostics, suppressUseSiteDiagnostics, out wasError, qualifierOpt, basesBeingResolved, options);
                 if (bindingResult.Kind == SymbolKind.Alias)
                 {
                     var aliasTarget = ((AliasSymbol)bindingResult).GetAliasTarget(basesBeingResolved);
@@ -1097,7 +1098,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             diagnostics.Add(node, useSiteDiagnostics);
 
             bool wasError;
-            Symbol lookupResultSymbol = ResultSymbol(lookupResult, plainName, arity, node, diagnostics, (basesBeingResolved != null), out wasError, qualifierOpt, options);
+            Symbol lookupResultSymbol = ResultSymbol(lookupResult, plainName, arity, node, diagnostics, (basesBeingResolved != null), out wasError, qualifierOpt, basesBeingResolved, options);
 
             // As we said in the method above, there are three cases here:
             //
@@ -1536,6 +1537,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool suppressUseSiteDiagnostics,
             out bool wasError,
             NamespaceOrTypeSymbol qualifierOpt,
+            ConsList<TypeSymbol> basesBeingResolved,
             LookupOptions options = default(LookupOptions))
         {
             Symbol symbol = resultSymbol(result, simpleName, arity, where, diagnostics, suppressUseSiteDiagnostics, out wasError, qualifierOpt, options);
@@ -1552,7 +1554,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case SymbolKind.Alias:
-                    if (shouldRecordUsedAssemblyReferences() && ((AliasSymbol)symbol).Target is TypeSymbol type)
+                    if (shouldRecordUsedAssemblyReferences() && ((AliasSymbol)symbol).GetAliasTarget(basesBeingResolved) is TypeSymbol type)
                     {
                         Compilation.AddAssembliesUsedByTypeReference(type);
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1652,7 +1652,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // binder.ResultSymbol is defined only for type/namespace lookups
                     bool wasError;
                     var diagnostics = DiagnosticBag.GetInstance();  // client code never expects a null diagnostic bag.
-                    Symbol singleSymbol = binder.ResultSymbol(lookupResult, name, arity, this.Root, diagnostics, true, out wasError, container, options);
+                    Symbol singleSymbol = binder.ResultSymbol(lookupResult, name, arity, this.Root, diagnostics, true, out wasError, container, basesBeingResolved: null, options);
                     diagnostics.Free();
 
                     if (!wasError)

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -762,13 +762,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _diagnostics.AddRange(diagnosticsThisMethod);
                     diagnosticsThisMethod.Free();
 
-                    // error while generating IL
-                    if (emittedBody == null)
+                    if (_emitMethodBodies)
                     {
-                        break;
-                    }
+                        // error while generating IL
+                        if (emittedBody == null)
+                        {
+                            break;
+                        }
 
-                    _moduleBeingBuiltOpt.SetMethodBody(method, emittedBody);
+                        _moduleBeingBuiltOpt.SetMethodBody(method, emittedBody);
+                    }
+                    else
+                    {
+                        Debug.Assert(emittedBody is null);
+                    }
                 }
             }
             finally

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return Compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor);
         }
 
-        private void EnsureEmbeddableAttributeExists(EmbeddableAttributes attribute)
+        private void EnsureEmbeddableAttributeExists(EmbeddableAttributes attribute, bool recordUsage)
         {
             Debug.Assert(!_needsGeneratedAttributes_IsFrozen);
 
@@ -1544,25 +1544,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
 
             // Don't report any errors. They should be reported during binding.
-            if (Compilation.CheckIfAttributeShouldBeEmbedded(attribute, recordUsage: false, diagnosticsOpt: null, locationOpt: null))
+            if (Compilation.CheckIfAttributeShouldBeEmbedded(attribute, recordUsage, diagnosticsOpt: null, locationOpt: null))
             {
                 SetNeedsGeneratedAttributes(attribute);
             }
         }
 
-        internal void EnsureIsReadOnlyAttributeExists()
+        internal void EnsureIsReadOnlyAttributeExists(bool recordUsage)
         {
-            EnsureEmbeddableAttributeExists(EmbeddableAttributes.IsReadOnlyAttribute);
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.IsReadOnlyAttribute, recordUsage);
         }
 
-        internal void EnsureIsUnmanagedAttributeExists()
+        internal void EnsureIsUnmanagedAttributeExists(bool recordUsage)
         {
-            EnsureEmbeddableAttributeExists(EmbeddableAttributes.IsUnmanagedAttribute);
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.IsUnmanagedAttribute, recordUsage);
         }
 
-        internal void EnsureNullableAttributeExists()
+        internal void EnsureNullableAttributeExists(bool recordUsage)
         {
-            EnsureEmbeddableAttributeExists(EmbeddableAttributes.NullableAttribute);
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.NullableAttribute, recordUsage);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var typeParameters = localFunction.TypeParameters;
             if (typeParameters.Any(typeParameter => typeParameter.HasUnmanagedTypeConstraint))
             {
-                _factory.CompilationState.ModuleBuilderOpt?.EnsureIsUnmanagedAttributeExists();
+                _factory.CompilationState.ModuleBuilderOpt?.EnsureIsUnmanagedAttributeExists(recordUsage: true);
             }
 
             if (_factory.CompilationState.Compilation.ShouldEmitNullableAttributes(localFunction))
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (constraintsNeedNullableAttribute || returnTypeNeedsNullableAttribute || parametersNeedNullableAttribute)
                 {
-                    _factory.CompilationState.ModuleBuilderOpt?.EnsureNullableAttributeExists();
+                    _factory.CompilationState.ModuleBuilderOpt?.EnsureNullableAttributeExists(recordUsage: true);
                 }
             }
 
@@ -840,7 +840,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (symbol.ReturnsByRefReadonly ||
                 symbol.Parameters.Any(p => p.RefKind == RefKind.In))
             {
-                _factory.CompilationState.ModuleBuilderOpt?.EnsureIsReadOnlyAttributeExists();
+                _factory.CompilationState.ModuleBuilderOpt?.EnsureIsReadOnlyAttributeExists(recordUsage: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -199,6 +199,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+        internal override bool MightContainNoPiaLocalTypes()
+        {
+            return _module.ContainsNoPiaLocalTypes();
+        }
+
         public override ImmutableArray<Location> Locations
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -98,6 +98,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal sealed override bool MightContainNoPiaLocalTypes()
+        {
+            return false;
+        }
+
         public override int GetHashCode()
         {
             return assembly.GetHashCode();

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -363,6 +363,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal abstract bool MightContainNoPiaLocalTypes();
+
         /// <summary>
         /// If this symbol represents a metadata module returns the underlying <see cref="ModuleMetadata"/>.
         /// 

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -403,6 +403,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     Dictionary<MetadataReference, int> referencedAssembliesMap, referencedModulesMap;
                     ImmutableArray<ImmutableArray<string>> aliasesOfReferencedAssemblies;
+                    Dictionary<MetadataReference, ImmutableArray<MetadataReference>> mergedAssemblyReferencesMapOpt;
+
                     BuildReferencedAssembliesAndModulesMaps(
                         bindingResult,
                         references,
@@ -413,7 +415,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         supersedeLowerVersions,
                         out referencedAssembliesMap,
                         out referencedModulesMap,
-                        out aliasesOfReferencedAssemblies);
+                        out aliasesOfReferencedAssemblies,
+                        out mergedAssemblyReferencesMapOpt);
 
                     // Create AssemblySymbols for assemblies that can't use any existing symbols.
                     var newSymbols = new List<int>();
@@ -507,7 +510,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     moduleReferences,
                                     assemblySymbol.SourceModule.GetReferencedAssemblySymbols(),
                                     aliasesOfReferencedAssemblies,
-                                    assemblySymbol.SourceModule.GetUnifiedAssemblies());
+                                    assemblySymbol.SourceModule.GetUnifiedAssemblies(),
+                                    mergedAssemblyReferencesMapOpt);
 
                                 // Make sure that the given compilation holds on this instance of reference manager.
                                 Debug.Assert(ReferenceEquals(compilation._referenceManager, this) || HasCircularReference);

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -130,6 +130,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
+        internal override bool MightContainNoPiaLocalTypes()
+        {
+            return _underlyingModule.MightContainNoPiaLocalTypes();
+        }
+
         public override bool IsImplicitlyDeclared
         {
             get { return _underlyingModule.IsImplicitlyDeclared; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal bool MightContainNoPiaLocalTypes()
+        internal override bool MightContainNoPiaLocalTypes()
         {
             return AnyReferencedAssembliesAreLinked ||
                 ContainsExplicitDefinitionOfNoPiaLocalTypes;

--- a/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -34,62 +40,253 @@ namespace Microsoft.CodeAnalysis.CSharp
             _compilation = compilation;
         }
 
-        private void AddAssembliesUsedBySymbolReference(BoundExpression receiverOpt, Symbol symbol)
+        private void AddAssembliesUsedBySymbolReference(BoundExpression? receiverOpt, Symbol symbol)
         {
             if (symbol.IsStatic && receiverOpt?.Kind != BoundKind.TypeExpression)
             {
                 _compilation.AddAssembliesUsedByTypeReference(symbol.ContainingType);
             }
+
+            if (MightReferenceNoPiaLocalTypes(symbol))
+            {
+                // Need to make sure we record assemblies containing canonical definitions for NoPia embedded types
+                switch (symbol.OriginalDefinition)
+                {
+                    case FieldSymbol field:
+                        addFromType(field.TypeWithAnnotations);
+                        break;
+                    case PropertySymbol property:
+                        addFromType(property.TypeWithAnnotations);
+                        addFromModifiers(property.RefCustomModifiers);
+                        addFromParameters(property.Parameters);
+                        break;
+                    case MethodSymbol method:
+                        addFromType(method.ReturnTypeWithAnnotations);
+                        addFromModifiers(method.RefCustomModifiers);
+                        addFromParameters(method.Parameters);
+                        break;
+                    case EventSymbol @event:
+                        addFromType(@event.TypeWithAnnotations);
+                        break;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
+                }
+            }
+
+            void addFromParameters(ImmutableArray<ParameterSymbol> parameters)
+            {
+                foreach (var parameter in parameters)
+                {
+                    addFromType(parameter.TypeWithAnnotations);
+                    addFromModifiers(parameter.RefCustomModifiers);
+                }
+            }
+
+            void addFromType(TypeWithAnnotations type)
+            {
+                _compilation.AddAssembliesUsedByTypeReference(type.Type);
+                addFromModifiers(type.CustomModifiers);
+            }
+
+            void addFromModifiers(ImmutableArray<CustomModifier> customModifiers)
+            {
+                foreach (CSharpCustomModifier modifier in customModifiers)
+                {
+                    _compilation.AddAssembliesUsedByTypeReference(modifier.ModifierSymbol);
+                }
+            }
         }
 
-        public override BoundNode VisitFieldAccess(BoundFieldAccess node)
+        private bool MightReferenceNoPiaLocalTypes(Symbol symbol)
+        {
+            ModuleSymbol containingModule = symbol.ContainingModule;
+            return containingModule is object &&
+                   containingModule != _compilation.SourceModule &&
+                   containingModule.MightContainNoPiaLocalTypes();
+        }
+
+        public override BoundNode? VisitFieldAccess(BoundFieldAccess node)
         {
             AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.FieldSymbol);
             return base.VisitFieldAccess(node);
         }
 
-        public override BoundNode VisitPropertyAccess(BoundPropertyAccess node)
+        public override BoundNode? VisitPropertyAccess(BoundPropertyAccess node)
         {
             AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.PropertySymbol);
             return base.VisitPropertyAccess(node);
         }
 
-        public override BoundNode VisitIndexerAccess(BoundIndexerAccess node)
+        public override BoundNode? VisitIndexerAccess(BoundIndexerAccess node)
         {
             AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.Indexer);
             return base.VisitIndexerAccess(node);
         }
 
-        public override BoundNode VisitCall(BoundCall node)
+        public override BoundNode? VisitCall(BoundCall node)
         {
             AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.Method);
             return base.VisitCall(node);
         }
 
-        public override BoundNode VisitEventAccess(BoundEventAccess node)
+        public override BoundNode? VisitEventAccess(BoundEventAccess node)
         {
             AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.EventSymbol);
             return base.VisitEventAccess(node);
         }
 
-        public override BoundNode VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
+        public override BoundNode? VisitEventAssignmentOperator(BoundEventAssignmentOperator node)
         {
             AddAssembliesUsedBySymbolReference(node.ReceiverOpt, node.Event);
             return base.VisitEventAssignmentOperator(node);
         }
 
-        public override BoundNode VisitNameOfOperator(BoundNameOfOperator node)
+        public override BoundNode? VisitNameOfOperator(BoundNameOfOperator node)
         {
-            if (node.Argument is BoundNamespaceExpression nsExpr)
+            switch (node.Argument)
             {
-                Debug.Assert(!nsExpr.NamespaceSymbol.IsGlobalNamespace);
-                _compilation.AddAssembliesUsedByNamespaceReference(nsExpr.NamespaceSymbol);
+                case BoundNamespaceExpression nsExpr:
+                    Debug.Assert(!nsExpr.NamespaceSymbol.IsGlobalNamespace);
+                    _compilation.AddAssembliesUsedByNamespaceReference(nsExpr.NamespaceSymbol);
+                    break;
+
+                case BoundMethodGroup methodGroup:
+                    if (methodGroup.ReceiverOpt?.Kind != BoundKind.TypeExpression)
+                    {
+                        foreach (var symbol in methodGroup.Methods)
+                        {
+                            _compilation.AddAssembliesUsedByTypeReference(symbol.ContainingType);
+                        }
+                    }
+                    break;
+                case BoundPropertyGroup _:
+                    ExceptionUtilities.UnexpectedValue(node.Argument.Kind);
+                    break;
             }
 
             return base.VisitNameOfOperator(node);
         }
 
-        public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
+        public override BoundNode? VisitConversion(BoundConversion node)
+        {
+            VisitConversion(node.Conversion);
+
+            // Need to make sure we record assemblies containing canonical definitions for NoPia embedded types
+            HashSet<TypeSymbol>? lookedAt = null;
+
+            if (!node.Conversion.IsIdentity)
+            {
+                addUsedAssemblies(node.Operand.Type);
+            }
+
+            return base.VisitConversion(node);
+
+            void addUsedAssemblies(TypeSymbol? typeOpt)
+            {
+                while (true)
+                {
+                    switch (typeOpt)
+                    {
+                        case null:
+                        case DynamicTypeSymbol _:
+                            break;
+                        case PointerTypeSymbol pointer:
+                            typeOpt = pointer.PointedAtTypeWithAnnotations.DefaultType;
+                            continue;
+                        case ArrayTypeSymbol array:
+                            typeOpt = array.ElementTypeWithAnnotations.DefaultType;
+                            continue;
+                        case NamedTypeSymbol named:
+                            if (!shouldVisit(named))
+                            {
+                                break;
+                            }
+
+                            named = named.TupleUnderlyingTypeOrSelf();
+                            addAssembliesUsedByTypeArguments(named);
+                            addAssembliesUsedByImplementedInterfaces(named.OriginalDefinition);
+
+                            typeOpt = named.BaseTypeNoUseSiteDiagnostics;
+                            continue;
+                        case TypeParameterSymbol typeParameter:
+                            if (shouldVisit(typeParameter))
+                            {
+                                addAssembliesUsedByConstraints(typeParameter.OriginalDefinition);
+                            }
+                            break;
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(typeOpt.TypeKind);
+                    }
+
+                    break;
+                }
+            }
+
+            bool shouldVisit(TypeSymbol type)
+            {
+                return (lookedAt ??= new HashSet<TypeSymbol>(Symbols.SymbolEqualityComparer.ConsiderEverything)).Add(type);
+            }
+
+            void addAssembliesUsedByTypeArguments(NamedTypeSymbol current)
+            {
+                do
+                {
+                    foreach (var typeArgument in current.TypeArgumentsWithAnnotationsNoUseSiteDiagnostics)
+                    {
+                        addUsedAssemblies(typeArgument.Type);
+                    }
+
+                    current = current.ContainingType;
+                }
+                while (current is object);
+            }
+
+            void addAssembliesUsedByImplementedInterfaces(NamedTypeSymbol current)
+            {
+                Debug.Assert(current.IsDefinition);
+                if (MightReferenceNoPiaLocalTypes(current))
+                {
+                    foreach (var @interface in current.InterfacesNoUseSiteDiagnostics())
+                    {
+                        _compilation.AddAssembliesUsedByTypeReference(@interface);
+                        addUsedAssemblies(@interface);
+                    }
+                }
+            }
+
+            void addAssembliesUsedByConstraints(TypeParameterSymbol current)
+            {
+                Debug.Assert(current.IsDefinition);
+                if (current.ContainingModule == _compilation.SourceModule)
+                {
+                    foreach (var type in current.ConstraintTypesNoUseSiteDiagnostics)
+                    {
+                        addUsedAssemblies(type.Type);
+                    }
+                }
+            }
+        }
+
+        private void VisitConversion(Conversion conversion)
+        {
+            foreach (var underlying in conversion.UnderlyingConversions.NullToEmpty())
+            {
+                VisitConversion(underlying);
+            }
+
+            if (conversion.Kind == ConversionKind.Deconstruction)
+            {
+                Visit(conversion.DeconstructionInfo.Invocation);
+            }
+        }
+
+        public override BoundNode? VisitCollectionElementInitializer(BoundCollectionElementInitializer node)
+        {
+            AddAssembliesUsedBySymbolReference(receiverOpt: null, node.AddMethod);
+            return base.VisitCollectionElementInitializer(node);
+        }
+
+        public override BoundNode? VisitBinaryOperator(BoundBinaryOperator node)
         {
             // It is very common for bound trees to be left-heavy binary operators, eg,
             // a + b + c + d + ...
@@ -116,7 +313,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
+        public override BoundNode? VisitUserDefinedConditionalLogicalOperator(BoundUserDefinedConditionalLogicalOperator node)
         {
             // In order to avoid blowing the stack, we end up visiting right children
             // before left children; this should not be a problem

--- a/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UsedAssembliesRecorder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _compilation.AddAssembliesUsedByTypeReference(symbol.ContainingType);
             }
 
-            if (MightReferenceNoPiaLocalTypes(symbol))
+            if (DefinitionMightReferenceNoPiaLocalTypes(symbol))
             {
                 // Need to make sure we record assemblies containing canonical definitions for NoPia embedded types
                 switch (symbol.OriginalDefinition)
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private bool MightReferenceNoPiaLocalTypes(Symbol symbol)
+        private bool DefinitionMightReferenceNoPiaLocalTypes(Symbol symbol)
         {
             ModuleSymbol containingModule = symbol.ContainingModule;
             return containingModule is object &&
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             named = named.TupleUnderlyingTypeOrSelf();
                             addAssembliesUsedByTypeArguments(named);
-                            addAssembliesUsedByImplementedInterfaces(named.OriginalDefinition);
+                            addAssembliesUsedByImplementedInterfaces(named);
 
                             typeOpt = named.BaseTypeNoUseSiteDiagnostics;
                             continue;
@@ -243,14 +243,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void addAssembliesUsedByImplementedInterfaces(NamedTypeSymbol current)
             {
-                Debug.Assert(current.IsDefinition);
-                if (MightReferenceNoPiaLocalTypes(current))
+                if (DefinitionMightReferenceNoPiaLocalTypes(current))
                 {
-                    foreach (var @interface in current.InterfacesNoUseSiteDiagnostics())
+                    foreach (var @interface in current.OriginalDefinition.InterfacesNoUseSiteDiagnostics())
                     {
                         _compilation.AddAssembliesUsedByTypeReference(@interface);
-                        addUsedAssemblies(@interface);
                     }
+                }
+
+                foreach (var @interface in current.InterfacesNoUseSiteDiagnostics())
+                {
+                    addUsedAssemblies(@interface);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
@@ -2915,6 +2915,36 @@ public class C
     }
 }
 ");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I1 x = new A();
+        _ = x;
+    }
+}
+
+class A : C1 {}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        IA x = null;
+        I1 y = x;
+        _ = y;
+    }
+}
+
+interface IA : I3 {}
+");
+
             void verify(string source2)
             {
                 CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/UsedAssembliesTests.cs
@@ -130,13 +130,24 @@ public class C2
             AssertEx.Equal(comp.References.Where(r => r.Properties.Kind == MetadataImageKind.Assembly), comp.GetUsedAssemblyReferences());
         }
 
-        private void CompileWithUsedAssemblyReferences(string source, TargetFramework targetFramework, params MetadataReference[] references)
+        private ImmutableArray<MetadataReference> CompileWithUsedAssemblyReferences(string source, TargetFramework targetFramework, params MetadataReference[] references)
         {
-            Compilation comp = CreateCompilation(source, targetFramework: targetFramework, references: references);
-            CompileWithUsedAssemblyReferences(comp);
+            return CompileWithUsedAssemblyReferences(source, targetFramework, options: null, references);
         }
 
-        private void CompileWithUsedAssemblyReferences(Compilation comp, string expectedOutput = null)
+        private ImmutableArray<MetadataReference> CompileWithUsedAssemblyReferences(string source, TargetFramework targetFramework, CSharpCompilationOptions options, params MetadataReference[] references)
+        {
+            options ??= TestOptions.ReleaseDll;
+            options = options.WithSpecificDiagnosticOptions(options.SpecificDiagnosticOptions.Add("CS1591", ReportDiagnostic.Suppress));
+
+            Compilation comp = CreateEmptyCompilation(source,
+                                                      references: TargetFrameworkUtil.GetReferences(targetFramework).Concat(references),
+                                                      options: options,
+                                                      parseOptions: TestOptions.Regular.WithDocumentationMode(DocumentationMode.Diagnose));
+            return CompileWithUsedAssemblyReferences(comp);
+        }
+
+        private ImmutableArray<MetadataReference> CompileWithUsedAssemblyReferences(Compilation comp, string expectedOutput = null)
         {
             var used = comp.GetUsedAssemblyReferences();
             CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: expectedOutput).VerifyDiagnostics();
@@ -146,6 +157,18 @@ public class C2
             var comp2 = comp.RemoveAllReferences().AddReferences(used.Concat(comp.References.Where(r => r.Properties.Kind == MetadataImageKind.Module)));
             comp2.VerifyDiagnostics();
             CompileAndVerify(comp2, verify: Verification.Skipped, expectedOutput: expectedOutput).VerifyDiagnostics();
+
+            return used;
+        }
+
+        private ImmutableArray<MetadataReference> CompileWithUsedAssemblyReferences(string source, params MetadataReference[] references)
+        {
+            return CompileWithUsedAssemblyReferences(source, TargetFramework.Standard, references);
+        }
+
+        private void CompileWithUsedAssemblyReferences(string source, CSharpCompilationOptions options, params MetadataReference[] references)
+        {
+            CompileWithUsedAssemblyReferences(source, TargetFramework.Standard, options: options, references);
         }
 
         [Fact]
@@ -324,6 +347,24 @@ public class C2
             verify<PEAssemblySymbol>(source2, comp0Ref, comp1ImageRef);
             verify<SourceAssemblySymbol>(source2, comp0Ref, comp1Ref);
             verify<RetargetingAssemblySymbol>(source2, comp0ImageRef, comp1Ref);
+
+            var source3 =
+@"
+using static C1;
+
+public class C2
+{
+    public static void Main()
+    {
+        Assert(F1);
+    }
+
+    [System.Diagnostics.Conditional(""Always"")]
+    public static void Assert(int condition) {}
+}
+";
+
+            verify<SourceAssemblySymbol>(source3, comp0Ref, comp1Ref);
 
             void verify<TAssemblySymbol>(string source2, MetadataReference reference0, MetadataReference reference1) where TAssemblySymbol : AssemblySymbol
             {
@@ -1488,6 +1529,276 @@ public class C3
         }
 
         [Fact]
+        public void MethodReference_08()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1
+{
+    public C0 M1() => null;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            comp1.VerifyDiagnostics();
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var source3 =
+@"
+public class C3
+{
+    public static void Main()
+    {
+        _ = nameof(C1.M1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source3, comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(source3, comp0Ref, comp1ImageRef);
+
+            var source5 =
+@"
+using static C1;
+
+public class C3
+{
+    public static void Main()
+    {
+        _ = nameof(M1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source5, new[] { comp0Ref, comp1Ref },
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static C1;").WithLocation(2, 1),
+                // (8,20): error CS0103: The name 'M1' does not exist in the current context
+                //         _ = nameof(M1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "M1").WithArguments("M1").WithLocation(8, 20)
+                );
+
+
+            var source6 =
+@"
+public class C3
+{
+    public static void Main()
+    {
+        var x = new C1();
+        _ = nameof(x.M1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source6, comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(source6, comp0Ref, comp1ImageRef);
+        }
+
+        [Fact]
+        public void MethodReference_09()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public class C1
+{
+    public static C0 M1() => null;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            comp1.VerifyDiagnostics();
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var source3 =
+@"
+public class C3
+{
+    public static void Main()
+    {
+        _ = nameof(C1.M1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source3, comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(source3, comp0Ref, comp1ImageRef);
+
+            var source5 =
+@"
+using static C1;
+
+public class C3
+{
+    public static void Main()
+    {
+        _ = nameof(M1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source5, comp0Ref, comp1Ref);
+            AssertUsedAssemblyReferences(source5, comp0Ref, comp1ImageRef);
+        }
+
+        [Fact]
+        public void MethodReference_10()
+        {
+            var source1 =
+@"
+public class C1
+{
+    [System.Diagnostics.Conditional(""Always"")]
+    public static void M1(){}
+}
+";
+            var comp1 = CreateCompilation(source1);
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        C1.M1();
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source2, comp1ImageRef);
+            verify<SourceAssemblySymbol>(source2, comp1Ref);
+
+
+            var source3 =
+@"
+using static C1;
+
+public class C2
+{
+    public static void Main()
+    {
+        M1();
+    }
+}
+";
+
+            verify<PEAssemblySymbol>(source3, comp1ImageRef);
+            verify<SourceAssemblySymbol>(source3, comp1Ref);
+
+            void verify<TAssemblySymbol>(string source2, MetadataReference reference) where TAssemblySymbol : AssemblySymbol
+            {
+                Compilation comp2 = AssertUsedAssemblyReferences(source2, reference);
+                Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference));
+            }
+        }
+
+        [Fact]
+        public void MethodReference_11()
+        {
+            var source0 =
+@"
+public class C0 : System.Collections.IEnumerable
+{
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        throw new System.NotImplementedException();
+    }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public static class C1
+{
+    public static void Add(this C0 x,  int y) => throw null;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = new C0() { 1 };
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+        }
+
+        [Fact]
+        public void MethodReference_12()
+        {
+            var source0 =
+@"
+public class C0 : System.Collections.IEnumerable
+{
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        throw new System.NotImplementedException();
+    }
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public static class C1
+{
+    [System.Diagnostics.Conditional(""Always"")]
+    public static void Add(this C0 x,  int y) => throw null;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = new C0() { 1 };
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+        }
+
+        [Fact]
         public void FieldDeclaration_01()
         {
             var source1 =
@@ -1822,10 +2133,799 @@ public class C2
             verify<RetargetingAssemblySymbol>(source2, comp0Ref, comp1Ref);
             verify<RetargetingAssemblySymbol>(source2, comp0ImageRef, comp1Ref);
 
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify<PEAssemblySymbol>(source2, comp3ImageRef, comp1ImageRef);
+            verify<PEAssemblySymbol>(source2, comp3Ref, comp1ImageRef);
+            verify<RetargetingAssemblySymbol>(source2, comp3Ref, comp1Ref);
+            verify<RetargetingAssemblySymbol>(source2, comp3ImageRef, comp1Ref);
+
             void verify<TAssemblySymbol>(string source2, MetadataReference reference0, MetadataReference reference1) where TAssemblySymbol : AssemblySymbol
             {
                 Compilation comp2 = AssertUsedAssemblyReferences(source2, new[] { reference0, reference1 }, reference1);
                 Assert.IsType<TAssemblySymbol>(((CSharpCompilation)comp2).GetAssemblyOrModuleSymbol(reference1));
+            }
+        }
+
+        [Fact]
+        public void NoPia_02()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1
+{
+    public static ITest33 F0 = null;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1.F0;
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1.F0);
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    /// <summary>
+    /// <see cref=""C1.F0""/>
+    /// </summary>
+    public static void Main()
+    {
+    }
+}
+");
+
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
+            }
+        }
+
+        [Fact]
+        public void NoPia_03()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1
+{
+    public static ITest33 M0() => null;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        C1.M0();
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1.M0);
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    /// <summary>
+    /// <see cref=""C1.M0""/>
+    /// </summary>
+    public static void Main()
+    {
+    }
+}
+");
+
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
+            }
+        }
+
+        [Fact]
+        public void NoPia_04()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1
+{
+    public static object M0(ITest33 x) => null;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        C1.M0(null);
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1.M0);
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    /// <summary>
+    /// <see cref=""C1.M0""/>
+    /// </summary>
+    public static void Main()
+    {
+    }
+}
+");
+
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
+            }
+        }
+
+        [Fact]
+        public void NoPia_05()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+public delegate void DTest33();
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+#pragma warning disable CS0414
+public class C1
+{
+    public static event DTest33 E0 = null;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        C1.E0 += Main;
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1.E0);
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    /// <summary>
+    /// <see cref=""C1.E0""/>
+    /// </summary>
+    public static void Main()
+    {
+    }
+}
+");
+
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
+            }
+        }
+
+        [Fact]
+        public void NoPia_06()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1
+{
+    public static ITest33 P0 => null;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = C1.P0;
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(C1.P0);
+    }
+}
+");
+
+            verify(
+@"
+public class C2
+{
+    /// <summary>
+    /// <see cref=""C1.P0""/>
+    /// </summary>
+    public static void Main()
+    {
+    }
+}
+");
+
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
+            }
+        }
+
+        [Fact]
+        public void NoPia_07()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1
+{
+    public object this[ITest33 x] => null;
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C2
+{
+    public static void Main()
+    {
+        _ = new C1()[null];
+    }
+}
+");
+
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
+            }
+        }
+
+        [Fact]
+        public void NoPia_08()
+        {
+            var source0 =
+@"
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssemblyAttribute(1,1)]
+[assembly: Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"")]
+
+[ComImport()]
+[Guid(""f9c2d51d-4f44-45f0-9eda-c9d599b58279"")]
+public interface ITest33
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            comp0.VerifyDiagnostics();
+
+            var comp0Ref = comp0.ToMetadataReference(embedInteropTypes: true);
+            var comp0ImageRef = comp0.EmitToImageReference(embedInteropTypes: true);
+
+            var source1 =
+@"
+public class C1 : ITest33, I1
+{
+}
+
+public interface I1
+{
+}
+
+public class C2 : I2<ITest33>, I1
+{
+}
+
+public class C3 : C2
+{
+}
+
+public interface I2<out T>
+{
+}
+
+public interface I3 : ITest33, I1
+{
+}
+
+public interface I4 : I3
+{
+}
+
+public struct S1 : ITest33, I1
+{
+}
+";
+            var comp1 = AssertUsedAssemblyReferences(source1, references: new[] { comp0Ref });
+
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1ImageRef = comp1.EmitToImageReference();
+
+            var comp3 = CreateCompilation(source0);
+            var comp3Ref = comp3.ToMetadataReference(embedInteropTypes: false);
+            var comp3ImageRef = comp3.EmitToImageReference(embedInteropTypes: false);
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        _ = (I2<object>)new C2();
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        _ = (I1)new C2();
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        _ = (I1)new C1();
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I2<object> x = new C2();
+        _ = x;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I1 x = new C2();
+        _ = x;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I1 x = new C1();
+        _ = x;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        _ = (I2<object>)new C3();
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I2<object> x = new C3();
+        _ = x;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I3 x = null;
+        I1 y = x;
+        _ = y;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I4 x = null;
+        I1 y = x;
+        _ = y;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I<C1[]> x = null;
+        I<I1[]> y = x;
+        _ = y;
+    }
+}
+
+interface I<out T> {}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I<C1> x = null;
+        I<I1> y = x;
+        _ = y;
+    }
+}
+
+interface I<out T> {}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I<I1>[] x = new I<C1>[10];
+        _ = x;
+    }
+}
+
+interface I<out T> {}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        I1[] x = new C1[10];
+        _ = x;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main()
+    {
+        S1? x = null;
+        I1 y = x;
+        _ = y;
+    }
+}
+");
+
+            verify(
+@"
+public class C
+{
+    public static void Main<T>() where T : C1
+    {
+        T x = null;
+        I1 y = x;
+        _ = y;
+    }
+}
+");
+            void verify(string source2)
+            {
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp0ImageRef, comp1Ref);
+
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1ImageRef);
+                CompileWithUsedAssemblyReferences(source2, comp3Ref, comp1Ref);
+                CompileWithUsedAssemblyReferences(source2, comp3ImageRef, comp1Ref);
             }
         }
 
@@ -3245,6 +4345,22 @@ Public Class C1
         Set
         End Set
     End Property
+
+    Public Shared Property P2(x As Integer) As C0
+        Get
+            Return Nothing
+        End Get
+        Set
+        End Set
+    End Property
+
+    Public Shared Property P2(x As String) As C0
+        Get
+            Return Nothing
+        End Get
+        Set
+        End Set
+    End Property
 End Class
 ";
             var comp1 = CreateVisualBasicCompilation(source1, referencedAssemblies: TargetFrameworkUtil.GetReferences(TargetFramework.Standard, new[] { comp0ImageRef }));
@@ -3328,6 +4444,84 @@ public class C3
                 // (8,13): error CS1545: Property, indexer, or event 'C1.P1[int]' is not supported by the language; try directly calling accessor methods 'C1.get_P1(int)' or 'C1.set_P1(int, C0)'
                 //         _ = P1[0];
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "P1").WithArguments("C1.P1[int]", "C1.get_P1(int)", "C1.set_P1(int, C0)").WithLocation(8, 13)
+                );
+
+            var source6 =
+@"
+public class C3
+{
+    public static void Main()
+    {
+        _ = nameof(C1.P1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source6, references,
+                // (6,23): error CS1545: Property, indexer, or event 'C1.P1[int]' is not supported by the language; try directly calling accessor methods 'C1.get_P1(int)' or 'C1.set_P1(int, C0)'
+                //         _ = nameof(C1.P1);
+                Diagnostic(ErrorCode.ERR_BindToBogusProp2, "P1").WithArguments("C1.P1[int]", "C1.get_P1(int)", "C1.set_P1(int, C0)").WithLocation(6, 23)
+                );
+
+            var source7 =
+@"
+using static C1;
+
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(P1);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source7, references,
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static C1;").WithLocation(2, 1),
+                // (8,20): error CS1545: Property, indexer, or event 'C1.P1[int]' is not supported by the language; try directly calling accessor methods 'C1.get_P1(int)' or 'C1.set_P1(int, C0)'
+                //         _ = nameof(P1);
+                Diagnostic(ErrorCode.ERR_BindToBogusProp2, "P1").WithArguments("C1.P1[int]", "C1.get_P1(int)", "C1.set_P1(int, C0)").WithLocation(8, 20)
+                );
+
+            var source8 =
+@"
+public class C3
+{
+    public static void Main()
+    {
+        _ = nameof(C1.P2);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source8, references,
+                // (6,23): error CS1545: Property, indexer, or event 'C1.P2[int]' is not supported by the language; try directly calling accessor methods 'C1.get_P2(int)' or 'C1.set_P2(int, C0)'
+                //         _ = nameof(C1.P2);
+                Diagnostic(ErrorCode.ERR_BindToBogusProp2, "P2").WithArguments("C1.P2[int]", "C1.get_P2(int)", "C1.set_P2(int, C0)").WithLocation(6, 23)
+                );
+
+            var source9 =
+@"
+using static C1;
+
+public class C2
+{
+    public static void Main()
+    {
+        _ = nameof(P2);
+    }
+}
+";
+
+            AssertUsedAssemblyReferences(source9, references,
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using static C1;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using static C1;").WithLocation(2, 1),
+                // (8,20): error CS1545: Property, indexer, or event 'C1.P2[int]' is not supported by the language; try directly calling accessor methods 'C1.get_P2(int)' or 'C1.set_P2(int, C0)'
+                //         _ = nameof(P2);
+                Diagnostic(ErrorCode.ERR_BindToBogusProp2, "P2").WithArguments("C1.P2[int]", "C1.get_P2(int)", "C1.set_P2(int, C0)").WithLocation(8, 20)
                 );
         }
 
@@ -3563,23 +4757,270 @@ setZ
         }
 
         [Fact]
-        public void UseMissingAccessor()
+        public void WellKnownTypeReference_05()
         {
-            var text = @"
-class C
+            var source1 =
+@"
+namespace System.Runtime.CompilerServices
 {
-    event System.Action E { remove { } } //CS0065
+    public class IsUnmanagedAttribute : System.Attribute { }
+}
+";
+            var comp1 = CreateCompilation(source1);
+            comp1.VerifyDiagnostics();
 
-    void Goo()
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+#pragma warning disable CS8321
+
+public class Test
+{
+    public void M()
     {
-        E += null; //no separate error
+        void N<T>() where T : unmanaged
+        {
+        }
     }
 }
 ";
-            CreateCompilation(text).VerifyEmitDiagnostics(
-                // (4,25): error CS0065: 'C.E': event property must have both add and remove accessors
-                //     event System.Action E { remove { } }
-                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("C.E")).GetUsedAssemblyReferences();
+            CompileWithUsedAssemblyReferences(source2, options: TestOptions.DebugModule, comp1Ref);
+        }
+
+        [Fact]
+        public void Deconstruction_01()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public static class C1
+{
+    public static void Deconstruct(this C0 x, out int y, out int z) => throw null;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        var (y, z) = new C0();
+        _ = y;
+        _ = z;
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+        }
+
+        [Fact]
+        public void Deconstruction_02()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+
+            var source1 =
+@"
+public static class C1
+{
+    public static void Deconstruct(this C0 x, out int y, out int z) => throw null;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            var comp1Ref = comp1.ToMetadataReference();
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        var (x, (y, z)) = (1, new C0());
+        _ = x;
+        _ = y;
+        _ = z;
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp1Ref);
+        }
+
+        [Fact]
+        public void ExternAliases_01()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            var comp0Ref = comp0.ToMetadataReference();
+            var comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            var source1 =
+@"
+public static class C1
+{
+    public static C0 F1;
+}
+";
+            var comp1 = CreateCompilation(source1, references: new[] { comp0Ref });
+            var comp1Ref = comp1.ToMetadataReference();
+            var comp1RefWithAlias = comp1Ref.WithAliases(new[] { "Alias0" });
+
+            var source2 =
+@"
+extern alias Alias0;
+
+public class C2
+{
+    public static void Main()
+    {
+        var x = new Alias0::C0();
+        _ = x;
+    }
+}
+";
+
+            var used = CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp1RefWithAlias);
+            Assert.DoesNotContain(comp1RefWithAlias, used);
+
+            used = CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp1Ref);
+            Assert.DoesNotContain(comp1Ref, used);
+
+            CreateCompilation(source2, references: new[] { comp0Ref, comp1RefWithAlias }).VerifyDiagnostics(
+                // (8,29): error CS0234: The type or namespace name 'C0' does not exist in the namespace 'Alias0' (are you missing an assembly reference?)
+                //         var x = new Alias0::C0();
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "C0").WithArguments("C0", "Alias0").WithLocation(8, 29)
+                );
+        }
+
+        [Fact]
+        public void ExternAliases_02()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            MetadataReference comp0Ref = comp0.ToMetadataReference();
+            var comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            var source2 =
+@"
+extern alias Alias0;
+
+public class C2
+{
+    public static void Main()
+    {
+        var x = new Alias0::C0();
+        _ = x;
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp0Ref);
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp0RefWithAlias);
+
+            comp0Ref = comp0.EmitToImageReference();
+            comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp0Ref);
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp0RefWithAlias);
+        }
+
+        [Fact]
+        public void ExternAliases_03()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            MetadataReference comp0Ref = comp0.ToMetadataReference();
+            var comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        var x = new global::C0();
+        _ = x;
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp0Ref);
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp0RefWithAlias);
+
+            comp0Ref = comp0.EmitToImageReference();
+            comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp0Ref);
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp0RefWithAlias);
+        }
+
+        [Fact]
+        public void ExternAliases_04()
+        {
+            var source0 =
+@"
+public class C0
+{
+}
+";
+            var comp0 = CreateCompilation(source0);
+            MetadataReference comp0Ref = comp0.ToMetadataReference();
+            var comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            var source2 =
+@"
+public class C2
+{
+    public static void Main()
+    {
+        var x = new C0();
+        _ = x;
+    }
+}
+";
+
+            CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp0Ref);
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp0RefWithAlias);
+
+            comp0Ref = comp0.EmitToImageReference();
+            comp0RefWithAlias = comp0Ref.WithAliases(new[] { "Alias0" });
+
+            CompileWithUsedAssemblyReferences(source2, comp0RefWithAlias, comp0Ref);
+            CompileWithUsedAssemblyReferences(source2, comp0Ref, comp0RefWithAlias);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
@@ -1441,10 +1441,15 @@ class C
     }
 }
 ";
-            CreateCompilation(text).VerifyDiagnostics(
+            var expected = new[] {
                 // (4,25): error CS0065: 'C.E': event property must have both add and remove accessors
                 //     event System.Action E { remove { } }
-                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("C.E"));
+                Diagnostic(ErrorCode.ERR_EventNeedsBothAccessors, "E").WithArguments("C.E")
+                };
+
+            CreateCompilation(text).VerifyDiagnostics(expected).VerifyEmitDiagnostics(expected);
+
+            CreateCompilation(text).VerifyEmitDiagnostics(expected);
         }
 
         [WorkItem(542570, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542570")]

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis
             private readonly int _index;
             private readonly ImmutableArray<string> _aliasesOpt;
             private readonly ImmutableArray<string> _recursiveAliasesOpt;
+            private readonly ImmutableArray<MetadataReference> _mergedReferencesOpt;
 
             // uninitialized aliases
             public ResolvedReference(int index, MetadataImageKind kind)
@@ -67,20 +68,23 @@ namespace Microsoft.CodeAnalysis
                 _kind = kind;
                 _aliasesOpt = default(ImmutableArray<string>);
                 _recursiveAliasesOpt = default(ImmutableArray<string>);
+                _mergedReferencesOpt = default(ImmutableArray<MetadataReference>);
             }
 
             // initialized aliases
-            public ResolvedReference(int index, MetadataImageKind kind, ImmutableArray<string> aliasesOpt, ImmutableArray<string> recursiveAliasesOpt)
+            public ResolvedReference(int index, MetadataImageKind kind, ImmutableArray<string> aliasesOpt, ImmutableArray<string> recursiveAliasesOpt, ImmutableArray<MetadataReference> mergedReferences)
                 : this(index, kind)
             {
                 // We have to have non-default aliases (empty are ok). We can have both recursive and non-recursive aliases if two references were merged.
                 Debug.Assert(!aliasesOpt.IsDefault || !recursiveAliasesOpt.IsDefault);
+                Debug.Assert(!mergedReferences.IsDefault);
 
                 _aliasesOpt = aliasesOpt;
                 _recursiveAliasesOpt = recursiveAliasesOpt;
+                _mergedReferencesOpt = mergedReferences;
             }
 
-            private bool IsUninitialized => _aliasesOpt.IsDefault && _recursiveAliasesOpt.IsDefault;
+            private bool IsUninitialized => (_aliasesOpt.IsDefault && _recursiveAliasesOpt.IsDefault) || _mergedReferencesOpt.IsDefault;
 
             /// <summary>
             /// Aliases that should be applied to the referenced assembly. 
@@ -107,6 +111,15 @@ namespace Microsoft.CodeAnalysis
                 {
                     Debug.Assert(!IsUninitialized);
                     return _recursiveAliasesOpt;
+                }
+            }
+
+            public ImmutableArray<MetadataReference> MergedReferences
+            {
+                get
+                {
+                    Debug.Assert(!IsUninitialized);
+                    return _mergedReferencesOpt;
                 }
             }
 
@@ -425,12 +438,18 @@ namespace Microsoft.CodeAnalysis
         private static ResolvedReference GetResolvedReferenceAndFreePropertyMapEntry(MetadataReference reference, int index, MetadataImageKind kind, Dictionary<MetadataReference, MergedAliases> propertyMapOpt)
         {
             ImmutableArray<string> aliasesOpt, recursiveAliasesOpt;
+            var mergedReferences = ImmutableArray<MetadataReference>.Empty;
 
             MergedAliases mergedProperties;
             if (propertyMapOpt != null && propertyMapOpt.TryGetValue(reference, out mergedProperties))
             {
                 aliasesOpt = mergedProperties.AliasesOpt?.ToImmutableAndFree() ?? default(ImmutableArray<string>);
                 recursiveAliasesOpt = mergedProperties.RecursiveAliasesOpt?.ToImmutableAndFree() ?? default(ImmutableArray<string>);
+
+                if (mergedProperties.MergedReferencesOpt is object)
+                {
+                    mergedReferences = mergedProperties.MergedReferencesOpt.ToImmutableAndFree();
+                }
             }
             else if (reference.Properties.HasRecursiveAliases)
             {
@@ -443,7 +462,7 @@ namespace Microsoft.CodeAnalysis
                 recursiveAliasesOpt = default(ImmutableArray<string>);
             }
 
-            return new ResolvedReference(index, kind, aliasesOpt, recursiveAliasesOpt);
+            return new ResolvedReference(index, kind, aliasesOpt, recursiveAliasesOpt, mergedReferences);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/ReferenceManager/MergedAliases.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/MergedAliases.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis
     {
         public ArrayBuilder<string> AliasesOpt;
         public ArrayBuilder<string> RecursiveAliasesOpt;
+        public ArrayBuilder<MetadataReference> MergedReferencesOpt;
 
         /// <summary>
         /// Adds aliases of a specified reference to the merged set of aliases.
@@ -52,6 +53,8 @@ namespace Microsoft.CodeAnalysis
             Merge(
                 aliases: reference.Properties.HasRecursiveAliases ? RecursiveAliasesOpt : AliasesOpt,
                 newAliases: reference.Properties.Aliases);
+
+            (MergedReferencesOpt ??= ArrayBuilder<MetadataReference>.GetInstance()).Add(reference);
         }
 
         internal static void Merge(ArrayBuilder<string> aliases, ImmutableArray<string> newAliases)

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -351,6 +351,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim referencedAssembliesMap As Dictionary(Of MetadataReference, Integer) = Nothing
                     Dim referencedModulesMap As Dictionary(Of MetadataReference, Integer) = Nothing
                     Dim aliasesOfReferencedAssemblies As ImmutableArray(Of ImmutableArray(Of String)) = Nothing
+                    Dim mergedAssemblyReferencesMapOpt As Dictionary(Of MetadataReference, ImmutableArray(Of MetadataReference)) = Nothing
 
                     BuildReferencedAssembliesAndModulesMaps(
                         bindingResult,
@@ -362,7 +363,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         supersedeLowerVersions,
                         referencedAssembliesMap,
                         referencedModulesMap,
-                        aliasesOfReferencedAssemblies)
+                        aliasesOfReferencedAssemblies,
+                        mergedAssemblyReferencesMapOpt)
 
                     ' Create AssemblySymbols for assemblies that can't use any existing symbols.
                     Dim newSymbols As New List(Of Integer)
@@ -443,7 +445,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     moduleReferences,
                                     assemblySymbol.SourceModule.GetReferencedAssemblySymbols(),
                                     aliasesOfReferencedAssemblies,
-                                    assemblySymbol.SourceModule.GetUnifiedAssemblies())
+                                    assemblySymbol.SourceModule.GetUnifiedAssemblies(),
+                                    mergedAssemblyReferencesMapOpt)
 
                                 ' Make sure that the given compilation holds on this instance of reference manager.
                                 Debug.Assert(compilation._referenceManager Is Me OrElse hasCircularReference)


### PR DESCRIPTION
- Merged extern aliases
- Embeddable attributes
- Usage of canonical definitions for NoPia embedded types
- nameof of a method
- Deconstruction
- Collection initializers

Related to #37768.