### PR TITLE
Copy any CommentTrivia to simple using statements 

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
@@ -935,5 +935,30 @@ class Program
 }",
 parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
         }
+
+        [WorkItem(35879, "https://github.com/dotnet/roslyn/issues/37678")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestCopyTrivia()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+    {
+        static void Main(string[] args)
+        {
+            using (var x = y)
+            {
+               // comment
+            }
+        }
+}",
+@"class Program
+    {
+        static void Main(string[] args)
+        {
+            using (var x = y)
+            // comment
+        }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseSimpleUsingStatement/UseSimpleUsingStatementTests.cs
@@ -936,7 +936,7 @@ class Program
 parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
         }
 
-        [WorkItem(35879, "https://github.com/dotnet/roslyn/issues/37678")]
+        [WorkItem(37678, "https://github.com/dotnet/roslyn/issues/37678")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
         public async Task TestCopyTrivia()
         {
@@ -945,20 +945,47 @@ parameters: new TestParameters(parseOptions: CSharp8ParseOptions));
     {
         static void Main(string[] args)
         {
-            using (var x = y)
+            [||]using (var x = y)
             {
                // comment
             }
         }
-}",
+    }",
 @"class Program
     {
         static void Main(string[] args)
         {
-            using (var x = y)
+            using var x = y;               
             // comment
         }
-}");
+    }");
+        }
+
+        [WorkItem(37678, "https://github.com/dotnet/roslyn/issues/37678")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseSimpleUsingStatement)]
+        public async Task TestMultiCopyTrivia()
+        {
+            await TestInRegularAndScript1Async(
+@"class Program
+    {
+        static void Main(string[] args)
+        {
+            [||]using (var x = y)
+            using (var a = b)
+            {
+                // comment
+            }
+        }
+    }",
+@"class Program
+    {
+        static void Main(string[] args)
+        {
+            using var x = y;
+            using var a = b;
+            // comment
+        }
+    }");
         }
     }
 }

--- a/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
             var blocks = topmostUsingStatements.Select(u => (BlockSyntax)u.Parent);
 
             // Process blocks in reverse order so we rewrite from inside-to-outside with nested
-            // usings.d
+            // usings.
             var root = editor.OriginalRoot;
             var updatedRoot = root.ReplaceNodes(
                 blocks.OrderByDescending(b => b.SpanStart),

--- a/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -84,10 +84,24 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
             var result = new List<StatementSyntax>();
             Expand(result, usingStatement);
 
+            var decendentTrivia = usingStatement.DescendantTrivia().ToList();
+            var comments = new List<SyntaxTrivia>();
+
+            decendentTrivia.ForEach(x =>
+            {
+                if (x.Kind() == SyntaxKind.SingleLineCommentTrivia || x.Kind() == SyntaxKind.MultiLineCommentTrivia)
+                {
+                    comments.Add(x);
+                    comments.Add(SyntaxFactory.EndOfLine(Environment.NewLine));
+                }
+            });
+
             for (int i = 0, n = result.Count; i < n; i++)
             {
                 result[i] = result[i].WithAdditionalAnnotations(Formatter.Annotation);
             }
+
+            result[0] = result[0].WithTrailingTrivia(comments);
 
             return result;
         }

--- a/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseSimpleUsingStatement/UseSimpleUsingStatementCodeFixProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
                 result[i] = result[i].WithAdditionalAnnotations(Formatter.Annotation);
             }
 
-            result[0] = result[0].WithTrailingTrivia(comments);
+            result[0] = result[0].WithLeadingTrivia(comments);
 
             return result;
         }


### PR DESCRIPTION
Fixes #37678 

I am very new to the Roslyn codebase so please forgive me if this is not the correct way to approach this issue. I have updated the simple using code fix to copy all the CommentTrivia from inside the block to before the simplified using statement. I would like to make it copy the comments to the respective location in the block but can't seem to work out how.

Any feedback would be welcomed.