### PR TITLE
Fixed IDE0009 suggestion in property pattern.

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -445,7 +445,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_Subpattern1()
+        public async Task QualifyPropertyAccess_PropertySubpattern1()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -464,7 +464,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_Subpattern2()
+        public async Task QualifyPropertyAccess_PropertySubpattern2()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -485,7 +485,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_Subpattern3()
+        public async Task QualifyPropertyAccess_PropertySubpattern3()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -502,6 +502,137 @@ CodeStyleOptions.QualifyPropertyAccess);
     }
 }",
 CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_PropertySubpattern4()
+        {
+            //  it's ok that we qualify here because it's not a legal pattern (because it is not const).
+            await TestAsyncWithOption(
+@"class Class
+{
+    int i { get; set; }
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { i: [|i|] } => 1,
+            _ => 0
+        };
+    }
+}",
+@"class Class
+{
+    int i { get; set; }
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { i: this.i } => 1,
+            _ => 0
+        };
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_FieldSubpattern1()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        if (c is { [|i|]: 1 })
+        {
+        }
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_FieldSubpattern2()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        switch (t)
+        {
+            case Class { [|i|]: 1 }:
+                return;
+        }
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_FieldSubpattern3()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { [|i|]: 0 } => 1,
+            _ => 0
+        };
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_FieldSubpattern4()
+        {
+            //  it's ok that we qualify here because it's not a legal pattern (because it is not const).
+            await TestAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { i: [|i|] } => 1,
+            _ => 0
+        };
+    }
+}",
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { i: this.i } => 1,
+            _ => 0
+        };
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
         }
 
         [WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")]

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -332,7 +332,7 @@ CodeStyleOptions.QualifyFieldAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyFieldAccess_Subputtern1()
+        public async Task QualifyFieldAccess_Subpattern1()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -351,7 +351,7 @@ CodeStyleOptions.QualifyFieldAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyFieldAccess_Subputtern2()
+        public async Task QualifyFieldAccess_Subpattern2()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -372,7 +372,7 @@ CodeStyleOptions.QualifyFieldAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyFieldAccess_Subputtern3()
+        public async Task QualifyFieldAccess_Subpattern3()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -445,7 +445,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_Subputtern1()
+        public async Task QualifyPropertyAccess_Subpattern1()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -464,7 +464,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_Subputtern2()
+        public async Task QualifyPropertyAccess_Subpattern2()
         {
             await TestMissingAsyncWithOption(
 @"class Class
@@ -485,7 +485,7 @@ CodeStyleOptions.QualifyPropertyAccess);
 
         [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
-        public async Task QualifyPropertyAccess_Subputtern3()
+        public async Task QualifyPropertyAccess_Subpattern3()
         {
             await TestMissingAsyncWithOption(
 @"class Class

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -330,6 +330,67 @@ CodeStyleOptions.QualifyFieldAccess);
 CodeStyleOptions.QualifyFieldAccess);
         }
 
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_Subputtern1()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        if (c is { [|i|]: 1 })
+        {
+        }
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_Subputtern2()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        switch (t)
+        {
+            case Class { [|i|]: 1 }:
+                return;
+        }
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyFieldAccess_Subputtern3()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i;
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { [|i|]: 0 } => 1,
+            _ => 0
+        };
+    }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
         [WorkItem(7065, "https://github.com/dotnet/roslyn/issues/7065")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyPropertyAccess_LHS()
@@ -377,6 +438,67 @@ CodeStyleOptions.QualifyPropertyAccess);
     void M()
     {
         var x = this.i;
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_Subputtern1()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i { get; set; }
+
+    void M(Class c)
+    {
+        if (c is { [|i|]: 1 })
+        {
+        }
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_Subputtern2()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i { get; set; }
+
+    void M(Class c)
+    {
+        switch (t)
+        {
+            case Class { [|i|]: 1 }:
+                return;
+        }
+    }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(40242, "https://github.com/dotnet/roslyn/issues/40242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyPropertyAccess_Subputtern3()
+        {
+            await TestMissingAsyncWithOption(
+@"class Class
+{
+    int i { get; set; }
+
+    void M(Class c)
+    {
+        var a = c switch
+        {
+            { [|i|]: 0 } => 1,
+            _ => 0
+        };
     }
 }",
 CodeStyleOptions.QualifyPropertyAccess);

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -118,6 +118,11 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
+            if (context.Operation.Parent.Kind == OperationKind.PropertySubpattern)
+            {
+                return;
+            }
+
             var syntaxTree = context.Operation.Syntax.SyntaxTree;
             var cancellationToken = context.CancellationToken;
             var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -92,6 +92,12 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
+            // We shouldn't qualify if it is inside a property pattern
+            if (context.Operation.Parent.Kind == OperationKind.PropertySubpattern)
+            {
+                return;
+            }
+
             // Initializer lists are IInvocationOperation which if passed to GetApplicableOptionFromSymbolKind
             // will incorrectly fetch the options for method call.
             // We still want to handle InstanceReferenceKind.ContainingTypeInstance
@@ -114,11 +120,6 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
             }
 
             if (!(instanceOperation.Syntax is TSimpleNameSyntax simpleName))
-            {
-                return;
-            }
-
-            if (context.Operation.Parent.Kind == OperationKind.PropertySubpattern)
             {
                 return;
             }


### PR DESCRIPTION
Fixes #40242
Fixes #40331
`AbstractQualifyMemberAccessDiagnosticAnalyzer` doesn't correctly handle property pattern.