### PR TITLE
EnC: Fix incorrect reporting of changes in non-UTF8 encoded source files

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -479,6 +479,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     }
 
                     var baseProject = DebuggingSession.LastCommittedSolution.GetProject(project.Id);
+                    if (baseProject == project)
+                    {
+                        continue;
+                    }
 
                     // When debugging session is started some projects might not have been loaded to the workspace yet. 
                     // We capture the base solution. Edits in files that are in projects that haven't been loaded won't be applied


### PR DESCRIPTION
EnC was detecting non-existing changes in source files that contained non-ascii characters and did not specify BOM. The APIs used by the EnC defaulted to UTF8 while the editor buffer defaulted to a different encoding (e.g. Win-1252). This discrepancy resulted in incorrectly reported changes.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1032968