### PR TITLE
Remove hard-coded TS check for RaiseDiagnosticsRemovedForDocument

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -188,9 +188,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             var removeDiagnosticsOnDocumentClose = document.Project.Solution.Options.GetOption(ServiceFeatureOnOffOptions.RemoveDocumentDiagnosticsOnDocumentClose, document.Project.Language);
 
-            // TODO: Remove the below hard-coded check for TypeScript once they update their code to explicitly set the above option.
-            if (document.Project.Language != "TypeScript" &&
-                !removeDiagnosticsOnDocumentClose)
+            if (!removeDiagnosticsOnDocumentClose)
             {
                 return;
             }


### PR DESCRIPTION
Removing the hard-coded workaround for TypeScript added in #39892.

@mavasani @minestarks