### PR TITLE
Add steps to determine if a signed build is on a -vs-deps branch

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -43,7 +43,7 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
 
-    - powershell: git merge "master-vs-deps"
+    - powershell: git merge origin/master-vs-deps
       displayName: Merging VS Deps 
       condition: and(succeeded(), variables['NonVSDepsBranch'])
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -45,7 +45,7 @@ stages:
 
     - powershell: git merge "master-vs-deps"
       displayName: Merging VS Deps 
-      condition: and(succeeded(), variables['NonVSDepsBranch']))
+      condition: and(succeeded(), variables['NonVSDepsBranch'])
 
     - task: NuGetToolInstaller@0
       inputs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -38,14 +38,14 @@ stages:
       displayName: Setting SourceBranchName variable
 
     - powershell: Write-Host "##vso[task.setvariable variable=NonVSDepsBranch]$($Build.SourceBranch -like '*-vs-deps')"
-      displayName: Setting NonVSDepsBranch variable
+      displayName: Setting VSDepsBranch variable
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
 
     - powershell: git branch -r | select-string "origin/$(Build.SourceBranch)-vs-deps" | select -First 1 | %{ Write-Host "git merge $_" }
       displayName: Merging VS Deps 
-      condition: and(succeeded(), variables['NonVSDepsBranch'])
+      condition: and(succeeded(), not(variables['VSDepsBranch']))
 
     - task: NuGetToolInstaller@0
       inputs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -43,7 +43,7 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
 
-    - powerhsell: git merge "master-vs-deps"
+    - powershell: git merge "master-vs-deps"
       displayName: Merging VS Deps 
       condition: and(succeeded(), variables['NonVSDepsBranch']))
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -37,8 +37,15 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
       displayName: Setting SourceBranchName variable
 
+    - powershell: Write-Host "##vso[task.setvariable variable=NonVSDepsBranch]$($Build.SourceBranch -like '*-vs-deps')"
+      displayName: Setting NonVSDepsBranch variable
+
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
+
+    - powerhsell: git merge "master-vs-deps"
+      displayName: Merging VS Deps 
+      condition: and(succeeded(), variables['NonVSDepsBranch']))
 
     - task: NuGetToolInstaller@0
       inputs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -43,7 +43,7 @@ stages:
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable
 
-    - powershell: git merge origin/master-vs-deps
+    - powershell: git branch -r | select-string "origin/$(Build.SourceBranch)-vs-deps" | select -First 1 | %{ Write-Host "git merge $_" }
       displayName: Merging VS Deps 
       condition: and(succeeded(), variables['NonVSDepsBranch'])
 


### PR DESCRIPTION
Adds two steps to the build: 

1. Set a variable "VSDepsBranch" that will determine if the current branch ends in -vs-deps
2. If not on a VSDepsBranch, then merge a relative vs-deps branch with the same name if it exists