### PR TITLE
Unskip tests that were skipped due to adaptive formatting triggering

### DIFF
--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1341,30 +1341,30 @@ static void Main(string[] args)
         }
 
         [WorkItem(2108, "https://github.com/dotnet/roslyn/issues/2108")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/39967"), Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void PressingEnter_Indentation5_UseTabs()
         {
             const string code =
 @"class C
 {
-    /// <summary>
+	/// <summary>
 	///     hello world$$
-    /// </summary>
-    void M()
-    {
-    }
+	/// </summary>
+	void M()
+	{
+	}
 }";
 
             const string expected =
 @"class C
 {
-    /// <summary>
+	/// <summary>
 	///     hello world
 	///     $$
-    /// </summary>
-    void M()
-    {
-    }
+	/// </summary>
+	void M()
+	{
+	}
 }";
 
             VerifyPressingEnter(code, expected, useTabs: true);
@@ -1813,18 +1813,18 @@ $$
         }
 
         [WorkItem(2090, "https://github.com/dotnet/roslyn/issues/2090")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/39967"), Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TestOpenLineAbove4_Tabs()
         {
             const string code =
 @"class C
 {
 		  /// <summary>
-    /// $$stuff
-    /// </summary>
-    void M()
-    {
-    }
+	/// $$stuff
+	/// </summary>
+	void M()
+	{
+	}
 }";
 
             const string expected =
@@ -1832,11 +1832,11 @@ $$
 {
 		  /// <summary>
 		  /// $$
-    /// stuff
-    /// </summary>
-    void M()
-    {
-    }
+	/// stuff
+	/// </summary>
+	void M()
+	{
+	}
 }";
 
             VerifyOpenLineAbove(code, expected, useTabs: true);
@@ -1923,30 +1923,30 @@ $$
         }
 
         [WorkItem(2090, "https://github.com/dotnet/roslyn/issues/2090")]
-        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/39967"), Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
         public void TestOpenLineBelow4_Tabs()
         {
             const string code =
 @"class C
 {
-    /// <summary>
+	/// <summary>
 		  /// $$stuff
-    /// </summary>
-    void M()
-    {
-    }
+	/// </summary>
+	void M()
+	{
+	}
 }";
 
             const string expected =
 @"class C
 {
-    /// <summary>
+	/// <summary>
 		  /// stuff
 		  /// $$
-    /// </summary>
-    void M()
-    {
-    }
+	/// </summary>
+	void M()
+	{
+	}
 }";
 
             VerifyOpenLineBelow(code, expected, useTabs: true);

--- a/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/DocumentationComments/DocumentationCommentTests.vb
@@ -763,25 +763,25 @@ End Class
         End Sub
 
         <WorkItem(2108, "https://github.com/dotnet/roslyn/issues/2108")>
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/39967"), Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub TestPressingEnter_Indentation5_UseTabs()
             Const code = "
 Class C
-    ''' <summary>
+	''' <summary>
 	'''     hello world$$
-    ''' </summary>
-    Sub M()
-    End Sub
+	''' </summary>
+	Sub M()
+	End Sub
 End Class
 "
             Const expected = "
 Class C
-    ''' <summary>
+	''' <summary>
 	'''     hello world
 	'''     $$
-    ''' </summary>
-    Sub M()
-    End Sub
+	''' </summary>
+	Sub M()
+	End Sub
 End Class
 "
             VerifyPressingEnter(code, expected, useTabs:=True)
@@ -1083,25 +1083,25 @@ End Class
         End Sub
 
         <WorkItem(2090, "https://github.com/dotnet/roslyn/issues/2090")>
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/39967"), Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub TestOpenLineAbove4_Tabs()
             Const code = "
 Class C
 		  ''' <summary>
-    ''' $$stuff
-    ''' </summary>
-    Sub M()
-    End Sub
+	''' $$stuff
+	''' </summary>
+	Sub M()
+	End Sub
 End Class
 "
             Const expected = "
 Class C
 		  ''' <summary>
 		  ''' $$
-    ''' stuff
-    ''' </summary>
-    Sub M()
-    End Sub
+	''' stuff
+	''' </summary>
+	Sub M()
+	End Sub
 End Class
 "
             VerifyOpenLineAbove(code, expected, useTabs:=True)
@@ -1173,25 +1173,25 @@ End Class
         End Sub
 
         <WorkItem(2090, "https://github.com/dotnet/roslyn/issues/2090")>
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/39967"), Trait(Traits.Feature, Traits.Features.DocumentationComments)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)>
         Public Sub TestOpenLineBelow4_Tabs()
             Const code = "
 Class C
-    ''' <summary>
+	''' <summary>
 		  ''' $$stuff
-    ''' </summary>
-    Sub M()
-    End Sub
+	''' </summary>
+	Sub M()
+	End Sub
 End Class
 "
             Const expected = "
 Class C
-    ''' <summary>
+	''' <summary>
 		  ''' stuff
 		  ''' $$
-    ''' </summary>
-    Sub M()
-    End Sub
+	''' </summary>
+	Sub M()
+	End Sub
 End Class
 "
             VerifyOpenLineBelow(code, expected, useTabs:=True)


### PR DESCRIPTION
We had tests that set "use tabs" but then were working in a file of mostly spaces. The editor behavior now is to treat this as if the file had the "use spaces" on. I alternatively could have chosen to disable inferrence, but then it seems we're not actually testing the more mainline scenario of somebody having tabs in the entire file, which seems like it's worth testing over odd mixed cases.

Closes https://github.com/dotnet/roslyn/issues/39967

**WARNING:** this PR contains changes to leading whitespace in files. Checking "Hide whitespace changes" in GitHub is going to result in an incorrect diff.