### PR TITLE
Fix for extract method does not respect .editorconfig settings

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.ExtractMethod
@@ -3788,6 +3789,200 @@ class C : B
         }
     }
 }", CodeActionIndex);
+        }
+
+        [Fact, WorkItem(40188, "https://github.com/dotnet/roslyn/issues/40188"), Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
+        public async Task TestEditorconfigSetting_StaticLocalFunction_True()
+        {
+            var input = @"
+<Workspace>
+    <Project Language = ""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath = ""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        [|bool test = true;|]
+        System.Console.WriteLine(b != true ? b = true : b = false);
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_prefer_static_local_function = true:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        {|Rename:NewMethod|}();
+        System.Console.WriteLine(b != true ? b = true : b = false);
+
+        static void NewMethod()
+        {
+            bool test = true;
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_prefer_static_local_function = true:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+        }
+
+
+        [Fact, WorkItem(40188, "https://github.com/dotnet/roslyn/issues/40188"), Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
+        public async Task TestEditorconfigSetting_StaticLocalFunction_False()
+        {
+            var input = @"
+<Workspace>
+    <Project Language = ""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath = ""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        [|bool test = true;|]
+        System.Console.WriteLine(b != true ? b = true : b = false);
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_prefer_static_local_function = false:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        {|Rename:NewMethod|}();
+        System.Console.WriteLine(b != true ? b = true : b = false);
+
+        void NewMethod()
+        {
+            bool test = true;
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_prefer_static_local_function = false:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+        }
+
+        [Fact, WorkItem(40188, "https://github.com/dotnet/roslyn/issues/40188"), Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
+        public async Task TestEditorconfigSetting_ExpressionBodiedLocalFunction_True()
+        {
+            var input = @"
+<Workspace>
+    <Project Language = ""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath = ""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        [|bool b = true;|]
+        System.Console.WriteLine(b != true ? b = true : b = false);
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_style_expression_bodied_local_functions = true:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        bool b = {|Rename:NewMethod|}();
+        System.Console.WriteLine(b != true ? b = true : b = false);
+
+        static bool NewMethod() => true;
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_style_expression_bodied_local_functions = true:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
+        }
+
+        [Fact, WorkItem(40188, "https://github.com/dotnet/roslyn/issues/40188"), Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]
+        public async Task TestEditorconfigSetting_ExpressionBodiedLocalFunction_False()
+        {
+            var input = @"
+<Workspace>
+    <Project Language = ""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath = ""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        [|bool b = true;|]
+        System.Console.WriteLine(b != true ? b = true : b = false);
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_style_expression_bodied_local_functions = false:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+         <Document FilePath=""z:\\file.cs"">
+class Program1
+{
+    static void Main()
+    {
+        bool b = {|Rename:NewMethod|}();
+        System.Console.WriteLine(b != true ? b = true : b = false);
+
+        static bool NewMethod()
+        {
+            return true;
+        }
+    }
+}
+        </Document>
+        <AnalyzerConfigDocument FilePath = ""z:\\.editorconfig"">[*.cs]
+csharp_style_expression_bodied_local_functions = false:silent
+</AnalyzerConfigDocument>
+    </Project>
+</Workspace>";
+
+            await TestInRegularAndScriptAsync(input, expected, CodeActionIndex);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractLocalFunction)]

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertLocalFunctionToMethod/CSharpConvertLocalFunctionToMethodCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertLocalFunctionToMethod/CSharpConvertLocalFunctionToMethodCodeRefactoringProvider.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -115,9 +116,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertLocalFunctionToM
                 typeParameters: typeParameters.ToImmutableArray(),
                 parameters: parameters.AddRange(capturesAsParameters));
 
-            var defaultOptions = CodeGenerationOptions.Default;
-            var method = MethodGenerator.GenerateMethodDeclaration(methodSymbol, CodeGenerationDestination.Unspecified,
-                document.Project.Solution.Workspace, defaultOptions, root.SyntaxTree.Options);
+            var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+            var defaultOptions = new CodeGenerationOptions(preferExpressionBodiedMethod: options.GetOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods).Value);
+            var method = MethodGenerator.GenerateMethodDeclaration(methodSymbol, CodeGenerationDestination.Unspecified, defaultOptions, root.SyntaxTree.Options);
 
             var generator = s_generator;
             var editor = new SyntaxEditor(root, generator);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 return SyntaxFactory.Identifier(nameGenerator.CreateUniqueMethodName(scope, "NewMethod"));
             }
 
-            protected override async Task<(ExpressionBodyPreference expressionBodiedMethod, ExpressionBodyPreference expressionBodiedLocalFunction, bool staticLocalFunction)> StaticLocalFunctionAndExpressionBodyPreferencesAsync(
+            protected override async Task<(ExpressionBodyPreference expressionBodiedMethod, ExpressionBodyPreference expressionBodiedLocalFunction, bool staticLocalFunction)> StaticLocalFunctionAndExpressionBodyPreferenceAsync(
                 SemanticDocument semanticDocument,
                 CancellationToken cancellationToken)
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -790,6 +792,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 }
 
                 return SyntaxFactory.Identifier(nameGenerator.CreateUniqueMethodName(scope, "NewMethod"));
+            }
+
+            protected override async Task<(ExpressionBodyPreference expressionBodiedMethod, ExpressionBodyPreference expressionBodiedLocalFunction, bool staticLocalFunction)> StaticLocalFunctionAndExpressionBodyPreferencesAsync(
+                SemanticDocument semanticDocument,
+                CancellationToken cancellationToken)
+            {
+                var options = await semanticDocument.Document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+
+                var preferExpressionBodiedMethods = options.GetOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods).Value;
+                var preferExpressionBodiedLocalFunctions = options.GetOption(CSharpCodeStyleOptions.PreferExpressionBodiedLocalFunctions).Value;
+
+                var preferStaticLocalFunctions = options.GetOption(CSharpCodeStyleOptions.PreferStaticLocalFunction).Value;
+                return (preferExpressionBodiedMethods, preferExpressionBodiedLocalFunctions, preferStaticLocalFunctions);
             }
         }
     }

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             protected abstract Task<SyntaxNode> GenerateBodyForCallSiteContainerAsync(CancellationToken cancellationToken);
             protected abstract SyntaxNode GetPreviousMember(SemanticDocument document);
             protected abstract OperationStatus<IMethodSymbol> GenerateMethodDefinition(bool localFunction, CancellationToken cancellationToken);
-            protected abstract Task<(ExpressionBodyPreference expressionBodiedMethod, ExpressionBodyPreference expressionBodiedLocalFunction, bool staticLocalFunction)> StaticLocalFunctionAndExpressionBodyPreferencesAsync(SemanticDocument semanticDocument, CancellationToken cancellationToken);
+            protected abstract Task<(ExpressionBodyPreference expressionBodiedMethod, ExpressionBodyPreference expressionBodiedLocalFunction, bool staticLocalFunction)> StaticLocalFunctionAndExpressionBodyPreferenceAsync(SemanticDocument semanticDocument, CancellationToken cancellationToken);
 
             protected abstract SyntaxToken CreateIdentifier(string name);
             protected abstract SyntaxToken CreateMethodName(bool localFunction);
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 var codeGenerationService = SemanticDocument.Document.GetLanguageService<ICodeGenerationService>();
                 var result = GenerateMethodDefinition(LocalFunction, cancellationToken);
 
-                var (expressionBodiedMethod, expressionBodiedLocalFunction, staticLocalFunction) = await StaticLocalFunctionAndExpressionBodyPreferencesAsync(SemanticDocument, cancellationToken).ConfigureAwait(false);
+                var (expressionBodiedMethod, expressionBodiedLocalFunction, staticLocalFunction) = await StaticLocalFunctionAndExpressionBodyPreferenceAsync(SemanticDocument, cancellationToken).ConfigureAwait(false);
 
                 SyntaxNode destination, newContainer;
                 if (LocalFunction)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -436,8 +436,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return SyntaxFactory.ExpressionStatement(expression:=callSignature)
             End Function
 
-            Protected Overrides Function StaticLocalFunctionAndExpressionBodyPreferencesAsync(semanticDocument As SemanticDocument, cancellationToken As CancellationToken) As Task(Of (expressionBodiedMethod As ExpressionBodyPreference, expressionBodiedLocalFunction As ExpressionBodyPreference, staticLocalFunction As Boolean))
-                ' Expression-bodied methods and static local functions don't apply to C# and VB
+            Protected Overrides Function StaticLocalFunctionAndExpressionBodyPreferenceAsync(semanticDocument As SemanticDocument, cancellationToken As CancellationToken) As Task(Of (expressionBodiedMethod As ExpressionBodyPreference, expressionBodiedLocalFunction As ExpressionBodyPreference, staticLocalFunction As Boolean))
+                ' Expression-bodied methods and static local functions don't apply to VB
                 Return Task.FromResult((ExpressionBodyPreference.Never, ExpressionBodyPreference.Never, True))
             End Function
         End Class

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.Options
 Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.CodeStyle
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
     Partial Friend Class VisualBasicMethodExtractor
@@ -433,6 +434,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 End If
 
                 Return SyntaxFactory.ExpressionStatement(expression:=callSignature)
+            End Function
+
+            Protected Overrides Function StaticLocalFunctionAndExpressionBodyPreferencesAsync(semanticDocument As SemanticDocument, cancellationToken As CancellationToken) As Task(Of (expressionBodiedMethod As ExpressionBodyPreference, expressionBodiedLocalFunction As ExpressionBodyPreference, staticLocalFunction As Boolean))
+                ' Expression-bodied methods and static local functions don't apply to C# and VB
+                Return Task.FromResult((ExpressionBodyPreference.Never, ExpressionBodyPreference.Never, True))
             End Function
         End Class
     End Class

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationService.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpCodeGenerationService.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 }
 
                 return Cast<TDeclarationNode>(MethodGenerator.AddMethodTo(
-                    typeDeclaration, method, Workspace, options, availableIndices));
+                    typeDeclaration, method, options, availableIndices));
             }
 
             if (method.IsConstructor() ||
@@ -167,12 +167,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             if (destination is CompilationUnitSyntax compilationUnit)
             {
                 return Cast<TDeclarationNode>(
-                    MethodGenerator.AddMethodTo(compilationUnit, method, Workspace, options, availableIndices));
+                    MethodGenerator.AddMethodTo(compilationUnit, method, options, availableIndices));
             }
 
             var ns = Cast<NamespaceDeclarationSyntax>(destination);
             return Cast<TDeclarationNode>(
-                MethodGenerator.AddMethodTo(ns, method, Workspace, options, availableIndices));
+                MethodGenerator.AddMethodTo(ns, method, options, availableIndices));
         }
 
         protected override TDeclarationNode AddProperty<TDeclarationNode>(TDeclarationNode destination, IPropertySymbol property, CodeGenerationOptions options, IList<bool> availableIndices)
@@ -594,13 +594,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
             else if (method.IsLocalFunction())
             {
-                return MethodGenerator.GenerateLocalMethodDeclaration(
-                    method, destination, Workspace, options, options.ParseOptions);
+                return MethodGenerator.GenerateLocalFunctionDeclaration(
+                    method, destination, options, options.ParseOptions);
             }
             else
             {
                 return MethodGenerator.GenerateMethodDeclaration(
-                    method, destination, Workspace, options, options.ParseOptions);
+                    method, destination, options, options.ParseOptions);
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/MethodGenerator.cs
@@ -144,7 +144,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return AddFormatterAndCodeGeneratorAnnotationsTo(localFunctionDeclaration);
         }
 
-        // issue: multiple methods seem to use workspace so have to be careful with removal
         private static MethodDeclarationSyntax UseExpressionBodyIfDesired(
             CodeGenerationOptions options, MethodDeclarationSyntax methodDeclaration, ParseOptions parseOptions)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
@@ -2,9 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationOptions.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
@@ -132,6 +134,21 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// </summary>
         public bool ReuseSyntax { get; }
 
+        /// <summary>
+        /// A hint to the code generator on whether they should attempt to generate a method with an expression body.
+        /// </summary>
+        public ExpressionBodyPreference PreferExpressionBodiedMethod { get; }
+
+        /// <summary>
+        /// A hint to the code generator on whether they should attempt to generate a local function with an expression body.
+        /// </summary>
+        public ExpressionBodyPreference PreferExpressionBodiedLocalFunction { get; }
+
+        /// <summary>
+        /// True if the code generator should attempt to generate static local functions.
+        /// </summary>
+        public bool PreferStaticLocalFunction { get; }
+
         public ParseOptions ParseOptions { get; }
 
         public CodeGenerationOptions(
@@ -150,6 +167,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             bool autoInsertionLocation = true,
             bool sortMembers = true,
             bool reuseSyntax = false,
+            ExpressionBodyPreference preferExpressionBodiedMethod = ExpressionBodyPreference.Never,
+            ExpressionBodyPreference preferExpressionBodiedLocalFunction = ExpressionBodyPreference.Never,
+            bool preferStaticLocalFunction = true,
             ParseOptions parseOptions = null)
         {
             CheckLocation(contextLocation, nameof(contextLocation));
@@ -171,6 +191,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             this.AutoInsertionLocation = autoInsertionLocation;
             this.SortMembers = sortMembers;
             this.ReuseSyntax = reuseSyntax;
+            this.PreferExpressionBodiedMethod = preferExpressionBodiedMethod;
+            this.PreferExpressionBodiedLocalFunction = preferExpressionBodiedLocalFunction;
+            this.PreferStaticLocalFunction = preferStaticLocalFunction;
 
             this.ParseOptions = parseOptions ?? this.BestLocation?.SourceTree.Options;
         }
@@ -211,6 +234,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             Optional<bool> autoInsertionLocation = default,
             Optional<bool> sortMembers = default,
             Optional<bool> reuseSyntax = default,
+            Optional<ExpressionBodyPreference> preferExpressionBodiedMethod = default,
+            Optional<ExpressionBodyPreference> preferExpressionBodiedLocalFunction = default,
+            Optional<bool> preferStaticLocalFunction = default,
             Optional<ParseOptions> parseOptions = default)
         {
             var newContextLocation = contextLocation.HasValue ? contextLocation.Value : this.ContextLocation;
@@ -228,6 +254,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             var newAutoInsertionLocation = autoInsertionLocation.HasValue ? autoInsertionLocation.Value : this.AutoInsertionLocation;
             var newSortMembers = sortMembers.HasValue ? sortMembers.Value : this.SortMembers;
             var newReuseSyntax = reuseSyntax.HasValue ? reuseSyntax.Value : this.ReuseSyntax;
+            var newPreferExpressionBodiedMethod = preferExpressionBodiedMethod.HasValue ? preferExpressionBodiedMethod.Value : this.PreferExpressionBodiedMethod;
+            var newPreferExpressionBodiedLocalFunction = preferExpressionBodiedLocalFunction.HasValue ? preferExpressionBodiedLocalFunction.Value : this.PreferExpressionBodiedLocalFunction;
+            var newPreferStaticLocalFunction = preferStaticLocalFunction.HasValue ? preferStaticLocalFunction.Value : this.PreferStaticLocalFunction;
             var newParseOptions = parseOptions.HasValue ? parseOptions.Value : this.ParseOptions;
 
             return new CodeGenerationOptions(
@@ -246,6 +275,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 newAutoInsertionLocation,
                 newSortMembers,
                 newReuseSyntax,
+                newPreferExpressionBodiedMethod,
+                newPreferExpressionBodiedLocalFunction,
+                newPreferStaticLocalFunction,
                 newParseOptions);
         }
     }


### PR DESCRIPTION
Fixes #40188 and adds applicable tests.

Specifically, ```csharp_prefer_static_local_function```, ```csharp_style_expression_bodied_methods```, and ```csharp_style_expression_bodied_local_functions``` should all now be properly respected when extracting a method or local function.

There were also some leftover instances in the code where local function was referred to as local method, so I went ahead and changed those as well.