### PR TITLE
Disallow pointer types to be used as top-level constraints on generic parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -223,13 +223,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var typeSyntax = typeConstraintSyntax.Type;
                             var typeSyntaxKind = typeSyntax.Kind();
 
-                            // For pointer types, don't report this error. It is already reported during binding typeSyntax below.
                             switch (typeSyntaxKind)
                             {
                                 case SyntaxKind.PredefinedType:
-                                case SyntaxKind.PointerType:
                                 case SyntaxKind.NullableType:
                                     break;
+                                case SyntaxKind.PointerType:
                                 default:
                                     if (!SyntaxFacts.IsName(typeSyntax.Kind()))
                                     {
@@ -525,7 +524,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case TypeKind.Array:
                 case TypeKind.Pointer:
-                    // CS0706 already reported by parser.
+                    // CS0706 already reported by binding above.
                     return false;
 
                 case TypeKind.Submission:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -227,8 +227,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 case SyntaxKind.PredefinedType:
                                 case SyntaxKind.NullableType:
-                                    break;
                                 case SyntaxKind.PointerType:
+                                    // Pointer error is reported by IsValidTypeConstraint
+                                    break;
                                 default:
                                     if (!SyntaxFacts.IsName(typeSyntax.Kind()))
                                     {
@@ -401,7 +402,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<TypeWithAnnotations> constraintTypes,
             DiagnosticBag diagnostics)
         {
-            if (!IsValidConstraintType(syntax, type, diagnostics))
+            if (!isValidConstraintType(syntax, type, diagnostics))
             {
                 return false;
             }
@@ -459,89 +460,91 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return true;
-        }
 
-        /// <summary>
-        /// Returns true if the type is a valid constraint type.
-        /// Otherwise returns false and generates a diagnostic.
-        /// </summary>
-        private static bool IsValidConstraintType(TypeConstraintSyntax syntax, TypeWithAnnotations typeWithAnnotations, DiagnosticBag diagnostics)
-        {
-            TypeSymbol type = typeWithAnnotations.Type;
-
-            switch (type.SpecialType)
+            // Returns true if the type is a valid constraint type.
+            // Otherwise returns false and generates a diagnostic.
+            static bool isValidConstraintType(TypeConstraintSyntax syntax, TypeWithAnnotations typeWithAnnotations, DiagnosticBag diagnostics)
             {
-                case SpecialType.System_Enum:
-                    CheckFeatureAvailability(syntax, MessageID.IDS_FeatureEnumGenericTypeConstraint, diagnostics);
-                    break;
+                TypeSymbol type = typeWithAnnotations.Type;
 
-                case SpecialType.System_Delegate:
-                case SpecialType.System_MulticastDelegate:
-                    CheckFeatureAvailability(syntax, MessageID.IDS_FeatureDelegateGenericTypeConstraint, diagnostics);
-                    break;
+                switch (type.SpecialType)
+                {
+                    case SpecialType.System_Enum:
+                        CheckFeatureAvailability(syntax, MessageID.IDS_FeatureEnumGenericTypeConstraint, diagnostics);
+                        break;
 
-                case SpecialType.System_Object:
-                case SpecialType.System_ValueType:
-                case SpecialType.System_Array:
-                    // "Constraint cannot be special class '{0}'"
-                    Error(diagnostics, ErrorCode.ERR_SpecialTypeAsBound, syntax, type);
-                    return false;
-            }
+                    case SpecialType.System_Delegate:
+                    case SpecialType.System_MulticastDelegate:
+                        CheckFeatureAvailability(syntax, MessageID.IDS_FeatureDelegateGenericTypeConstraint, diagnostics);
+                        break;
 
-            switch (type.TypeKind)
-            {
-                case TypeKind.Error:
-                case TypeKind.TypeParameter:
-                    return true;
-
-                case TypeKind.Interface:
-                    break;
-
-                case TypeKind.Dynamic:
-                    // "Constraint cannot be the dynamic type"
-                    Error(diagnostics, ErrorCode.ERR_DynamicTypeAsBound, syntax);
-                    return false;
-
-                case TypeKind.Class:
-                    if (type.IsSealed)
-                    {
-                        goto case TypeKind.Struct;
-                    }
-                    else if (type.IsStatic)
-                    {
-                        // "'{0}': static classes cannot be used as constraints"
-                        Error(diagnostics, ErrorCode.ERR_ConstraintIsStaticClass, syntax, type);
+                    case SpecialType.System_Object:
+                    case SpecialType.System_ValueType:
+                    case SpecialType.System_Array:
+                        // "Constraint cannot be special class '{0}'"
+                        Error(diagnostics, ErrorCode.ERR_SpecialTypeAsBound, syntax, type);
                         return false;
-                    }
-                    break;
+                }
 
-                case TypeKind.Delegate:
-                case TypeKind.Enum:
-                case TypeKind.Struct:
-                    // "'{0}' is not a valid constraint. A type used as a constraint must be an interface, a non-sealed class or a type parameter."
-                    Error(diagnostics, ErrorCode.ERR_BadBoundType, syntax, type);
+                switch (type.TypeKind)
+                {
+                    case TypeKind.Error:
+                    case TypeKind.TypeParameter:
+                        return true;
+
+                    case TypeKind.Interface:
+                        break;
+
+                    case TypeKind.Dynamic:
+                        // "Constraint cannot be the dynamic type"
+                        Error(diagnostics, ErrorCode.ERR_DynamicTypeAsBound, syntax);
+                        return false;
+
+                    case TypeKind.Class:
+                        if (type.IsSealed)
+                        {
+                            goto case TypeKind.Struct;
+                        }
+                        else if (type.IsStatic)
+                        {
+                            // "'{0}': static classes cannot be used as constraints"
+                            Error(diagnostics, ErrorCode.ERR_ConstraintIsStaticClass, syntax, type);
+                            return false;
+                        }
+                        break;
+
+                    case TypeKind.Delegate:
+                    case TypeKind.Enum:
+                    case TypeKind.Struct:
+                        // "'{0}' is not a valid constraint. A type used as a constraint must be an interface, a non-sealed class or a type parameter."
+                        Error(diagnostics, ErrorCode.ERR_BadBoundType, syntax, type);
+                        return false;
+
+                    case TypeKind.Array:
+                        // CS0706 already reported by binding above.
+                        return false;
+
+                    case TypeKind.Pointer:
+                        // "Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter."
+                        Error(diagnostics, ErrorCode.ERR_BadConstraintType, syntax.GetLocation());
+                        return false;
+
+                    case TypeKind.Submission:
+                    // script class is synthesized, never used as a constraint
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
+                }
+
+                if (type.ContainsDynamic())
+                {
+                    // "Constraint cannot be a dynamic type '{0}'"
+                    Error(diagnostics, ErrorCode.ERR_ConstructedDynamicTypeAsBound, syntax, type);
                     return false;
+                }
 
-                case TypeKind.Array:
-                case TypeKind.Pointer:
-                    // CS0706 already reported by binding above.
-                    return false;
-
-                case TypeKind.Submission:
-                // script class is synthesized, never used as a constraint
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
+                return true;
             }
-
-            if (type.ContainsDynamic())
-            {
-                // "Constraint cannot be a dynamic type '{0}'"
-                Error(diagnostics, ErrorCode.ERR_ConstructedDynamicTypeAsBound, syntax, type);
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -221,22 +221,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             var typeConstraintSyntax = (TypeConstraintSyntax)syntax;
                             var typeSyntax = typeConstraintSyntax.Type;
-                            var typeSyntaxKind = typeSyntax.Kind();
-
-                            switch (typeSyntaxKind)
-                            {
-                                case SyntaxKind.PredefinedType:
-                                case SyntaxKind.NullableType:
-                                case SyntaxKind.PointerType:
-                                    // Pointer error is reported by IsValidTypeConstraint
-                                    break;
-                                default:
-                                    if (!SyntaxFacts.IsName(typeSyntax.Kind()))
-                                    {
-                                        diagnostics.Add(ErrorCode.ERR_BadConstraintType, typeSyntax.GetLocation());
-                                    }
-                                    break;
-                            }
 
                             var type = BindTypeOrConstraintKeyword(typeSyntax, diagnostics, out ConstraintContextualKeyword keyword);
 
@@ -521,9 +505,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return false;
 
                     case TypeKind.Array:
-                        // CS0706 already reported by binding above.
-                        return false;
-
                     case TypeKind.Pointer:
                         // "Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter."
                         Error(diagnostics, ErrorCode.ERR_BadConstraintType, syntax.GetLocation());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -531,13 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var elementType = BindType(node.ElementType, diagnostics, basesBeingResolved);
                 ReportUnsafeIfNotAllowed(node, diagnostics);
 
-                // Checking BinderFlags.GenericConstraintsClause to prevent cycles in binding
-                if (Flags.HasFlag(BinderFlags.GenericConstraintsClause) && elementType.TypeKind == TypeKind.TypeParameter)
-                {
-                    // Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
-                    Error(diagnostics, ErrorCode.ERR_BadConstraintType, node);
-                }
-                else if (!Flags.HasFlag(BinderFlags.SuppressConstraintChecks))
+                if (!Flags.HasFlag(BinderFlags.SuppressConstraintChecks))
                 {
                     CheckManagedAddr(Compilation, elementType.Type, node.Location, diagnostics);
                 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -24041,5 +24041,62 @@ public class C
                 Diagnostic(ErrorCode.ERR_ExpressionTreeContainsSwitchExpression, "a switch { 0 => 1, _ => 2 }").WithLocation(9, 45)
                 );
         }
+
+        [Fact]
+        public void PointerGenericConstraintTypes()
+        {
+            var source = @"
+namespace A
+{
+    class D {}
+}
+
+class B {}
+
+unsafe class C<T, U, V, X, Y, Z> where T : byte*
+                                 where U : unmanaged
+                                 where V : U*
+                                 where X : object*
+                                 where Y : B*
+                                 where Z : A.D*
+{
+    void M1<A>() where A : byte* {}
+    void M2<A, B>() where A : unmanaged 
+                    where B : A* {}
+    void M3<A>() where A : object* {}
+    void M4<A>() where A : B* {}
+    void M5<A>() where A : T {}
+}";
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(
+                    // (9,44): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    // unsafe class C<T, U, V, X, Y, Z> where T : byte*
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "byte*").WithLocation(9, 44),
+                    // (11,44): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //                                  where V : U*
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "U*").WithLocation(11, 44),
+                    // (12,44): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //                                  where X : object*
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "object*").WithLocation(12, 44),
+                    // (13,44): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //                                  where Y : B*
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "B*").WithLocation(13, 44),
+                    // (14,44): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //                                  where Z : A.D*
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "A.D*").WithLocation(14, 44),
+                    // (16,28): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //     void M1<A>() where A : byte* {}
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "byte*").WithLocation(16, 28),
+                    // (18,31): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //                     where B : A* {}
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "A*").WithLocation(18, 31),
+                    // (19,28): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //     void M3<A>() where A : object* {}
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "object*").WithLocation(19, 28),
+                    // (20,28): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    //     void M4<A>() where A : B* {}
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "B*").WithLocation(20, 28)
+            );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -24098,5 +24098,17 @@ unsafe class C<T, U, V, X, Y, Z> where T : byte*
                     Diagnostic(ErrorCode.ERR_BadConstraintType, "B*").WithLocation(20, 28)
             );
         }
+
+        [Fact]
+        public void ArrayGenericConstraintTypes()
+        {
+            var source = @"class A<T> where T : object[] {}";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                    // (1,22): error CS0706: Invalid constraint type. A type used as a constraint must be an interface, a non-sealed class or a type parameter.
+                    // class A<T> where T : object[] {}
+                    Diagnostic(ErrorCode.ERR_BadConstraintType, "object[]").WithLocation(1, 22));
+        }
     }
 }


### PR DESCRIPTION
Fixes #40182

Tagging @dotnet/roslyn-compiler @jaredpar for review.