### PR TITLE
Fix statement attribute parsing

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7140,6 +7140,7 @@ done:;
                 case SyntaxKind.VolatileKeyword:
                 case SyntaxKind.RefKeyword:
                 case SyntaxKind.ExternKeyword:
+                case SyntaxKind.OpenBracketToken:
                     return true;
 
                 case SyntaxKind.IdentifierToken:
@@ -7156,9 +7157,6 @@ done:;
                 case SyntaxKind.InternalKeyword:
                 case SyntaxKind.ProtectedKeyword:
                 case SyntaxKind.PrivateKeyword:
-                // PROTOTYPE(local-function-attributes): We should unconditionally accept attribute lists on statements
-                // in parsing and then give an error on statement kinds that don't support attributes during binding.
-                case SyntaxKind.OpenBracketToken:
                     return acceptAccessibilityMods;
                 default:
                     return IsPredefinedType(tk)
@@ -8147,14 +8145,11 @@ tryAgain:
 
                 if (canParseAsLocalFunction)
                 {
-                    // If we find an attribute or accessibility modifier but no local function it's likely
+                    // If we find an accessibility modifier but no local function it's likely
                     // the user forgot a closing brace. Let's back out of statement parsing.
-                    if (attributes.Count > 0)
-                    {
-                        return null;
-                    }
-
-                    if (mods.Count > 0 && IsAccessibilityModifier(((SyntaxToken)mods[0]).ContextualKind))
+                    // We check just for a leading accessibility modifier in the syntax because
+                    // SkipBadStatementListTokens will not skip attribute lists.
+                    if (attributes.Count == 0 && mods.Count > 0 && IsAccessibilityModifier(((SyntaxToken)mods[0]).ContextualKind))
                     {
                         return null;
                     }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -3447,40 +3447,36 @@ public class C2 { }
 ";
             // Dev10 fails in Emit or emits invalid metadata
             CreateCompilation(source).VerifyDiagnostics(
-                // (25,6): error CS1513: } expected {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, ""),
-                // (29,1): error CS1022: Type or namespace definition, or end-of-file expected }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}"),
                 // (13,9): error CS0501: 'C.F2(int, string)' must declare a body because it is not marked abstract, extern, or partial
-                //     int F2(int bufSize, StringBuilder buf);
-                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "F2").WithArguments("C.F2(int, string)"),
+                //     int F2(int bufSize, string buf);
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "F2").WithArguments("C.F2(int, string)").WithLocation(13, 9),
                 // (6,6): error CS0601: The DllImport attribute must be specified on a method marked 'static' and 'extern'
                 //     [DllImport("D.DLL")]
-                Diagnostic(ErrorCode.ERR_DllImportOnInvalidMethod, "DllImport"),
+                Diagnostic(ErrorCode.ERR_DllImportOnInvalidMethod, "DllImport").WithLocation(6, 6),
                 // (9,6): error CS0592: Attribute 'DllImport' is not valid on this declaration type. It is only valid on 'method' declarations.
                 //     [DllImport("D.DLL")]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, @"DllImport").WithArguments("DllImport", "method"),
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "DllImport").WithArguments("DllImport", "method").WithLocation(9, 6),
                 // (12,6): error CS0601: The DllImport attribute must be specified on a method marked 'static' and 'extern'
                 //     [DllImport("D.DLL")]
-                Diagnostic(ErrorCode.ERR_DllImportOnInvalidMethod, "DllImport"),
+                Diagnostic(ErrorCode.ERR_DllImportOnInvalidMethod, "DllImport").WithLocation(12, 6),
                 // (15,6): error CS0592: Attribute 'DllImport' is not valid on this declaration type. It is only valid on 'method' declarations.
                 //     [DllImport("D.DLL")]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, @"DllImport").WithArguments("DllImport", "method"),
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "DllImport").WithArguments("DllImport", "method").WithLocation(15, 6),
                 // (18,6): error CS0592: Attribute 'DllImport' is not valid on this declaration type. It is only valid on 'method' declarations.
                 //     [DllImport("d.dll")]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, @"DllImport").WithArguments("DllImport", "method"),
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "DllImport").WithArguments("DllImport", "method").WithLocation(18, 6),
                 // (21,26): error CS0579: Duplicate 'DllImport' attribute
                 //     [DllImport("D.DLL"), DllImport("GDI.DLL")]
-                Diagnostic(ErrorCode.ERR_DuplicateAttribute, @"DllImport").WithArguments("DllImport"),
-                // (26,9): error CS0592: Attribute 'DllImport' is not valid on this declaration type. It is only valid on 'method' declarations.
-                //     [DllImport("d.dll")]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, @"DllImport").WithArguments("DllImport", "method"),
+                Diagnostic(ErrorCode.ERR_DuplicateAttribute, "DllImport").WithArguments("DllImport").WithLocation(21, 26),
+                // (26,8): error CS7014: Attributes are not valid in this context.
+                //        [DllImport("d.dll")]
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, @"[DllImport(""d.dll"")]").WithLocation(26, 8),
                 // (31,2): error CS0592: Attribute 'DllImport' is not valid on this declaration type. It is only valid on 'method' declarations.
-                //     [DllImport("dd.dllL")]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, @"DllImport").WithArguments("DllImport", "method"),
+                // [DllImport("dd.dllL")]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "DllImport").WithArguments("DllImport", "method").WithLocation(31, 2),
                 // (34,2): error CS0592: Attribute 'DllImport' is not valid on this declaration type. It is only valid on 'method' declarations.
-                //     [DllImport("dd.dll")]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, @"DllImport").WithArguments("DllImport", "method"));
+                // [DllImport("dd.dll")]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "DllImport").WithArguments("DllImport", "method").WithLocation(34, 2));
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -885,7 +885,13 @@ class C
             }
             EOF();
 
-            tree.GetDiagnostics().Verify(); // TODO: get binding diagnostics
+            CreateCompilation(tree).VerifyDiagnostics(
+                // (6,9): error CS7014: Attributes are not valid in this context.
+                //         [A] object local;
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,20): warning CS0168: The variable 'local' is declared but never used
+                //         [A] object local;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "local").WithArguments("local").WithLocation(6, 20));
         }
 
         [Fact]
@@ -964,7 +970,16 @@ class C
             }
             EOF();
 
-            tree.GetDiagnostics().Verify(); // TODO: get binding diagnostics
+            CreateCompilation(tree).VerifyDiagnostics(
+                // (6,9): error CS7014: Attributes are not valid in this context.
+                //         [A] object local1, local2;
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,20): warning CS0168: The variable 'local1' is declared but never used
+                //         [A] object local1, local2;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "local1").WithArguments("local1").WithLocation(6, 20),
+                // (6,28): warning CS0168: The variable 'local2' is declared but never used
+                //         [A] object local1, local2;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "local2").WithArguments("local2").WithLocation(6, 28));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -849,35 +849,35 @@ class C
                         N(SyntaxKind.Block);
                         {
                             N(SyntaxKind.OpenBraceToken);
-                            M(SyntaxKind.CloseBraceToken);
-                        }
-                    }
-                    N(SyntaxKind.FieldDeclaration);
-                    {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
+                            N(SyntaxKind.LocalDeclarationStatement);
                             {
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.AttributeList);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "A");
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
                                 }
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.ObjectKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "local");
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
                             }
-                            N(SyntaxKind.CloseBracketToken);
+                            N(SyntaxKind.CloseBraceToken);
                         }
-                        N(SyntaxKind.VariableDeclaration);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.ObjectKeyword);
-                            }
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "local");
-                            }
-                        }
-                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
@@ -885,13 +885,7 @@ class C
             }
             EOF();
 
-            tree.GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+            tree.GetDiagnostics().Verify(); // TODO: get binding diagnostics
         }
 
         [Fact]
@@ -929,40 +923,40 @@ class C
                         N(SyntaxKind.Block);
                         {
                             N(SyntaxKind.OpenBraceToken);
-                            M(SyntaxKind.CloseBraceToken);
-                        }
-                    }
-                    N(SyntaxKind.FieldDeclaration);
-                    {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
+                            N(SyntaxKind.LocalDeclarationStatement);
                             {
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.AttributeList);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "A");
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
                                 }
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.ObjectKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "local1");
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "local2");
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
                             }
-                            N(SyntaxKind.CloseBracketToken);
+                            N(SyntaxKind.CloseBraceToken);
                         }
-                        N(SyntaxKind.VariableDeclaration);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.ObjectKeyword);
-                            }
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "local1");
-                            }
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "local2");
-                            }
-                        }
-                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
@@ -970,13 +964,7 @@ class C
             }
             EOF();
 
-            tree.GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+            tree.GetDiagnostics().Verify(); // TODO: get binding diagnostics
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementAttributeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementAttributeParsingTests.cs
@@ -14,15 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void AttributeOnBlock()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]{}
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -81,15 +80,14 @@ class C
         [Fact]
         public void AttributeOnEmptyStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A];
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -147,7 +145,7 @@ class C
         [Fact]
         public void AttributeOnLabeledStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -156,8 +154,7 @@ class C
         bar:
             Goo();
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -235,7 +232,7 @@ class C
         [Fact]
         public void AttributeOnGotoStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -245,8 +242,7 @@ class C
         bar:
             Goo();
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -331,7 +327,7 @@ class C
         [Fact]
         public void AttributeOnBreakStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -342,8 +338,7 @@ class C
             break;
         }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -417,7 +412,7 @@ class C
         [Fact]
         public void AttributeOnContinueStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -428,8 +423,7 @@ class C
             continue;
         }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -503,15 +497,14 @@ class C
         [Fact]
         public void AttributeOnReturn()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]return;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -570,15 +563,14 @@ class C
         [Fact]
         public void AttributeOnThrow()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]throw;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -640,15 +632,14 @@ class C
         [Fact]
         public void AttributeOnYieldReturn()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]yield return 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -715,15 +706,14 @@ class C
         [Fact]
         public void AttributeOnYieldBreak()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]yield return 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -790,15 +780,14 @@ class C
         [Fact]
         public void AttributeOnNakedYield()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]yield
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -866,15 +855,14 @@ class C
         [Fact]
         public void AttributeOnWhileStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]while (true);
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -942,15 +930,14 @@ class C
         [Fact]
         public void AttributeOnDoStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]do { } while (true);
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1021,15 +1008,14 @@ class C
         [Fact]
         public void AttributeOnForStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]for (;;) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1096,15 +1082,14 @@ class C
         [Fact]
         public void AttributeOnNormalForEachStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(string[] vals)
     {
         [A]foreach (var v in vals) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1199,15 +1184,14 @@ class C
         [Fact]
         public void AttributeOnForEachVariableStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo((int, string)[] vals)
     {
         [A]foreach (var (i, s) in vals) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1334,15 +1318,14 @@ class C
         [Fact]
         public void AttributeOnUsingStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]using (null) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1411,15 +1394,14 @@ class C
         [Fact]
         public void AttributeOnAwaitUsingStatement1()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]await using (null) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1498,15 +1480,14 @@ class C
         [Fact]
         public void AttributeOnAwaitUsingStatement2()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     async void Goo()
     {
         [A]await using (null) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1583,15 +1564,14 @@ class C
         [Fact]
         public void AttributeOnFixedStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     unsafe void Goo(int[] vals)
     {
         [A]fixed (int* p = vals) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1703,15 +1683,14 @@ class C
         [Fact]
         public void AttributeOnCheckedStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]checked { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1774,15 +1753,14 @@ class C
         [Fact]
         public void AttributeOnCheckedBlock()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         checked [A]{ }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1845,15 +1823,14 @@ class C
         [Fact]
         public void AttributeOnUncheckedStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]unchecked { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1916,15 +1893,14 @@ class C
         [Fact]
         public void AttributeOnUnsafeStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]unsafe { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1990,15 +1966,14 @@ class C
         [Fact]
         public void AttributeOnUnsafeBlock()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         unsafe [A]{ }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2088,15 +2063,14 @@ class C
         [Fact]
         public void AttributeOnLockStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]lock (null) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2165,15 +2139,14 @@ class C
         [Fact]
         public void AttributeOnIfStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]if (true) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2242,15 +2215,14 @@ class C
         [Fact]
         public void AttributeOnSwitchStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]switch (0) { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2319,7 +2291,7 @@ class C
         [Fact]
         public void AttributeOnStatementInSwitchSection()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -2330,8 +2302,7 @@ class C
                 [A]return;
         }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2410,7 +2381,7 @@ class C
         [Fact]
         public void AttributeOnStatementAboveCase()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -2422,8 +2393,7 @@ class C
                 return;
         }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2534,7 +2504,7 @@ class C
         [Fact]
         public void AttributeOnStatementAboveDefaultCase()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
@@ -2546,8 +2516,7 @@ class C
                 return;
         }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2644,15 +2613,14 @@ class C
         [Fact]
         public void AttributeOnTryStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]try { } finally { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2724,15 +2692,14 @@ class C
         [Fact]
         public void AttributeOnTryBlock()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         try [A] { } finally { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2804,15 +2771,14 @@ class C
         [Fact]
         public void AttributeOnFinally()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         try { } [A] finally { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2914,15 +2880,14 @@ class C
         [Fact]
         public void AttributeOnFinallyBlock()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         try { } finally [A] { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2994,15 +2959,14 @@ class C
         [Fact]
         public void AttributeOnCatch()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         try { } [A] catch { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3104,15 +3068,14 @@ class C
         [Fact]
         public void AttributeOnCatchBlock()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         try { } catch [A] { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3184,15 +3147,14 @@ class C
         [Fact]
         public void AttributeOnEmbeddedStatement()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         if (true) [A]return;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3261,15 +3223,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AnonymousMethod_NoParameters()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]delegate { }
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3339,15 +3300,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AnonymousMethod_NoBody()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]delegate
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3420,15 +3380,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AnonymousMethod_Parameters()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]delegate () { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3503,15 +3462,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Lambda_NoParameters()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]() => { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3586,15 +3544,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Lambda_Parameters1()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A](int i) => { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3677,15 +3634,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Lambda_Parameters2()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]i => { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3759,15 +3715,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AnonymousObject()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]new { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3834,15 +3789,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_ArrayCreation()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]new int[] { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -3928,15 +3882,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AnonymousArrayCreation()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]new [] { 0 };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4012,15 +3965,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Assignment()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a)
     {
         [A]a = 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4098,15 +4050,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_CompoundAssignment()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a)
     {
         [A]a += 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4184,15 +4135,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AwaitExpression_NonAsyncContext()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]await a;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4267,15 +4217,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_AwaitExpression_AsyncContext()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     async void Goo()
     {
         [A]await a;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4345,15 +4294,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_BinaryExpression()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a)
     {
         [A]a + a;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4434,15 +4382,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_CastExpression()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a)
     {
         [A](object)a;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4524,15 +4471,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_ConditionalAccess()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(string a)
     {
         [A]a?.ToString();
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4622,15 +4568,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_DefaultExpression()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]default(int);
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4701,15 +4646,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_DefaultLiteral()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]default;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4777,15 +4721,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_ElementAccess()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(string s)
     {
         [A]s[0];
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4873,15 +4816,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_ElementBinding()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(string s)
     {
         [A]s?[0];
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -4973,15 +4915,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Invocation()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]Goo();
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5051,15 +4992,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Literal()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5124,15 +5064,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_MemberAccess()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int i)
     {
         [A]i.ToString;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5213,15 +5152,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_ObjectCreation_Builtin()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]new int();
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5292,15 +5230,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_ObjectCreation_TypeName()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]new System.Int32();
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5379,15 +5316,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Parenthesized()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A](1);
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5457,15 +5393,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_PostfixUnary()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int i)
     {
         [A]i++;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5539,15 +5474,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_PrefixUnary()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int i)
     {
         [A]++i;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5621,7 +5555,7 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Query()
         {
-            var test = @"
+            var test = UsingTree(@"
 using System.Linq;
 class C
 {
@@ -5629,8 +5563,7 @@ class C
     {
         [A]from c in s select c;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5740,15 +5673,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Range1()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a, int b)
     {
         [A]a..b;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5847,15 +5779,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Range2()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a, int b)
     {
         [A]a..;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -5947,15 +5878,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Range3()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a, int b)
     {
         [A]..b;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6047,15 +5977,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Range4()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a, int b)
     {
         [A]..;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6140,15 +6069,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_Sizeof()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]sizeof(int);
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6219,15 +6147,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_SwitchExpression()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(int a)
     {
         [A]a switch { };
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6312,15 +6239,14 @@ class C
         [Fact]
         public void AttributeOnExpressionStatement_TypeOf()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]typeof(int);
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6391,15 +6317,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember1()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]int i;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6471,15 +6396,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember2()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]int i, j;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6559,15 +6483,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember3()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]int i = 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6647,15 +6570,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember4()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]int this[int i] => 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6787,15 +6709,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember5()
         {
-            var test = @"
+            var tree = UsingTree(@"
 class C
 {
     void Goo()
     {
         [A]const int i = 0;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6864,7 +6785,7 @@ class C
             }
             EOF();
 
-            CreateCompilation(test).GetDiagnostics().Verify(
+            CreateCompilation(tree).GetDiagnostics().Verify(
                 // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]const int i = 0;
                 Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
@@ -7228,15 +7149,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember8()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(System.IAsyncDisposable d)
     {
         [A]await using var i = d;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -7340,15 +7260,14 @@ class C
         [Fact]
         public void AttributeOnLocalDeclOrMember9()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     async void Goo(System.IAsyncDisposable d)
     {
         [A]await using var i = d;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementAttributeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementAttributeParsingTests.cs
@@ -2654,7 +2654,6 @@ class C
 }";
             UsingTree(test);
 
-
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -4183,7 +4182,7 @@ class C
         }
 
         [Fact]
-        public void AttributeOnExpressionStatement_AwaitExpresion_NonAsyncContext()
+        public void AttributeOnExpressionStatement_AwaitExpression_NonAsyncContext()
         {
             var test = @"
 class C
@@ -4195,29 +4194,78 @@ class C
 }";
             UsingTree(test);
 
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "Goo");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.AttributeList);
+                                {
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
+                                }
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "await");
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "a");
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+
             CreateCompilation(test).GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]await a;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
-                //         [A]await a;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
                 // (6,12): error CS0246: The type or namespace name 'await' could not be found (are you missing a using directive or an assembly reference?)
                 //         [A]await a;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "await").WithArguments("await").WithLocation(6, 12),
-                // (6,18): warning CS0169: The field 'C.a' is never used
+                // (6,18): warning CS0168: The variable 'a' is declared but never used
                 //         [A]await a;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "a").WithArguments("C.a").WithLocation(6, 18),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "a").WithArguments("a").WithLocation(6, 18));
         }
 
         [Fact]
-        public void AttributeOnExpressionStatement_AwaitExpresion_AsyncContext()
+        public void AttributeOnExpressionStatement_AwaitExpression_AsyncContext()
         {
             var test = @"
 class C
@@ -5501,7 +5549,6 @@ class C
 }";
             UsingTree(test);
 
-
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -6354,22 +6401,71 @@ class C
 }";
             UsingTree(test);
 
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "Goo");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.AttributeList);
+                                {
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
+                                }
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "i");
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+
             CreateCompilation(test).GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]int i;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,16): warning CS0168: The variable 'i' is declared but never used
                 //         [A]int i;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
-                // (6,16): warning CS0169: The field 'C.i' is never used
-                //         [A]int i;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "i").WithArguments("C.i").WithLocation(6, 16),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "i").WithArguments("i").WithLocation(6, 16));
         }
 
         [Fact]
@@ -6407,40 +6503,40 @@ class C
                         N(SyntaxKind.Block);
                         {
                             N(SyntaxKind.OpenBraceToken);
-                            M(SyntaxKind.CloseBraceToken);
-                        }
-                    }
-                    N(SyntaxKind.FieldDeclaration);
-                    {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
+                            N(SyntaxKind.LocalDeclarationStatement);
                             {
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.AttributeList);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "A");
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
                                 }
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "i");
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "j");
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
                             }
-                            N(SyntaxKind.CloseBracketToken);
+                            N(SyntaxKind.CloseBraceToken);
                         }
-                        N(SyntaxKind.VariableDeclaration);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "i");
-                            }
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "j");
-                            }
-                        }
-                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
@@ -6449,30 +6545,15 @@ class C
             EOF();
 
             CreateCompilation(test).GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]int i, j;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,16): warning CS0168: The variable 'i' is declared but never used
                 //         [A]int i, j;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "i").WithArguments("i").WithLocation(6, 16),
+                // (6,19): warning CS0168: The variable 'j' is declared but never used
                 //         [A]int i, j;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
-                //         [A]int i, j;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
-                // (6,16): warning CS0169: The field 'C.i' is never used
-                //         [A]int i, j;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "i").WithArguments("C.i").WithLocation(6, 16),
-                // (6,19): warning CS0169: The field 'C.j' is never used
-                //         [A]int i, j;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "j").WithArguments("C.j").WithLocation(6, 19),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "j").WithArguments("j").WithLocation(6, 19));
         }
 
         [Fact]
@@ -6510,43 +6591,43 @@ class C
                         N(SyntaxKind.Block);
                         {
                             N(SyntaxKind.OpenBraceToken);
-                            M(SyntaxKind.CloseBraceToken);
-                        }
-                    }
-                    N(SyntaxKind.FieldDeclaration);
-                    {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
+                            N(SyntaxKind.LocalDeclarationStatement);
                             {
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.AttributeList);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "A");
-                                }
-                            }
-                            N(SyntaxKind.CloseBracketToken);
-                        }
-                        N(SyntaxKind.VariableDeclaration);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "i");
-                                N(SyntaxKind.EqualsValueClause);
-                                {
-                                    N(SyntaxKind.EqualsToken);
-                                    N(SyntaxKind.NumericLiteralExpression);
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
                                     {
-                                        N(SyntaxKind.NumericLiteralToken, "0");
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
+                                }
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "i");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "0");
+                                            }
+                                        }
                                     }
                                 }
+                                N(SyntaxKind.SemicolonToken);
                             }
+                            N(SyntaxKind.CloseBraceToken);
                         }
-                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
@@ -6555,21 +6636,12 @@ class C
             EOF();
 
             CreateCompilation(test).GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]int i = 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,16): warning CS0219: The variable 'i' is assigned but its value is never used
                 //         [A]int i = 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
-                // (6,16): warning CS0414: The field 'C.i' is assigned but its value is never used
-                //         [A]int i = 0;
-                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "i").WithArguments("C.i").WithLocation(6, 16),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 16));
         }
 
         [Fact]
@@ -6607,50 +6679,74 @@ class C
                         N(SyntaxKind.Block);
                         {
                             N(SyntaxKind.OpenBraceToken);
-                            M(SyntaxKind.CloseBraceToken);
-                        }
-                    }
-                    N(SyntaxKind.IndexerDeclaration);
-                    {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
+                            N(SyntaxKind.LocalDeclarationStatement);
                             {
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.AttributeList);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "A");
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
                                 }
-                            }
-                            N(SyntaxKind.CloseBracketToken);
-                        }
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.ThisKeyword);
-                        N(SyntaxKind.BracketedParameterList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Parameter);
-                            {
-                                N(SyntaxKind.PredefinedType);
+                                N(SyntaxKind.VariableDeclaration);
                                 {
-                                    N(SyntaxKind.IntKeyword);
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    M(SyntaxKind.VariableDeclarator);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
                                 }
-                                N(SyntaxKind.IdentifierToken, "i");
+                                M(SyntaxKind.SemicolonToken);
                             }
-                            N(SyntaxKind.CloseBracketToken);
-                        }
-                        N(SyntaxKind.ArrowExpressionClause);
-                        {
-                            N(SyntaxKind.EqualsGreaterThanToken);
-                            N(SyntaxKind.NumericLiteralExpression);
+                            N(SyntaxKind.ExpressionStatement);
                             {
-                                N(SyntaxKind.NumericLiteralToken, "0");
+                                N(SyntaxKind.ElementAccessExpression);
+                                {
+                                    N(SyntaxKind.ThisExpression);
+                                    {
+                                        N(SyntaxKind.ThisKeyword);
+                                    }
+                                    N(SyntaxKind.BracketedArgumentList);
+                                    {
+                                        N(SyntaxKind.OpenBracketToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                        }
+                                        M(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "i");
+                                            }
+                                        }
+                                        N(SyntaxKind.CloseBracketToken);
+                                    }
+                                }
+                                M(SyntaxKind.SemicolonToken);
                             }
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
                         }
-                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
@@ -6659,18 +6755,33 @@ class C
             EOF();
 
             CreateCompilation(test).GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]int this[int i] => 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,16): error CS1001: Identifier expected
                 //         [A]int this[int i] => 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "this").WithLocation(6, 16),
+                // (6,16): error CS1002: ; expected
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "this").WithLocation(6, 16),
+                // (6,21): error CS1525: Invalid expression term 'int'
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(6, 21),
+                // (6,25): error CS1003: Syntax error, ',' expected
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "i").WithArguments(",", "").WithLocation(6, 25),
+                // (6,25): error CS0103: The name 'i' does not exist in the current context
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "i").WithArguments("i").WithLocation(6, 25),
+                // (6,28): error CS1002: ; expected
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "=>").WithLocation(6, 28),
+                // (6,28): error CS1513: } expected
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "=>").WithLocation(6, 28),
+                // (6,31): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
+                //         [A]int this[int i] => 0;
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "0").WithLocation(6, 31));
         }
 
         [Fact]
@@ -6708,44 +6819,44 @@ class C
                         N(SyntaxKind.Block);
                         {
                             N(SyntaxKind.OpenBraceToken);
-                            M(SyntaxKind.CloseBraceToken);
-                        }
-                    }
-                    N(SyntaxKind.FieldDeclaration);
-                    {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
+                            N(SyntaxKind.LocalDeclarationStatement);
                             {
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.AttributeList);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "A");
-                                }
-                            }
-                            N(SyntaxKind.CloseBracketToken);
-                        }
-                        N(SyntaxKind.ConstKeyword);
-                        N(SyntaxKind.VariableDeclaration);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.VariableDeclarator);
-                            {
-                                N(SyntaxKind.IdentifierToken, "i");
-                                N(SyntaxKind.EqualsValueClause);
-                                {
-                                    N(SyntaxKind.EqualsToken);
-                                    N(SyntaxKind.NumericLiteralExpression);
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
                                     {
-                                        N(SyntaxKind.NumericLiteralToken, "0");
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
+                                }
+                                N(SyntaxKind.ConstKeyword);
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "i");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "0");
+                                            }
+                                        }
                                     }
                                 }
+                                N(SyntaxKind.SemicolonToken);
                             }
+                            N(SyntaxKind.CloseBraceToken);
                         }
-                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }
@@ -6754,47 +6865,25 @@ class C
             EOF();
 
             CreateCompilation(test).GetDiagnostics().Verify(
-                // (5,6): error CS1513: } expected
-                //     {
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]const int i = 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,22): warning CS0219: The variable 'i' is assigned but its value is never used
                 //         [A]const int i = 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
-                // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 22));
         }
 
         [Fact]
-        public void AttributeOnLocalDeclOrMember6()
+        public void AccessModOnLocalDeclOrMember_01()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo()
     {
-        [A]public int i = 0;
+        public extern int i = 1;
     }
-}";
-            UsingTree(test);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+}");
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -6823,19 +6912,8 @@ class C
                     }
                     N(SyntaxKind.FieldDeclaration);
                     {
-                        N(SyntaxKind.AttributeList);
-                        {
-                            N(SyntaxKind.OpenBracketToken);
-                            N(SyntaxKind.Attribute);
-                            {
-                                N(SyntaxKind.IdentifierName);
-                                {
-                                    N(SyntaxKind.IdentifierToken, "A");
-                                }
-                            }
-                            N(SyntaxKind.CloseBracketToken);
-                        }
                         N(SyntaxKind.PublicKeyword);
+                        N(SyntaxKind.ExternKeyword);
                         N(SyntaxKind.VariableDeclaration);
                         {
                             N(SyntaxKind.PredefinedType);
@@ -6850,7 +6928,7 @@ class C
                                     N(SyntaxKind.EqualsToken);
                                     N(SyntaxKind.NumericLiteralExpression);
                                     {
-                                        N(SyntaxKind.NumericLiteralToken, "0");
+                                        N(SyntaxKind.NumericLiteralToken, "1");
                                     }
                                 }
                             }
@@ -6863,33 +6941,200 @@ class C
             }
             EOF();
 
-            CreateCompilation(test).GetDiagnostics().Verify(
+            CreateCompilation(test).VerifyDiagnostics(
                 // (5,6): error CS1513: } expected
                 //     {
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 6),
-                // (6,10): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
-                //         [A]public int i = 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(6, 10),
-                // (6,10): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
-                //         [A]public int i = 0;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(6, 10),
+                // (6,27): error CS0106: The modifier 'extern' is not valid for this item
+                //         public extern int i = 1;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "i").WithArguments("extern").WithLocation(6, 27),
                 // (8,1): error CS1022: Type or namespace definition, or end-of-file expected
                 // }
                 Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(8, 1));
         }
 
         [Fact]
+        public void AccessModOnLocalDeclOrMember_02()
+        {
+            var test = UsingTree(@"
+class C
+{
+    void Goo()
+    {
+        extern public int i = 1;
+    }
+}");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "Goo");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.ExternKeyword);
+                                N(SyntaxKind.PublicKeyword);
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "i");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "1");
+                                            }
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+
+            CreateCompilation(test).VerifyDiagnostics(
+                // (6,9): error CS0106: The modifier 'extern' is not valid for this item
+                //         extern public int i = 1;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "extern").WithArguments("extern").WithLocation(6, 9),
+                // (6,16): error CS0106: The modifier 'public' is not valid for this item
+                //         extern public int i = 1;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "public").WithArguments("public").WithLocation(6, 16),
+                // (6,27): warning CS0219: The variable 'i' is assigned but its value is never used
+                //         extern public int i = 1;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 27));
+        }
+
+        [Fact]
+        public void AttributeOnLocalDeclOrMember6()
+        {
+            var test = UsingTree(@"
+class C
+{
+    void Goo()
+    {
+        [A]public int i = 0;
+    }
+}");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "Goo");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.AttributeList);
+                                {
+                                    N(SyntaxKind.OpenBracketToken);
+                                    N(SyntaxKind.Attribute);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "A");
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBracketToken);
+                                }
+                                N(SyntaxKind.PublicKeyword);
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "i");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "0");
+                                            }
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+
+            CreateCompilation(test).GetDiagnostics().Verify(
+                // (6,9): error CS7014: Attributes are not valid in this context.
+                //         [A]public int i = 0;
+                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),
+                // (6,12): error CS0106: The modifier 'public' is not valid for this item
+                //         [A]public int i = 0;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "public").WithArguments("public").WithLocation(6, 12),
+                // (6,23): warning CS0219: The variable 'i' is assigned but its value is never used
+                //         [A]public int i = 0;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 23));
+        }
+
+        [Fact]
         public void AttributeOnLocalDeclOrMember7()
         {
-            var test = @"
+            var test = UsingTree(@"
 class C
 {
     void Goo(System.IDisposable d)
     {
         [A]using var i = d;
     }
-}";
-            UsingTree(test);
+}");
 
             N(SyntaxKind.CompilationUnit);
             {


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/40011#discussion_r356329949

It looks like something in the merge of @CyrusNajmabadi's work went awry and caused us to stop actually parsing attributes on some statements. This work fixes up the implementation and some tests to get us going as expected again.

The fix involves tweaking the heuristic for whether we give up on parsing a statement and assume instead that there is a missing `}` and this statement is really a member. It could potentially be improved by scanning tokens in `IsPossibleStatement` and using a reset point but it seemed like a bit more work for small gain. Would like to know what you think though.