### PR TITLE
Avoid going into an infinite cycle while resolving erroneous event/property implementation within an interface

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -225,6 +225,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //do a lookup anyway
             }
 
+            // Do not look in itself
+            if (containingType == (object)explicitInterfaceNamedType.OriginalDefinition)
+            {
+                // An error will be reported elsewhere.
+                // Either the interface is not implemented, or it causes a cycle in the interface hierarchy.
+                return null;
+            }
+
             var hasParamsParam = implementingMember.HasParamsParameter();
 
             // Setting this flag to true does not imply that an interface member has been successfully implemented.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2168,10 +2168,7 @@ class C<T> : System.Attribute { }";
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M").WithArguments("default interface implementation", "8.0").WithLocation(3, 20),
                 // (3,18): error CS0540: 'I.M()': containing type does not implement interface 'I'
                 //     partial void I.M();
-                Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I").WithArguments("I.M()", "I").WithLocation(3, 18),
-                // (3,20): error CS0539: 'I.M()' in explicit interface declaration is not found among members of the interface that can be implemented
-                //     partial void I.M();
-                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M").WithArguments("I.M()").WithLocation(3, 20)
+                Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I").WithArguments("I.M()", "I").WithLocation(3, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -59830,5 +59830,28 @@ interface I1 : I2
 
             AssertNoEventImplementation(compilation1);
         }
+
+        [Fact]
+        [WorkItem(1029574, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1029574")]
+        public void Errors_16()
+        {
+            var source1 =
+@"
+interface I1<T>
+{
+    int I1<int>.P1 => throw null;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular,
+                                                 targetFramework: TargetFramework.NetStandardLatest);
+
+            compilation1.VerifyDiagnostics(
+                // (4,9): error CS0540: 'I1<T>.P1': containing type does not implement interface 'I1<int>'
+                //     int I1<int>.P1 => throw null;
+                Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I1<int>").WithArguments("I1<T>.P1", "I1<int>").WithLocation(4, 9)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1029574.