### PR TITLE
Add fail-fast exception filters to improve diagnosability of crash dumps

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2310,9 +2310,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Parallel.For(0, syntaxTrees.Length, parallelOptions,
                         UICultureUtilities.WithCurrentUICulture<int>(i =>
                         {
-                            var syntaxTree = syntaxTrees[i];
-                            AppendLoadDirectiveDiagnostics(builder, _syntaxAndDeclarations, syntaxTree);
-                            builder.AddRange(syntaxTree.GetDiagnostics(cancellationToken));
+                            try
+                            {
+                                var syntaxTree = syntaxTrees[i];
+                                AppendLoadDirectiveDiagnostics(builder, _syntaxAndDeclarations, syntaxTree);
+                                builder.AddRange(syntaxTree.GetDiagnostics(cancellationToken));
+                            }
+                            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                            {
+                                throw ExceptionUtilities.Unreachable;
+                            }
                         }));
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol_Completion.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,8 +53,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                                 Parallel.For(0, members.Length, po, UICultureUtilities.WithCurrentUICulture<int>(i =>
                                 {
-                                    var member = members[i];
-                                    ForceCompleteMemberByLocation(locationOpt, member, cancellationToken);
+                                    try
+                                    {
+                                        var member = members[i];
+                                        ForceCompleteMemberByLocation(locationOpt, member, cancellationToken);
+                                    }
+                                    catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                                    {
+                                        throw ExceptionUtilities.Unreachable;
+                                    }
                                 }));
 
                                 foreach (var member in members)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -672,7 +672,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 AnalyzerDriver driver = null;
                 Task computeTask = null;
-                CancellationTokenSource cts;
+                CancellationTokenSource cancellationSource;
 
                 try
                 {
@@ -696,72 +696,70 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         suspended = false;
 
                         // Create a new cancellation source to allow higher priority requests to suspend our analysis.
-                        using (cts = new CancellationTokenSource())
+                        using (cancellationSource = new CancellationTokenSource())
                         {
                             // Link the cancellation source with client supplied cancellation source, so the public API callee can also cancel analysis.
-                            using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken))
-                            {
-                                try
-                                {
-                                    // Fetch the cancellation token here to avoid capturing linkedCts in the getComputeTask lambda as the task may run after linkedCts has been disposed due to cancellation.
-                                    var linkedCancellationToken = linkedCts.Token;
+                            using var linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationSource.Token, cancellationToken);
 
-                                    // Core task to compute analyzer diagnostics.
-                                    Func<Tuple<Task, CancellationTokenSource>> getComputeTask = () => Tuple.Create(
-                                        Task.Run(async () =>
+                            try
+                            {
+                                // Fetch the cancellation token here to avoid capturing linkedCts in the getComputeTask lambda as the task may run after linkedCts has been disposed due to cancellation.
+                                var linkedCancellationToken = linkedCancellationSource.Token;
+
+                                // Core task to compute analyzer diagnostics.
+                                Func<Tuple<Task, CancellationTokenSource>> getComputeTask = () => Tuple.Create(
+                                    Task.Run(async () =>
+                                    {
+                                        try
                                         {
+                                            AsyncQueue<CompilationEvent> eventQueue = s_EmptyEventQueue;
                                             try
                                             {
-                                                AsyncQueue<CompilationEvent> eventQueue = s_EmptyEventQueue;
-                                                try
+                                                // Get event queue with pending events to analyze.
+                                                if (getPendingEventsOpt != null)
                                                 {
-                                                    // Get event queue with pending events to analyze.
-                                                    if (getPendingEventsOpt != null)
-                                                    {
-                                                        pendingEvents = getPendingEventsOpt();
-                                                        eventQueue = CreateEventsQueue(pendingEvents);
-                                                    }
-
-                                                    linkedCancellationToken.ThrowIfCancellationRequested();
-
-                                                    // Execute analyzer driver on the given analysis scope with the given event queue.
-                                                    await ComputeAnalyzerDiagnosticsCoreAsync(driver, eventQueue, analysisScope, cancellationToken: linkedCancellationToken).ConfigureAwait(false);
+                                                    pendingEvents = getPendingEventsOpt();
+                                                    eventQueue = CreateEventsQueue(pendingEvents);
                                                 }
-                                                finally
-                                                {
-                                                    FreeEventQueue(eventQueue, _eventQueuePool);
-                                                }
+
+                                                linkedCancellationToken.ThrowIfCancellationRequested();
+
+                                                // Execute analyzer driver on the given analysis scope with the given event queue.
+                                                await ComputeAnalyzerDiagnosticsCoreAsync(driver, eventQueue, analysisScope, cancellationToken: linkedCancellationToken).ConfigureAwait(false);
                                             }
-                                            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                                            finally
                                             {
-                                                throw ExceptionUtilities.Unreachable;
+                                                FreeEventQueue(eventQueue, _eventQueuePool);
                                             }
-                                        },
-                                            linkedCancellationToken),
-                                        cts);
+                                        }
+                                        catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+                                        {
+                                            throw ExceptionUtilities.Unreachable;
+                                        }
+                                    }, linkedCancellationToken),
+                                    cancellationSource);
 
-                                    // Wait for higher priority tree document tasks to complete.
-                                    computeTask = await SetActiveAnalysisTaskAsync(getComputeTask, analysisScope.FilterTreeOpt, newTaskToken, cancellationToken).ConfigureAwait(false);
+                                // Wait for higher priority tree document tasks to complete.
+                                computeTask = await SetActiveAnalysisTaskAsync(getComputeTask, analysisScope.FilterTreeOpt, newTaskToken, cancellationToken).ConfigureAwait(false);
 
-                                    cancellationToken.ThrowIfCancellationRequested();
+                                cancellationToken.ThrowIfCancellationRequested();
 
-                                    await computeTask.ConfigureAwait(false);
-                                }
-                                catch (OperationCanceledException)
+                                await computeTask.ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                if (!cancellationSource.IsCancellationRequested)
                                 {
-                                    cancellationToken.ThrowIfCancellationRequested();
-                                    if (!cts.IsCancellationRequested)
-                                    {
-                                        throw;
-                                    }
+                                    throw;
+                                }
 
-                                    suspended = true;
-                                }
-                                finally
-                                {
-                                    ClearExecutingTask(computeTask, analysisScope.FilterTreeOpt);
-                                    computeTask = null;
-                                }
+                                suspended = true;
+                            }
+                            finally
+                            {
+                                ClearExecutingTask(computeTask, analysisScope.FilterTreeOpt);
+                                computeTask = null;
                             }
                         }
                     } while (suspended);
@@ -781,8 +779,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private async Task GenerateCompilationEventsAndPopulateEventsCacheAsync(AnalysisScope analysisScope, AnalyzerDriver driver, CancellationToken cancellationToken)
         {
-            GenerateCompilationEvents(analysisScope, cancellationToken);
-            await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                GenerateCompilationEvents(analysisScope, cancellationToken);
+                await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
         }
 
         private void GenerateCompilationEvents(AnalysisScope analysisScope, CancellationToken cancellationToken)
@@ -791,12 +796,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // Discard the returned diagnostics.
             if (analysisScope.FilterTreeOpt == null)
             {
-                var unused = _compilation.GetDiagnostics(cancellationToken);
+                _ = _compilation.GetDiagnostics(cancellationToken);
             }
             else if (!analysisScope.IsSyntaxOnlyTreeAnalysis)
             {
                 var mappedModel = _compilationData.GetOrCreateCachedSemanticModel(analysisScope.FilterTreeOpt, _compilation, cancellationToken);
-                var unused = mappedModel.GetDiagnostics(cancellationToken: cancellationToken);
+                _ = mappedModel.GetDiagnostics(cancellationToken: cancellationToken);
             }
         }
 
@@ -835,28 +840,39 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private async Task<AnalyzerDriver> GetAnalyzerDriverAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Get instance of analyzer driver from the driver pool.
-            AnalyzerDriver driver = _driverPool.Allocate();
-
             try
             {
-                // Start the initialization task, if required.
-                if (driver.WhenInitializedTask == null)
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Get instance of analyzer driver from the driver pool.
+                AnalyzerDriver driver = _driverPool.Allocate();
+
+                bool success = false;
+                try
                 {
-                    driver.Initialize(_compilation, _analysisOptions, _compilationData, categorizeDiagnostics: true, cancellationToken: cancellationToken);
+                    // Start the initialization task, if required.
+                    if (driver.WhenInitializedTask == null)
+                    {
+                        driver.Initialize(_compilation, _analysisOptions, _compilationData, categorizeDiagnostics: true, cancellationToken: cancellationToken);
+                    }
+
+                    // Wait for driver initialization to complete: this executes the Initialize and CompilationStartActions to compute all registered actions per-analyzer.
+                    await driver.WhenInitializedTask.ConfigureAwait(false);
+
+                    success = true;
+                    return driver;
                 }
-
-                // Wait for driver initialization to complete: this executes the Initialize and CompilationStartActions to compute all registered actions per-analyzer.
-                await driver.WhenInitializedTask.ConfigureAwait(false);
-
-                return driver;
+                finally
+                {
+                    if (!success)
+                    {
+                        FreeDriver(driver);
+                    }
+                }
             }
-            catch (OperationCanceledException)
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
-                FreeDriver(driver);
-                throw;
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -685,7 +685,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    await GenerateCompilationEventsAndPopulateEventsCacheAsync(analysisScope, driver, cancellationToken).ConfigureAwait(false);
+                    GenerateCompilationEvents(analysisScope, cancellationToken);
+
+                    await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
 
                     // Track if this task was suspended by another tree diagnostics request for the same tree.
                     // If so, we wait for the high priority requests to complete before restarting analysis.
@@ -770,19 +772,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     FreeDriver(driver);
                 }
-            }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
-            {
-                throw ExceptionUtilities.Unreachable;
-            }
-        }
-
-        private async Task GenerateCompilationEventsAndPopulateEventsCacheAsync(AnalysisScope analysisScope, AnalyzerDriver driver, CancellationToken cancellationToken)
-        {
-            try
-            {
-                GenerateCompilationEvents(analysisScope, cancellationToken);
-                await PopulateEventsCacheAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1991,8 +1991,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Otherwise IDE performance might be affect.
                 If Options.ConcurrentBuild Then
                     Dim options = New ParallelOptions() With {.CancellationToken = cancellationToken}
-                    Parallel.For(0, SyntaxTrees.Length, options,
-                            UICultureUtilities.WithCurrentUICulture(Sub(i As Integer) builder.AddRange(SyntaxTrees(i).GetDiagnostics(cancellationToken))))
+                    Parallel.For(0, SyntaxTrees.Length, options, UICultureUtilities.WithCurrentUICulture(
+                        Sub(i As Integer)
+                            Try
+                                builder.AddRange(SyntaxTrees(i).GetDiagnostics(cancellationToken))
+                            Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                                Throw ExceptionUtilities.Unreachable
+                            End Try
+                        End Sub))
                 Else
                     For Each tree In SyntaxTrees
                         cancellationToken.ThrowIfCancellationRequested()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -618,8 +618,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Parallel.For(0, trees.Count, options,
                     UICultureUtilities.WithCurrentUICulture(
                         Sub(i As Integer)
-                            cancellationToken.ThrowIfCancellationRequested()
-                            TryGetSourceFile(trees(i)).GenerateAllDeclarationErrors()
+                            Try
+                                cancellationToken.ThrowIfCancellationRequested()
+                                TryGetSourceFile(trees(i)).GenerateAllDeclarationErrors()
+                            Catch e As Exception When FatalError.ReportUnlessCanceled(e)
+                                Throw ExceptionUtilities.Unreachable
+                            End Try
                         End Sub))
                 trees.Free()
             Else


### PR DESCRIPTION
When the compiler crashes in `SourceNamespaceSymbol.ForceComplete` or in `CompilationWithAnalyzers.ComputeAnalyzerDiagnosticsAsync` the dump is captured after stack frame have been unwound, making it hard to diagnose the cause.