### PR TITLE
Nullable progress: InternalUtilities and Diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/TypeCompilationState.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/TypeCompilationState.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            MethodSymbol next = method2;
+            MethodSymbol? next = method2;
             while (true)
             {
                 if (_constructorInitializers.TryGetValue(next, out next))

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1117,7 +1117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (TypeSymbol.Equals(underlyingMemberDefinition.ContainingType, TupleUnderlyingType.OriginalDefinition, TypeCompareKind.ConsiderEverything))
                 {
-                    if (UnderlyingDefinitionToMemberMap.TryGetValue(underlyingMemberDefinition, out Symbol result))
+                    if (UnderlyingDefinitionToMemberMap.TryGetValue(underlyingMemberDefinition, out Symbol? result))
                     {
                         return (TMember)result;
                     }

--- a/src/Compilers/Core/Portable/AdditionalTextFile.cs
+++ b/src/Compilers/Core/Portable/AdditionalTextFile.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -15,7 +17,7 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly CommandLineSourceFile _sourceFile;
         private readonly CommonCompiler _compiler;
-        private SourceText _text;
+        private SourceText? _text;
         private IList<DiagnosticInfo> _diagnostics;
 
         private readonly object _lockObject = new object();

--- a/src/Compilers/Core/Portable/AssemblyUtilities.cs
+++ b/src/Compilers/Core/Portable/AssemblyUtilities.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -9,6 +11,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Roslyn.Utilities
 {
@@ -29,8 +32,8 @@ namespace Roslyn.Utilities
         /// <exception cref="BadImageFormatException">If the file is not an assembly or is somehow corrupted.</exception>
         public static ImmutableArray<string> FindAssemblySet(string filePath)
         {
-            Debug.Assert(filePath != null);
-            Debug.Assert(PathUtilities.IsAbsolute(filePath));
+            RoslynDebug.Assert(filePath != null);
+            RoslynDebug.Assert(PathUtilities.IsAbsolute(filePath));
 
             Queue<string> workList = new Queue<string>();
             HashSet<string> assemblySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -137,9 +140,9 @@ namespace Roslyn.Utilities
         /// <exception cref="BadImageFormatException">If one of the files is not an assembly or is somehow corrupted.</exception>
         public static ImmutableArray<AssemblyIdentity> IdentifyMissingDependencies(string assemblyPath, IEnumerable<string> dependencyFilePaths)
         {
-            Debug.Assert(assemblyPath != null);
-            Debug.Assert(PathUtilities.IsAbsolute(assemblyPath));
-            Debug.Assert(dependencyFilePaths != null);
+            RoslynDebug.Assert(assemblyPath != null);
+            RoslynDebug.Assert(PathUtilities.IsAbsolute(assemblyPath));
+            RoslynDebug.Assert(dependencyFilePaths != null);
 
             HashSet<AssemblyIdentity> assemblyDefinitions = new HashSet<AssemblyIdentity>();
             foreach (var potentialDependency in dependencyFilePaths)

--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -290,7 +293,7 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public static int GetHashCode(string value)
         {
-            Debug.Assert(value != null);
+            RoslynDebug.Assert(value != null);
 
             return s_comparer.GetHashCode(value);
         }
@@ -300,7 +303,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static string ToLower(string value)
+        [return: NotNullIfNotNull(parameterName: "value")]
+        public static string? ToLower(string value)
         {
             if ((object)value == null)
                 return null;

--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -304,9 +304,9 @@ namespace Microsoft.CodeAnalysis
         /// <param name="value"></param>
         /// <returns></returns>
         [return: NotNullIfNotNull(parameterName: "value")]
-        public static string? ToLower(string value)
+        public static string? ToLower(string? value)
         {
-            if ((object)value == null)
+            if (value is null)
                 return null;
 
             if (value.Length == 0)

--- a/src/Compilers/Core/Portable/CodeAnalysisResourcesLocalizableErrorArgument.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResourcesLocalizableErrorArgument.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -12,7 +15,7 @@ namespace Microsoft.CodeAnalysis
 
         internal CodeAnalysisResourcesLocalizableErrorArgument(string targetResourceId)
         {
-            Debug.Assert(targetResourceId != null);
+            RoslynDebug.Assert(targetResourceId != null);
             _targetResourceId = targetResourceId;
         }
 
@@ -21,7 +24,7 @@ namespace Microsoft.CodeAnalysis
             return ToString(null, null);
         }
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
         {
             if (_targetResourceId != null)
             {

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
@@ -710,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
             EmitOpCode(ILOpCode.Ldnull);
         }
 
-        internal void EmitStringConstant(string value)
+        internal void EmitStringConstant(string? value)
         {
             if (value == null)
             {

--- a/src/Compilers/Core/Portable/CodeGen/SwitchStringJumpTableEmitter.cs
+++ b/src/Compilers/Core/Portable/CodeGen/SwitchStringJumpTableEmitter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// Delegate to compute string hash code.
         /// This piece is language-specific because VB treats "" and null as equal while C# does not.
         /// </summary>
-        public delegate uint GetStringHashCode(string key);
+        public delegate uint GetStringHashCode(string? key);
 
         /// <summary>
         /// Delegate to emit string compare call
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                 ConstantValue stringConstant = kvPair.Key;
                 Debug.Assert(stringConstant.IsNull || stringConstant.IsString);
 
-                uint hash = computeStringHashcodeDelegate((string)stringConstant.Value);
+                uint hash = computeStringHashcodeDelegate((string?)stringConstant.Value);
 
                 HashBucket bucket;
                 if (!stringHashMap.TryGetValue(hash, out bucket))

--- a/src/Compilers/Core/Portable/Collections/BitVector.cs
+++ b/src/Compilers/Core/Portable/Collections/BitVector.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -47,7 +49,7 @@ namespace Microsoft.CodeAnalysis
 
         public override bool Equals(object obj)
         {
-            return obj is BitVector && Equals((BitVector)obj);
+            return obj is BitVector other && Equals(other);
         }
 
         public static bool operator ==(BitVector left, BitVector right)
@@ -111,7 +113,7 @@ namespace Microsoft.CodeAnalysis
 
             for (int i = 0, n = _bits?.Length ?? 0; i < n; i++)
             {
-                yield return _bits[i];
+                yield return _bits![i];
             }
         }
 
@@ -205,7 +207,17 @@ namespace Microsoft.CodeAnalysis
         /// <returns></returns>
         public BitVector Clone()
         {
-            return new BitVector(_bits0, (_bits == null) ? null : (_bits.Length == 0) ? s_emptyArray : (Word[])_bits.Clone(), _capacity);
+            Word[] newBits;
+            if (_bits is null || _bits.Length == 0)
+            {
+                newBits = s_emptyArray;
+            }
+            else
+            {
+                newBits = (Word[])_bits.Clone();
+            }
+
+            return new BitVector(_bits0, newBits, _capacity);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -38,7 +38,8 @@ namespace Microsoft.CodeAnalysis
         private AvlNode? _root;
         public readonly IEqualityComparer<K> Comparer;
 
-        public static readonly SmallDictionary<K, V> Empty = new SmallDictionary<K, V>(EqualityComparer<K>.Default);
+        // https://github.com/dotnet/roslyn/issues/40344
+        public static readonly SmallDictionary<K, V> Empty = new SmallDictionary<K, V>(null!);
 
         public SmallDictionary() : this(EqualityComparer<K>.Default) { }
 
@@ -71,7 +72,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (_root != null)
             {
-                return TryGetValue(GetHashCode(key), key, out value);
+                return TryGetValue(GetHashCode(key), key, out value!);
             }
 
             value = default!;
@@ -88,7 +89,7 @@ namespace Microsoft.CodeAnalysis
             get
             {
                 V value;
-                if (!TryGetValue(key, out value))
+                if (!TryGetValue(key, out value!))
                 {
                     throw new KeyNotFoundException($"Could not find key {key}");
                 }
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis
         public bool ContainsKey(K key)
         {
             V value;
-            return TryGetValue(key, out value);
+            return TryGetValue(key, out value!);
         }
 
         [Conditional("DEBUG")]
@@ -228,7 +229,7 @@ hasBucket:
                 return true;
             }
 
-            return GetFromList(b.Next, key, out value);
+            return GetFromList(b.Next, key, out value!);
         }
 
         private bool GetFromList(Node? next, K key, [MaybeNullWhen(returnValue: false)] out V value)
@@ -527,7 +528,7 @@ hasBucket:
                         // left == right only if both are nulls
                         if (root.Left == root.Right)
                         {
-                            _next = dict._root;
+                            _next = root;
                         }
                         else
                         {
@@ -645,7 +646,7 @@ hasBucket:
                     // left == right only if both are nulls
                     if (root.Left == root.Right)
                     {
-                        _next = dict._root;
+                        _next = root;
                     }
                     else
                     {

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis
             return Comparer.GetHashCode(k);
         }
 
-        public bool TryGetValue(K key, [NotNullWhen(returnValue: true)] out V value)
+        public bool TryGetValue(K key, [MaybeNullWhen(returnValue: false)] out V value)
         {
             if (_root != null)
             {
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis
 #endif
         }
 
-        private bool TryGetValue(int hashCode, K key, [NotNullWhen(returnValue: true)] out V value)
+        private bool TryGetValue(int hashCode, K key, [MaybeNullWhen(returnValue: false)] out V value)
         {
             RoslynDebug.Assert(_root is object);
             AvlNode? b = _root;
@@ -231,7 +231,7 @@ hasBucket:
             return GetFromList(b.Next, key, out value);
         }
 
-        private bool GetFromList(Node? next, K key, [NotNullWhen(returnValue: true)] out V value)
+        private bool GetFromList(Node? next, K key, [MaybeNullWhen(returnValue: false)] out V value)
         {
             while (next != null)
             {
@@ -393,8 +393,8 @@ hasBucket:
 
         private static AvlNode LeftComplex(AvlNode unbalanced)
         {
-            RoslynDebug.Assert(unbalanced.Right != null);
-            RoslynDebug.Assert(unbalanced.Right.Left != null);
+            RoslynDebug.Assert(unbalanced.Right is object);
+            RoslynDebug.Assert(unbalanced.Right.Left is object);
             var right = unbalanced.Right;
             var rightLeft = right.Left;
             right.Left = rightLeft.Right;

--- a/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
+++ b/src/Compilers/Core/Portable/Collections/TopologicalSort.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Compilers/Core/Portable/Collections/UnionCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/UnionCollection.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
@@ -63,8 +63,8 @@ namespace Microsoft.CodeAnalysis
 
             _writer.Write("level", GetLevel(diagnostic.Severity));
 
-            string message = diagnostic.GetMessage(_culture);
-            if (!string.IsNullOrEmpty(message))
+            string? message = diagnostic.GetMessage(_culture);
+            if (!RoslynString.IsNullOrEmpty(message))
             {
                 _writer.Write("message", message);
             }
@@ -149,14 +149,14 @@ namespace Microsoft.CodeAnalysis
                     _writer.WriteObjectStart(pair.Key); // rule
                     _writer.Write("id", descriptor.Id);
 
-                    string shortDescription = descriptor.Title.ToString(_culture);
-                    if (!string.IsNullOrEmpty(shortDescription))
+                    string? shortDescription = descriptor.Title.ToString(_culture);
+                    if (!RoslynString.IsNullOrEmpty(shortDescription))
                     {
                         _writer.Write("shortDescription", shortDescription);
                     }
 
-                    string fullDescription = descriptor.Description.ToString(_culture);
-                    if (!string.IsNullOrEmpty(fullDescription))
+                    string? fullDescription = descriptor.Description.ToString(_culture);
+                    if (!RoslynString.IsNullOrEmpty(fullDescription))
                     {
                         _writer.Write("fullDescription", fullDescription);
                     }

--- a/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV2ErrorLogger.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -53,8 +54,8 @@ namespace Microsoft.CodeAnalysis
 
             _writer.Write("level", GetLevel(diagnostic.Severity));
 
-            string message = diagnostic.GetMessage(_culture);
-            if (!string.IsNullOrEmpty(message))
+            string? message = diagnostic.GetMessage(_culture);
+            if (!RoslynString.IsNullOrEmpty(message))
             {
                 _writer.WriteObjectStart("message");
                 _writer.Write("text", message);
@@ -177,16 +178,16 @@ namespace Microsoft.CodeAnalysis
                     _writer.WriteObjectStart(); // rule
                     _writer.Write("id", descriptor.Id);
 
-                    string shortDescription = descriptor.Title.ToString(_culture);
-                    if (!string.IsNullOrEmpty(shortDescription))
+                    string? shortDescription = descriptor.Title.ToString(_culture);
+                    if (!RoslynString.IsNullOrEmpty(shortDescription))
                     {
                         _writer.WriteObjectStart("shortDescription");
                         _writer.Write("text", shortDescription);
                         _writer.WriteObjectEnd();
                     }
 
-                    string fullDescription = descriptor.Description.ToString(_culture);
-                    if (!string.IsNullOrEmpty(fullDescription))
+                    string? fullDescription = descriptor.Description.ToString(_culture);
+                    if (!RoslynString.IsNullOrEmpty(fullDescription))
                     {
                         _writer.WriteObjectStart("fullDescription");
                         _writer.Write("text", fullDescription);

--- a/src/Compilers/Core/Portable/CommitHashAttribute.cs
+++ b/src/Compilers/Core/Portable/CommitHashAttribute.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/Core/Portable/Compilation.EmitStream.cs
+++ b/src/Compilers/Core/Portable/Compilation.EmitStream.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -44,7 +46,7 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly EmitStreamProvider _emitStreamProvider;
             private readonly EmitStreamSignKind _emitStreamSignKind;
-            private readonly StrongNameProvider _strongNameProvider;
+            private readonly StrongNameProvider? _strongNameProvider;
             private (Stream tempStream, string tempFilePath)? _tempInfo;
 
             /// <summary>
@@ -53,21 +55,21 @@ namespace Microsoft.CodeAnalysis
             /// which case it is owned by that. Or it is just an alias for the value that is stored 
             /// in <see cref="_tempInfo"/> in which case it will be disposed from there.
             /// </summary>
-            private Stream _stream;
+            private Stream? _stream;
 
             internal EmitStream(
                 EmitStreamProvider emitStreamProvider,
                 EmitStreamSignKind emitStreamSignKind,
-                StrongNameProvider strongNameProvider)
+                StrongNameProvider? strongNameProvider)
             {
-                Debug.Assert(emitStreamProvider != null);
-                Debug.Assert(strongNameProvider != null || emitStreamSignKind == EmitStreamSignKind.None);
+                RoslynDebug.Assert(emitStreamProvider != null);
+                RoslynDebug.Assert(strongNameProvider != null || emitStreamSignKind == EmitStreamSignKind.None);
                 _emitStreamProvider = emitStreamProvider;
                 _emitStreamSignKind = emitStreamSignKind;
                 _strongNameProvider = strongNameProvider;
             }
 
-            internal Func<Stream> GetCreateStreamFunc(DiagnosticBag diagnostics)
+            internal Func<Stream?> GetCreateStreamFunc(DiagnosticBag diagnostics)
             {
                 return () => CreateStream(diagnostics);
             }
@@ -104,10 +106,10 @@ namespace Microsoft.CodeAnalysis
             /// <summary>
             /// Create the stream which should be used for Emit. This should only be called one time.
             /// </summary>
-            private Stream CreateStream(DiagnosticBag diagnostics)
+            private Stream? CreateStream(DiagnosticBag diagnostics)
             {
-                Debug.Assert(_stream == null);
-                Debug.Assert(diagnostics != null);
+                RoslynDebug.Assert(_stream == null);
+                RoslynDebug.Assert(diagnostics != null);
 
                 if (diagnostics.HasAnyErrors())
                 {
@@ -126,7 +128,7 @@ namespace Microsoft.CodeAnalysis
                 // stream that this method was called with.
                 if (_emitStreamSignKind == EmitStreamSignKind.SignedWithFile)
                 {
-                    Debug.Assert(_strongNameProvider != null);
+                    RoslynDebug.Assert(_strongNameProvider != null);
 
                     Stream tempStream;
                     string tempFilePath;
@@ -155,14 +157,15 @@ namespace Microsoft.CodeAnalysis
 
             internal bool Complete(StrongNameKeys strongNameKeys, CommonMessageProvider messageProvider, DiagnosticBag diagnostics)
             {
-                Debug.Assert(_stream != null);
-                Debug.Assert(_emitStreamSignKind != EmitStreamSignKind.SignedWithFile || _tempInfo.HasValue);
+                RoslynDebug.Assert(_stream != null);
+                RoslynDebug.Assert(_emitStreamSignKind != EmitStreamSignKind.SignedWithFile || _tempInfo.HasValue);
 
                 try
                 {
                     if (_tempInfo.HasValue)
                     {
-                        Debug.Assert(_emitStreamSignKind == EmitStreamSignKind.SignedWithFile);
+                        RoslynDebug.Assert(_emitStreamSignKind == EmitStreamSignKind.SignedWithFile);
+                        RoslynDebug.Assert(_strongNameProvider is object);
                         var (tempStream, tempFilePath) = _tempInfo.GetValueOrDefault();
 
                         try

--- a/src/Compilers/Core/Portable/Compilation.EmitStreamProvider.cs
+++ b/src/Compilers/Core/Portable/Compilation.EmitStreamProvider.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -47,7 +49,7 @@ namespace Microsoft.CodeAnalysis
 
             internal SimpleEmitStreamProvider(Stream stream)
             {
-                Debug.Assert(stream != null);
+                RoslynDebug.Assert(stream != null);
                 _stream = stream;
             }
 

--- a/src/Compilers/Core/Portable/Compilation/SourceReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/Compilation/SourceReferenceResolver.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +27,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="path">The source path to normalize. May be absolute or relative.</param>
         /// <param name="baseFilePath">Path of the source file that contains the <paramref name="path"/> (may also be relative), or null if not available.</param>
         /// <returns>Normalized path, or null if <paramref name="path"/> can't be normalized. The resulting path doesn't need to exist.</returns>
-        public abstract string NormalizePath(string path, string baseFilePath);
+        public abstract string? NormalizePath(string path, string baseFilePath);
 
         /// <summary>
         /// Resolves specified path with respect to base file path.
@@ -33,7 +35,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="path">The path to resolve. May be absolute or relative.</param>
         /// <param name="baseFilePath">Path of the source file that contains the <paramref name="path"/> (may also be relative), or null if not available.</param>
         /// <returns>Normalized path, or null if the file can't be resolved.</returns>
-        public abstract string ResolveReference(string path, string baseFilePath);
+        public abstract string? ResolveReference(string path, string baseFilePath);
 
         /// <summary>
         /// Opens a <see cref="Stream"/> that allows reading the content of the specified file.

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis
         DateTime,
     }
 
-    internal abstract partial class ConstantValue : IEquatable<ConstantValue>
+    internal abstract partial class ConstantValue : IEquatable<ConstantValue?>
     {
         public abstract ConstantValueTypeDiscriminator Discriminator { get; }
         internal abstract SpecialType SpecialType { get; }

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Reflection.Metadata;
@@ -34,8 +36,8 @@ namespace Microsoft.CodeAnalysis
         public abstract ConstantValueTypeDiscriminator Discriminator { get; }
         internal abstract SpecialType SpecialType { get; }
 
-        public virtual string StringValue { get { throw new InvalidOperationException(); } }
-        internal virtual Rope RopeValue { get { throw new InvalidOperationException(); } }
+        public virtual string? StringValue { get { throw new InvalidOperationException(); } }
+        internal virtual Rope? RopeValue { get { throw new InvalidOperationException(); } }
 
         public virtual bool BooleanValue { get { throw new InvalidOperationException(); } }
 
@@ -101,7 +103,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static ConstantValue CreateFromRope(Rope value)
         {
-            Debug.Assert(value != null);
+            RoslynDebug.Assert(value != null);
             return new ConstantValueString(value);
         }
 
@@ -437,7 +439,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public object Value
+        public object? Value
         {
             get
             {
@@ -726,19 +728,19 @@ namespace Microsoft.CodeAnalysis
 
         public override string ToString()
         {
-            string valueToDisplay = this.GetValueToDisplay();
+            string? valueToDisplay = this.GetValueToDisplay();
             return String.Format("{0}({1}: {2})", this.GetType().Name, valueToDisplay, this.Discriminator);
         }
 
-        internal virtual string GetValueToDisplay()
+        internal virtual string? GetValueToDisplay()
         {
-            return this.Value.ToString();
+            return this.Value?.ToString();
         }
 
         // equal constants must have matching discriminators
         // derived types override this if equivalence is more than just discriminators match. 
         // singletons also override this since they only need a reference compare.
-        public virtual bool Equals(ConstantValue other)
+        public virtual bool Equals(ConstantValue? other)
         {
             if (ReferenceEquals(other, this))
             {
@@ -753,7 +755,7 @@ namespace Microsoft.CodeAnalysis
             return this.Discriminator == other.Discriminator;
         }
 
-        public static bool operator ==(ConstantValue left, ConstantValue right)
+        public static bool operator ==(ConstantValue? left, ConstantValue? right)
         {
             if (ReferenceEquals(right, left))
             {
@@ -768,7 +770,7 @@ namespace Microsoft.CodeAnalysis
             return left.Equals(right);
         }
 
-        public static bool operator !=(ConstantValue left, ConstantValue right)
+        public static bool operator !=(ConstantValue? left, ConstantValue? right)
         {
             return !(left == right);
         }

--- a/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
+++ b/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -41,7 +43,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // all instances of this class are singletons
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return ReferenceEquals(this, other);
             }
@@ -77,7 +79,7 @@ namespace Microsoft.CodeAnalysis
                 get { return SpecialType.None; }
             }
 
-            public override string StringValue
+            public override string? StringValue
             {
                 get
                 {
@@ -85,7 +87,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            internal override Rope RopeValue
+            internal override Rope? RopeValue
             {
                 get
                 {
@@ -94,7 +96,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // all instances of this class are singletons
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return ReferenceEquals(this, other);
             }
@@ -125,14 +127,14 @@ namespace Microsoft.CodeAnalysis
             public ConstantValueString(string value)
             {
                 // we should have just one Null regardless string or object.
-                System.Diagnostics.Debug.Assert(value != null, "null strings should be represented as Null constant.");
+                RoslynDebug.Assert(value != null, "null strings should be represented as Null constant.");
                 _value = Rope.ForString(value);
             }
 
             public ConstantValueString(Rope value)
             {
                 // we should have just one Null regardless string or object.
-                System.Diagnostics.Debug.Assert(value != null, "null strings should be represented as Null constant.");
+                RoslynDebug.Assert(value != null, "null strings should be represented as Null constant.");
                 _value = value;
             }
 
@@ -170,7 +172,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value.Equals(other.RopeValue);
             }
@@ -216,7 +218,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value == other.DecimalValue;
             }
@@ -257,7 +259,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value == other.DateTimeValue;
             }
@@ -376,7 +378,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // all instances of this class are singletons
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return ReferenceEquals(this, other);
             }
@@ -399,7 +401,7 @@ namespace Microsoft.CodeAnalysis
             {
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 if (ReferenceEquals(other, this))
                 {
@@ -422,7 +424,7 @@ namespace Microsoft.CodeAnalysis
             {
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 if (ReferenceEquals(other, this))
                 {
@@ -445,7 +447,7 @@ namespace Microsoft.CodeAnalysis
             {
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 if (ReferenceEquals(other, this))
                 {
@@ -530,7 +532,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // all instances of this class are singletons
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return ReferenceEquals(this, other);
             }
@@ -548,7 +550,7 @@ namespace Microsoft.CodeAnalysis
             {
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 if (ReferenceEquals(other, this))
                 {
@@ -601,7 +603,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value == other.ByteValue;
             }
@@ -658,7 +660,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value == other.Int16Value;
             }
@@ -701,7 +703,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value == other.Int32Value;
             }
@@ -744,7 +746,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value == other.Int64Value;
             }
@@ -778,7 +780,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value.Equals(other.DoubleValue);
             }
@@ -823,7 +825,7 @@ namespace Microsoft.CodeAnalysis
                 return Hash.Combine(base.GetHashCode(), _value.GetHashCode());
             }
 
-            public override bool Equals(ConstantValue other)
+            public override bool Equals(ConstantValue? other)
             {
                 return base.Equals(other) && _value.Equals(other.DoubleValue);
             }

--- a/src/Compilers/Core/Portable/CryptographicHashProvider.cs
+++ b/src/Compilers/Core/Portable/CryptographicHashProvider.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -25,7 +27,7 @@ namespace Microsoft.CodeAnalysis
 
         internal ImmutableArray<byte> GetHash(AssemblyHashAlgorithm algorithmId)
         {
-            using (HashAlgorithm algorithm = TryGetAlgorithm(algorithmId))
+            using (HashAlgorithm? algorithm = TryGetAlgorithm(algorithmId))
             {
                 // ERR_CryptoHashFailed has already been reported:
                 if (algorithm == null)
@@ -72,7 +74,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal static HashAlgorithm TryGetAlgorithm(SourceHashAlgorithm algorithmId)
+        internal static HashAlgorithm? TryGetAlgorithm(SourceHashAlgorithm algorithmId)
         {
             switch (algorithmId)
             {
@@ -102,7 +104,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal static HashAlgorithm TryGetAlgorithm(AssemblyHashAlgorithm algorithmId)
+        internal static HashAlgorithm? TryGetAlgorithm(AssemblyHashAlgorithm algorithmId)
         {
             switch (algorithmId)
             {

--- a/src/Compilers/Core/Portable/CvtRes.cs
+++ b/src/Compilers/Core/Portable/CvtRes.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,8 +20,8 @@ namespace Microsoft.CodeAnalysis
 {
     internal class RESOURCE
     {
-        internal RESOURCE_STRING pstringType;
-        internal RESOURCE_STRING pstringName;
+        internal RESOURCE_STRING? pstringType;
+        internal RESOURCE_STRING? pstringName;
 
         internal DWORD DataSize;               // size of data without header
         internal DWORD HeaderSize;     // Length of the header
@@ -30,13 +32,13 @@ namespace Microsoft.CodeAnalysis
         internal WORD LanguageId;     // Unicode support for NLS
         internal DWORD Version;        // Version of the resource data
         internal DWORD Characteristics;        // Characteristics of the data
-        internal byte[] data;       //data
+        internal byte[]? data;       //data
     };
 
     internal class RESOURCE_STRING
     {
         internal WORD Ordinal;
-        internal string theString;
+        internal string? theString;
     };
 
     /// <summary>
@@ -504,10 +506,10 @@ namespace Microsoft.CodeAnalysis
             Version assemblyVersion, //individual values must be smaller than 65535
             string fileDescription = " ",   //the old compiler put blank here if nothing was user-supplied
             string legalCopyright = " ",    //the old compiler put blank here if nothing was user-supplied
-            string legalTrademarks = null,
-            string productName = null,
-            string comments = null,
-            string companyName = null)
+            string? legalTrademarks = null,
+            string? productName = null,
+            string? comments = null,
+            string? companyName = null)
         {
             var resWriter = new BinaryWriter(resStream, Encoding.Unicode);
             resStream.Position = (resStream.Position + 3) & ~3;
@@ -571,15 +573,15 @@ namespace Microsoft.CodeAnalysis
 
         private class VersionResourceSerializer
         {
-            private readonly string _commentsContents;
-            private readonly string _companyNameContents;
+            private readonly string? _commentsContents;
+            private readonly string? _companyNameContents;
             private readonly string _fileDescriptionContents;
             private readonly string _fileVersionContents;
             private readonly string _internalNameContents;
             private readonly string _legalCopyrightContents;
-            private readonly string _legalTrademarksContents;
+            private readonly string? _legalTrademarksContents;
             private readonly string _originalFileNameContents;
-            private readonly string _productNameContents;
+            private readonly string? _productNameContents;
             private readonly string _productVersionContents;
             private readonly Version _assemblyVersionContents;
 
@@ -593,8 +595,8 @@ namespace Microsoft.CodeAnalysis
             private const ushort sizeVS_FIXEDFILEINFO = sizeof(DWORD) * 13;
             private readonly bool _isDll;
 
-            internal VersionResourceSerializer(bool isDll, string comments, string companyName, string fileDescription, string fileVersion,
-                string internalName, string legalCopyright, string legalTrademark, string originalFileName, string productName, string productVersion,
+            internal VersionResourceSerializer(bool isDll, string? comments, string? companyName, string fileDescription, string fileVersion,
+                string internalName, string legalCopyright, string? legalTrademark, string originalFileName, string? productName, string productVersion,
                 Version assemblyVersion)
             {
                 _isDll = isDll;
@@ -700,7 +702,7 @@ namespace Microsoft.CodeAnalysis
 
             private static void WriteVersionString(KeyValuePair<string, string> keyValuePair, BinaryWriter writer)
             {
-                System.Diagnostics.Debug.Assert(keyValuePair.Value != null);
+                RoslynDebug.Assert(keyValuePair.Value != null);
 
                 ushort cbBlock = SizeofVerString(keyValuePair.Key, keyValuePair.Value);
                 int cbKey = (keyValuePair.Key.Length + 1) * 2;     // includes terminating NUL

--- a/src/Compilers/Core/Portable/Diagnostic/CommonDiagnosticComparer.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonDiagnosticComparer.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Roslyn.Utilities;
 

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
@@ -28,7 +30,7 @@ namespace Microsoft.CodeAnalysis
         /// "fill-in" placeholders, those should be expressed in standard string.Format notation
         /// and be in the string.
         /// </summary>
-        public abstract string LoadMessage(int code, CultureInfo language);
+        public abstract string LoadMessage(int code, CultureInfo? language);
 
         /// <summary>
         /// Get an optional localizable title for the given diagnostic code.
@@ -94,7 +96,7 @@ namespace Microsoft.CodeAnalysis
         /// Given a message identifier (e.g., CS0219), severity, warning as error and a culture, 
         /// get the entire prefix (e.g., "error CS0219: Warning as Error:" for C# or "error BC42024:" for VB) used on error messages.
         /// </summary>
-        public abstract string GetMessagePrefix(string id, DiagnosticSeverity severity, bool isWarningAsError, CultureInfo culture);
+        public abstract string GetMessagePrefix(string id, DiagnosticSeverity severity, bool isWarningAsError, CultureInfo? culture);
 
         /// <summary>
         /// Convert given symbol to string representation.
@@ -126,7 +128,7 @@ namespace Microsoft.CodeAnalysis
         /// Filter a <see cref="DiagnosticInfo"/> based on the compilation options so that /nowarn and /warnaserror etc. take effect.options
         /// </summary>
         /// <returns>A <see cref="DiagnosticInfo"/> with effective severity based on option or null if suppressed.</returns>
-        public DiagnosticInfo FilterDiagnosticInfo(DiagnosticInfo diagnosticInfo, CompilationOptions options)
+        public DiagnosticInfo? FilterDiagnosticInfo(DiagnosticInfo diagnosticInfo, CompilationOptions options)
         {
             var report = this.GetDiagnosticReport(diagnosticInfo, options);
             switch (report)

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -20,9 +22,9 @@ namespace Microsoft.CodeAnalysis
                 Diagnostic originalUnsuppressedDiagnostic,
                 ProgrammaticSuppressionInfo programmaticSuppressionInfo)
             {
-                Debug.Assert(!originalUnsuppressedDiagnostic.IsSuppressed);
-                Debug.Assert(originalUnsuppressedDiagnostic.ProgrammaticSuppressionInfo == null);
-                Debug.Assert(programmaticSuppressionInfo != null);
+                RoslynDebug.Assert(!originalUnsuppressedDiagnostic.IsSuppressed);
+                RoslynDebug.Assert(originalUnsuppressedDiagnostic.ProgrammaticSuppressionInfo == null);
+                RoslynDebug.Assert(programmaticSuppressionInfo != null);
 
                 _originalUnsuppressedDiagnostic = originalUnsuppressedDiagnostic;
                 _programmaticSuppressionInfo = programmaticSuppressionInfo;
@@ -38,10 +40,10 @@ namespace Microsoft.CodeAnalysis
                 get { return Descriptor.Id; }
             }
 
-            public override string GetMessage(IFormatProvider formatProvider = null)
+            public override string? GetMessage(IFormatProvider? formatProvider = null)
                 => _originalUnsuppressedDiagnostic.GetMessage(formatProvider);
 
-            internal override IReadOnlyList<object> Arguments
+            internal override IReadOnlyList<object>? Arguments
             {
                 get { return _originalUnsuppressedDiagnostic.Arguments; }
             }
@@ -81,7 +83,7 @@ namespace Microsoft.CodeAnalysis
                 get { return _originalUnsuppressedDiagnostic.Properties; }
             }
 
-            public override bool Equals(Diagnostic obj)
+            public override bool Equals(Diagnostic? obj)
             {
                 var other = obj as DiagnosticWithProgrammaticSuppression;
                 if (other == null)

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
@@ -40,10 +40,10 @@ namespace Microsoft.CodeAnalysis
                 get { return Descriptor.Id; }
             }
 
-            public override string? GetMessage(IFormatProvider? formatProvider = null)
+            public override string GetMessage(IFormatProvider? formatProvider = null)
                 => _originalUnsuppressedDiagnostic.GetMessage(formatProvider);
 
-            internal override IReadOnlyList<object>? Arguments
+            internal override IReadOnlyList<object?>? Arguments
             {
                 get { return _originalUnsuppressedDiagnostic.Arguments; }
             }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis
         public static Diagnostic Create(
             DiagnosticDescriptor descriptor,
             Location location,
-            params object[] messageArgs)
+            params object?[] messageArgs)
         {
             return Create(descriptor, location, null, null, messageArgs);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis
             DiagnosticDescriptor descriptor,
             Location location,
             ImmutableDictionary<string, string>? properties,
-            params object[]? messageArgs)
+            params object?[] messageArgs)
         {
             return Create(descriptor, location, null, properties, messageArgs);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
             DiagnosticDescriptor descriptor,
             Location location,
             IEnumerable<Location>? additionalLocations,
-            params object[]? messageArgs)
+            params object?[] messageArgs)
         {
             return Create(descriptor, location, additionalLocations, properties: null, messageArgs: messageArgs);
         }
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis
             Location location,
             IEnumerable<Location>? additionalLocations,
             ImmutableDictionary<string, string>? properties,
-            params object[]? messageArgs)
+            params object?[] messageArgs)
         {
             return Create(descriptor, location, effectiveSeverity: descriptor.DefaultSeverity, additionalLocations, properties, messageArgs);
         }
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis
             DiagnosticSeverity effectiveSeverity,
             IEnumerable<Location>? additionalLocations,
             ImmutableDictionary<string, string>? properties,
-            params object[]? messageArgs)
+            params object?[] messageArgs)
         {
             if (descriptor == null)
             {
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Get the culture specific text of the message.
         /// </summary>
-        public abstract string? GetMessage(IFormatProvider? formatProvider = null);
+        public abstract string GetMessage(IFormatProvider? formatProvider = null);
 
         /// <summary>
         /// Gets the default <see cref="DiagnosticSeverity"/> of the diagnostic's <see cref="DiagnosticDescriptor"/>.
@@ -466,9 +466,9 @@ namespace Microsoft.CodeAnalysis
         // compatibility
         internal virtual int Code { get { return 0; } }
 
-        internal virtual IReadOnlyList<object>? Arguments
+        internal virtual IReadOnlyList<object?>? Arguments
         {
-            get { return SpecializedCollections.EmptyReadOnlyList<object>(); }
+            get { return SpecializedCollections.EmptyReadOnlyList<object?>(); }
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
     /// Represents a diagnostic, such as a compiler error or a warning, along with the location where it occurred.
     /// </summary>
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-    public abstract partial class Diagnostic : IEquatable<Diagnostic>, IFormattable
+    public abstract partial class Diagnostic : IEquatable<Diagnostic?>, IFormattable
     {
         internal const string CompilerDiagnosticCategory = "Compiler";
 
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis
 
         public abstract override int GetHashCode();
 
-        public abstract bool Equals(Diagnostic obj);
+        public abstract bool Equals(Diagnostic? obj);
 
         private string GetDebuggerDisplay()
         {

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -54,8 +56,8 @@ namespace Microsoft.CodeAnalysis
         public static Diagnostic Create(
             DiagnosticDescriptor descriptor,
             Location location,
-            ImmutableDictionary<string, string> properties,
-            params object[] messageArgs)
+            ImmutableDictionary<string, string>? properties,
+            params object[]? messageArgs)
         {
             return Create(descriptor, location, null, properties, messageArgs);
         }
@@ -75,8 +77,8 @@ namespace Microsoft.CodeAnalysis
         public static Diagnostic Create(
             DiagnosticDescriptor descriptor,
             Location location,
-            IEnumerable<Location> additionalLocations,
-            params object[] messageArgs)
+            IEnumerable<Location>? additionalLocations,
+            params object[]? messageArgs)
         {
             return Create(descriptor, location, additionalLocations, properties: null, messageArgs: messageArgs);
         }
@@ -101,9 +103,9 @@ namespace Microsoft.CodeAnalysis
         public static Diagnostic Create(
             DiagnosticDescriptor descriptor,
             Location location,
-            IEnumerable<Location> additionalLocations,
-            ImmutableDictionary<string, string> properties,
-            params object[] messageArgs)
+            IEnumerable<Location>? additionalLocations,
+            ImmutableDictionary<string, string>? properties,
+            params object[]? messageArgs)
         {
             return Create(descriptor, location, effectiveSeverity: descriptor.DefaultSeverity, additionalLocations, properties, messageArgs);
         }
@@ -130,9 +132,9 @@ namespace Microsoft.CodeAnalysis
             DiagnosticDescriptor descriptor,
             Location location,
             DiagnosticSeverity effectiveSeverity,
-            IEnumerable<Location> additionalLocations,
-            ImmutableDictionary<string, string> properties,
-            params object[] messageArgs)
+            IEnumerable<Location>? additionalLocations,
+            ImmutableDictionary<string, string>? properties,
+            params object[]? messageArgs)
         {
             if (descriptor == null)
             {
@@ -187,13 +189,13 @@ namespace Microsoft.CodeAnalysis
             DiagnosticSeverity defaultSeverity,
             bool isEnabledByDefault,
             int warningLevel,
-            LocalizableString title = null,
-            LocalizableString description = null,
-            string helpLink = null,
-            Location location = null,
-            IEnumerable<Location> additionalLocations = null,
-            IEnumerable<string> customTags = null,
-            ImmutableDictionary<string, string> properties = null)
+            LocalizableString? title = null,
+            LocalizableString? description = null,
+            string? helpLink = null,
+            Location? location = null,
+            IEnumerable<Location>? additionalLocations = null,
+            IEnumerable<string>? customTags = null,
+            ImmutableDictionary<string, string>? properties = null)
         {
             return Create(id, category, message, severity, defaultSeverity, isEnabledByDefault, warningLevel, false,
                 title, description, helpLink, location, additionalLocations, customTags, properties);
@@ -238,13 +240,13 @@ namespace Microsoft.CodeAnalysis
             bool isEnabledByDefault,
             int warningLevel,
             bool isSuppressed,
-            LocalizableString title = null,
-            LocalizableString description = null,
-            string helpLink = null,
-            Location location = null,
-            IEnumerable<Location> additionalLocations = null,
-            IEnumerable<string> customTags = null,
-            ImmutableDictionary<string, string> properties = null)
+            LocalizableString? title = null,
+            LocalizableString? description = null,
+            string? helpLink = null,
+            Location? location = null,
+            IEnumerable<Location>? additionalLocations = null,
+            IEnumerable<string>? customTags = null,
+            ImmutableDictionary<string, string>? properties = null)
         {
             if (id == null)
             {
@@ -298,7 +300,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Get the culture specific text of the message.
         /// </summary>
-        public abstract string GetMessage(IFormatProvider formatProvider = null);
+        public abstract string? GetMessage(IFormatProvider? formatProvider = null);
 
         /// <summary>
         /// Gets the default <see cref="DiagnosticSeverity"/> of the diagnostic's <see cref="DiagnosticDescriptor"/>.
@@ -332,14 +334,14 @@ namespace Microsoft.CodeAnalysis
         /// Gets the <see cref="SuppressionInfo"/> for suppressed diagnostics, i.e. <see cref="IsSuppressed"/> = true.
         /// Otherwise, returns null.
         /// </summary>
-        public SuppressionInfo GetSuppressionInfo(Compilation compilation)
+        public SuppressionInfo? GetSuppressionInfo(Compilation compilation)
         {
             if (!IsSuppressed)
             {
                 return null;
             }
 
-            AttributeData attribute;
+            AttributeData? attribute;
             var suppressMessageState = new SuppressMessageAttributeState(compilation);
             if (!suppressMessageState.IsDiagnosticSuppressed(
                     this,
@@ -453,18 +455,18 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal Diagnostic WithProgrammaticSuppression(ProgrammaticSuppressionInfo programmaticSuppressionInfo)
         {
-            Debug.Assert(this.ProgrammaticSuppressionInfo == null);
-            Debug.Assert(programmaticSuppressionInfo != null);
+            RoslynDebug.Assert(this.ProgrammaticSuppressionInfo == null);
+            RoslynDebug.Assert(programmaticSuppressionInfo != null);
 
             return new DiagnosticWithProgrammaticSuppression(this, programmaticSuppressionInfo);
         }
 
-        internal virtual ProgrammaticSuppressionInfo ProgrammaticSuppressionInfo { get { return null; } }
+        internal virtual ProgrammaticSuppressionInfo? ProgrammaticSuppressionInfo { get { return null; } }
 
         // compatibility
         internal virtual int Code { get { return 0; } }
 
-        internal virtual IReadOnlyList<object> Arguments
+        internal virtual IReadOnlyList<object>? Arguments
         {
             get { return SpecializedCollections.EmptyReadOnlyList<object>(); }
         }
@@ -506,7 +508,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal Diagnostic WithReportDiagnostic(ReportDiagnostic reportAction)
+        internal Diagnostic? WithReportDiagnostic(ReportDiagnostic reportAction)
         {
             switch (reportAction)
             {

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticBag.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -28,7 +30,7 @@ namespace Microsoft.CodeAnalysis
     internal class DiagnosticBag
     {
         // The lazyBag field is populated lazily -- the first time an error is added.
-        private ConcurrentQueue<Diagnostic> _lazyBag;
+        private ConcurrentQueue<Diagnostic>? _lazyBag;
 
         /// <summary>
         /// Return true if the bag is completely empty - not even containing void diagnostics.
@@ -45,7 +47,7 @@ namespace Microsoft.CodeAnalysis
                 // then a report phase, and we shouldn't be called during the "report" phase. We
                 // also never remove diagnostics, so the worst that happens is that we don't return
                 // an element that is added a split second after this is called.
-                ConcurrentQueue<Diagnostic> bag = _lazyBag;
+                ConcurrentQueue<Diagnostic>? bag = _lazyBag;
                 return bag == null || bag.IsEmpty;
             }
         }
@@ -167,7 +169,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public ImmutableArray<TDiagnostic> ToReadOnlyAndFree<TDiagnostic>() where TDiagnostic : Diagnostic
         {
-            ConcurrentQueue<Diagnostic> oldBag = _lazyBag;
+            ConcurrentQueue<Diagnostic>? oldBag = _lazyBag;
             Free();
 
             return ToReadOnlyCore<TDiagnostic>(oldBag);
@@ -180,7 +182,7 @@ namespace Microsoft.CodeAnalysis
 
         public ImmutableArray<TDiagnostic> ToReadOnly<TDiagnostic>() where TDiagnostic : Diagnostic
         {
-            ConcurrentQueue<Diagnostic> oldBag = _lazyBag;
+            ConcurrentQueue<Diagnostic>? oldBag = _lazyBag;
             return ToReadOnlyCore<TDiagnostic>(oldBag);
         }
 
@@ -189,7 +191,7 @@ namespace Microsoft.CodeAnalysis
             return ToReadOnly<Diagnostic>();
         }
 
-        private static ImmutableArray<TDiagnostic> ToReadOnlyCore<TDiagnostic>(ConcurrentQueue<Diagnostic> oldBag) where TDiagnostic : Diagnostic
+        private static ImmutableArray<TDiagnostic> ToReadOnlyCore<TDiagnostic>(ConcurrentQueue<Diagnostic>? oldBag) where TDiagnostic : Diagnostic
         {
             if (oldBag == null)
             {
@@ -285,7 +287,7 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                ConcurrentQueue<Diagnostic> bag = _lazyBag;
+                ConcurrentQueue<Diagnostic>? bag = _lazyBag;
                 if (bag != null)
                 {
                     return bag;
@@ -302,7 +304,7 @@ namespace Microsoft.CodeAnalysis
         ///       broken and we cannot do anything about it here.
         internal void Clear()
         {
-            ConcurrentQueue<Diagnostic> bag = _lazyBag;
+            ConcurrentQueue<Diagnostic>? bag = _lazyBag;
             if (bag != null)
             {
                 _lazyBag = null;
@@ -347,7 +349,7 @@ namespace Microsoft.CodeAnalysis
             {
                 get
                 {
-                    ConcurrentQueue<Diagnostic> lazyBag = _bag._lazyBag;
+                    ConcurrentQueue<Diagnostic>? lazyBag = _bag._lazyBag;
                     if (lazyBag != null)
                     {
                         return lazyBag.ToArray();

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -81,8 +83,8 @@ namespace Microsoft.CodeAnalysis
             string category,
             DiagnosticSeverity defaultSeverity,
             bool isEnabledByDefault,
-            string description = null,
-            string helpLinkUri = null,
+            string? description = null,
+            string? helpLinkUri = null,
             params string[] customTags)
             : this(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault, description, helpLinkUri, customTags.AsImmutableOrEmpty())
         {
@@ -118,8 +120,8 @@ namespace Microsoft.CodeAnalysis
             string category,
             DiagnosticSeverity defaultSeverity,
             bool isEnabledByDefault,
-            LocalizableString description = null,
-            string helpLinkUri = null,
+            LocalizableString? description = null,
+            string? helpLinkUri = null,
             params string[] customTags)
             : this(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault, description, helpLinkUri, customTags.AsImmutableOrEmpty())
         {
@@ -132,8 +134,8 @@ namespace Microsoft.CodeAnalysis
             string category,
             DiagnosticSeverity defaultSeverity,
             bool isEnabledByDefault,
-            LocalizableString description,
-            string helpLinkUri,
+            LocalizableString? description,
+            string? helpLinkUri,
             ImmutableArray<string> customTags)
         {
             if (string.IsNullOrWhiteSpace(id))
@@ -167,7 +169,7 @@ namespace Microsoft.CodeAnalysis
             this.CustomTags = customTags;
         }
 
-        public bool Equals(DiagnosticDescriptor other)
+        public bool Equals(DiagnosticDescriptor? other)
         {
             return
                 other != null &&
@@ -181,7 +183,7 @@ namespace Microsoft.CodeAnalysis
                 this.Title.Equals(other.Title);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as DiagnosticDescriptor);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Provides a description about a <see cref="Diagnostic"/>
     /// </summary>
-    public sealed class DiagnosticDescriptor : IEquatable<DiagnosticDescriptor>
+    public sealed class DiagnosticDescriptor : IEquatable<DiagnosticDescriptor?>
     {
         /// <summary>
         /// An unique identifier for the diagnostic.

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticFormatter.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticFormatter.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 using Microsoft.CodeAnalysis.Text;
@@ -18,7 +20,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="diagnostic">The diagnostic.</param>
         /// <param name="formatter">The formatter; or null to use the default formatter.</param>
         /// <returns>The formatted message.</returns>
-        public virtual string Format(Diagnostic diagnostic, IFormatProvider formatter = null)
+        public virtual string Format(Diagnostic diagnostic, IFormatProvider? formatter = null)
         {
             if (diagnostic == null)
             {
@@ -39,7 +41,7 @@ namespace Microsoft.CodeAnalysis
                         goto default;
                     }
 
-                    string path, basePath;
+                    string? path, basePath;
                     if (mappedSpan.HasMappedPath)
                     {
                         path = mappedSpan.Path;
@@ -64,13 +66,13 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal virtual string FormatSourcePath(string path, string basePath, IFormatProvider formatter)
+        internal virtual string FormatSourcePath(string path, string? basePath, IFormatProvider? formatter)
         {
             // ignore base path
             return path;
         }
 
-        internal virtual string FormatSourceSpan(LinePositionSpan span, IFormatProvider formatter)
+        internal virtual string FormatSourceSpan(LinePositionSpan span, IFormatProvider? formatter)
         {
             return string.Format("({0},{1})", span.Start.Line + 1, span.Start.Character + 1);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticSeverity.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticSeverity.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -20,8 +22,8 @@ namespace Microsoft.CodeAnalysis
 
         internal DiagnosticWithInfo(DiagnosticInfo info, Location location, bool isSuppressed = false)
         {
-            Debug.Assert(info != null);
-            Debug.Assert(location != null);
+            RoslynDebug.Assert(info != null);
+            RoslynDebug.Assert(location != null);
             _info = info;
             _location = location;
             _isSuppressed = isSuppressed;
@@ -95,12 +97,12 @@ namespace Microsoft.CodeAnalysis
             get { return this.Info.WarningLevel; }
         }
 
-        public override string GetMessage(IFormatProvider formatProvider = null)
+        public override string GetMessage(IFormatProvider? formatProvider = null)
         {
             return this.Info.GetMessage(formatProvider);
         }
 
-        internal override IReadOnlyList<object> Arguments
+        internal override IReadOnlyList<object>? Arguments
         {
             get { return this.Info.Arguments; }
         }
@@ -139,12 +141,12 @@ namespace Microsoft.CodeAnalysis
             return Hash.Combine(this.Location.GetHashCode(), this.Info.GetHashCode());
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as Diagnostic);
         }
 
-        public override bool Equals(Diagnostic obj)
+        public override bool Equals(Diagnostic? obj)
         {
             if (this == obj)
             {

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -30,9 +32,9 @@ namespace Microsoft.CodeAnalysis
                 DiagnosticSeverity severity,
                 int warningLevel,
                 Location location,
-                IEnumerable<Location> additionalLocations,
-                object[] messageArgs,
-                ImmutableDictionary<string, string> properties,
+                IEnumerable<Location>? additionalLocations,
+                object[]? messageArgs,
+                ImmutableDictionary<string, string>? properties,
                 bool isSuppressed)
             {
                 if ((warningLevel == 0 && severity != DiagnosticSeverity.Error) ||
@@ -56,9 +58,9 @@ namespace Microsoft.CodeAnalysis
                 DiagnosticSeverity severity,
                 int warningLevel,
                 Location location,
-                IEnumerable<Location> additionalLocations,
-                object[] messageArgs,
-                ImmutableDictionary<string, string> properties,
+                IEnumerable<Location>? additionalLocations,
+                object[]? messageArgs,
+                ImmutableDictionary<string, string>? properties,
                 bool isSuppressed = false)
             {
                 return new SimpleDiagnostic(descriptor, severity, warningLevel, location, additionalLocations, messageArgs, properties, isSuppressed);
@@ -67,8 +69,8 @@ namespace Microsoft.CodeAnalysis
             internal static SimpleDiagnostic Create(string id, LocalizableString title, string category, LocalizableString message, LocalizableString description, string helpLink,
                                       DiagnosticSeverity severity, DiagnosticSeverity defaultSeverity,
                                       bool isEnabledByDefault, int warningLevel, Location location,
-                                      IEnumerable<Location> additionalLocations, IEnumerable<string> customTags,
-                                      ImmutableDictionary<string, string> properties, bool isSuppressed = false)
+                                      IEnumerable<Location>? additionalLocations, IEnumerable<string>? customTags,
+                                      ImmutableDictionary<string, string>? properties, bool isSuppressed = false)
             {
                 var descriptor = new DiagnosticDescriptor(id, title, message,
                      category, defaultSeverity, isEnabledByDefault, description, helpLink, customTags.ToImmutableArrayOrEmpty());
@@ -85,7 +87,7 @@ namespace Microsoft.CodeAnalysis
                 get { return _descriptor.Id; }
             }
 
-            public override string GetMessage(IFormatProvider formatProvider = null)
+            public override string? GetMessage(IFormatProvider? formatProvider = null)
             {
                 if (_messageArgs.Length == 0)
                 {
@@ -140,7 +142,7 @@ namespace Microsoft.CodeAnalysis
                 get { return _properties; }
             }
 
-            public override bool Equals(Diagnostic obj)
+            public override bool Equals(Diagnostic? obj)
             {
                 var other = obj as SimpleDiagnostic;
                 if (other == null)
@@ -176,7 +178,7 @@ namespace Microsoft.CodeAnalysis
 
             internal override Diagnostic WithLocation(Location location)
             {
-                if (location == null)
+                if (location is null)
                 {
                     throw new ArgumentNullException(nameof(location));
                 }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis
             private readonly int _warningLevel;
             private readonly Location _location;
             private readonly IReadOnlyList<Location> _additionalLocations;
-            private readonly object[] _messageArgs;
+            private readonly object?[] _messageArgs;
             private readonly ImmutableDictionary<string, string> _properties;
             private readonly bool _isSuppressed;
 
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
                 int warningLevel,
                 Location location,
                 IEnumerable<Location>? additionalLocations,
-                object[]? messageArgs,
+                object?[]? messageArgs,
                 ImmutableDictionary<string, string>? properties,
                 bool isSuppressed)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis
                 _warningLevel = warningLevel;
                 _location = location ?? Location.None;
                 _additionalLocations = additionalLocations?.ToImmutableArray() ?? SpecializedCollections.EmptyReadOnlyList<Location>();
-                _messageArgs = messageArgs ?? Array.Empty<object>();
+                _messageArgs = messageArgs ?? Array.Empty<object?>();
                 _properties = properties ?? ImmutableDictionary<string, string>.Empty;
                 _isSuppressed = isSuppressed;
             }
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis
                 int warningLevel,
                 Location location,
                 IEnumerable<Location>? additionalLocations,
-                object[]? messageArgs,
+                object?[]? messageArgs,
                 ImmutableDictionary<string, string>? properties,
                 bool isSuppressed = false)
             {
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis
                 get { return _descriptor.Id; }
             }
 
-            public override string? GetMessage(IFormatProvider? formatProvider = null)
+            public override string GetMessage(IFormatProvider? formatProvider = null)
             {
                 if (_messageArgs.Length == 0)
                 {
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            internal override IReadOnlyList<object> Arguments
+            internal override IReadOnlyList<object?> Arguments
             {
                 get { return _messageArgs; }
             }

--- a/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -46,12 +48,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return this.Equals(obj as ExternalFileLocation);
         }
 
-        public bool Equals(ExternalFileLocation obj)
+        public bool Equals(ExternalFileLocation? obj)
         {
             if (ReferenceEquals(obj, this))
             {

--- a/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// A program location in source code.
     /// </summary>
-    internal sealed class ExternalFileLocation : Location, IEquatable<ExternalFileLocation>
+    internal sealed class ExternalFileLocation : Location, IEquatable<ExternalFileLocation?>
     {
         private readonly TextSpan _sourceSpan;
         private readonly FileLinePositionSpan _lineSpan;

--- a/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis
@@ -15,14 +17,14 @@ namespace Microsoft.CodeAnalysis
 
             private readonly string _fixedString;
 
-            public static FixedLocalizableString Create(string fixedResource)
+            public static FixedLocalizableString Create(string? fixedResource)
             {
                 if (string.IsNullOrEmpty(fixedResource))
                 {
                     return s_empty;
                 }
 
-                return new FixedLocalizableString(fixedResource);
+                return new FixedLocalizableString(fixedResource!);
             }
 
             private FixedLocalizableString(string fixedResource)
@@ -30,12 +32,12 @@ namespace Microsoft.CodeAnalysis
                 _fixedString = fixedResource;
             }
 
-            protected override string GetText(IFormatProvider formatProvider)
+            protected override string GetText(IFormatProvider? formatProvider)
             {
                 return _fixedString;
             }
 
-            protected override bool AreEqual(object other)
+            protected override bool AreEqual(object? other)
             {
                 var fixedStr = other as FixedLocalizableString;
                 return fixedStr != null && string.Equals(_fixedString, fixedStr._fixedString);

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
@@ -3,6 +3,7 @@
 #nullable enable
 
 using System;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -19,12 +20,12 @@ namespace Microsoft.CodeAnalysis
 
             public static FixedLocalizableString Create(string? fixedResource)
             {
-                if (string.IsNullOrEmpty(fixedResource))
+                if (RoslynString.IsNullOrEmpty(fixedResource))
                 {
                     return s_empty;
                 }
 
-                return new FixedLocalizableString(fixedResource!);
+                return new FixedLocalizableString(fixedResource);
             }
 
             private FixedLocalizableString(string fixedResource)

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        protected override string? GetText(IFormatProvider? formatProvider)
+        protected override string GetText(IFormatProvider? formatProvider)
         {
             var culture = formatProvider as CultureInfo ?? CultureInfo.CurrentUICulture;
             var resourceString = _resourceManager.GetString(_nameOfLocalizableResource, culture);

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 using System.Linq;
@@ -107,7 +109,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        protected override string GetText(IFormatProvider formatProvider)
+        protected override string? GetText(IFormatProvider? formatProvider)
         {
             var culture = formatProvider as CultureInfo ?? CultureInfo.CurrentUICulture;
             var resourceString = _resourceManager.GetString(_nameOfLocalizableResource, culture);
@@ -116,7 +118,7 @@ namespace Microsoft.CodeAnalysis
                 string.Empty;
         }
 
-        protected override bool AreEqual(object other)
+        protected override bool AreEqual(object? other)
         {
             var otherResourceString = other as LocalizableResourceString;
             return otherResourceString != null &&

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis
@@ -14,12 +16,12 @@ namespace Microsoft.CodeAnalysis
         /// Fired when an exception is raised by any of the public methods of <see cref="LocalizableString"/>.
         /// If the exception handler itself throws an exception, that exception is ignored.
         /// </summary>
-        public event EventHandler<Exception> OnException;
+        public event EventHandler<Exception>? OnException;
 
         /// <summary>
         /// Formats the value of the current instance using the optionally specified format. 
         /// </summary>
-        public string ToString(IFormatProvider formatProvider)
+        public string? ToString(IFormatProvider? formatProvider)
         {
             try
             {
@@ -32,22 +34,22 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static explicit operator string(LocalizableString localizableResource)
+        public static explicit operator string?(LocalizableString localizableResource)
         {
             return localizableResource.ToString(null);
         }
 
-        public static implicit operator LocalizableString(string fixedResource)
+        public static implicit operator LocalizableString(string? fixedResource)
         {
             return FixedLocalizableString.Create(fixedResource);
         }
 
-        public sealed override string ToString()
+        public sealed override string? ToString()
         {
             return ToString(null);
         }
 
-        string IFormattable.ToString(string ignored, IFormatProvider formatProvider)
+        string? IFormattable.ToString(string? ignored, IFormatProvider? formatProvider)
         {
             return ToString(formatProvider);
         }
@@ -65,7 +67,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public sealed override bool Equals(object other)
+        public sealed override bool Equals(object? other)
         {
             try
             {
@@ -78,9 +80,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public bool Equals(LocalizableString other)
+        public bool Equals(LocalizableString? other)
         {
-            return Equals((object)other);
+            return Equals((object?)other);
         }
 
         /// <summary>
@@ -88,7 +90,7 @@ namespace Microsoft.CodeAnalysis
         /// Provides the implementation of ToString. ToString will provide a default value
         /// if this method throws an exception.
         /// </summary>
-        protected abstract string GetText(IFormatProvider formatProvider);
+        protected abstract string? GetText(IFormatProvider? formatProvider);
 
         /// <summary>
         /// Provides the implementation of GetHashCode. GetHashCode will provide a default value
@@ -102,7 +104,7 @@ namespace Microsoft.CodeAnalysis
         /// if this method throws an exception.
         /// </summary>
         /// <returns></returns>
-        protected abstract bool AreEqual(object other);
+        protected abstract bool AreEqual(object? other);
 
         private void RaiseOnException(Exception ex)
         {

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis
     /// A string that may possibly be formatted differently depending on culture.
     /// NOTE: Types implementing <see cref="LocalizableString"/> must be serializable.
     /// </summary>
-    public abstract partial class LocalizableString : IFormattable, IEquatable<LocalizableString>
+    public abstract partial class LocalizableString : IFormattable, IEquatable<LocalizableString?>
     {
         /// <summary>
         /// Fired when an exception is raised by any of the public methods of <see cref="LocalizableString"/>.

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Formats the value of the current instance using the optionally specified format. 
         /// </summary>
-        public string? ToString(IFormatProvider? formatProvider)
+        public string ToString(IFormatProvider? formatProvider)
         {
             try
             {
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis
         /// Provides the implementation of ToString. ToString will provide a default value
         /// if this method throws an exception.
         /// </summary>
-        protected abstract string? GetText(IFormatProvider? formatProvider);
+        protected abstract string GetText(IFormatProvider? formatProvider);
 
         /// <summary>
         /// Provides the implementation of GetHashCode. GetHashCode will provide a default value

--- a/src/Compilers/Core/Portable/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Location.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Symbols;
@@ -35,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The syntax tree this location is located in or <c>null</c> if not in a syntax tree.
         /// </summary>
-        public virtual SyntaxTree SourceTree { get { return null; } }
+        public virtual SyntaxTree? SourceTree { get { return null; } }
 
         /// <summary>
         /// Returns the metadata module the location is associated with or <c>null</c> if the module is not available.
@@ -44,9 +46,9 @@ namespace Microsoft.CodeAnalysis
         /// Might return null even if <see cref="IsInMetadata"/> returns true. The module symbol might not be available anymore, 
         /// for example, if the location is serialized and deserialized.
         /// </remarks>
-        public IModuleSymbol MetadataModule { get { return (IModuleSymbol)MetadataModuleInternal?.GetISymbol(); } }
+        public IModuleSymbol? MetadataModule { get { return (IModuleSymbol?)MetadataModuleInternal?.GetISymbol(); } }
 
-        internal virtual IModuleSymbolInternal MetadataModuleInternal { get { return null; } }
+        internal virtual IModuleSymbolInternal? MetadataModuleInternal { get { return null; } }
 
         /// <summary>
         /// The location within the syntax tree that this location is associated with.
@@ -85,7 +87,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // Derived classes should provide value equality semantics.
-        public abstract override bool Equals(object obj);
+        public abstract override bool Equals(object? obj);
         public abstract override int GetHashCode();
 
         public override string ToString()
@@ -115,7 +117,7 @@ namespace Microsoft.CodeAnalysis
             return result;
         }
 
-        public static bool operator ==(Location left, Location right)
+        public static bool operator ==(Location? left, Location? right)
         {
             if (object.ReferenceEquals(left, null))
             {
@@ -125,7 +127,7 @@ namespace Microsoft.CodeAnalysis
             return left.Equals(right);
         }
 
-        public static bool operator !=(Location left, Location right)
+        public static bool operator !=(Location? left, Location? right)
         {
             return !(left == right);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/LocationKind.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocationKind.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/Core/Portable/Diagnostic/MetadataLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/MetadataLocation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// A program location in metadata.
     /// </summary>
-    internal sealed class MetadataLocation : Location, IEquatable<MetadataLocation>
+    internal sealed class MetadataLocation : Location, IEquatable<MetadataLocation?>
     {
         private readonly IModuleSymbolInternal _module;
 

--- a/src/Compilers/Core/Portable/Diagnostic/MetadataLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/MetadataLocation.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -15,7 +18,7 @@ namespace Microsoft.CodeAnalysis
 
         internal MetadataLocation(IModuleSymbolInternal module)
         {
-            Debug.Assert(module != null);
+            RoslynDebug.Assert(module != null);
             _module = module;
         }
 
@@ -34,14 +37,14 @@ namespace Microsoft.CodeAnalysis
             return _module.GetHashCode();
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as MetadataLocation);
         }
 
-        public bool Equals(MetadataLocation other)
+        public bool Equals(MetadataLocation? other)
         {
-            return other != null && other._module == _module;
+            return other is object && other._module == _module;
         }
     }
 }

--- a/src/Compilers/Core/Portable/Diagnostic/NoLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/NoLocation.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
@@ -19,7 +21,7 @@ namespace Microsoft.CodeAnalysis
             get { return LocationKind.None; }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (object)this == obj;
         }

--- a/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// <summary>
     /// Contains information about the source of a programmatic diagnostic suppression produced by an <see cref="DiagnosticSuppressor"/>.
     /// </summary>
-    internal sealed class ProgrammaticSuppressionInfo : IEquatable<ProgrammaticSuppressionInfo>
+    internal sealed class ProgrammaticSuppressionInfo : IEquatable<ProgrammaticSuppressionInfo?>
     {
         public ImmutableHashSet<(string Id, LocalizableString Justification)> Suppressions { get; }
 

--- a/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 
@@ -17,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Suppressions = suppressions;
         }
 
-        public bool Equals(ProgrammaticSuppressionInfo other)
+        public bool Equals(ProgrammaticSuppressionInfo? other)
         {
             if (ReferenceEquals(this, other))
             {

--- a/src/Compilers/Core/Portable/Diagnostic/ReportDiagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ReportDiagnostic.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -101,7 +103,7 @@ namespace Microsoft.CodeAnalysis
             return _syntaxTree.GetMappedLineSpan(_span);
         }
 
-        public bool Equals(SourceLocation other)
+        public bool Equals(SourceLocation? other)
         {
             if (ReferenceEquals(this, other))
             {
@@ -111,7 +113,7 @@ namespace Microsoft.CodeAnalysis
             return other != null && other._syntaxTree == _syntaxTree && other._span == _span;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return this.Equals(obj as SourceLocation);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// A program location in source code.
     /// </summary>
-    internal sealed class SourceLocation : Location, IEquatable<SourceLocation>
+    internal sealed class SourceLocation : Location, IEquatable<SourceLocation?>
     {
         private readonly SyntaxTree _syntaxTree;
         private readonly TextSpan _span;

--- a/src/Compilers/Core/Portable/Diagnostic/SuppressionDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SuppressionDescriptor.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Utilities;
@@ -68,7 +70,7 @@ namespace Microsoft.CodeAnalysis
             this.Justification = justification ?? throw new ArgumentNullException(nameof(justification));
         }
 
-        public bool Equals(SuppressionDescriptor other)
+        public bool Equals(SuppressionDescriptor? other)
         {
             if (ReferenceEquals(this, other))
             {
@@ -82,7 +84,7 @@ namespace Microsoft.CodeAnalysis
                 this.Justification.Equals(other.Justification);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as SuppressionDescriptor);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/SuppressionDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SuppressionDescriptor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Provides a description about a programmatic suppression of a <see cref="Diagnostic"/> by a <see cref="DiagnosticSuppressor"/>.
     /// </summary>
-    public sealed class SuppressionDescriptor : IEquatable<SuppressionDescriptor>
+    public sealed class SuppressionDescriptor : IEquatable<SuppressionDescriptor?>
     {
         /// <summary>
         /// An unique identifier for the suppression.

--- a/src/Compilers/Core/Portable/Diagnostic/SuppressionInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SuppressionInfo.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     /// <summary>
@@ -16,9 +18,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// If the diagnostic was suppressed by an attribute, then returns that attribute.
         /// Otherwise, returns null.
         /// </summary>
-        public AttributeData Attribute { get; }
+        public AttributeData? Attribute { get; }
 
-        internal SuppressionInfo(string id, AttributeData attribute)
+        internal SuppressionInfo(string id, AttributeData? attribute)
         {
             Id = id;
             Attribute = attribute;

--- a/src/Compilers/Core/Portable/Diagnostic/WellKnownDiagnosticTags.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/WellKnownDiagnosticTags.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/Core/Portable/Diagnostic/XmlLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/XmlLocation.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Xml.Linq;
@@ -56,7 +58,7 @@ namespace Microsoft.CodeAnalysis
             return _positionSpan;
         }
 
-        public bool Equals(XmlLocation other)
+        public bool Equals(XmlLocation? other)
         {
             if (ReferenceEquals(this, other))
             {
@@ -66,7 +68,7 @@ namespace Microsoft.CodeAnalysis
             return other != null && other._positionSpan.Equals(_positionSpan);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return this.Equals(obj as XmlLocation);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/XmlLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/XmlLocation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// A program location in an XML file.
     /// </summary>
-    internal class XmlLocation : Location, IEquatable<XmlLocation>
+    internal class XmlLocation : Location, IEquatable<XmlLocation?>
     {
         private readonly FileLinePositionSpan _positionSpan;
 

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -131,7 +133,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets the first declaration symbol that matches the declaration id string, order undefined.
         /// </summary>
-        public static ISymbol GetFirstSymbolForDeclarationId(string id, Compilation compilation)
+        public static ISymbol? GetFirstSymbolForDeclarationId(string id, Compilation compilation)
         {
             if (id == null)
             {
@@ -214,7 +216,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets the first symbol that matches the reference id string, order undefined.
         /// </summary>
-        public static ISymbol GetFirstSymbolForReferenceId(string id, Compilation compilation)
+        public static ISymbol? GetFirstSymbolForReferenceId(string id, Compilation compilation)
         {
             if (id == null)
             {
@@ -243,7 +245,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static int GetTotalTypeParameterCount(INamedTypeSymbol symbol)
+        private static int GetTotalTypeParameterCount(INamedTypeSymbol? symbol)
         {
             int n = 0;
             while (symbol != null)
@@ -354,7 +356,7 @@ namespace Microsoft.CodeAnalysis
             private class Generator : SymbolVisitor<bool>
             {
                 private readonly StringBuilder _builder;
-                private ReferenceGenerator _referenceGenerator;
+                private ReferenceGenerator? _referenceGenerator;
 
                 public Generator(StringBuilder builder)
                 {
@@ -502,15 +504,15 @@ namespace Microsoft.CodeAnalysis
         private class ReferenceGenerator : SymbolVisitor<bool>
         {
             private readonly StringBuilder _builder;
-            private readonly ISymbol _typeParameterContext;
+            private readonly ISymbol? _typeParameterContext;
 
-            public ReferenceGenerator(StringBuilder builder, ISymbol typeParameterContext)
+            public ReferenceGenerator(StringBuilder builder, ISymbol? typeParameterContext)
             {
                 _builder = builder;
                 _typeParameterContext = typeParameterContext;
             }
 
-            public ISymbol TypeParameterContext
+            public ISymbol? TypeParameterContext
             {
                 get { return _typeParameterContext; }
             }
@@ -810,7 +812,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private static ITypeSymbol ParseTypeSymbol(string id, ref int index, Compilation compilation, ISymbol typeParameterContext)
+            private static ITypeSymbol? ParseTypeSymbol(string id, ref int index, Compilation compilation, ISymbol? typeParameterContext)
             {
                 var results = s_symbolListPool.Allocate();
                 try
@@ -831,7 +833,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private static void ParseTypeSymbol(string id, ref int index, Compilation compilation, ISymbol typeParameterContext, List<ISymbol> results)
+            private static void ParseTypeSymbol(string id, ref int index, Compilation compilation, ISymbol? typeParameterContext, List<ISymbol> results)
             {
                 var ch = PeekNextChar(id, index);
 
@@ -919,7 +921,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private static void ParseTypeParameterSymbol(string id, ref int index, ISymbol typeParameterContext, List<ISymbol> results)
+            private static void ParseTypeParameterSymbol(string id, ref int index, ISymbol? typeParameterContext, List<ISymbol> results)
             {
                 // skip the first `
                 System.Diagnostics.Debug.Assert(PeekNextChar(id, index) == '`');
@@ -956,7 +958,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            private static void ParseNamedTypeSymbol(string id, ref int index, Compilation compilation, ISymbol typeParameterContext, List<ISymbol> results)
+            private static void ParseNamedTypeSymbol(string id, ref int index, Compilation compilation, ISymbol? typeParameterContext, List<ISymbol> results)
             {
                 var containers = s_namespaceOrTypeListPool.Allocate();
                 try
@@ -968,7 +970,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         var name = ParseName(id, ref index);
 
-                        List<ITypeSymbol> typeArguments = null;
+                        List<ITypeSymbol>? typeArguments = null;
                         int arity = 0;
 
                         // type arguments
@@ -1067,7 +1069,7 @@ namespace Microsoft.CodeAnalysis
                 return bounds;
             }
 
-            private static bool ParseTypeArguments(string id, ref int index, Compilation compilation, ISymbol typeParameterContext, List<ITypeSymbol> typeArguments)
+            private static bool ParseTypeArguments(string id, ref int index, Compilation compilation, ISymbol? typeParameterContext, List<ITypeSymbol> typeArguments)
             {
                 index++; // skip over {
 
@@ -1187,7 +1189,7 @@ namespace Microsoft.CodeAnalysis
                             var methodSymbol = symbol as IMethodSymbol;
                             if (methodSymbol != null && methodSymbol.Arity == arity)
                             {
-                                parameters?.Clear();
+                                parameters.Clear();
 
                                 if (PeekNextChar(id, index) == '(')
                                 {
@@ -1198,15 +1200,7 @@ namespace Microsoft.CodeAnalysis
                                     }
                                 }
 
-                                if (parameters == null)
-                                {
-                                    if (methodSymbol.Parameters.Length != 0)
-                                    {
-                                        // parameters don't match, try next method symbol
-                                        continue;
-                                    }
-                                }
-                                else if (!AllParametersMatch(methodSymbol.Parameters, parameters))
+                                if (!AllParametersMatch(methodSymbol.Parameters, parameters))
                                 {
                                     // parameters don't match, try next method symbol
                                     continue;
@@ -1215,7 +1209,7 @@ namespace Microsoft.CodeAnalysis
                                 if (PeekNextChar(id, index) == '~')
                                 {
                                     index++;
-                                    ITypeSymbol returnType = ParseTypeSymbol(id, ref index, compilation, methodSymbol);
+                                    ITypeSymbol? returnType = ParseTypeSymbol(id, ref index, compilation, methodSymbol);
 
                                     // if return type is specified, then it must match
                                     if (returnType != null && methodSymbol.ReturnType.Equals(returnType))
@@ -1248,7 +1242,7 @@ namespace Microsoft.CodeAnalysis
                 int startIndex = index;
                 int endIndex = index;
 
-                List<ParameterInfo> parameters = null;
+                List<ParameterInfo>? parameters = null;
                 try
                 {
                     for (int i = 0, n = containers.Count; i < n; i++)
@@ -1442,7 +1436,7 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            private static ParameterInfo? ParseParameter(string id, ref int index, Compilation compilation, ISymbol typeParameterContext)
+            private static ParameterInfo? ParseParameter(string id, ref int index, Compilation compilation, ISymbol? typeParameterContext)
             {
                 bool isRefOrOut = false;
 

--- a/src/Compilers/Core/Portable/EmbeddedText.cs
+++ b/src/Compilers/Core/Portable/EmbeddedText.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -50,7 +52,7 @@ namespace Microsoft.CodeAnalysis
 
         private EmbeddedText(string filePath, ImmutableArray<byte> checksum, SourceHashAlgorithm checksumAlgorithm, ImmutableArray<byte> blob)
         {
-            Debug.Assert(filePath?.Length > 0);
+            Debug.Assert(filePath.Length > 0);
             Debug.Assert(SourceHashAlgorithms.IsSupportedAlgorithm(checksumAlgorithm));
             Debug.Assert(!blob.IsDefault && blob.Length >= sizeof(int));
 
@@ -209,9 +211,9 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal static ImmutableArray<byte> CreateBlob(Stream stream)
         {
-            Debug.Assert(stream != null);
-            Debug.Assert(stream.CanRead);
-            Debug.Assert(stream.CanSeek);
+            RoslynDebug.Assert(stream != null);
+            RoslynDebug.Assert(stream.CanRead);
+            RoslynDebug.Assert(stream.CanSeek);
 
             long longLength = stream.Length;
             Debug.Assert(longLength >= 0);
@@ -262,7 +264,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static ImmutableArray<byte> CreateBlob(ArraySegment<byte> bytes)
         {
-            Debug.Assert(bytes.Array != null);
+            RoslynDebug.Assert(bytes.Array != null);
 
             if (bytes.Count < CompressionThreshold)
             {
@@ -291,10 +293,10 @@ namespace Microsoft.CodeAnalysis
 
         private static ImmutableArray<byte> CreateBlob(SourceText text)
         {
-            Debug.Assert(text != null);
-            Debug.Assert(text.CanBeEmbedded);
-            Debug.Assert(text.Encoding != null);
-            Debug.Assert(text.PrecomputedEmbeddedTextBlob.IsDefault);
+            RoslynDebug.Assert(text != null);
+            RoslynDebug.Assert(text.CanBeEmbedded);
+            RoslynDebug.Assert(text.Encoding != null);
+            RoslynDebug.Assert(text.PrecomputedEmbeddedTextBlob.IsDefault);
 
             int maxByteCount;
             try

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -69,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Text
         /// </exception>
         /// <exception cref="IOException">An IO error occurred while reading from the stream.</exception>
         internal static SourceText Create(Stream stream,
-            Encoding defaultEncoding = null,
+            Encoding? defaultEncoding = null,
             SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1,
             bool canBeEmbedded = false)
         {
@@ -81,12 +83,12 @@ namespace Microsoft.CodeAnalysis.Text
         }
 
         private static SourceText Create(Stream stream, Lazy<Encoding> getEncoding,
-            Encoding defaultEncoding = null,
+            Encoding? defaultEncoding = null,
             SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1,
             bool canBeEmbedded = false)
         {
-            Debug.Assert(stream != null);
-            Debug.Assert(stream.CanRead && stream.CanSeek);
+            RoslynDebug.Assert(stream != null);
+            RoslynDebug.Assert(stream.CanRead && stream.CanSeek);
 
             bool detectEncoding = defaultEncoding == null;
             if (detectEncoding)
@@ -129,8 +131,8 @@ namespace Microsoft.CodeAnalysis.Text
             bool throwIfBinaryDetected = false,
             bool canBeEmbedded = false)
         {
-            Debug.Assert(data != null);
-            Debug.Assert(encoding != null);
+            RoslynDebug.Assert(data != null);
+            RoslynDebug.Assert(encoding != null);
 
             data.Seek(0, SeekOrigin.Begin);
 
@@ -188,8 +190,8 @@ namespace Microsoft.CodeAnalysis.Text
         private static bool TryGetBytesFromFileStream(FileStream stream,
                                                       out ArraySegment<byte> bytes)
         {
-            Debug.Assert(stream != null);
-            Debug.Assert(stream.Position == 0);
+            RoslynDebug.Assert(stream != null);
+            RoslynDebug.Assert(stream.Position == 0);
 
             int length = (int)stream.Length;
             if (length == 0)

--- a/src/Compilers/Core/Portable/EnumConstantHelper.cs
+++ b/src/Compilers/Core/Portable/EnumConstantHelper.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;

--- a/src/Compilers/Core/Portable/FileKey.cs
+++ b/src/Compilers/Core/Portable/FileKey.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Compilers/Core/Portable/FileSystemExtensions.cs
+++ b/src/Compilers/Core/Portable/FileSystemExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -30,10 +32,10 @@ namespace Microsoft.CodeAnalysis
         public static EmitResult Emit(
             this Compilation compilation,
             string outputPath,
-            string pdbPath = null,
-            string xmlDocPath = null,
-            string win32ResourcesPath = null,
-            IEnumerable<ResourceDescription> manifestResources = null,
+            string? pdbPath = null,
+            string? xmlDocPath = null,
+            string? win32ResourcesPath = null,
+            IEnumerable<ResourceDescription>? manifestResources = null,
             CancellationToken cancellationToken = default)
         {
             if (compilation == null)

--- a/src/Compilers/Core/Portable/InternalImplementationOnlyAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalImplementationOnlyAttribute.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace System.Runtime.CompilerServices
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/BlobBuildingStream.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/BlobBuildingStream.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/MultiDictionary.cs
@@ -1,20 +1,25 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
     // Note that this is not threadsafe for concurrent reading and writing.
     internal sealed class MultiDictionary<K, V> : IEnumerable<KeyValuePair<K, MultiDictionary<K, V>.ValueSet>>
+        where K : notnull
     {
         public struct ValueSet : IEnumerable<V>
         {
             public struct Enumerator : IEnumerator<V>
             {
+                [AllowNull]
                 private readonly V _value;
                 private ImmutableHashSet<V>.Enumerator _values;
                 private int _count;
@@ -57,7 +62,7 @@ namespace Roslyn.Utilities
                     throw new NotSupportedException();
                 }
 
-                object IEnumerator.Current => this.Current;
+                object? IEnumerator.Current => this.Current;
 
                 // Note that this property is not guaranteed to throw either before MoveNext()
                 // has been called or after the end of the set has been reached.
@@ -93,7 +98,7 @@ namespace Roslyn.Utilities
             }
 
             // Stores either a single V or an ImmutableHashSet<V>
-            private readonly object _value;
+            private readonly object? _value;
 
             private readonly IEqualityComparer<V> _equalityComparer;
 
@@ -123,7 +128,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            public ValueSet(object value, IEqualityComparer<V> equalityComparer = null)
+            public ValueSet(object? value, IEqualityComparer<V>? equalityComparer = null)
             {
                 _value = value;
                 _equalityComparer = equalityComparer ?? ImmutableHashSet<V>.Empty.KeyComparer;
@@ -151,12 +156,12 @@ namespace Roslyn.Utilities
                 var set = _value as ImmutableHashSet<V>;
                 if (set == null)
                 {
-                    if (_equalityComparer.Equals((V)_value, v))
+                    if (_equalityComparer.Equals((V)_value!, v))
                     {
                         return this;
                     }
 
-                    set = ImmutableHashSet.Create(_equalityComparer, (V)_value);
+                    set = ImmutableHashSet.Create(_equalityComparer, (V)_value!);
                 }
 
                 return new ValueSet(set.Add(v), _equalityComparer);
@@ -167,7 +172,7 @@ namespace Roslyn.Utilities
                 var set = _value as ImmutableHashSet<V>;
                 if (set == null)
                 {
-                    return _equalityComparer.Equals((V)_value, v);
+                    return _equalityComparer.Equals((V)_value!, v);
                 }
 
                 return set.Contains(v);
@@ -188,7 +193,7 @@ namespace Roslyn.Utilities
 
             public V Single()
             {
-                Debug.Assert(_value is V); // Implies value != null
+                RoslynDebug.Assert(_value is V); // Implies value != null
                 return (V)_value;
             }
 
@@ -200,7 +205,7 @@ namespace Roslyn.Utilities
 
         private readonly Dictionary<K, ValueSet> _dictionary;
 
-        private readonly IEqualityComparer<V> _valueComparer;
+        private readonly IEqualityComparer<V>? _valueComparer;
 
         public int Count => _dictionary.Count;
 
@@ -231,7 +236,7 @@ namespace Roslyn.Utilities
             _dictionary = new Dictionary<K, ValueSet>(comparer);
         }
 
-        public MultiDictionary(int capacity, IEqualityComparer<K> comparer, IEqualityComparer<V> valueComparer = null)
+        public MultiDictionary(int capacity, IEqualityComparer<K> comparer, IEqualityComparer<V>? valueComparer = null)
         {
             _dictionary = new Dictionary<K, ValueSet>(capacity, comparer);
             _valueComparer = valueComparer;

--- a/src/Compilers/Core/Portable/InternalUtilities/NullableAttributes.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NullableAttributes.cs
@@ -5,6 +5,8 @@
 // This was copied from https://github.com/dotnet/coreclr/blob/60f1e6265bd1039f023a82e0643b524d6aaf7845/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.
 
+#nullable enable
+
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/ReadOnlyUnmanagedMemoryStream.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReadOnlyUnmanagedMemoryStream.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/Compilers/Core/Portable/InternalUtilities/SetWithInsertionOrder.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SetWithInsertionOrder.cs
@@ -96,7 +96,6 @@ namespace Roslyn.Utilities
 
         public ImmutableArray<T> AsImmutable() => _elements.ToImmutableArrayOrEmpty();
 
-        [MaybeNull]
-        public T this[int i] => _elements is null ? default : _elements[i];
+        public T this[int i] => _elements![i];
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/SetWithInsertionOrder.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SetWithInsertionOrder.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,8 +20,8 @@ namespace Roslyn.Utilities
     /// </summary>
     internal sealed class SetWithInsertionOrder<T> : IEnumerable<T>, IReadOnlySet<T>
     {
-        private HashSet<T> _set = null;
-        private ArrayBuilder<T> _elements = null;
+        private HashSet<T>? _set = null;
+        private ArrayBuilder<T>? _elements = null;
 
         public bool Add(T value)
         {
@@ -33,7 +36,7 @@ namespace Roslyn.Utilities
                 return false;
             }
 
-            _elements.Add(value);
+            _elements!.Add(value);
             return true;
         }
 
@@ -56,7 +59,7 @@ namespace Roslyn.Utilities
 
                 try
                 {
-                    _elements.Insert(index, value);
+                    _elements!.Insert(index, value);
                 }
                 catch
                 {
@@ -69,11 +72,16 @@ namespace Roslyn.Utilities
 
         public bool Remove(T value)
         {
+            if (_set is null)
+            {
+                return false;
+            }
+
             if (!_set.Remove(value))
             {
                 return false;
             }
-            _elements.RemoveAt(_elements.IndexOf(value));
+            _elements!.RemoveAt(_elements.IndexOf(value));
             return true;
         }
 
@@ -88,6 +96,7 @@ namespace Roslyn.Utilities
 
         public ImmutableArray<T> AsImmutable() => _elements.ToImmutableArrayOrEmpty();
 
-        public T this[int i] => _elements[i];
+        [MaybeNull]
+        public T this[int i] => _elements is null ? default : _elements[i];
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Text;
@@ -76,18 +78,17 @@ namespace Roslyn.Utilities
         // implement Poolable object pattern
         #region "Poolable"
 
-        private StringTable(ObjectPool<StringTable> pool)
+        private StringTable(ObjectPool<StringTable>? pool)
         {
             _pool = pool;
         }
 
-        private readonly ObjectPool<StringTable> _pool;
+        private readonly ObjectPool<StringTable>? _pool;
         private static readonly ObjectPool<StringTable> s_staticPool = CreatePool();
 
         private static ObjectPool<StringTable> CreatePool()
         {
-            ObjectPool<StringTable> pool = null;
-            pool = new ObjectPool<StringTable>(() => new StringTable(pool), Environment.ProcessorCount * 2);
+            var pool = new ObjectPool<StringTable>(pool => new StringTable(pool), Environment.ProcessorCount * 2);
             return pool;
         }
 
@@ -102,7 +103,7 @@ namespace Roslyn.Utilities
             // Array.Clear(this.localTable, 0, this.localTable.Length);
             // Array.Clear(sharedTable, 0, sharedTable.Length);
 
-            _pool.Free(this);
+            _pool?.Free(this);
         }
 
         #endregion // Poolable
@@ -127,7 +128,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            string shared = FindSharedEntry(chars, start, len, hashCode);
+            string? shared = FindSharedEntry(chars, start, len, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -161,7 +162,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            string shared = FindSharedEntry(chars, start, len, hashCode);
+            string? shared = FindSharedEntry(chars, start, len, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -195,7 +196,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -229,7 +230,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -263,7 +264,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -280,12 +281,12 @@ namespace Roslyn.Utilities
         }
 
 
-        private static string FindSharedEntry(char[] chars, int start, int len, int hashCode)
+        private static string? FindSharedEntry(char[] chars, int start, int len, int hashCode)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -315,12 +316,12 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        private static string FindSharedEntry(string chars, int start, int len, int hashCode)
+        private static string? FindSharedEntry(string chars, int start, int len, int hashCode)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -350,12 +351,12 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        private static string FindSharedEntryASCII(int hashCode, ReadOnlySpan<byte> asciiChars)
+        private static string? FindSharedEntryASCII(int hashCode, ReadOnlySpan<byte> asciiChars)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -385,12 +386,12 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        private static string FindSharedEntry(char chars, int hashCode)
+        private static string? FindSharedEntry(char chars, int hashCode)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -419,12 +420,12 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        private static string FindSharedEntry(StringBuilder chars, int hashCode)
+        private static string? FindSharedEntry(StringBuilder chars, int hashCode)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -454,12 +455,12 @@ namespace Roslyn.Utilities
             return e;
         }
 
-        private static string FindSharedEntry(string chars, int hashCode)
+        private static string? FindSharedEntry(string chars, int hashCode)
         {
             var arr = s_sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -565,7 +566,7 @@ foundIdx:
         {
             var hashCode = Hash.GetFNVHashCode(chars);
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 return shared;
@@ -587,7 +588,7 @@ foundIdx:
 
             if (isAscii)
             {
-                string shared = FindSharedEntryASCII(hashCode, bytes);
+                string? shared = FindSharedEntryASCII(hashCode, bytes);
                 if (shared != null)
                 {
                     return shared;

--- a/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
@@ -113,8 +113,7 @@ namespace Roslyn.Utilities
 
         #endregion // Poolable
 
-        [return: MaybeNull]
-        internal T FindItem(char[] chars, int start, int len, int hashCode)
+        internal T? FindItem(char[] chars, int start, int len, int hashCode)
         {
             // get direct element reference to avoid extra range checks
             ref var localSlot = ref _localTable[LocalIdxFromHash(hashCode)];

--- a/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/TextKeyedCache.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -67,7 +70,7 @@ namespace Roslyn.Utilities
 
         // random - used for selecting a victim in the shared cache.
         // TODO: consider whether a counter is random enough
-        private Random _random;
+        private Random? _random;
 
         internal TextKeyedCache() :
             this(null)
@@ -77,19 +80,20 @@ namespace Roslyn.Utilities
         // implement Poolable object pattern
         #region "Poolable"
 
-        private TextKeyedCache(ObjectPool<TextKeyedCache<T>> pool)
+        private TextKeyedCache(ObjectPool<TextKeyedCache<T>>? pool)
         {
             _pool = pool;
             _strings = new StringTable();
         }
 
-        private readonly ObjectPool<TextKeyedCache<T>> _pool;
+        private readonly ObjectPool<TextKeyedCache<T>>? _pool;
         private static readonly ObjectPool<TextKeyedCache<T>> s_staticPool = CreatePool();
 
         private static ObjectPool<TextKeyedCache<T>> CreatePool()
         {
-            ObjectPool<TextKeyedCache<T>> pool = null;
-            pool = new ObjectPool<TextKeyedCache<T>>(() => new TextKeyedCache<T>(pool), Environment.ProcessorCount * 4);
+            var pool = new ObjectPool<TextKeyedCache<T>>(
+                pool => new TextKeyedCache<T>(pool),
+                Environment.ProcessorCount * 4);
             return pool;
         }
 
@@ -104,11 +108,12 @@ namespace Roslyn.Utilities
             // Array.Clear(this.localTable, 0, this.localTable.Length);
             // Array.Clear(sharedTable, 0, sharedTable.Length);
 
-            _pool.Free(this);
+            _pool?.Free(this);
         }
 
         #endregion // Poolable
 
+        [return: MaybeNull]
         internal T FindItem(char[] chars, int start, int len, int hashCode)
         {
             // get direct element reference to avoid extra range checks
@@ -124,7 +129,7 @@ namespace Roslyn.Utilities
                 }
             }
 
-            SharedEntryValue e = FindSharedEntry(chars, start, len, hashCode);
+            SharedEntryValue? e = FindSharedEntry(chars, start, len, hashCode);
             if (e != null)
             {
                 localSlot.HashCode = hashCode;
@@ -136,15 +141,15 @@ namespace Roslyn.Utilities
                 return tk;
             }
 
-            return null;
+            return null!;
         }
 
-        private SharedEntryValue FindSharedEntry(char[] chars, int start, int len, int hashCode)
+        private SharedEntryValue? FindSharedEntry(char[] chars, int start, int len, int hashCode)
         {
             var arr = _sharedTableInst;
             int idx = SharedIdxFromHash(hashCode);
 
-            SharedEntryValue e = null;
+            SharedEntryValue? e = null;
             int hash;
 
             // we use quadratic probing here

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -123,7 +125,7 @@ namespace Roslyn.Utilities
             {
                 while (j < oldSize)
                 {
-                    _items[j++] = null;
+                    _items[j++] = null!;
                 }
             }
         }

--- a/src/Compilers/Core/Portable/Optional.cs
+++ b/src/Compilers/Core/Portable/Optional.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis

--- a/src/Compilers/Core/Portable/PEWriter/IFileReference.cs
+++ b/src/Compilers/Core/Portable/PEWriter/IFileReference.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// File name with extension.
         /// </summary>
-        string FileName { get; }
+        string? FileName { get; }
 
         /// <summary>
         /// A hash of the file contents.

--- a/src/Compilers/Core/Portable/PEWriter/ManagedResource.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ManagedResource.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Cci
         /// <paramref name="streamProvider"/> streamProvider callers will dispose result after use.
         /// <paramref name="streamProvider"/> and <paramref name="fileReference"/> are mutually exclusive.
         /// </summary>
-        internal ManagedResource(string name, bool isPublic, Func<Stream> streamProvider, IFileReference fileReference, uint offset)
+        internal ManagedResource(string name, bool isPublic, Func<Stream>? streamProvider, IFileReference? fileReference, uint offset)
         {
-            Debug.Assert(streamProvider == null ^ fileReference == null);
+            RoslynDebug.Assert(streamProvider == null ^ fileReference == null);
 
             _streamProvider = streamProvider;
             _name = name;

--- a/src/Compilers/Core/Portable/RealParser.cs
+++ b/src/Compilers/Core/Portable/RealParser.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Numerics;

--- a/src/Compilers/Core/Portable/ResourceDescription.cs
+++ b/src/Compilers/Core/Portable/ResourceDescription.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.IO;
 using Roslyn.Utilities;
@@ -17,7 +19,7 @@ namespace Microsoft.CodeAnalysis
     public sealed class ResourceDescription : Cci.IFileReference
     {
         internal readonly string ResourceName;
-        internal readonly string FileName; // null if embedded
+        internal readonly string? FileName; // null if embedded
         internal readonly bool IsPublic;
         internal readonly Func<Stream> DataProvider;
         private readonly CryptographicHashProvider _hashes;
@@ -34,7 +36,7 @@ namespace Microsoft.CodeAnalysis
         /// Returns a stream of the data to embed.
         /// </remarks> 
         public ResourceDescription(string resourceName, Func<Stream> dataProvider, bool isPublic)
-            : this(resourceName, null, dataProvider, isPublic, isEmbedded: true, checkArgs: true)
+            : this(resourceName, fileName: null, dataProvider, isPublic, isEmbedded: true, checkArgs: true)
         {
         }
 
@@ -50,12 +52,12 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Function returning a stream of the resource content (used to calculate hash).
         /// </remarks>
-        public ResourceDescription(string resourceName, string fileName, Func<Stream> dataProvider, bool isPublic)
+        public ResourceDescription(string resourceName, string? fileName, Func<Stream> dataProvider, bool isPublic)
             : this(resourceName, fileName, dataProvider, isPublic, isEmbedded: false, checkArgs: true)
         {
         }
 
-        internal ResourceDescription(string resourceName, string fileName, Func<Stream> dataProvider, bool isPublic, bool isEmbedded, bool checkArgs)
+        internal ResourceDescription(string resourceName, string? fileName, Func<Stream> dataProvider, bool isPublic, bool isEmbedded, bool checkArgs)
         {
             if (checkArgs)
             {
@@ -101,7 +103,7 @@ namespace Microsoft.CodeAnalysis
 
             public ResourceHashProvider(ResourceDescription resource)
             {
-                Debug.Assert(resource != null);
+                RoslynDebug.Assert(resource != null);
                 _resource = resource;
             }
 
@@ -141,7 +143,7 @@ namespace Microsoft.CodeAnalysis
             return _hashes.GetHash(algorithmId);
         }
 
-        string Cci.IFileReference.FileName
+        string? Cci.IFileReference.FileName
         {
             get { return FileName; }
         }

--- a/src/Compilers/Core/Portable/ResourceException.cs
+++ b/src/Compilers/Core/Portable/ResourceException.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.CodeAnalysis
 {
     internal sealed class ResourceException : Exception
     {
-        internal ResourceException(string name, Exception inner = null)
+        internal ResourceException(string? name, Exception? inner = null)
             : base(name, inner)
         {
         }

--- a/src/Compilers/Core/Portable/SignatureComparer.cs
+++ b/src/Compilers/Core/Portable/SignatureComparer.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -17,23 +19,23 @@ namespace Microsoft.CodeAnalysis
     {
         public static SourceFileResolver Default { get; } = new SourceFileResolver(ImmutableArray<string>.Empty, baseDirectory: null);
 
-        private readonly string _baseDirectory;
+        private readonly string? _baseDirectory;
         private readonly ImmutableArray<string> _searchPaths;
         private readonly ImmutableArray<KeyValuePair<string, string>> _pathMap;
 
-        public SourceFileResolver(IEnumerable<string> searchPaths, string baseDirectory)
+        public SourceFileResolver(IEnumerable<string> searchPaths, string? baseDirectory)
             : this(searchPaths.AsImmutableOrNull(), baseDirectory)
         {
         }
 
-        public SourceFileResolver(ImmutableArray<string> searchPaths, string baseDirectory)
+        public SourceFileResolver(ImmutableArray<string> searchPaths, string? baseDirectory)
             : this(searchPaths, baseDirectory, ImmutableArray<KeyValuePair<string, string>>.Empty)
         {
         }
 
         public SourceFileResolver(
             ImmutableArray<string> searchPaths,
-            string baseDirectory,
+            string? baseDirectory,
             ImmutableArray<KeyValuePair<string, string>> pathMap)
         {
             if (searchPaths.IsDefault)
@@ -86,19 +88,19 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public string BaseDirectory => _baseDirectory;
+        public string? BaseDirectory => _baseDirectory;
 
         public ImmutableArray<string> SearchPaths => _searchPaths;
 
         public ImmutableArray<KeyValuePair<string, string>> PathMap => _pathMap;
 
-        public override string NormalizePath(string path, string baseFilePath)
+        public override string? NormalizePath(string path, string baseFilePath)
         {
             string normalizedPath = FileUtilities.NormalizeRelativePath(path, baseFilePath, _baseDirectory);
             return (normalizedPath == null || _pathMap.IsDefaultOrEmpty) ? normalizedPath : PathUtilities.NormalizePathPrefix(normalizedPath, _pathMap);
         }
 
-        public override string ResolveReference(string path, string baseFilePath)
+        public override string? ResolveReference(string path, string baseFilePath)
         {
             string resolvedPath = FileUtilities.ResolveRelativePath(path, baseFilePath, _baseDirectory, _searchPaths, FileExists);
             if (resolvedPath == null)

--- a/src/Compilers/Core/Portable/SpecialMembers.cs
+++ b/src/Compilers/Core/Portable/SpecialMembers.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.RuntimeMembers;

--- a/src/Compilers/Core/Portable/SpecialTypeExtensions.cs
+++ b/src/Compilers/Core/Portable/SpecialTypeExtensions.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -249,7 +252,7 @@ namespace Microsoft.CodeAnalysis
 
         public static SpecialType FromRuntimeTypeOfLiteralValue(object value)
         {
-            Debug.Assert(value != null);
+            RoslynDebug.Assert(value != null);
 
             // Perf: Note that JIT optimizes each expression val.GetType() == typeof(T) to a single register comparison.
             // Also the checks are sorted by commonality of the checked types.

--- a/src/Compilers/Core/Portable/SwitchConstantValueHelper.cs
+++ b/src/Compilers/Core/Portable/SwitchConstantValueHelper.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -47,11 +49,11 @@ namespace Microsoft.CodeAnalysis
         /// </returns>
         public static int CompareSwitchCaseLabelConstants(ConstantValue first, ConstantValue second)
         {
-            Debug.Assert(first != null);
-            Debug.Assert(second != null);
+            RoslynDebug.Assert(first != null);
+            RoslynDebug.Assert(second != null);
 
-            Debug.Assert(IsValidSwitchCaseLabelConstant(first));
-            Debug.Assert(IsValidSwitchCaseLabelConstant(second));
+            RoslynDebug.Assert(IsValidSwitchCaseLabelConstant(first));
+            RoslynDebug.Assert(IsValidSwitchCaseLabelConstant(second));
 
             if (first.IsNull)
             {
@@ -96,7 +98,7 @@ namespace Microsoft.CodeAnalysis
         {
             public override bool Equals(object first, object second)
             {
-                Debug.Assert(first != null && second != null);
+                RoslynDebug.Assert(first != null && second != null);
 
                 var firstConstant = first as ConstantValue;
                 if (firstConstant != null)
@@ -147,7 +149,7 @@ namespace Microsoft.CodeAnalysis
                             return constant.UInt64Value.GetHashCode();
 
                         case ConstantValueTypeDiscriminator.String:
-                            return constant.RopeValue.GetHashCode();
+                            return constant.RopeValue!.GetHashCode();
                     }
                 }
 

--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis
         public static string DumpXML(TreeDumperNode root, string? indent = null)
         {
             var dumper = new TreeDumper();
-            dumper.DoDumpXML(root, string.Empty, string.IsNullOrEmpty(indent) ? string.Empty : indent!);
+            dumper.DoDumpXML(root, string.Empty, indent ?? string.Empty);
             return dumper._sb.ToString();
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis
 
         public TreeDumperNode(string text) : this(text, null, null) { }
         public object? Value { get; }
-        public string? Text { get; }
+        public string Text { get; }
         public IEnumerable<TreeDumperNode> Children { get; }
         public TreeDumperNode this[string child]
         {

--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -75,8 +77,8 @@ namespace Microsoft.CodeAnalysis
 
         private void DoDumpCompact(TreeDumperNode node, string indent)
         {
-            Debug.Assert(node != null);
-            Debug.Assert(indent != null);
+            RoslynDebug.Assert(node != null);
+            RoslynDebug.Assert(indent != null);
 
             // Precondition: indentation and prefix has already been output
             // Precondition: indent is correct for node's *children*
@@ -106,16 +108,16 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static string DumpXML(TreeDumperNode root, string indent = null)
+        public static string DumpXML(TreeDumperNode root, string? indent = null)
         {
             var dumper = new TreeDumper();
-            dumper.DoDumpXML(root, string.Empty, string.IsNullOrEmpty(indent) ? string.Empty : indent);
+            dumper.DoDumpXML(root, string.Empty, string.IsNullOrEmpty(indent) ? string.Empty : indent!);
             return dumper._sb.ToString();
         }
 
         private void DoDumpXML(TreeDumperNode node, string indent, string relativeIndent)
         {
-            Debug.Assert(node != null);
+            RoslynDebug.Assert(node != null);
             if (node.Children.All(child => child == null))
             {
                 _sb.Append(indent);
@@ -205,7 +207,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class TreeDumperNode
     {
-        public TreeDumperNode(string text, object value, IEnumerable<TreeDumperNode> children)
+        public TreeDumperNode(string text, object? value, IEnumerable<TreeDumperNode>? children)
         {
             this.Text = text;
             this.Value = value;
@@ -213,8 +215,8 @@ namespace Microsoft.CodeAnalysis
         }
 
         public TreeDumperNode(string text) : this(text, null, null) { }
-        public object Value { get; }
-        public string Text { get; }
+        public object? Value { get; }
+        public string? Text { get; }
         public IEnumerable<TreeDumperNode> Children { get; }
         public TreeDumperNode this[string child]
         {
@@ -225,10 +227,10 @@ namespace Microsoft.CodeAnalysis
         }
 
         // enumerates all edges of the tree yielding (parent, node) pairs. The first yielded value is (null, this).
-        public IEnumerable<KeyValuePair<TreeDumperNode, TreeDumperNode>> PreorderTraversal()
+        public IEnumerable<KeyValuePair<TreeDumperNode?, TreeDumperNode>> PreorderTraversal()
         {
-            var stack = new Stack<KeyValuePair<TreeDumperNode, TreeDumperNode>>();
-            stack.Push(new KeyValuePair<TreeDumperNode, TreeDumperNode>(null, this));
+            var stack = new Stack<KeyValuePair<TreeDumperNode?, TreeDumperNode>>();
+            stack.Push(new KeyValuePair<TreeDumperNode?, TreeDumperNode>(null, this));
             while (stack.Count != 0)
             {
                 var currentEdge = stack.Pop();
@@ -236,7 +238,7 @@ namespace Microsoft.CodeAnalysis
                 var currentNode = currentEdge.Value;
                 foreach (var child in currentNode.Children.Where(x => x != null).Reverse())
                 {
-                    stack.Push(new KeyValuePair<TreeDumperNode, TreeDumperNode>(currentNode, child));
+                    stack.Push(new KeyValuePair<TreeDumperNode?, TreeDumperNode>(currentNode, child));
                 }
             }
         }

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -169,7 +171,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// If build and/or revision numbers are 65535 they are replaced with time-based values.
         /// </summary>
-        public static Version GenerateVersionFromPatternAndCurrentTime(DateTime time, Version pattern)
+        public static Version? GenerateVersionFromPatternAndCurrentTime(DateTime time, Version pattern)
         {
             if (pattern == null || pattern.Revision != ushort.MaxValue)
             {

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -523,6 +523,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         break;
                     case LocationKind.SourceFile:
                         {
+                            RoslynDebug.Assert(location.SourceTree != null);
                             if (project.GetDocument(location.SourceTree) == null)
                             {
                                 // Disallow diagnostics with source locations outside this project.

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             // For most of analyzers, the number of diagnostic descriptors is small, so this should be cheap.
             var descriptors = AnalyzerService.GetDiagnosticDescriptors(analyzer);
-            return descriptors.Any(d => d.GetEffectiveSeverity(project.CompilationOptions) != ReportDiagnostic.Hidden);
+            return descriptors.Any(d => d.GetEffectiveSeverity(project.CompilationOptions!) != ReportDiagnostic.Hidden);
         }
 
         private void RaiseProjectDiagnosticsIfNeeded(

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     if (firstDeclaratingErrorOpt != null)
                     {
                         var location = firstDeclaratingErrorOpt.Location;
-                        DocumentAnalysisResults.Log.Write("Declaration errors, first: {0}", location.IsInSource ? location.SourceTree.FilePath : location.MetadataModule.Name);
+                        DocumentAnalysisResults.Log.Write("Declaration errors, first: {0}", location.IsInSource ? location.SourceTree!.FilePath : location.MetadataModule!.Name);
 
                         return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), ImmutableArray<RudeEditDiagnostic>.Empty, hasSemanticErrors: true);
                     }

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     case CommittedSolution.DocumentState.OutOfSync:
                         var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee);
-                        outOfSyncDiagnostics.Add(Diagnostic.Create(descriptor, Location.Create(document.FilePath!, textSpan: default, lineSpan: default), new[] { document.FilePath! }));
+                        outOfSyncDiagnostics.Add(Diagnostic.Create(descriptor, Location.Create(document.FilePath!, textSpan: default, lineSpan: default), new[] { document.FilePath }));
                         continue;
 
                     default:

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     case CommittedSolution.DocumentState.OutOfSync:
                         var descriptor = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.DocumentIsOutOfSyncWithDebuggee);
-                        outOfSyncDiagnostics.Add(Diagnostic.Create(descriptor, Location.Create(document.FilePath, textSpan: default, lineSpan: default), new[] { document.FilePath }));
+                        outOfSyncDiagnostics.Add(Diagnostic.Create(descriptor, Location.Create(document.FilePath!, textSpan: default, lineSpan: default), new[] { document.FilePath! }));
                         continue;
 
                     default:

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -23,8 +23,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         public readonly string Id;
         public readonly string Category;
-        public readonly string Message;
-        public readonly string ENUMessageForBingSearch;
+        public readonly string? Message;
+        public readonly string? ENUMessageForBingSearch;
 
         public readonly DiagnosticSeverity Severity;
         public readonly DiagnosticSeverity DefaultSeverity;
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public DiagnosticData(
             string id,
             string category,
-            string message,
-            string enuMessageForBingSearch,
+            string? message,
+            string? enuMessageForBingSearch,
             DiagnosticSeverity severity,
             DiagnosticSeverity defaultSeverity,
             bool isEnabledByDefault,
@@ -384,7 +384,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // Get the effective severity of the diagnostic from the compilation options.
                 // PERF: We do not check if the diagnostic was suppressed by a source suppression, as this requires us to force complete the assembly attributes, which is very expensive.
-                var reportDiagnostic = descriptor.GetEffectiveSeverity(project.CompilationOptions);
+                var reportDiagnostic = descriptor.GetEffectiveSeverity(project.CompilationOptions!);
                 if (reportDiagnostic == ReportDiagnostic.Suppress)
                 {
                     // Rule is disabled by compilation options.

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -24,14 +24,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     {
         public static readonly CultureInfo USCultureInfo = new CultureInfo("en-US");
 
-        public static string GetBingHelpMessage(this Diagnostic diagnostic, OptionSet options)
+        public static string? GetBingHelpMessage(this Diagnostic diagnostic, OptionSet options)
         {
             // We use the ENU version of the message for bing search.
             return options.GetOption(InternalDiagnosticsOptions.PutCustomTypeInBingSearch) ?
                 diagnostic.GetMessage(USCultureInfo) : diagnostic.Descriptor.GetBingHelpMessage();
         }
 
-        public static string GetBingHelpMessage(this DiagnosticDescriptor descriptor)
+        public static string? GetBingHelpMessage(this DiagnosticDescriptor descriptor)
         {
             // We use the ENU version of the message for bing search.
             return descriptor.MessageFormat.ToString(USCultureInfo);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -1029,7 +1029,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return null;
             }
 
-            ISymbol symbol;
+            ISymbol? symbol;
             if (crefAttribute is null)
             {
                 Contract.ThrowIfNull(candidate);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/LocationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/LocationExtensions.cs
@@ -9,16 +9,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
     internal static class LocationExtensions
     {
         public static SyntaxToken FindToken(this Location location, CancellationToken cancellationToken)
-            => location.SourceTree.GetRoot(cancellationToken).FindToken(location.SourceSpan.Start);
+            => location.SourceTree!.GetRoot(cancellationToken).FindToken(location.SourceSpan.Start);
 
         public static SyntaxNode FindNode(this Location location, CancellationToken cancellationToken)
-            => location.SourceTree.GetRoot(cancellationToken).FindNode(location.SourceSpan);
+            => location.SourceTree!.GetRoot(cancellationToken).FindNode(location.SourceSpan);
 
         public static SyntaxNode FindNode(this Location location, bool getInnermostNodeForTie, CancellationToken cancellationToken)
-            => location.SourceTree.GetRoot(cancellationToken).FindNode(location.SourceSpan, getInnermostNodeForTie: getInnermostNodeForTie);
+            => location.SourceTree!.GetRoot(cancellationToken).FindNode(location.SourceSpan, getInnermostNodeForTie: getInnermostNodeForTie);
 
         public static SyntaxNode FindNode(this Location location, bool findInsideTrivia, bool getInnermostNodeForTie, CancellationToken cancellationToken)
-            => location.SourceTree.GetRoot(cancellationToken).FindNode(location.SourceSpan, findInsideTrivia, getInnermostNodeForTie);
+            => location.SourceTree!.GetRoot(cancellationToken).FindNode(location.SourceSpan, findInsideTrivia, getInnermostNodeForTie);
 
         public static bool IsVisibleSourceLocation(this Location loc)
         {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/LocationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/LocationExtensions.cs
@@ -3,22 +3,29 @@
 #nullable enable
 
 using System.Threading;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static class LocationExtensions
     {
+        public static SyntaxTree GetSourceTreeOrThrow(this Location location)
+        {
+            Contract.ThrowIfNull(location.SourceTree);
+            return location.SourceTree;
+        }
+
         public static SyntaxToken FindToken(this Location location, CancellationToken cancellationToken)
-            => location.SourceTree!.GetRoot(cancellationToken).FindToken(location.SourceSpan.Start);
+            => location.GetSourceTreeOrThrow().GetRoot(cancellationToken).FindToken(location.SourceSpan.Start);
 
         public static SyntaxNode FindNode(this Location location, CancellationToken cancellationToken)
-            => location.SourceTree!.GetRoot(cancellationToken).FindNode(location.SourceSpan);
+            => location.GetSourceTreeOrThrow().GetRoot(cancellationToken).FindNode(location.SourceSpan);
 
         public static SyntaxNode FindNode(this Location location, bool getInnermostNodeForTie, CancellationToken cancellationToken)
-            => location.SourceTree!.GetRoot(cancellationToken).FindNode(location.SourceSpan, getInnermostNodeForTie: getInnermostNodeForTie);
+            => location.GetSourceTreeOrThrow().GetRoot(cancellationToken).FindNode(location.SourceSpan, getInnermostNodeForTie: getInnermostNodeForTie);
 
         public static SyntaxNode FindNode(this Location location, bool findInsideTrivia, bool getInnermostNodeForTie, CancellationToken cancellationToken)
-            => location.SourceTree!.GetRoot(cancellationToken).FindNode(location.SourceSpan, findInsideTrivia, getInnermostNodeForTie);
+            => location.GetSourceTreeOrThrow().GetRoot(cancellationToken).FindNode(location.SourceSpan, findInsideTrivia, getInnermostNodeForTie);
 
         public static bool IsVisibleSourceLocation(this Location loc)
         {


### PR DESCRIPTION
This change can be read commit by commit for easier reviewing. Each commit is limited to a single directory of files that changed. In the future I will try and divide up my pull requests better. Didn't realize it had grown to 80+ files.

This enables nullability for Microsoft.CodeAnalysis inside the Diagnostics and InternalUtilities directories. 
