### PR TITLE
Run nullable analysis unconditionally in debug compilers

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -572,7 +572,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
             {
 #if DEBUG
-                // Run analysis even though it's not needed
+                // Always run analysis in debug builds so that we can more reliably catch
+                // nullable regressions e.g. https://github.com/dotnet/roslyn/issues/40136
                 diagnostics = new DiagnosticBag();
 #else
                 return;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -571,7 +571,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             var compilation = binder.Compilation;
             if (compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion() || !compilation.ShouldRunNullableWalker)
             {
+#if DEBUG
+                // Run analysis even though it's not needed
+                diagnostics = new DiagnosticBag();
+#else
                 return;
+#endif
             }
 
             Analyze(


### PR DESCRIPTION
In triaging #40136 I wondered if we ran nullable analysis on all our tests. It seems that in DefiniteAssignment there is a `#if DEBUG` block that makes us always run `NullableWalker.Analyze` on a given method. `AnalyzeIfNeeded` was still conditional, though, and this resulted in different behavior than when we manually add `#nullable enable` to the top of the test.

/cc @333fred. If you have any ideas about where other behavioral inconsistencies could arise (i.e. scenarios where nullable analysis only crashes if `#nullable enable` is added to the top of the file), please let me know.