### PR TITLE
Fix a false positive in IDE0059 in presence of try/finally

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -7301,5 +7301,49 @@ class C
     bool Some(IntPtr a) => true;
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [WorkItem(39755, "https://github.com/dotnet/roslyn/issues/39755")]
+        public async Task AssignmentInTry_NotUsedInFinally_Diagnostic()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M(int i)
+    {
+        bool b = false;
+        try 
+        { 
+            if (i == 0)
+            {
+                [|b|] = true;
+            }
+        }
+        finally 
+        {
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    void M(int i)
+    {
+        bool b = false;
+        try 
+        { 
+            if (i == 0)
+            {
+            }
+        }
+        finally 
+        {
+        }
+    }
+}", options: PreferDiscard);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -7239,5 +7239,67 @@ public class Test
     }
 }", options: PreferDiscard, parseOptions: new CSharpParseOptions(LanguageVersion.CSharp8));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [WorkItem(39344, "https://github.com/dotnet/roslyn/issues/39344")]
+        public async Task AssignmentInTry_UsedInFinally_NoDiagnostic()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System;
+
+class C
+{
+    void M(int i)
+    {
+        bool b = false;
+        try
+        {
+            if (i == 0)
+            {
+                [|b|] = true;
+            }
+        }
+        finally
+        {
+            if (!b)
+            {
+                Console.WriteLine(i);
+            }
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [WorkItem(39755, "https://github.com/dotnet/roslyn/issues/39755")]
+        public async Task AssignmentInTry_UsedInFinally_NoDiagnostic_02()
+        {
+            await TestDiagnosticMissingAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        IntPtr a = (IntPtr)1;
+        try
+        {
+            var b = a;
+
+            if (Some(a))
+                [|a|] = IntPtr.Zero;
+        }
+        finally
+        {
+            if (a != IntPtr.Zero)
+            {
+
+            }
+        }
+    }
+
+    bool Some(IntPtr a) => true;
+}");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
@@ -179,6 +179,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                         {
                             _analysisData.CurrentBlockAnalysisData.Clear(local);
                         }
+
+                        if (region.Kind == ControlFlowRegionKind.TryAndFinally)
+                        {
+                            // Locals defined in the outer regions of try/finally might be used in finally region.
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We were aggressively trimming down tracked locals when encountering a branch that leaves a try/finally region. The fix makes us more conservative for such cases.

Fixes #39344
Fixes #39755

Verified that both the added unit tests fail before the product fix.