### PR TITLE
Allow overriding the cache path for the default persistent storage se…

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IPersistentStorageLocationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/IPersistentStorageLocationService.cs
@@ -25,6 +25,16 @@ namespace Microsoft.CodeAnalysis.Host
         }
 
         public virtual bool IsSupported(Workspace workspace) => false;
+        
+        protected virtual string GetCacheDirectory()
+        {
+            // Store in the LocalApplicationData/Roslyn/hash folder (%appdatalocal%/... on Windows,
+            // ~/.local/share/... on unix).  This will place the folder in a location we can trust
+            // to be able to get back to consistently as long as we're working with the same
+            // solution and the same workspace kind.
+            var appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create);
+            return Path.Combine(appDataFolder, "Microsoft", "VisualStudio", "Roslyn", "Cache");
+        }
 
         public string? TryGetStorageLocation(Solution solution)
         {
@@ -37,15 +47,12 @@ namespace Microsoft.CodeAnalysis.Host
             // Ensure that each unique workspace kind for any given solution has a unique
             // folder to store their data in.
 
-            // Store in the LocalApplicationData/Roslyn/hash folder (%appdatalocal%/... on Windows,
-            // ~/.local/share/... on unix).  This will place the folder in a location we can trust
-            // to be able to get back to consistently as long as we're working with the same
-            // solution and the same workspace kind.
-            var appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create);
+
+            var cacheDirectory = GetCacheDirectory();
             var kind = StripInvalidPathChars(solution.Workspace.Kind ?? "");
             var hash = StripInvalidPathChars(Checksum.Create(solution.FilePath).ToString());
 
-            return Path.Combine(appDataFolder, "Microsoft", "VisualStudio", "Roslyn", "Cache", kind, hash);
+            return Path.Combine(cacheDirectory, kind, hash);
 
             static string StripInvalidPathChars(string val)
             {


### PR DESCRIPTION
…rvice

For systems like macOS, ~/.local/share is not the well known place to store caches. Allow overriding this at host level, to something that is platform specific (like ~/Library/Caches).