### PR TITLE
Use a temp when a local or parameter is ref/in/out in pattern input

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -397,7 +397,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 out BoundExpression savedInputExpression)
             {
                 var inputDagTemp = BoundDagTemp.ForOriginalInput(loweredInput);
-                if (loweredInput.Kind == BoundKind.Local || loweredInput.Kind == BoundKind.Parameter)
+                if ((loweredInput.Kind == BoundKind.Local || loweredInput.Kind == BoundKind.Parameter)
+                    && loweredInput.GetRefKind() == RefKind.None)
                 {
                     // If we're switching on a local variable and there is no when clause (checked by the caller),
                     // we assume the value of the local variable does not change during the execution of the

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -773,6 +773,195 @@ public class C
 }");
         }
 
+        [Fact, WorkItem(40403, "https://github.com/dotnet/roslyn/issues/40403")]
+        public void RefParameter_StoreToTemp()
+        {
+            var source =
+@"public class C
+{
+    static bool M1(ref object x)
+    {
+        return x is 42;
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1",
+@"{
+  // Code size       24 (0x18)
+  .maxstack  2
+  .locals init (object V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldind.ref
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  isinst     ""int""
+  IL_0009:  brfalse.s  IL_0016
+  IL_000b:  ldloc.0
+  IL_000c:  unbox.any  ""int""
+  IL_0011:  ldc.i4.s   42
+  IL_0013:  ceq
+  IL_0015:  ret
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+}");
+        }
+
+        [Fact, WorkItem(40403, "https://github.com/dotnet/roslyn/issues/40403")]
+        public void RefLocal_StoreToTemp()
+        {
+            var source =
+@"public class C
+{
+    static bool M1(bool b, ref object x, ref object y)
+    {
+        ref object z = ref b ? ref x : ref y;
+        return z is 42;
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1",
+@"{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  .locals init (object V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  brtrue.s   IL_0006
+  IL_0003:  ldarg.2
+  IL_0004:  br.s       IL_0007
+  IL_0006:  ldarg.1
+  IL_0007:  ldind.ref
+  IL_0008:  stloc.0
+  IL_0009:  ldloc.0
+  IL_000a:  isinst     ""int""
+  IL_000f:  brfalse.s  IL_001c
+  IL_0011:  ldloc.0
+  IL_0012:  unbox.any  ""int""
+  IL_0017:  ldc.i4.s   42
+  IL_0019:  ceq
+  IL_001b:  ret
+  IL_001c:  ldc.i4.0
+  IL_001d:  ret
+}");
+        }
+
+        [Fact, WorkItem(40403, "https://github.com/dotnet/roslyn/issues/40403")]
+        public void InParameter_StoreToTemp()
+        {
+            var source =
+@"public class C
+{
+    static bool M1(in object x)
+    {
+        return x is 42;
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1",
+@"{
+  // Code size       24 (0x18)
+  .maxstack  2
+  .locals init (object V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldind.ref
+  IL_0002:  stloc.0
+  IL_0003:  ldloc.0
+  IL_0004:  isinst     ""int""
+  IL_0009:  brfalse.s  IL_0016
+  IL_000b:  ldloc.0
+  IL_000c:  unbox.any  ""int""
+  IL_0011:  ldc.i4.s   42
+  IL_0013:  ceq
+  IL_0015:  ret
+  IL_0016:  ldc.i4.0
+  IL_0017:  ret
+}");
+        }
+
+        [Fact, WorkItem(40403, "https://github.com/dotnet/roslyn/issues/40403")]
+        public void RefReadonlyLocal_StoreToTemp()
+        {
+            var source =
+@"public class C
+{
+    static bool M1(bool b, in object x, in object y)
+    {
+        ref readonly object z = ref b ? ref x : ref y;
+        return z is 42;
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1",
+@"{
+  // Code size       30 (0x1e)
+  .maxstack  2
+  .locals init (object V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  brtrue.s   IL_0006
+  IL_0003:  ldarg.2
+  IL_0004:  br.s       IL_0007
+  IL_0006:  ldarg.1
+  IL_0007:  ldind.ref
+  IL_0008:  stloc.0
+  IL_0009:  ldloc.0
+  IL_000a:  isinst     ""int""
+  IL_000f:  brfalse.s  IL_001c
+  IL_0011:  ldloc.0
+  IL_0012:  unbox.any  ""int""
+  IL_0017:  ldc.i4.s   42
+  IL_0019:  ceq
+  IL_001b:  ret
+  IL_001c:  ldc.i4.0
+  IL_001d:  ret
+}");
+        }
+
+        [Fact, WorkItem(40403, "https://github.com/dotnet/roslyn/issues/40403")]
+        public void OutParameter_StoreToTemp()
+        {
+            var source =
+@"public class C
+{
+    static bool M1(out object x)
+    {
+        x = null;
+        return x is 42;
+    }
+}";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics();
+            var compVerifier = CompileAndVerify(compilation);
+            compVerifier.VerifyIL("C.M1",
+@"{
+  // Code size       27 (0x1b)
+  .maxstack  2
+  .locals init (object V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldnull
+  IL_0002:  stind.ref
+  IL_0003:  ldarg.0
+  IL_0004:  ldind.ref
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  isinst     ""int""
+  IL_000c:  brfalse.s  IL_0019
+  IL_000e:  ldloc.0
+  IL_000f:  unbox.any  ""int""
+  IL_0014:  ldc.i4.s   42
+  IL_0016:  ceq
+  IL_0018:  ret
+  IL_0019:  ldc.i4.0
+  IL_001a:  ret
+}");
+        }
+
         [Fact, WorkItem(22654, "https://github.com/dotnet/roslyn/issues/22654")]
         public void NoRedundantTypeCheck()
         {


### PR DESCRIPTION
Closes #40403

I manually verified that the bug repros with the 3.5.0-beta2 compiler, but does not repro with a compiler freshly built with this change.

I wasn't sure whether or not to make this defensive copy for all ref kinds-- I figured that for a ref parameter or local, "somebody else" controls the actual storage being referenced, and it could always change out from under you if you read it multiple times. It makes me wonder if there's the same risk if you pass a regular parameter off by 'ref' and then use the parameter as input to a pattern. This seems to put into question whether you can ever "safely" reuse a local/parameter input to a pattern, and when/whether we want to say "caveat emptor" in some situations and do something that is "probably" safe but not certain to be safe.