### PR TITLE
Remove unnecessary allocations in 'keyword highlighting'

### DIFF
--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/AsyncAwaitHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/AsyncAwaitHighlighter.cs
@@ -27,17 +27,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         protected override bool IsHighlightableNode(SyntaxNode node)
             => node.IsReturnableConstruct();
 
-        protected override IEnumerable<TextSpan> GetHighlightsForNode(SyntaxNode node, CancellationToken cancellationToken)
+        protected override void AddHighlightsForNode(SyntaxNode node, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
-            var spans = new List<TextSpan>();
-
             foreach (var current in WalkChildren(node))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                HighlightRelatedKeywords(current, spans);
+                HighlightRelatedKeywords(current, highlights);
             }
-
-            return spans;
         }
 
         private IEnumerable<SyntaxNode> WalkChildren(SyntaxNode node)

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/CheckedExpressionHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/CheckedExpressionHighlighter.cs
@@ -18,16 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override void AddHighlights(
-            CheckedExpressionSyntax checkedExpressionSyntax, List<TextSpan> highlights, CancellationToken cancellationToken)
-        {
-            switch (checkedExpressionSyntax.Kind())
-            {
-                case SyntaxKind.CheckedExpression:
-                case SyntaxKind.UncheckedExpression:
-                    highlights.Add(checkedExpressionSyntax.Keyword.Span);
-                    break;
-            }
-        }
+        protected override void AddHighlights(CheckedExpressionSyntax checkedExpressionSyntax, List<TextSpan> highlights, CancellationToken cancellationToken)
+            => highlights.Add(checkedExpressionSyntax.Keyword.Span);
     }
 }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/CheckedExpressionHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/CheckedExpressionHighlighter.cs
@@ -18,17 +18,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            CheckedExpressionSyntax checkedExpressionSyntax, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            CheckedExpressionSyntax checkedExpressionSyntax, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
             switch (checkedExpressionSyntax.Kind())
             {
                 case SyntaxKind.CheckedExpression:
                 case SyntaxKind.UncheckedExpression:
-                    yield return checkedExpressionSyntax.Keyword.Span;
+                    highlights.Add(checkedExpressionSyntax.Keyword.Span);
                     break;
-                default:
-                    yield break;
             }
         }
     }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/CheckedStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/CheckedStatementHighlighter.cs
@@ -17,10 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            CheckedStatementSyntax checkedStatement, CancellationToken cancellationToken)
-        {
-            yield return checkedStatement.Keyword.Span;
-        }
+        protected override void AddHighlights(CheckedStatementSyntax checkedStatement, List<TextSpan> highlights, CancellationToken cancellationToken)
+            => highlights.Add(checkedStatement.Keyword.Span);
     }
 }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.cs
@@ -18,20 +18,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            DirectiveTriviaSyntax directive, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            DirectiveTriviaSyntax directive, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
             var conditionals = directive.GetMatchingConditionalDirectives(cancellationToken);
             if (conditionals == null)
             {
-                yield break;
+                return;
             }
 
             foreach (var conditional in conditionals)
             {
-                yield return TextSpan.FromBounds(
+                highlights.Add(TextSpan.FromBounds(
                     conditional.HashToken.SpanStart,
-                    conditional.DirectiveNameToken.Span.End);
+                    conditional.DirectiveNameToken.Span.End));
             }
         }
     }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/IfStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/IfStatementHighlighter.cs
@@ -21,21 +21,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            IfStatementSyntax ifStatement, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            IfStatementSyntax ifStatement, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
             if (ifStatement.Parent.Kind() != SyntaxKind.ElseClause)
             {
-                return ComputeSpans(ifStatement);
+                ComputeSpans(ifStatement, highlights);
             }
-
-            return Enumerable.Empty<TextSpan>();
         }
 
-        private IEnumerable<TextSpan> ComputeSpans(
-            IfStatementSyntax ifStatement)
+        private void ComputeSpans(
+            IfStatementSyntax ifStatement, List<TextSpan> highlights)
         {
-            yield return ifStatement.IfKeyword.Span;
+            highlights.Add(ifStatement.IfKeyword.Span);
 
             // Loop to get all the else if parts
             while (ifStatement != null && ifStatement.Else != null)
@@ -48,15 +46,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting
                     if (OnlySpacesBetween(elseKeyword, elseIfStatement.IfKeyword))
                     {
                         // Highlight both else and if tokens if they are on the same line
-                        yield return TextSpan.FromBounds(
+                        highlights.Add(TextSpan.FromBounds(
                             elseKeyword.SpanStart,
-                            elseIfStatement.IfKeyword.Span.End);
+                            elseIfStatement.IfKeyword.Span.End));
                     }
                     else
                     {
                         // Highlight the else and if tokens separately
-                        yield return elseKeyword.Span;
-                        yield return elseIfStatement.IfKeyword.Span;
+                        highlights.Add(elseKeyword.Span);
+                        highlights.Add(elseIfStatement.IfKeyword.Span);
                     }
 
                     // Continue the enumeration looking for more else blocks
@@ -65,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting
                 else
                 {
                     // Highlight just the else and we're done
-                    yield return elseKeyword.Span;
+                    highlights.Add(elseKeyword.Span);
                     break;
                 }
             }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/LockStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/LockStatementHighlighter.cs
@@ -17,10 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            LockStatementSyntax lockStatement, CancellationToken cancellationToken)
-        {
-            yield return lockStatement.LockKeyword.Span;
-        }
+        protected override void AddHighlights(LockStatementSyntax lockStatement, List<TextSpan> highlights, CancellationToken cancellationToken)
+            => highlights.Add(lockStatement.LockKeyword.Span);
     }
 }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/LoopHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/LoopHighlighter.cs
@@ -22,11 +22,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         protected override bool IsHighlightableNode(SyntaxNode node)
             => node.IsContinuableConstruct();
 
-        protected override IEnumerable<TextSpan> GetHighlightsForNode(
-            SyntaxNode node, CancellationToken cancellationToken)
+        protected override void AddHighlightsForNode(
+            SyntaxNode node, List<TextSpan> spans, CancellationToken cancellationToken)
         {
-            var spans = new List<TextSpan>();
-
             switch (node)
             {
                 case DoStatementSyntax doStatement:
@@ -44,8 +42,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
             }
 
             HighlightRelatedKeywords(node, spans, highlightBreaks: true, highlightContinues: true);
-
-            return spans;
         }
 
         private void HighlightDoStatement(DoStatementSyntax statement, List<TextSpan> spans)

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/RegionHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/RegionHighlighter.cs
@@ -18,22 +18,22 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            DirectiveTriviaSyntax directive, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            DirectiveTriviaSyntax directive, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
             var matchingDirective = directive.GetMatchingDirective(cancellationToken);
             if (matchingDirective == null)
             {
-                yield break;
+                return;
             }
 
-            yield return TextSpan.FromBounds(
+            highlights.Add(TextSpan.FromBounds(
                 directive.HashToken.SpanStart,
-                directive.DirectiveNameToken.Span.End);
+                directive.DirectiveNameToken.Span.End));
 
-            yield return TextSpan.FromBounds(
+            highlights.Add(TextSpan.FromBounds(
                 matchingDirective.HashToken.SpanStart,
-                matchingDirective.DirectiveNameToken.Span.End);
+                matchingDirective.DirectiveNameToken.Span.End));
         }
     }
 }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/ReturnStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/ReturnStatementHighlighter.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Highlighting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighlighters
 {
@@ -21,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            ReturnStatementSyntax returnStatement, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            ReturnStatementSyntax returnStatement, List<TextSpan> spans, CancellationToken cancellationToken)
         {
             var parent = returnStatement
                              .GetAncestorsOrThis<SyntaxNode>()
@@ -30,14 +29,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
 
             if (parent == null)
             {
-                return SpecializedCollections.EmptyEnumerable<TextSpan>();
+                return;
             }
 
-            var spans = new List<TextSpan>();
-
             HighlightRelatedKeywords(parent, spans);
-
-            return spans;
         }
 
         /// <summary>

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/ReturnStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/ReturnStatementHighlighter.cs
@@ -47,13 +47,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
                     spans.Add(EmptySpan(statement.SemicolonToken.Span.End));
                     break;
                 default:
-                    foreach (var child in node.ChildNodes())
+                    foreach (var child in node.ChildNodesAndTokens())
                     {
+                        if (child.IsToken)
+                            continue;
+
                         // Only recurse if we have anything to do
-                        if (!child.IsReturnableConstruct())
-                        {
-                            HighlightRelatedKeywords(child, spans);
-                        }
+                        if (!child.AsNode().IsReturnableConstruct())
+                            HighlightRelatedKeywords(child.AsNode(), spans);
                     }
                     break;
             }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -70,8 +70,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
             }
             else
             {
-                foreach (var child in node.ChildNodes())
+                foreach (var childNodeOrToken in node.ChildNodesAndTokens())
                 {
+                    if (childNodeOrToken.IsToken)
+                        continue;
+
+                    var child = childNodeOrToken.AsNode();
                     var highlightBreaksForChild = highlightBreaks && !child.IsBreakableConstruct();
                     var highlightGotosForChild = highlightGotos && !child.IsKind(SyntaxKind.SwitchStatement);
 

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -20,11 +20,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            SwitchStatementSyntax switchStatement, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            SwitchStatementSyntax switchStatement, List<TextSpan> spans, CancellationToken cancellationToken)
         {
-            var spans = new List<TextSpan>();
-
             spans.Add(switchStatement.SwitchKeyword.Span);
 
             foreach (var switchSection in switchStatement.Sections)
@@ -37,8 +35,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
 
                 HighlightRelatedKeywords(switchSection, spans, highlightBreaks: true, highlightGotos: true);
             }
-
-            return spans;
         }
 
         /// <summary>

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/TryStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/TryStatementHighlighter.cs
@@ -17,24 +17,24 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            TryStatementSyntax tryStatement, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            TryStatementSyntax tryStatement, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
-            yield return tryStatement.TryKeyword.Span;
+            highlights.Add(tryStatement.TryKeyword.Span);
 
             foreach (var catchDeclaration in tryStatement.Catches)
             {
-                yield return catchDeclaration.CatchKeyword.Span;
+                highlights.Add(catchDeclaration.CatchKeyword.Span);
 
                 if (catchDeclaration.Filter != null)
                 {
-                    yield return catchDeclaration.Filter.WhenKeyword.Span;
+                    highlights.Add(catchDeclaration.Filter.WhenKeyword.Span);
                 }
             }
 
             if (tryStatement.Finally != null)
             {
-                yield return tryStatement.Finally.FinallyKeyword.Span;
+                highlights.Add(tryStatement.Finally.FinallyKeyword.Span);
             }
         }
     }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/UnsafeStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/UnsafeStatementHighlighter.cs
@@ -17,10 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            UnsafeStatementSyntax unsafeStatement, CancellationToken cancellationToken)
-        {
-            yield return unsafeStatement.UnsafeKeyword.Span;
-        }
+        protected override void AddHighlights(UnsafeStatementSyntax unsafeStatement, List<TextSpan> highlights, CancellationToken cancellationToken)
+            => highlights.Add(unsafeStatement.UnsafeKeyword.Span);
     }
 }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/UsingStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/UsingStatementHighlighter.cs
@@ -17,10 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            UsingStatementSyntax usingStatement, CancellationToken cancellationToken)
-        {
-            yield return usingStatement.UsingKeyword.Span;
-        }
+        protected override void AddHighlights(UsingStatementSyntax usingStatement, List<TextSpan> highlights, CancellationToken cancellationToken)
+            => highlights.Add(usingStatement.UsingKeyword.Span);
     }
 }

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/YieldStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/YieldStatementHighlighter.cs
@@ -51,12 +51,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
                     spans.Add(EmptySpan(statement.SemicolonToken.Span.End));
                     break;
                 default:
-                    foreach (var child in node.ChildNodes())
+                    foreach (var child in node.ChildNodesAndTokens())
                     {
+                        if (child.IsToken)
+                            continue;
+
                         // Only recurse if we have anything to do
-                        if (!child.IsReturnableConstruct())
+                        if (!child.AsNode().IsReturnableConstruct())
                         {
-                            HighlightRelatedKeywords(child, spans);
+                            HighlightRelatedKeywords(child.AsNode(), spans);
                         }
                     }
                     break;

--- a/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/YieldStatementHighlighter.cs
+++ b/src/EditorFeatures/CSharp/Highlighting/KeywordHighlighters/YieldStatementHighlighter.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Highlighting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighlighters
 {
@@ -21,8 +20,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
         {
         }
 
-        protected override IEnumerable<TextSpan> GetHighlights(
-            YieldStatementSyntax yieldStatement, CancellationToken cancellationToken)
+        protected override void AddHighlights(
+            YieldStatementSyntax yieldStatement, List<TextSpan> spans, CancellationToken cancellationToken)
         {
             var parent = yieldStatement
                              .GetAncestorsOrThis<SyntaxNode>()
@@ -30,14 +29,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.KeywordHighlighting.KeywordHighli
 
             if (parent == null)
             {
-                return SpecializedCollections.EmptyEnumerable<TextSpan>();
+                return;
             }
 
-            var spans = new List<TextSpan>();
-
             HighlightRelatedKeywords(parent, spans);
-
-            return spans;
         }
 
         /// <summary>

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/AsyncAnonymousFunctionHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/AsyncAnonymousFunctionHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class AsyncAnonymousFunctionHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new AsyncAwaitHighlighter();
-        }
+            => new AsyncAwaitHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestSimpleLambda()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/AsyncLocalFunctionHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/AsyncLocalFunctionHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class AsyncLocalFunctionHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new AsyncAwaitHighlighter();
-        }
+            => new AsyncAwaitHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestLocalFunction()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/AsyncMethodHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/AsyncMethodHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class AsyncMethodHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new AsyncAwaitHighlighter();
-        }
+            => new AsyncAwaitHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/AwaitHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/AwaitHighlighterTests.cs
@@ -11,9 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class AwaitHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new AsyncAwaitHighlighter();
-        }
+            => new AsyncAwaitHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample2_2()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/CheckedExpressionHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/CheckedExpressionHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class CheckedExpressionHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new CheckedExpressionHighlighter();
-        }
+            => new CheckedExpressionHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/CheckedStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/CheckedStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class CheckedStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new CheckedStatementHighlighter();
-        }
+            => new CheckedStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/ConditionalPreprocessorHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/ConditionalPreprocessorHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class ConditionalPreprocessorHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new ConditionalPreprocessorHighlighter();
-        }
+            => new ConditionalPreprocessorHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/IfStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/IfStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class IfStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new IfStatementHighlighter();
-        }
+            => new IfStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestIfStatementWithIfAndSingleElse1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/LockStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/LockStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class LockStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new LockStatementHighlighter();
-        }
+            => new LockStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/LoopHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/LoopHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class LoopHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new LoopHighlighter();
-        }
+            => new LoopHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/RegionHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/RegionHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class RegionHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new RegionHighlighter();
-        }
+            => new RegionHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/ReturnStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/ReturnStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class ReturnStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new ReturnStatementHighlighter();
-        }
+            => new ReturnStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestInLambda()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/SwitchStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/SwitchStatementHighlighterTests.cs
@@ -11,9 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class SwitchStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new SwitchStatementHighlighter();
-        }
+            => new SwitchStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_OnSwitchKeyword()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/TryStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/TryStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class TryStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new TryStatementHighlighter();
-        }
+            => new TryStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/UnsafeStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/UnsafeStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class UnsafeStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new UnsafeStatementHighlighter();
-        }
+            => new UnsafeStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/UsingStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/UsingStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class UsingStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new UsingStatementHighlighter();
-        }
+            => new UsingStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/YieldStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/YieldStatementHighlighterTests.cs
@@ -10,9 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.KeywordHighlighting
     public class YieldStatementHighlighterTests : AbstractCSharpKeywordHighlighterTests
     {
         internal override IHighlighter CreateHighlighter()
-        {
-            return new YieldStatementHighlighter();
-        }
+            => new YieldStatementHighlighter();
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordHighlighting)]
         public async Task TestExample1_1()

--- a/src/EditorFeatures/Core/Extensibility/Highlighting/IHighlighter.cs
+++ b/src/EditorFeatures/Core/Extensibility/Highlighting/IHighlighter.cs
@@ -8,6 +8,6 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface IHighlighter
     {
-        IEnumerable<TextSpan> GetHighlights(SyntaxNode root, int position, CancellationToken cancellationToken);
+        void AddHighlights(SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/IHighlightingService.cs
+++ b/src/EditorFeatures/Core/IHighlightingService.cs
@@ -8,6 +8,12 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface IHighlightingService
     {
-        IEnumerable<TextSpan> GetHighlights(SyntaxNode root, int position, CancellationToken cancellationToken);
+        /// <summary>
+        /// Adds all the relevant highlihts to <paramref name="highlights"/> given the specified
+        /// <paramref name="position"/> in the tree.
+        /// <para/>
+        /// Highlights will be unique and will be in sorted order. All highlights will be non-empty.
+        /// </summary>
+        void AddHighlights(SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/AbstractKeywordHighlighter.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/AbstractKeywordHighlighter.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
         public void AddHighlights(
             SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
-            var _1 = s_textSpanListPool.GetPooledObject();
-            var _2 = s_tokenListPool.GetPooledObject();
+            using var _1 = s_textSpanListPool.GetPooledObject();
+            using var _2 = s_tokenListPool.GetPooledObject();
 
             var tempHighlights = _1.Object;
             var touchingTokens = _2.Object;

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/AbstractKeywordHighlighter.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/AbstractKeywordHighlighter.cs
@@ -3,10 +3,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.PooledObjects;
-using System;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
 {

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/AbstractKeywordHighlighter.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/AbstractKeywordHighlighter.cs
@@ -29,11 +29,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
         public void AddHighlights(
             SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
-            using var _1 = s_textSpanListPool.GetPooledObject();
-            using var _2 = s_tokenListPool.GetPooledObject();
+            using var highlightsListPooledObject = s_textSpanListPool.GetPooledObject();
+            using var tokensListPooledObject = s_tokenListPool.GetPooledObject();
 
-            var tempHighlights = _1.Object;
-            var touchingTokens = _2.Object;
+            var tempHighlights = highlightsListPooledObject.Object;
+            var touchingTokens = tokensListPooledObject.Object;
             AddTouchingTokens(root, position, touchingTokens);
 
             foreach (var token in touchingTokens)

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -98,11 +98,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
             }
 
             using (Logger.LogBlock(FunctionId.Tagger_Highlighter_TagProducer_ProduceTags, cancellationToken))
+            using (s_listPool.GetPooledObject(out var highlights))
             {
                 var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-                using var _ = s_listPool.GetPooledObject();
-                var highlights = _.Object;
 
                 _highlightingService.AddHighlights(root, position, highlights, cancellationToken);
 

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
@@ -27,23 +27,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
         public void AddHighlights(
              SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
-            using var _ = s_listPool.GetPooledObject();
-            var tempHighlights = _.Object;
-
-            foreach (var highlighter in _highlighters.Where(h => h.Metadata.Language == root.Language))
+            using (s_listPool.GetPooledObject(out var tempHighlights))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                highlighter.Value.AddHighlights(root, position, tempHighlights, cancellationToken);
-            }
-
-            tempHighlights.Sort();
-            var lastSpan = default(TextSpan);
-            foreach (var span in tempHighlights)
-            {
-                if (span != lastSpan && !span.IsEmpty)
+                foreach (var highlighter in _highlighters.Where(h => h.Metadata.Language == root.Language))
                 {
-                    highlights.Add(span);
-                    lastSpan = span;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    highlighter.Value.AddHighlights(root, position, tempHighlights, cancellationToken);
+                }
+
+                tempHighlights.Sort();
+                var lastSpan = default(TextSpan);
+                foreach (var span in tempHighlights)
+                {
+                    if (span != lastSpan && !span.IsEmpty)
+                    {
+                        highlights.Add(span);
+                        lastSpan = span;
+                    }
                 }
             }
         }

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlightingService.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
 {
@@ -16,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
     internal class HighlightingService : IHighlightingService
     {
         private readonly List<Lazy<IHighlighter, LanguageMetadata>> _highlighters;
+        private static readonly PooledObjects.ObjectPool<List<TextSpan>> s_listPool = new PooledObjects.ObjectPool<List<TextSpan>>(() => new List<TextSpan>());
 
         [ImportingConstructor]
         public HighlightingService(
@@ -24,14 +24,28 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
             _highlighters = highlighters.ToList();
         }
 
-        public IEnumerable<TextSpan> GetHighlights(
-             SyntaxNode root, int position, CancellationToken cancellationToken)
+        public void AddHighlights(
+             SyntaxNode root, int position, List<TextSpan> highlights, CancellationToken cancellationToken)
         {
-            return _highlighters.Where(h => h.Metadata.Language == root.Language)
-                                .Select(h => h.Value.GetHighlights(root, position, cancellationToken))
-                                .WhereNotNull()
-                                .Flatten()
-                                .Distinct();
+            using var _ = s_listPool.GetPooledObject();
+            var tempHighlights = _.Object;
+
+            foreach (var highlighter in _highlighters.Where(h => h.Metadata.Language == root.Language))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                highlighter.Value.AddHighlights(root, position, tempHighlights, cancellationToken);
+            }
+
+            tempHighlights.Sort();
+            var lastSpan = default(TextSpan);
+            foreach (var span in tempHighlights)
+            {
+                if (span != lastSpan && !span.IsEmpty)
+                {
+                    highlights.Add(span);
+                    lastSpan = span;
+                }
+            }
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/KeywordHighlighting/AbstractKeywordHighlighterTests.cs
+++ b/src/EditorFeatures/TestUtilities/KeywordHighlighting/AbstractKeywordHighlighterTests.cs
@@ -8,8 +8,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using Xunit;
+using Microsoft.CodeAnalysis.Editor.Implementation.Highlighting;
+using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.KeywordHighlighting
 {
@@ -29,35 +30,34 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.KeywordHighlighting
             }
         }
 
-        private async Task TestAsync(
-            string markup,
-            ParseOptions options,
-            bool optionIsEnabled = true)
+        private async Task TestAsync(string markup, ParseOptions options)
         {
-            using (var workspace = CreateWorkspaceFromFile(markup, options))
+            using var workspace = CreateWorkspaceFromFile(markup, options);
+            var testDocument = workspace.Documents.Single();
+            var expectedHighlightSpans = testDocument.SelectedSpans.ToList();
+            expectedHighlightSpans.Sort();
+
+            var cursorSpan = testDocument.AnnotatedSpans["Cursor"].Single();
+            var textSnapshot = testDocument.GetTextBuffer().CurrentSnapshot;
+            var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+
+            var highlighter = CreateHighlighter();
+            var service = new HighlightingService(new List<Lazy<IHighlighter, LanguageMetadata>>
             {
-                var testDocument = workspace.Documents.Single();
-                var expectedHighlightSpans = testDocument.SelectedSpans ?? new List<TextSpan>();
-                expectedHighlightSpans = Sort(expectedHighlightSpans);
-                var cursorSpan = testDocument.AnnotatedSpans["Cursor"].Single();
-                var textSnapshot = testDocument.GetTextBuffer().CurrentSnapshot;
-                var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+                new Lazy<IHighlighter, LanguageMetadata>(() => highlighter, new LanguageMetadata(document.Project.Language)),
+            });
 
-                // If the position being tested is immediately following the keyword, 
-                // we should get the token before this position to find the appropriate 
-                // ancestor node.
-                var highlighter = CreateHighlighter();
+            var root = await document.GetSyntaxRootAsync();
 
-                var root = await document.GetSyntaxRootAsync();
+            // Check that every point within the span (inclusive) produces the expected set of
+            // results.
+            for (var i = 0; i <= cursorSpan.Length; i++)
+            {
+                var position = cursorSpan.Start + i;
+                var highlightSpans = new List<TextSpan>();
+                service.AddHighlights(root, position, highlightSpans, CancellationToken.None);
 
-                for (var i = 0; i <= cursorSpan.Length; i++)
-                {
-                    var position = cursorSpan.Start + i;
-                    var highlightSpans = highlighter.GetHighlights(root, position, CancellationToken.None).ToList();
-                    highlightSpans = Sort(highlightSpans);
-
-                    CheckSpans(root.SyntaxTree, expectedHighlightSpans, highlightSpans);
-                }
+                CheckSpans(root.SyntaxTree, expectedHighlightSpans, highlightSpans);
             }
         }
 
@@ -84,11 +84,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.KeywordHighlighting
                 if (actual != expected)
                     Assert.Equal(tree.GetLineSpan(expected).Span, tree.GetLineSpan(actual).Span);
             }
-        }
-
-        private List<TextSpan> Sort(IEnumerable<TextSpan> spans)
-        {
-            return spans.OrderBy((s1, s2) => s1.Start - s2.Start).ToList();
         }
     }
 }

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/AccessorDeclarationHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/AccessorDeclarationHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim methodBlock = node.GetAncestor(Of MethodBlockBaseSyntax)()
             If methodBlock Is Nothing OrElse Not TypeOf methodBlock.BlockStatement Is AccessorStatementSyntax Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With methodBlock
                 Dim isIterator = False
@@ -52,8 +50,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndBlockStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ConditionalPreprocessorHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(directive As DirectiveTriviaSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(directive As DirectiveTriviaSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim conditionals = directive.GetMatchingConditionalDirectives(cancellationToken)
             If conditionals Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             For Each conditional In conditionals
                 If TypeOf conditional Is IfDirectiveTriviaSyntax Then
@@ -41,8 +39,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     End With
                 End If
             Next
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ConstructorDeclarationHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ConstructorDeclarationHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim methodBlock = node.GetAncestor(Of MethodBlockBaseSyntax)()
             If methodBlock Is Nothing OrElse Not TypeOf methodBlock.BlockStatement Is SubNewStatementSyntax Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With methodBlock
                 With DirectCast(.BlockStatement, SubNewStatementSyntax)
@@ -36,8 +34,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndBlockStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/DoLoopBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/DoLoopBlockHighlighter.vb
@@ -15,21 +15,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             If node.IsIncorrectContinueStatement(SyntaxKind.ContinueDoStatement) Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             If node.IsIncorrectExitStatement(SyntaxKind.ExitDoStatement) Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             Dim doLoop = node.GetAncestor(Of DoLoopBlockSyntax)()
             If doLoop Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             With doLoop.DoStatement
                 If .WhileOrUntilClause IsNot Nothing Then
@@ -50,8 +48,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.LoopKeyword.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/EnumBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/EnumBlockHighlighter.vb
@@ -15,20 +15,18 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim endBlockStatement = TryCast(node, EndBlockStatementSyntax)
             If endBlockStatement IsNot Nothing Then
                 If endBlockStatement.Kind <> SyntaxKind.EndEnumStatement Then
-                    Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                    Return
                 End If
             End If
 
             Dim enumBlock = node.GetAncestor(Of EnumBlockSyntax)()
             If enumBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             With enumBlock
                 With .EnumStatement
@@ -38,8 +36,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndEnumStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/EventBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/EventBlockHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim eventBlock = node.GetAncestor(Of EventBlockSyntax)()
             If eventBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With eventBlock
                 With .EventStatement
@@ -36,8 +34,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndEventStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/EventDeclarationHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/EventDeclarationHighlighter.vb
@@ -15,15 +15,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overrides Function GetHighlights(eventDeclaration As EventStatementSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overrides Sub AddHighlights(eventDeclaration As EventStatementSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             ' If the ancestor is not a event block, treat this as a single line event.
             ' Otherwise, let the EventBlockHighlighter take over.
             Dim eventBlock = eventDeclaration.GetAncestor(Of EventBlockSyntax)()
             If eventBlock IsNot Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With eventDeclaration
                 Dim firstKeyword = If(.Modifiers.Count > 0, .Modifiers.First(), .DeclarationKeyword)
@@ -33,8 +31,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.ImplementsClause.ImplementsKeyword.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/ForLoopBlockHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim forBlock = GetForBlockFromNode(node)
             If forBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             If TypeOf forBlock.ForOrForEachStatement Is ForStatementSyntax Then
                 With DirectCast(forBlock.ForOrForEachStatement, ForStatementSyntax)
@@ -49,9 +47,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
             If nextStatement IsNot Nothing Then
                 highlights.Add(nextStatement.NextKeyword.Span)
             End If
-
-            Return highlights
-        End Function
+        End Sub
 
         Private Function GetForBlockFromNode(node As SyntaxNode) As ForOrForEachBlockSyntax
             If node.IsIncorrectContinueStatement(SyntaxKind.ContinueForStatement) OrElse

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/MethodDeclarationHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/MethodDeclarationHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim methodBlock = node.GetAncestor(Of MethodBlockBaseSyntax)()
             If methodBlock Is Nothing OrElse Not TypeOf methodBlock.BlockStatement Is MethodStatementSyntax Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With methodBlock
                 Dim isAsync = False
@@ -58,8 +56,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndBlockStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/MultiLineIfBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/MultiLineIfBlockHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(ifBlock As MultiLineIfBlockSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub addHighlights(ifBlock As MultiLineIfBlockSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             With ifBlock.IfStatement
                 ' ElseIf case
                 highlights.Add(.IfKeyword.Span)
@@ -47,8 +45,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
             End If
 
             highlights.Add(ifBlock.EndIfStatement.Span)
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/MultiLineLambdaExpressionHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/MultiLineLambdaExpressionHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim lambdaExpression = node.GetAncestor(Of MultiLineLambdaExpressionSyntax)()
             If lambdaExpression Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With lambdaExpression
                 Dim isAsync = False
@@ -50,8 +48,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndSubOrFunctionStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/NamespaceBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/NamespaceBlockHighlighter.vb
@@ -15,16 +15,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim namespaceBlock = node.GetAncestor(Of NamespaceBlockSyntax)()
             If namespaceBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             With namespaceBlock
-                Return { .NamespaceStatement.NamespaceKeyword.Span,
-                        .EndNamespaceStatement.Span}
+                highlights.Add(.NamespaceStatement.NamespaceKeyword.Span)
+                highlights.Add(.EndNamespaceStatement.Span)
             End With
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/OperatorDeclarationHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/OperatorDeclarationHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim methodBlock = node.GetAncestor(Of MethodBlockBaseSyntax)()
             If methodBlock Is Nothing OrElse Not TypeOf methodBlock.BlockStatement Is OperatorStatementSyntax Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With methodBlock
                 With DirectCast(.BlockStatement, OperatorStatementSyntax)
@@ -36,8 +34,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndBlockStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/PropertyBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/PropertyBlockHighlighter.vb
@@ -15,13 +15,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim propertyBlock = node.GetAncestor(Of PropertyBlockSyntax)()
             If propertyBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With propertyBlock
                 With .PropertyStatement
@@ -35,8 +33,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndPropertyStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/PropertyDeclarationHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/PropertyDeclarationHighlighter.vb
@@ -15,15 +15,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overrides Function GetHighlights(propertyDeclaration As PropertyStatementSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overrides Sub AddHighlights(propertyDeclaration As PropertyStatementSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             ' If the ancestor is not a property block, treat this as an auto-property.
             ' Otherwise, let the PropertyBlockHighlighter take over.
             Dim propertyBlock = propertyDeclaration.GetAncestor(Of PropertyBlockSyntax)()
             If propertyBlock IsNot Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)()
 
             With propertyDeclaration
                 Dim firstKeyword = If(.Modifiers.Count > 0, .Modifiers.First(), .DeclarationKeyword)
@@ -33,8 +31,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.ImplementsClause.ImplementsKeyword.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/RegionHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/RegionHighlighter.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(directive As DirectiveTriviaSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(directive As DirectiveTriviaSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             If TypeOf directive Is RegionDirectiveTriviaSyntax OrElse
                TypeOf directive Is EndRegionDirectiveTriviaSyntax Then
 
@@ -30,12 +30,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                                        DirectCast(directive, EndRegionDirectiveTriviaSyntax),
                                        DirectCast(match, EndRegionDirectiveTriviaSyntax))
 
-                    Return {TextSpan.FromBounds(region.HashToken.SpanStart, region.RegionKeyword.Span.End),
-                            TextSpan.FromBounds(endRegion.HashToken.SpanStart, endRegion.RegionKeyword.Span.End)}
+                    highlights.Add(TextSpan.FromBounds(region.HashToken.SpanStart, region.RegionKeyword.Span.End))
+                    highlights.Add(TextSpan.FromBounds(endRegion.HashToken.SpanStart, endRegion.RegionKeyword.Span.End))
                 End If
             End If
-
-            Return Enumerable.Empty(Of TextSpan)()
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/SelectBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/SelectBlockHighlighter.vb
@@ -15,17 +15,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             If node.IsIncorrectExitStatement(SyntaxKind.ExitSelectStatement) Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             Dim selectBlock = node.GetAncestor(Of SelectBlockSyntax)()
             If selectBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             With selectBlock
                 With .SelectStatement
@@ -52,9 +50,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndSelectStatement.Span)
             End With
-
-            Return highlights
-        End Function
-
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/SingleLineIfBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/SingleLineIfBlockHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(ifStatement As SingleLineIfStatementSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub AddHighlights(ifStatement As SingleLineIfStatementSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             highlights.Add(ifStatement.IfKeyword.Span)
 
             highlights.Add(ifStatement.ThenKeyword.Span)
@@ -25,8 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
             If ifStatement.ElseClause IsNot Nothing Then
                 highlights.Add(ifStatement.ElseClause.ElseKeyword.Span)
             End If
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/SyncLockBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/SyncLockBlockHighlighter.vb
@@ -15,16 +15,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim syncLockBlock = node.GetAncestor(Of SyncLockBlockSyntax)()
             If syncLockBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             With syncLockBlock
-                Return { .SyncLockStatement.SyncLockKeyword.Span,
-                        .EndSyncLockStatement.Span}
+                highlights.Add(.SyncLockStatement.SyncLockKeyword.Span)
+                highlights.Add(.EndSyncLockStatement.Span)
             End With
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/TryBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/TryBlockHighlighter.vb
@@ -15,17 +15,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             If TypeOf node Is ExitStatementSyntax AndAlso node.Kind <> SyntaxKind.ExitTryStatement Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             Dim tryBlock = node.GetAncestor(Of TryBlockSyntax)()
             If tryBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             With tryBlock
                 highlights.Add(.TryStatement.TryKeyword.Span)
@@ -48,10 +46,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                 End If
 
                 highlights.Add(.EndTryStatement.Span)
-
-                Return highlights
             End With
-        End Function
+        End Sub
 
         Private Sub HighlightRelatedStatements(node As SyntaxNode, highlights As List(Of TextSpan))
             If node.Kind = SyntaxKind.ExitTryStatement Then

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/TypeBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/TypeBlockHighlighter.vb
@@ -15,23 +15,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim endBlockStatement = TryCast(node, EndBlockStatementSyntax)
             If endBlockStatement IsNot Nothing Then
                 If Not endBlockStatement.IsKind(SyntaxKind.EndClassStatement,
                                                 SyntaxKind.EndInterfaceStatement,
                                                 SyntaxKind.EndModuleStatement,
                                                 SyntaxKind.EndStructureStatement) Then
-                    Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                    Return
                 End If
             End If
 
             Dim typeBlock = node.GetAncestor(Of TypeBlockSyntax)()
             If typeBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             With typeBlock
                 With .BlockStatement
@@ -41,8 +39,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndBlockStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/UsingBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/UsingBlockHighlighter.vb
@@ -15,16 +15,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim usingBlock = node.GetAncestor(Of UsingBlockSyntax)()
             If usingBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             With usingBlock
-                Return { .UsingStatement.UsingKeyword.Span,
-                        .EndUsingStatement.Span}
+                highlights.Add(.UsingStatement.UsingKeyword.Span)
+                highlights.Add(.EndUsingStatement.Span)
             End With
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/WhileBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/WhileBlockHighlighter.vb
@@ -15,21 +15,19 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             If node.IsIncorrectContinueStatement(SyntaxKind.ContinueWhileStatement) Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             If node.IsIncorrectExitStatement(SyntaxKind.ExitWhileStatement) Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             Dim whileBlock = node.GetAncestor(Of WhileBlockSyntax)()
             If whileBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
-
-            Dim highlights As New List(Of TextSpan)
 
             With whileBlock
                 highlights.Add(.WhileStatement.WhileKeyword.Span)
@@ -40,9 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
 
                 highlights.Add(.EndWhileStatement.Span)
             End With
-
-            Return highlights
-        End Function
+        End Sub
 
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/WithBlockHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/WithBlockHighlighter.vb
@@ -15,16 +15,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As SyntaxNode, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
+        Protected Overloads Overrides Sub AddHighlights(node As SyntaxNode, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim withBlock = node.GetAncestor(Of WithBlockSyntax)()
             If withBlock Is Nothing Then
-                Return SpecializedCollections.EmptyEnumerable(Of TextSpan)()
+                Return
             End If
 
             With withBlock
-                Return { .WithStatement.WithKeyword.Span,
-                        .EndWithStatement.Span}
+                highlights.Add(.WithStatement.WithKeyword.Span)
+                highlights.Add(.EndWithStatement.Span)
             End With
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlCDataHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlCDataHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(xmlComment As XmlCDataSectionSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub addHighlights(xmlComment As XmlCDataSectionSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             With xmlComment
                 If Not .ContainsDiagnostics AndAlso
                    Not .HasAncestor(Of DocumentationCommentTriviaSyntax)() Then
@@ -25,8 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.EndCDataToken.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlCommentHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlCommentHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(xmlComment As XmlCommentSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub addHighlights(xmlComment As XmlCommentSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             With xmlComment
                 If Not .ContainsDiagnostics AndAlso
                    Not .HasAncestor(Of DocumentationCommentTriviaSyntax)() Then
@@ -25,8 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.MinusMinusGreaterThanToken.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlDocumentPrologueHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlDocumentPrologueHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(xmlProcessingInstruction As XmlProcessingInstructionSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub addHighlights(xmlProcessingInstruction As XmlProcessingInstructionSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             With xmlProcessingInstruction
                 If Not .ContainsDiagnostics AndAlso
                    Not .HasAncestor(Of DocumentationCommentTriviaSyntax)() Then
@@ -25,8 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.QuestionGreaterThanToken.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlElementHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlElementHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(node As XmlNodeSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub AddHighlights(node As XmlNodeSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             Dim xmlElement = node.GetAncestor(Of XmlElementSyntax)()
             With xmlElement
                 If xmlElement IsNot Nothing AndAlso
@@ -36,8 +34,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                 End If
 
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlEmbeddedExpressionHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlEmbeddedExpressionHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(xmlEmbeddExpression As XmlEmbeddedExpressionSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub addHighlights(xmlEmbeddExpression As XmlEmbeddedExpressionSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             With xmlEmbeddExpression
                 If Not .ContainsDiagnostics AndAlso
                    Not .HasAncestor(Of DocumentationCommentTriviaSyntax)() Then
@@ -25,8 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.PercentGreaterThanToken.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlProcessingInstructionHighlighter.vb
+++ b/src/EditorFeatures/VisualBasic/Highlighting/KeywordHighlighters/XmlProcessingInstructionHighlighter.vb
@@ -15,9 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
         Public Sub New()
         End Sub
 
-        Protected Overloads Overrides Function GetHighlights(xmlDocumentPrologue As XmlDeclarationSyntax, cancellationToken As CancellationToken) As IEnumerable(Of TextSpan)
-            Dim highlights As New List(Of TextSpan)
-
+        Protected Overloads Overrides Sub addHighlights(xmlDocumentPrologue As XmlDeclarationSyntax, highlights As List(Of TextSpan), cancellationToken As CancellationToken)
             With xmlDocumentPrologue
                 If Not .ContainsDiagnostics AndAlso
                    Not .HasAncestor(Of DocumentationCommentTriviaSyntax)() Then
@@ -25,8 +23,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.KeywordHighlighting
                     highlights.Add(.QuestionGreaterThanToken.Span)
                 End If
             End With
-
-            Return highlights
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Utilities/ObjectPools/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ObjectPools/Extensions.cs
@@ -46,6 +46,13 @@ namespace Microsoft.CodeAnalysis
             return PooledObject<List<TItem>>.Create(pool);
         }
 
+        public static PooledObject<List<TItem>> GetPooledObject<TItem>(this ObjectPool<List<TItem>> pool, out List<TItem> list)
+        {
+            var pooledObject = PooledObject<List<TItem>>.Create(pool);
+            list = pooledObject.Object;
+            return pooledObject;
+        }
+
         public static PooledObject<T> GetPooledObject<T>(this ObjectPool<T> pool) where T : class
         {
             return new PooledObject<T>(pool, p => p.Allocate(), (p, o) => p.Free(o));


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/40211

Removes usages of iterators and pools objects.

VB, in particular, became much nicer as it was always just making lists anyways and using those.