### PR TITLE
Remove null from Diagnostic.Arguments

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,18 @@
         ],
         "problemMatcher": "$msCompile",
         "group": "build"
+    },
+    {
+        "label": "build csc skip analyzers",
+        "command": "dotnet",
+        "type": "shell",
+        "args": [
+          "msbuild",
+          "src/Compilers/CSharp/csc/csc.csproj",
+          "-p:UseRoslynAnalyzers=false"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "build"
     }
   ]
 }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis
             public override string GetMessage(IFormatProvider? formatProvider = null)
                 => _originalUnsuppressedDiagnostic.GetMessage(formatProvider);
 
-            internal override IReadOnlyList<object?>? Arguments
+            internal override IReadOnlyList<object?> Arguments
             {
                 get { return _originalUnsuppressedDiagnostic.Arguments; }
             }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -466,7 +466,7 @@ namespace Microsoft.CodeAnalysis
         // compatibility
         internal virtual int Code { get { return 0; } }
 
-        internal virtual IReadOnlyList<object?>? Arguments
+        internal virtual IReadOnlyList<object?> Arguments
         {
             get { return SpecializedCollections.EmptyReadOnlyList<object?>(); }
         }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticWithInfo.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis
             return this.Info.GetMessage(formatProvider);
         }
 
-        internal override IReadOnlyList<object>? Arguments
+        internal override IReadOnlyList<object> Arguments
         {
             get { return this.Info.Arguments; }
         }


### PR DESCRIPTION
This changes the implementation of `DiagnosticInfo` to use an empty
array in all cases for arguments vs. a mix of empty arrays and `null`
for the empty case. This allows us to ensure the `Diagnostic.Arguments`
is always a non-null value.

This makes adopting nullability higher in the stack significantly
simpler as there are assumptions this is non-null in places.