### PR TITLE
Fix for lambda parameter type inference in completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10231,10 +10231,15 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task CompletionForLambdaPassedAsArgumentInReducedExtensionMethod()
+        public async Task CompletionForLambdaPassedAsArgumentInReducedExtensionMethod_NonInteractive()
         {
             var markup = @"
 using System;
+
+static class CExtensions
+{
+    public static void X(this C x, Action<string> y) { }
+}
 
 class C
 {
@@ -10243,14 +10248,27 @@ class C
         new C().X(t => Console.WriteLine(t.$$));
     }
 }
+";
+            await VerifyItemExistsAsync(markup, "Length", sourceCodeKind: SourceCodeKind.Regular);
+        }
 
-static class CExtensions
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CompletionForLambdaPassedAsArgumentInReducedExtensionMethod_Interactive()
+        {
+            var markup = @"
+using System;
+
+public static void X(this C x, Action<string> y) { }
+
+public class C
 {
-    public static void X(this C x, Action<string> y) { }
+    void Test()
+    {
+        new C().X(t => Console.WriteLine(t.$$));
+    }
 }
 ";
-
-            await VerifyItemExistsAsync(markup, "Length");
+            await VerifyItemExistsAsync(markup, "Length", sourceCodeKind: SourceCodeKind.Script);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -10189,6 +10189,71 @@ namespace ClassLibrary1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(40216, "https://github.com/dotnet/roslyn/issues/40216")]
+        public async Task CompletionForLambdaPassedAsNamedArgumentAtDifferentPositionFromCorrespondingParameter1()
+        {
+            var markup = @"
+using System;
+
+class C
+{
+    void Test()
+    {
+        X(y: t => Console.WriteLine(t.$$));
+    }
+
+    void X(int x = 7, Action<string> y = null) { }
+}
+";
+
+            await VerifyItemExistsAsync(markup, "Length");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(40216, "https://github.com/dotnet/roslyn/issues/40216")]
+        public async Task CompletionForLambdaPassedAsNamedArgumentAtDifferentPositionFromCorrespondingParameter2()
+        {
+            var markup = @"
+using System;
+
+class C
+{
+    void Test()
+    {
+        X(y: t => Console.WriteLine(t.$$));
+    }
+
+    void X(int x, int z, Action<string> y) { }
+}
+";
+
+            await VerifyItemExistsAsync(markup, "Length");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CompletionForLambdaPassedAsArgumentInReducedExtensionMethod()
+        {
+            var markup = @"
+using System;
+
+class C
+{
+    void Test()
+    {
+        new C().X(t => Console.WriteLine(t.$$));
+    }
+}
+
+static class CExtensions
+{
+    public static void X(this C x, Action<string> y) { }
+}
+";
+
+            await VerifyItemExistsAsync(markup, "Length");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CompletionInsideMethodsWithNonFunctionsAsArguments()
         {
             var markup = @"

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -8162,6 +8162,28 @@ End Class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(40216, "https://github.com/dotnet/roslyn/issues/40216")>
+        Public Async Function CompletionForLambdaPassedAsNamedArgumentAtDifferentPositionFromCorrespondingParameterWithDifferentCasing() As Task
+            Dim source =
+                <code><![CDATA[
+Imports System
+
+Class C
+    Sub Test()
+        M(Z:=Sub(x)
+                 x.$$
+          End Sub)
+    End Sub
+
+    Sub M(x As Integer, y As Integer, z As Action(Of String))
+    End Sub
+End Class
+]]></code>.Value
+
+            Await VerifyItemExistsAsync(source, "Length")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CompletionInsideMethodsWithNonFunctionsAsArguments() As Task
             Dim source =
 <code><![CDATA[

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -8118,6 +8118,50 @@ End Namespace
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(40216, "https://github.com/dotnet/roslyn/issues/40216")>
+        Public Async Function CompletionForLambdaPassedAsNamedArgumentAtDifferentPositionFromCorrespondingParameter1() As Task
+            Dim source =
+                <code><![CDATA[
+Imports System
+
+Class C
+    Sub Test()
+        M(y:=Sub(x)
+                 x.$$
+          End Sub)
+    End Sub
+
+    Sub M(Optional x As Integer = 0, Optional y As Action(Of String) = Nothing)
+    End Sub
+End Class
+]]></code>.Value
+
+            Await VerifyItemExistsAsync(source, "Length")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(40216, "https://github.com/dotnet/roslyn/issues/40216")>
+        Public Async Function CompletionForLambdaPassedAsNamedArgumentAtDifferentPositionFromCorrespondingParameter2() As Task
+            Dim source =
+                <code><![CDATA[
+Imports System
+
+Class C
+    Sub Test()
+        M(z:=Sub(x)
+                 x.$$
+          End Sub)
+    End Sub
+
+    Sub M(x As Integer, y As Integer, z As Action(Of String))
+    End Sub
+End Class
+]]></code>.Value
+
+            Await VerifyItemExistsAsync(source, "Length")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function CompletionInsideMethodsWithNonFunctionsAsArguments() As Task
             Dim source =
 <code><![CDATA[

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
         protected readonly TSyntaxContext _context;
         protected readonly bool _filterOutOfScopeLocals;
         protected readonly CancellationToken _cancellationToken;
+        private readonly StringComparer _stringComparerForLanguage;
 
         public AbstractRecommendationServiceRunner(
             TSyntaxContext context,
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
             CancellationToken cancellationToken)
         {
             _context = context;
+            _stringComparerForLanguage = _context.GetLanguageService<ISyntaxFactsService>().StringComparer;
             _filterOutOfScopeLocals = filterOutOfScopeLocals;
             _cancellationToken = cancellationToken;
         }
@@ -151,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
         {
             if (!string.IsNullOrEmpty(argumentName))
             {
-                parameterType = method.Parameters.FirstOrDefault(p => p.Name == argumentName)?.Type;
+                parameterType = method.Parameters.FirstOrDefault(p => _stringComparerForLanguage.Equals(p.Name, argumentName))?.Type;
                 return parameterType != null;
             }
 

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -65,6 +66,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
 
             var invocationExpression = lambdaSyntax.Parent.Parent.Parent;
             var arguments = syntaxFactsService.GetArgumentsOfInvocationExpression(invocationExpression);
+            var argumentName = syntaxFactsService.GetNameForArgument(lambdaSyntax.Parent);
             var ordinalInInvocation = arguments.IndexOf(lambdaSyntax.Parent);
             var expressionOfInvocationExpression = syntaxFactsService.GetExpressionOfInvocationExpression(invocationExpression);
 
@@ -74,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
 
             // parameter.Ordinal is the ordinal within (a,b,c) => b.
             // For candidate symbols of (a,b,c) => b., get types of all possible b.
-            var parameterTypeSymbols = GetTypeSymbols(candidateSymbols, ordinalInInvocation: ordinalInInvocation, ordinalInLambda: parameter.Ordinal);
+            var parameterTypeSymbols = GetTypeSymbols(candidateSymbols, argumentName, ordinalInInvocation, ordinalInLambda: parameter.Ordinal);
 
             // For each type of b., return all suitable members.
             return parameterTypeSymbols
@@ -91,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
         /// <param name="ordinalInInvocation">ordinal of the arguments of function: (a,b) or (a,b,c) in the example above</param>
         /// <param name="ordinalInLambda">ordinal of the lambda parameters, e.g. a, b or c.</param>
         /// <returns></returns>
-        private ImmutableArray<ITypeSymbol> GetTypeSymbols(ImmutableArray<ISymbol> candidateSymbols, int ordinalInInvocation, int ordinalInLambda)
+        private ImmutableArray<ITypeSymbol> GetTypeSymbols(ImmutableArray<ISymbol> candidateSymbols, string argumentName, int ordinalInInvocation, int ordinalInLambda)
         {
             var expressionSymbol = _context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Expression<>).FullName);
 
@@ -101,23 +103,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
             {
                 if (candidateSymbol is IMethodSymbol method)
                 {
-                    ITypeSymbol type;
-                    if (method.IsParams() && (ordinalInInvocation >= method.Parameters.Length - 1))
-                    {
-                        if (method.Parameters.LastOrDefault()?.Type is IArrayTypeSymbol arrayType)
-                        {
-                            type = arrayType.ElementType;
-                        }
-                        else
-                        {
-                            continue;
-                        }
-                    }
-                    else if (ordinalInInvocation < method.Parameters.Length)
-                    {
-                        type = method.Parameters[ordinalInInvocation].Type;
-                    }
-                    else
+                    if (!TryGetMatchingParameterTypeForArgument(method, argumentName, ordinalInInvocation, out var type))
                     {
                         continue;
                     }
@@ -159,6 +145,39 @@ namespace Microsoft.CodeAnalysis.Recommendations
             }
 
             return builder.ToImmutableAndFree().Distinct();
+        }
+
+        private bool TryGetMatchingParameterTypeForArgument(IMethodSymbol method, string argumentName, int ordinalInInvocation, out ITypeSymbol parameterType)
+        {
+            if (!string.IsNullOrEmpty(argumentName))
+            {
+                parameterType = method.Parameters.FirstOrDefault(p => p.Name == argumentName)?.Type;
+                return parameterType != null;
+            }
+
+            // We don't know the argument name, so have to find the parameter based on position
+            if (method.IsParams() && (ordinalInInvocation >= method.Parameters.Length - 1))
+            {
+                if (method.Parameters.LastOrDefault()?.Type is IArrayTypeSymbol arrayType)
+                {
+                    parameterType = arrayType.ElementType;
+                    return true;
+                }
+                else
+                {
+                    parameterType = null;
+                    return false;
+                }
+            }
+
+            if (ordinalInInvocation < method.Parameters.Length)
+            {
+                parameterType = method.Parameters[ordinalInInvocation].Type;
+                return true;
+            }
+
+            parameterType = null;
+            return false;
         }
 
         protected ImmutableArray<ISymbol> GetSymbolsForNamespaceDeclarationNameContext<TNamespaceDeclarationSyntax>()


### PR DESCRIPTION
Fixes #40216

Completion was incorrectly inferring lambda parameter types when the lambda was passed as a named argument in a different position than the corresponding parameter. We now use the name of the named argument as a first lookup to find the matching parameter, followed by a positional match.