### PR TITLE
Skip failing C# REPL integration tests.

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveCommands.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveCommands.cs
@@ -38,7 +38,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("\"1\"");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyMaybeExecuteInput()
         {
             VisualStudio.InteractiveWindow.InsertCode("2 + 3");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveCommands.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveCommands.cs
@@ -46,7 +46,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("5");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyNewLineAndIndent()
         {
             VisualStudio.InteractiveWindow.InsertCode("3 + ");
@@ -73,7 +73,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.Verify.ReplPromptConsistency("<![CDATA[1 + 2 + 3]]>", "6");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyCancelInput()
         {
             VisualStudio.InteractiveWindow.InsertCode("1 + 4");
@@ -82,7 +82,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.Verify.LastReplInput(string.Empty);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyUndoAndRedo()
         {
             VisualStudio.InteractiveWindow.ClearReplText();
@@ -95,7 +95,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("6");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void CutDeletePasteSelectAll()
         {
             ClearInteractiveWindow();
@@ -132,7 +132,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         //     of these tests and convert them to unit-tests.
         //     -->
         //<!-- TODO(https://github.com/dotnet/roslyn/issues/4235)
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyReturnIndentCurrentLine()
         {
             VisualStudio.InteractiveWindow.ClearScreen();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveDirectives.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveDirectives.cs
@@ -16,7 +16,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyHostCommandsCompletionList()
         {
             VisualStudio.InteractiveWindow.InsertCode("#");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplClassification.cs
@@ -16,7 +16,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyColorOfSomeTokens()
         {
             VisualStudio.InteractiveWindow.InsertCode(@"using System.Console;

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
@@ -32,14 +32,14 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.WaitForLastReplOutput("42");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyCodeActionsNotAvailableInPreviousSubmission()
         {
             VisualStudio.InteractiveWindow.InsertCode("Console.WriteLine(42);");
             VisualStudio.InteractiveWindow.Verify.CodeActionsNotShowing();
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyQuickInfoOnStringDocCommentsFromMetadata()
         {
             VisualStudio.InteractiveWindow.InsertCode("static void Goo(string[] args) { }");
@@ -49,7 +49,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             Assert.Equal("class System.String", s);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void International()
         {
             VisualStudio.InteractiveWindow.InsertCode(@"delegate void العربية();
@@ -60,7 +60,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             Assert.Equal("(field) العربية func", s);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void HighlightRefsSingleSubmissionVerifyRenameTagsShowUpWhenInvokedOnUnsubmittedText()
         {
             VisualStudio.InteractiveWindow.InsertCode("int someint; someint = 22; someint = 23;");
@@ -71,7 +71,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.VerifyTags(WellKnownTagNames.MarkerFormatDefinition_HighlightedDefinition, 1);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void HighlightRefsSingleSubmissionVerifyRenameTagsGoAway()
         {
             VisualStudio.InteractiveWindow.InsertCode("int someint; someint = 22; someint = 23;");
@@ -159,7 +159,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.VerifyTags(WellKnownTagNames.MarkerFormatDefinition_HighlightedReference, 0);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void DisabledCommandsPart1()
         {
             VisualStudio.InteractiveWindow.InsertCode(@"public class Class
@@ -194,7 +194,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             Assert.False(VisualStudio.IsCommandAvailable(WellKnownCommandNames.Refactor_ReorderParameters));
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void AddUsing()
         {
             VisualStudio.InteractiveWindow.InsertCode("typeof(ArrayList)");
@@ -210,7 +210,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 typeof(ArrayList)");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void QualifyName()
         {
             VisualStudio.InteractiveWindow.InsertCode("typeof(ArrayList)");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
@@ -18,14 +18,14 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyCompletionListOnEmptyTextAtTopLevel()
         {
             VisualStudio.InteractiveWindow.InvokeCompletionList();
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("var", "public", "readonly", "goto");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifySharpRCompletionList()
         {
             VisualStudio.InteractiveWindow.InsertCode("#r \"");
@@ -33,7 +33,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("System");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyCommitCompletionOnTopLevel()
         {
             VisualStudio.InteractiveWindow.InsertCode("pub");
@@ -44,7 +44,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.SendKeys.Send(VirtualKey.Escape);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyCompletionListForAmbiguousParsingCases()
         {
             VisualStudio.InteractiveWindow.InsertCode(@"class C { }
@@ -54,7 +54,7 @@ Del<C, System");
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("ArgumentException");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifySharpLoadCompletionList()
         {
             VisualStudio.InteractiveWindow.InsertCode("#load \"");
@@ -62,14 +62,14 @@ Del<C, System");
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("C:");
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyNoCrashOnEnter()
         {
             VisualStudio.Editor.SetUseSuggestionMode(false);
             VisualStudio.SendKeys.Send("#help", VirtualKey.Enter, VirtualKey.Enter);
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/40160")]
         public void VerifyCorrectIntellisenseSelectionOnEnter()
         {
             VisualStudio.Editor.SetUseSuggestionMode(false);


### PR DESCRIPTION
After CI image was updated with 16.4 Preview 5 some REPL tests started
failing consistently. https://github.com/dotnet/roslyn/issues/40160