### PR TITLE
Pass a default value for the parameterList in SyntaxFactory.ParenthesizedLambdaExpression(SyntaxNode)

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2564,7 +2564,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : SimpleLambdaExpression(asyncKeyword, parameter, arrowToken, null, (ExpressionSyntax)body);
 
         public static ParenthesizedLambdaExpressionSyntax ParenthesizedLambdaExpression(CSharpSyntaxNode body)
-            => ParenthesizedLambdaExpression(parameterList: null, body);
+            => ParenthesizedLambdaExpression(ParameterList(), body);
 
         public static ParenthesizedLambdaExpressionSyntax ParenthesizedLambdaExpression(ParameterListSyntax parameterList, CSharpSyntaxNode body)
             => body is BlockSyntax block

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -572,5 +572,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var fullySpecified = SyntaxFactory.ParenthesizedLambdaExpression(parameterList: SyntaxFactory.ParameterList(), body: SyntaxFactory.Block());
             Assert.Equal(fullySpecified.ToFullString(), lambda.ToFullString());
         }
+
+        [Fact, WorkItem(40342, "https://github.com/dotnet/roslyn/issues/40342")]
+        public void TestParenthesizedLambdaNoParameterList_ExpressionBody()
+        {
+            var lambda = SyntaxFactory.ParenthesizedLambdaExpression(body: SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)));
+            Assert.NotNull(lambda);
+            Assert.Equal("()=>1", lambda.ToFullString());
+
+            var fullySpecified = SyntaxFactory.ParenthesizedLambdaExpression(
+                parameterList: SyntaxFactory.ParameterList(),
+                body: SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)));
+            Assert.Equal(fullySpecified.ToFullString(), lambda.ToFullString());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -561,5 +561,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 );
             Assert.Equal("int[]M(){};", syntaxNode.ToFullString());
         }
+
+        [Fact, WorkItem(40342, "https://github.com/dotnet/roslyn/issues/40342")]
+        public void TestParenthesizedLambdaNoParameterList()
+        {
+            var lambda = SyntaxFactory.ParenthesizedLambdaExpression(body: SyntaxFactory.Block());
+            Assert.NotNull(lambda);
+            Assert.Equal("()=>{}", lambda.ToFullString());
+
+            var fullySpecified = SyntaxFactory.ParenthesizedLambdaExpression(parameterList: SyntaxFactory.ParameterList(), body: SyntaxFactory.Block());
+            Assert.Equal(fullySpecified.ToFullString(), lambda.ToFullString());
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/40342. @dotnet/roslyn-compiler for review.