### PR TITLE
Validate that nodes from UsingTree/UsingNode are consumed

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -1348,6 +1348,7 @@ class C
                 N(SyntaxKind.OpenBraceToken);
                 N(memberKind);
                 N(SyntaxKind.AsyncKeyword);
+                Flush();
             };
 
             // ... 'async' <typedecl> ...

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -1326,126 +1326,483 @@ class C
             });
         }
 
+        // Comment directly from CParser::IsAsyncMethod.
+        // ... 'async' [partial] <typedecl> ...
+        // ... 'async' [partial] <event> ...
+        // ... 'async' [partial] <implicit> <operator> ...
+        // ... 'async' [partial] <explicit> <operator> ...
+        // ... 'async' [partial] <typename> <operator> ...
+        // ... 'async' [partial] <typename> <membername> ...
+        // DEVNOTE: Although we parse async user defined conversions, operators, etc. here,
+        // anything other than async methods are detected as erroneous later, during the define phase
+
         [Fact]
-        public void AsyncModifierCases()
+        public void AsyncInterface()
         {
-            // Comment directly from CParser::IsAsyncMethod.
-            // ... 'async' [partial] <typedecl> ...
-            // ... 'async' [partial] <event> ...
-            // ... 'async' [partial] <implicit> <operator> ...
-            // ... 'async' [partial] <explicit> <operator> ...
-            // ... 'async' [partial] <typename> <operator> ...
-            // ... 'async' [partial] <typename> <membername> ...
-            // DEVNOTE: Although we parse async user defined conversions, operators, etc. here,
-            // anything other than async methods are detected as erroneous later, during the define phase
-
-            Action<SyntaxKind> Check = memberKind =>
-            {
-                N(SyntaxKind.CompilationUnit);
-                N(SyntaxKind.ClassDeclaration);
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken);
-                N(SyntaxKind.OpenBraceToken);
-                N(memberKind);
-                N(SyntaxKind.AsyncKeyword);
-                Flush();
-            };
-
             // ... 'async' <typedecl> ...
             UsingTree(@"
 class C
 {
     async interface
 ");
-            Check(SyntaxKind.InterfaceDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.InterfaceDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.InterfaceKeyword);
+                        M(SyntaxKind.IdentifierToken);
+                        M(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncPartialClass()
+        {
             // ... 'async' 'partial' <typedecl> ...
             UsingTree(@"
 class C
 {
     async partial class
 ");
-            Check(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ClassDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PartialKeyword);
+                        N(SyntaxKind.ClassKeyword);
+                        M(SyntaxKind.IdentifierToken);
+                        M(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncEvent()
+        {
             // ... 'async' <event> ...
             UsingTree(@"
 class C
 {
     async event
 ");
-            Check(SyntaxKind.EventDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.EventDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.EventKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.IdentifierToken);
+                        M(SyntaxKind.AccessorList);
+                        {
+                            M(SyntaxKind.OpenBraceToken);
+                            M(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncPartialEvent()
+        {
             // ... 'async' 'partial' <event> ...
             UsingTree(@"
 class C
 {
     async partial event
 ");
-            Check(SyntaxKind.IncompleteMember);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.IncompleteMember);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                    }
+                    N(SyntaxKind.EventDeclaration);
+                    {
+                        N(SyntaxKind.EventKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.IdentifierToken);
+                        M(SyntaxKind.AccessorList);
+                        {
+                            M(SyntaxKind.OpenBraceToken);
+                            M(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncImplicitOperator()
+        {
             // ... 'async' <implicit> <operator> ...
             UsingTree(@"
 class C
 {
     async implicit operator
 ");
-            Check(SyntaxKind.ConversionOperatorDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ConversionOperatorDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.ImplicitKeyword);
+                        N(SyntaxKind.OperatorKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncPartialImplicitOperator()
+        {
             // ... 'async' 'partial' <implicit> <operator> ...
             UsingTree(@"
 class C
 {
     async partial implicit operator
 ");
-            Check(SyntaxKind.OperatorDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.OperatorDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        M(SyntaxKind.OperatorKeyword);
+                        M(SyntaxKind.PlusToken);
+                        M(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncExplicitOperator()
+        {
             // ... 'async' <explicit> <operator> ...
             UsingTree(@"
 class C
 {
     async explicit operator
 ");
-            Check(SyntaxKind.ConversionOperatorDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ConversionOperatorDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.ExplicitKeyword);
+                        N(SyntaxKind.OperatorKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncPartialExplicitOperator()
+        {
             // ... 'async' 'partial' <explicit> <operator> ...
             UsingTree(@"
 class C
 {
     async partial explicit operator
 ");
-            Check(SyntaxKind.OperatorDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.OperatorDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        M(SyntaxKind.OperatorKeyword);
+                        M(SyntaxKind.PlusToken);
+                        M(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncTypeOperator()
+        {
             // ... 'async' <typename> <operator> ...
             UsingTree(@"
 class C
 {
     async C operator
 ");
-            Check(SyntaxKind.OperatorDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.OperatorDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "C");
+                        }
+                        N(SyntaxKind.OperatorKeyword);
+                        M(SyntaxKind.PlusToken);
+                        M(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncPartialTypeOperator()
+        {
             // ... 'async' 'partial' <typename> <operator> ...
             UsingTree(@"
 class C
 {
     async partial int operator
 ");
-            Check(SyntaxKind.IncompleteMember);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.IncompleteMember);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                    }
+                    N(SyntaxKind.OperatorDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.OperatorKeyword);
+                        M(SyntaxKind.PlusToken);
+                        M(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncField()
+        {
             // ... 'async' <typename> <membername> ...
             UsingTree(@"
 class C
 {
     async C C
 ");
-            Check(SyntaxKind.FieldDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.FieldDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.VariableDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "C");
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "C");
+                            }
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
 
+        [Fact]
+        public void AsyncPartialIndexer()
+        {
             // ... 'async' 'partial' <typename> <membername> ...
             UsingTree(@"
 class C
 {
     async partial C this
 ");
-            Check(SyntaxKind.IndexerDeclaration);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.IndexerDeclaration);
+                    {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PartialKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "C");
+                        }
+                        N(SyntaxKind.ThisKeyword);
+                        M(SyntaxKind.BracketedParameterList);
+                        {
+                            M(SyntaxKind.OpenBracketToken);
+                            M(SyntaxKind.CloseBracketToken);
+                        }
+                        M(SyntaxKind.AccessorList);
+                        {
+                            M(SyntaxKind.OpenBraceToken);
+                            M(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
@@ -441,10 +441,25 @@ async () => await base.g();
                     {
                         N(SyntaxKind.SimpleMemberAccessExpression);
                         {
+                            N(SyntaxKind.BaseExpression);
+                            {
+                                N(SyntaxKind.BaseKeyword);
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "g");
+                            }
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
                         }
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -468,9 +483,27 @@ async () => await this.g();
                     N(SyntaxKind.AwaitKeyword);
                     N(SyntaxKind.InvocationExpression);
                     {
+                        N(SyntaxKind.SimpleMemberAccessExpression);
+                        {
+                            N(SyntaxKind.ThisExpression);
+                            {
+                                N(SyntaxKind.ThisKeyword);
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "g");
+                            }
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -494,9 +527,17 @@ async () => await default(Task);
                     N(SyntaxKind.AwaitKeyword);
                     N(SyntaxKind.DefaultExpression);
                     {
+                        N(SyntaxKind.DefaultKeyword);
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Task");
+                        }
+                        N(SyntaxKind.CloseParenToken);
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -520,9 +561,11 @@ async () => await goo;
                     N(SyntaxKind.AwaitKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
+                        N(SyntaxKind.IdentifierToken, "goo");
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -546,9 +589,17 @@ async () => await checked { };
                     N(SyntaxKind.AwaitKeyword);
                     N(SyntaxKind.CheckedExpression);
                     {
+                        N(SyntaxKind.CheckedKeyword);
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CloseParenToken);
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -572,9 +623,17 @@ async () => await unchecked { };
                     N(SyntaxKind.AwaitKeyword);
                     N(SyntaxKind.UncheckedExpression);
                     {
+                        N(SyntaxKind.UncheckedKeyword);
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CloseParenToken);
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -599,9 +658,23 @@ async () => await (goo());
                     N(SyntaxKind.ParenthesizedExpression);
                     {
                         N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "goo");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseParenToken);
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]
@@ -625,9 +698,20 @@ async () => await new Goo();
                     N(SyntaxKind.AwaitKeyword);
                     N(SyntaxKind.ObjectCreationExpression);
                     {
+                        N(SyntaxKind.NewKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Goo");
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -4049,6 +4049,20 @@ select t";
                 // (1,2): error CS8401: Unexpected character sequence '...'
                 // 1...2
                 Diagnostic(ErrorCode.ERR_TripleDotNotAllowed, "").WithLocation(1, 2));
+
+            N(SyntaxKind.RangeExpression);
+            {
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+                N(SyntaxKind.DotDotToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, ".2");
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4561,6 +4575,20 @@ select t";
                 // (1,4): error CS1001: Identifier expected
                 // 1. .2
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, ".2").WithLocation(1, 4));
+
+            N(SyntaxKind.SimpleMemberAccessExpression);
+            {
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+                N(SyntaxKind.DotToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4570,6 +4598,12 @@ select t";
                 // (1,1): error CS1073: Unexpected token '.'
                 // .. .ToString()
                 Diagnostic(ErrorCode.ERR_UnexpectedToken, "..").WithArguments(".").WithLocation(1, 1));
+
+            N(SyntaxKind.RangeExpression);
+            {
+                N(SyntaxKind.DotDotToken);
+            }
+            EOF();
         }
 
         [Fact]
@@ -4579,6 +4613,16 @@ select t";
                 // (1,1): error CS1073: Unexpected token '.'
                 // 1.. .ToString()
                 Diagnostic(ErrorCode.ERR_UnexpectedToken, "1..").WithArguments(".").WithLocation(1, 1));
+
+            N(SyntaxKind.RangeExpression);
+            {
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "1");
+                }
+                N(SyntaxKind.DotDotToken);
+            }
+            EOF();
         }
 
         [Fact]
@@ -4657,6 +4701,29 @@ select t";
                 // (1,6): error CS1733: Expected expression
                 // c?..b
                 Diagnostic(ErrorCode.ERR_ExpressionExpected, "").WithLocation(1, 6));
+
+            N(SyntaxKind.ConditionalExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "c");
+                }
+                N(SyntaxKind.QuestionToken);
+                N(SyntaxKind.RangeExpression);
+                {
+                    N(SyntaxKind.DotDotToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                }
+                M(SyntaxKind.ColonToken);
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4830,6 +4897,37 @@ select t";
                 // (1,17): error CS1525: Invalid expression term '}'
                 // new C { P = ref }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, 17));
+
+            N(SyntaxKind.ObjectCreationExpression);
+            {
+                N(SyntaxKind.NewKeyword);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "C");
+                }
+                N(SyntaxKind.ObjectInitializerExpression);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.SimpleAssignmentExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "P");
+                        }
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.RefExpression);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4843,6 +4941,29 @@ select t";
                 // (1,13): error CS1525: Invalid expression term '}'
                 // new C { ref }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, 13));
+
+            N(SyntaxKind.ObjectCreationExpression);
+            {
+                N(SyntaxKind.NewKeyword);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "C");
+                }
+                N(SyntaxKind.CollectionInitializerExpression);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.RefExpression);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4856,6 +4977,39 @@ select t";
                 // (1,18): error CS1525: Invalid expression term '}'
                 // new C { { 0, ref } }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "}").WithArguments("}").WithLocation(1, 18));
+
+            N(SyntaxKind.ObjectCreationExpression);
+            {
+                N(SyntaxKind.NewKeyword);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "C");
+                }
+                N(SyntaxKind.CollectionInitializerExpression);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ComplexElementInitializerExpression);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.RefExpression);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4941,6 +5095,56 @@ select t";
                 // (1,20): error CS1525: Invalid expression term ';'
                 // for (int i = 0; ref; i++) { }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(1, 20));
+
+            N(SyntaxKind.ForStatement);
+            {
+                N(SyntaxKind.ForKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.VariableDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.VariableDeclarator);
+                    {
+                        N(SyntaxKind.IdentifierToken, "i");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "0");
+                            }
+                        }
+                    }
+                }
+                N(SyntaxKind.SemicolonToken);
+                N(SyntaxKind.RefExpression);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                }
+                N(SyntaxKind.SemicolonToken);
+                N(SyntaxKind.PostIncrementExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "i");
+                    }
+                    N(SyntaxKind.PlusPlusToken);
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4951,6 +5155,19 @@ select t";
                 // (1,9): error CS1003: Syntax error, ',' expected
                 // new[] { in[] }
                 Diagnostic(ErrorCode.ERR_SyntaxError, "in").WithArguments(",", "in").WithLocation(1, 9));
+
+            N(SyntaxKind.ImplicitArrayCreationExpression);
+            {
+                N(SyntaxKind.NewKeyword);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.CloseBracketToken);
+                N(SyntaxKind.ArrayInitializerExpression);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]
@@ -4961,6 +5178,19 @@ select t";
                     // (1,9): error CS1003: Syntax error, ',' expected
                     // new[] { out[] }
                     Diagnostic(ErrorCode.ERR_SyntaxError, "out").WithArguments(",", "out").WithLocation(1, 9));
+
+            N(SyntaxKind.ImplicitArrayCreationExpression);
+            {
+                N(SyntaxKind.NewKeyword);
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.CloseBracketToken);
+                N(SyntaxKind.ArrayInitializerExpression);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -1157,6 +1157,7 @@ class c
             };
 
             UsingDeclaration(text, options: TestOptions.Regular7_3, expected);
+            verify();
 
             expected = new[]
             {
@@ -1175,8 +1176,74 @@ class c
             };
 
             UsingDeclaration(text, options: TestOptions.Regular8, expected);
+            verify();
 
             UsingDeclaration(text, options: TestOptions.RegularPreview, expected);
+            verify();
+
+            void verify()
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "Program");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.VoidKeyword);
+                                    }
+                                    M(SyntaxKind.VariableDeclarator);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.StaticKeyword);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "F");
+                                }
+                                M(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.Block);
+                                {
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                EOF();
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -169,11 +169,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             _treeEnumerator = nodes.GetEnumerator();
         }
 
-        protected void Flush()
-        {
-            _treeEnumerator = null;
-        }
-
         /// <summary>
         /// Moves the enumerator and asserts that the current node is of the given kind.
         /// </summary>

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -2185,6 +2185,36 @@ case KeyValuePair<String, DateTime>[] pairs2:
                 // switch (e) { case (
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 20)
             );
+
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "e");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CasePatternSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.RecursivePattern);
+                        {
+                            N(SyntaxKind.PositionalPatternClause);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                M(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        M(SyntaxKind.ColonToken);
+                    }
+                }
+                M(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
         }
 
         [Fact]
@@ -2239,6 +2269,32 @@ case KeyValuePair<String, DateTime>[] pairs2:
                 // switch (e) { case
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 18)
                 );
+
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "e");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.ColonToken);
+                    }
+                }
+                M(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
         }
 
         [Fact]
@@ -8083,30 +8139,37 @@ switch (e)
                 // () => {} + d
                 Diagnostic(ErrorCode.ERR_UnexpectedToken, "+").WithArguments("+").WithLocation(1, 10)
                 );
+            verify();
+
             UsingExpression("()=>{} + d");
-            N(SyntaxKind.AddExpression);
+            verify();
+
+            void verify()
             {
-                N(SyntaxKind.ParenthesizedLambdaExpression);
+                N(SyntaxKind.AddExpression);
                 {
-                    N(SyntaxKind.ParameterList);
+                    N(SyntaxKind.ParenthesizedLambdaExpression);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
                     }
-                    N(SyntaxKind.EqualsGreaterThanToken);
-                    N(SyntaxKind.Block);
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.IdentifierToken, "d");
                     }
                 }
-                N(SyntaxKind.PlusToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "d");
-                }
+                EOF();
             }
-            EOF();
         }
 
         [Fact, WorkItem(10492, "https://github.com/dotnet/roslyn/issues/10492")]
@@ -8118,25 +8181,32 @@ switch (e)
                 // delegate {} + d
                 Diagnostic(ErrorCode.ERR_UnexpectedToken, "+").WithArguments("+").WithLocation(1, 13)
                 );
+            verify();
+
             UsingExpression("delegate {} + d");
-            N(SyntaxKind.AddExpression);
+            verify();
+
+            void verify()
             {
-                N(SyntaxKind.AnonymousMethodExpression);
+                N(SyntaxKind.AddExpression);
                 {
-                    N(SyntaxKind.DelegateKeyword);
-                    N(SyntaxKind.Block);
+                    N(SyntaxKind.AnonymousMethodExpression);
                     {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.DelegateKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "d");
                     }
                 }
-                N(SyntaxKind.PlusToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "d");
-                }
+                EOF();
             }
-            EOF();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -1553,6 +1553,45 @@ public partial bool this[int index] {}
             var tree = UsingTree(@"
 new public bool this[int index] { get; }
 ");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.IndexerDeclaration);
+                {
+                    N(SyntaxKind.NewKeyword);
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.BoolKeyword);
+                    }
+                    N(SyntaxKind.ThisKeyword);
+                    N(SyntaxKind.BracketedParameterList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "index");
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
         }
 
         [Fact]
@@ -1561,6 +1600,45 @@ new public bool this[int index] { get; }
             var tree = UsingTree(@"
 new public bool this[int index] { get; }
 ");
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.IndexerDeclaration);
+                {
+                    N(SyntaxKind.NewKeyword);
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.BoolKeyword);
+                    }
+                    N(SyntaxKind.ThisKeyword);
+                    N(SyntaxKind.BracketedParameterList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "index");
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -3559,6 +3559,22 @@ System.Console.WriteLine(true)";
                 // { label: public
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "public").WithLocation(1, 10)
                 );
+
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.LabeledStatement);
+                {
+                    N(SyntaxKind.IdentifierToken, "label");
+                    N(SyntaxKind.ColonToken);
+                    M(SyntaxKind.EmptyStatement);
+                    {
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                }
+                M(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
         }
 
         [WorkItem(27866, "https://github.com/dotnet/roslyn/issues/27866")]


### PR DESCRIPTION
/cc @CyrusNajmabadi 

This PR modifies ParsingTests to check after each test case whether there are any remaining nodes in the tree enumerator initialized by UsingTree/UsingNode or similar methods. It also checks in each UsingTree/UsingNode call whether the nodes produced by the previous call were consumed. This should help us remember to validate the structure of the tree in our tests and also should remove the need to uncomment `#define PARSING_TESTS_DUMP` and remember to not commit it, etc.

Commit-by-commit review helps a bit, but I think the changes ended up not being too complex considering.