### PR TITLE
Fix binding for AutomationName in preview pane

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml
@@ -11,7 +11,7 @@
              Foreground="{DynamicResource {x:Static vsui:EnvironmentColors.PanelTextBrushKey}}"
              d:DesignHeight="300" d:DesignWidth="400" 
              x:Name="ThisPane"
-             AutomationProperties.Name="{Binding ElementName=ThisPane, Path=AutomationName}">
+             AutomationProperties.Name="{Binding Path=AutomationName, RelativeSource={RelativeSource Self}}">
     <UserControl.Resources>
         <SolidColorBrush x:Key="Expander.MouseOver.Circle.Stroke" Color="#FF5593FF"/>
         <SolidColorBrush x:Key="Expander.MouseOver.Circle.Fill" Color="#FFF3F9FF"/>


### PR DESCRIPTION
Binding with ElementName requires that an x:Name property be specified
that relates to the given name. Binding uses a lookup order to find
the names available by querying above the current element, which
won't have the property yet.

Fixes https://devdiv.visualstudio.com/_workitems/edit/1019763?fullScreen=True 

```
System.Windows.Data Warning: 70 : BindingExpression (hash=17108371):
Found data context element: <null> (OK)
System.Windows.Data Warning: 74 :     Lookup name ThisPane:  queried
Border (hash=10270353)
System.Windows.Data Warning: 74 :     Lookup name ThisPane:  queried
LightBulbMenuItem (hash=49364328)
System.Windows.Data Error: 4 : Cannot find source for binding with
reference 'ElementName=ThisPane'. BindingExpression:Path=AutomationName;
DataItem=null; target element is 'PreviewPane' (Name='ThisPane'); target
property is 'Name' (type 'String')
```

Fix by using self as a relative source instead of ElementName