### PR TITLE
Assert that ParsingTests.N nodes are not missing, fix up tests that didn't assume this.

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -649,9 +649,9 @@ class C
                             N(SyntaxKind.TypeArgumentList);
                             {
                                 N(SyntaxKind.LessThanToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                                 M(SyntaxKind.GreaterThanToken);
                             }
@@ -696,9 +696,9 @@ class C
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                     M(SyntaxKind.GreaterThanToken);
                                 }
@@ -745,9 +745,9 @@ class C
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                     M(SyntaxKind.GreaterThanToken);
                                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
@@ -1854,7 +1854,7 @@ async () => {
                             N(SyntaxKind.VariableDeclarator);
                             {
                                 N(SyntaxKind.IdentifierToken);
-                                N(SyntaxKind.BracketedArgumentList);
+                                M(SyntaxKind.BracketedArgumentList);
                                 {
                                     M(SyntaxKind.OpenBracketToken);
                                     M(SyntaxKind.CloseBracketToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
@@ -1475,9 +1475,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             UsingNode("2");
 
-            N(SyntaxKind.NameMemberCref);
+            M(SyntaxKind.NameMemberCref);
             {
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.IdentifierName);
                 {
                     M(SyntaxKind.IdentifierToken);
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -6260,7 +6260,7 @@ class C
                 N(SyntaxKind.ClassDeclaration);
                 {
                     N(SyntaxKind.ClassKeyword);
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "C");
                     N(SyntaxKind.OpenBraceToken);
                     N(SyntaxKind.PropertyDeclaration);
                     {
@@ -6268,7 +6268,7 @@ class C
                         {
                             N(SyntaxKind.IntKeyword);
                         }
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "A");
                         N(SyntaxKind.AccessorList);
                         {
                             N(SyntaxKind.OpenBraceToken);
@@ -6284,17 +6284,21 @@ class C
                                         N(SyntaxKind.SimpleMemberAccessExpression);
                                         {
                                             N(SyntaxKind.ThisExpression);
-                                            N(SyntaxKind.ThisKeyword);
+                                            {
+                                                N(SyntaxKind.ThisKeyword);
+                                            }
                                             N(SyntaxKind.DotToken);
-                                            N(SyntaxKind.IdentifierName);
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierName);
+                                            {
+                                                M(SyntaxKind.IdentifierToken);
+                                            }
                                         }
-                                        N(SyntaxKind.SemicolonToken);
+                                        M(SyntaxKind.SemicolonToken);
                                     }
-                                    N(SyntaxKind.CloseBraceToken);
+                                    M(SyntaxKind.CloseBraceToken);
                                 }
                             }
-                            N(SyntaxKind.CloseBraceToken);
+                            M(SyntaxKind.CloseBraceToken);
                         }
                     }
                     N(SyntaxKind.FieldDeclaration);
@@ -6308,7 +6312,7 @@ class C
                             }
                             N(SyntaxKind.VariableDeclarator);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "B");
                             }
                         }
                         N(SyntaxKind.SemicolonToken);
@@ -6317,6 +6321,7 @@ class C
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -406,7 +406,7 @@ class C {
                                                         }
                                                         N(SyntaxKind.IdentifierToken); // parameter name
                                                     }
-                                                    N(SyntaxKind.CloseParenToken);
+                                                    M(SyntaxKind.CloseParenToken);
                                                 }
                                                 M(SyntaxKind.EqualsGreaterThanToken);
                                                 M(SyntaxKind.IdentifierName); // lambda body

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/NullableParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/NullableParsingTests.cs
@@ -557,9 +557,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         }
                     }
                     N(SyntaxKind.QuestionQuestionToken);
-                    N(SyntaxKind.IdentifierName);
+                    M(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        M(SyntaxKind.IdentifierToken);
                     }
                 }
                 N(SyntaxKind.QuestionToken);
@@ -567,10 +567,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     N(SyntaxKind.IdentifierToken, "y");
                 }
-                N(SyntaxKind.ColonToken);
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.ColonToken);
+                M(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierToken);
+                    M(SyntaxKind.IdentifierToken);
                 }
             }
             EOF();
@@ -695,12 +695,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                 N(SyntaxKind.IdentifierToken, "t");
                             }
                             N(SyntaxKind.ColonToken);
-                            N(SyntaxKind.IdentifierName);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.ColonToken);
+                        M(SyntaxKind.ColonToken);
                     }
                     N(SyntaxKind.BreakStatement);
                     {
@@ -752,11 +752,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                 N(SyntaxKind.BracketedArgumentList);
                                 {
                                     N(SyntaxKind.OpenBracketToken);
-                                    N(SyntaxKind.Argument);
+                                    M(SyntaxKind.Argument);
                                     {
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
                                     N(SyntaxKind.CloseBracketToken);
@@ -768,12 +768,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                                 N(SyntaxKind.IdentifierToken, "t");
                             }
                             N(SyntaxKind.ColonToken);
-                            N(SyntaxKind.IdentifierName);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.ColonToken);
+                        M(SyntaxKind.ColonToken);
                     }
                     N(SyntaxKind.BreakStatement);
                     {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5772,7 +5772,7 @@ class TestClass { }";
                                 N(SyntaxKind.IdentifierToken, "One");
                             }
                         }
-                        N(SyntaxKind.CommaToken, ""); // missing
+                        M(SyntaxKind.CommaToken);
                         N(SyntaxKind.Attribute);
                         {
                             N(SyntaxKind.IdentifierName);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -187,6 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             {
                 Assert.True(_treeEnumerator!.MoveNext());
                 Assert.Equal(kind, _treeEnumerator.Current.Kind());
+                Assert.False(_treeEnumerator.Current.IsMissing);
 
                 if (value != null)
                 {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -170,7 +170,7 @@ bar();
                             N(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
                 }
 
                 N(SyntaxKind.GlobalStatement);
@@ -209,7 +209,7 @@ bar();
                             N(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
                 }
 
                 N(SyntaxKind.FieldDeclaration);
@@ -2396,7 +2396,7 @@ delegate D();
                     {
                         N(SyntaxKind.IdentifierToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    M(SyntaxKind.IdentifierToken);
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -2595,19 +2595,20 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                             }
                             N(SyntaxKind.AsteriskToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                             }
                         }
-                        N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -2628,13 +2629,13 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.GenericName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                     N(SyntaxKind.TypeArgumentList);
                                     {
                                         N(SyntaxKind.LessThanToken);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "t");
                                         }
                                         N(SyntaxKind.GreaterThanToken);
                                     }
@@ -2642,7 +2643,7 @@ fixed int x[10];
                                 N(SyntaxKind.DotToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "n");
                                 }
                             }
                             N(SyntaxKind.AsteriskToken);
@@ -2650,7 +2651,7 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "f");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -2659,18 +2660,19 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "x");
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         #endregion
@@ -2930,24 +2932,25 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
                         N(SyntaxKind.CommaToken);
-                        N(SyntaxKind.VariableDeclarator);
+                        M(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken).IsMissing.ShouldBe(true);
+                            M(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -2964,32 +2967,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                             N(SyntaxKind.EqualsValueClause);
                             {
                                 N(SyntaxKind.EqualsToken);
                                 N(SyntaxKind.NumericLiteralExpression);
                                 {
-                                    N(SyntaxKind.NumericLiteralToken);
+                                    N(SyntaxKind.NumericLiteralToken, "1");
                                 }
                             }
                         }
                         N(SyntaxKind.CommaToken);
-                        N(SyntaxKind.VariableDeclarator);
+                        M(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         // properties //
@@ -3006,19 +3010,20 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3033,7 +3038,7 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
@@ -3041,19 +3046,20 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
                         N(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "b");
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3068,7 +3074,7 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
@@ -3076,28 +3082,29 @@ fixed int x[10];
                     {
                         N(SyntaxKind.GenericName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                             N(SyntaxKind.TypeArgumentList);
                             {
                                 N(SyntaxKind.LessThanToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.GreaterThanToken);
                             }
                         }
                         N(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "b");
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3112,7 +3119,7 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
@@ -3122,7 +3129,7 @@ fixed int x[10];
                         {
                             N(SyntaxKind.GenericName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
@@ -3130,7 +3137,7 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "T");
                                         }
                                         N(SyntaxKind.QuestionToken);
                                     }
@@ -3140,13 +3147,13 @@ fixed int x[10];
                             N(SyntaxKind.DotToken);
                             N(SyntaxKind.GenericName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "S");
                                     }
                                     N(SyntaxKind.GreaterThanToken);
                                 }
@@ -3154,15 +3161,16 @@ fixed int x[10];
                         }
                         N(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "c");
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         // methods //
@@ -3179,11 +3187,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3192,11 +3200,12 @@ fixed int x[10];
                     N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3211,11 +3220,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3224,23 +3233,24 @@ fixed int x[10];
                     N(SyntaxKind.TypeParameterConstraintClause);
                     {
                         N(SyntaxKind.WhereKeyword);
-                        N(SyntaxKind.IdentifierName).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken).IsMissing.ShouldBe(true);
+                            M(SyntaxKind.IdentifierToken);
                         }
-                        N(SyntaxKind.ColonToken).IsMissing.ShouldBe(true);
-                        N(SyntaxKind.TypeConstraint);
+                        M(SyntaxKind.ColonToken);
+                        M(SyntaxKind.TypeConstraint);
                         {
-                            N(SyntaxKind.IdentifierName).IsMissing.ShouldBe(true);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken).IsMissing.ShouldBe(true);
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3255,11 +3265,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3267,16 +3277,17 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
-                        N(SyntaxKind.CloseParenToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3291,7 +3302,7 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
@@ -3299,11 +3310,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
                         N(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "b");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3311,16 +3322,17 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "c");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3335,7 +3347,7 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
@@ -3343,26 +3355,26 @@ fixed int x[10];
                     {
                         N(SyntaxKind.GenericName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                             N(SyntaxKind.TypeArgumentList);
                             {
                                 N(SyntaxKind.LessThanToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "A");
                                 }
                                 N(SyntaxKind.GreaterThanToken);
                             }
                         }
                         N(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "b");
                     N(SyntaxKind.TypeParameterList);
                     {
                         N(SyntaxKind.LessThanToken);
                         N(SyntaxKind.TypeParameter);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "B");
                         }
                         N(SyntaxKind.GreaterThanToken);
                     }
@@ -3373,16 +3385,17 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "C");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "c");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3397,11 +3410,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3414,23 +3427,24 @@ fixed int x[10];
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "Attr");
                                     }
                                 }
                                 N(SyntaxKind.CloseBracketToken);
                             }
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "C");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "c");
                         }
-                        N(SyntaxKind.CloseParenToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3445,11 +3459,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3462,7 +3476,7 @@ fixed int x[10];
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "Attr");
                                     }
                                     N(SyntaxKind.AttributeArgumentList);
                                     {
@@ -3473,13 +3487,13 @@ fixed int x[10];
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "a");
                                                 }
                                                 N(SyntaxKind.EqualsToken);
                                             }
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "b");
                                             }
                                         }
                                         N(SyntaxKind.CloseParenToken);
@@ -3489,16 +3503,17 @@ fixed int x[10];
                             }
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "c");
                             }
-                            N(SyntaxKind.IdentifierToken).IsMissing.ShouldBe(true);
+                            M(SyntaxKind.IdentifierToken);
                         }
-                        N(SyntaxKind.CloseParenToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3513,11 +3528,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3526,16 +3541,17 @@ fixed int x[10];
                             N(SyntaxKind.OutKeyword);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "C");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "c");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3550,11 +3566,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3564,7 +3580,7 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "C");
                                 }
                                 N(SyntaxKind.ArrayRankSpecifier);
                                 {
@@ -3576,14 +3592,15 @@ fixed int x[10];
                                     N(SyntaxKind.CloseBracketToken);
                                 }
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3598,29 +3615,30 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
                         N(SyntaxKind.Parameter);
                         {
                             N(SyntaxKind.ParamsKeyword);
-                            N(SyntaxKind.IdentifierName).IsMissing.ShouldBe(true);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken).IsMissing.ShouldBe(true);
+                                M(SyntaxKind.IdentifierToken);
                             }
-                            N(SyntaxKind.IdentifierToken).IsMissing.ShouldBe(true);
+                            M(SyntaxKind.IdentifierToken);
                         }
-                        N(SyntaxKind.CloseParenToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3635,11 +3653,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3650,18 +3668,19 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.QuestionToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3676,11 +3695,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3691,18 +3710,19 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.QuestionToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3717,11 +3737,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3732,18 +3752,19 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.QuestionToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
-                        N(SyntaxKind.CloseParenToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3758,11 +3779,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3775,7 +3796,7 @@ fixed int x[10];
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "Attr");
                                     }
                                 }
                                 N(SyntaxKind.CloseBracketToken);
@@ -3784,18 +3805,19 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.QuestionToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3810,11 +3832,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3824,27 +3846,28 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.QuestionToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
                         N(SyntaxKind.CommaToken);
-                        N(SyntaxKind.Parameter);
+                        M(SyntaxKind.Parameter);
                         {
-                            N(SyntaxKind.IdentifierName);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.IdentifierToken);
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3859,11 +3882,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3873,18 +3896,19 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.QuestionToken);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "b");
                         }
                         N(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3899,11 +3923,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3911,16 +3935,17 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "c");
                         }
                         N(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3935,11 +3960,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3948,16 +3973,17 @@ fixed int x[10];
                             N(SyntaxKind.ThisKeyword);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "c");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "d");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -3972,11 +3998,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -3986,16 +4012,17 @@ fixed int x[10];
                             N(SyntaxKind.OutKeyword);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4010,11 +4037,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -4024,14 +4051,15 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IntKeyword);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4046,11 +4074,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -4061,14 +4089,15 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IntKeyword);
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4083,11 +4112,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -4095,24 +4124,25 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                             N(SyntaxKind.EqualsValueClause);
                             {
                                 N(SyntaxKind.EqualsToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4127,11 +4157,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -4141,7 +4171,7 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "T");
                                 }
                                 N(SyntaxKind.ArrayRankSpecifier);
                                 {
@@ -4158,14 +4188,15 @@ fixed int x[10];
                                     N(SyntaxKind.CloseBracketToken);
                                 }
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4180,11 +4211,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -4196,7 +4227,7 @@ fixed int x[10];
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "T");
                                     }
                                     N(SyntaxKind.QuestionToken);
                                 }
@@ -4205,19 +4236,20 @@ fixed int x[10];
                                     N(SyntaxKind.OpenBracketToken);
                                     N(SyntaxKind.NumericLiteralExpression);
                                     {
-                                        N(SyntaxKind.NumericLiteralToken);
+                                        N(SyntaxKind.NumericLiteralToken, "10");
                                     }
                                     N(SyntaxKind.CloseBracketToken);
                                 }
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
                         N(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         /// <summary>
@@ -4235,11 +4267,11 @@ fixed int x[10];
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "T");
                         }
                         N(SyntaxKind.QuestionToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "m");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -4247,30 +4279,31 @@ fixed int x[10];
                         {
                             N(SyntaxKind.GenericName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "b");
                                     }
                                     N(SyntaxKind.CommaToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "c");
                                     }
                                     N(SyntaxKind.GreaterThanToken);
                                 }
                             }
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "d");
                         }
                         N(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         // expressions //
@@ -4289,24 +4322,25 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.NumericLiteralExpression);
                             {
-                                N(SyntaxKind.NumericLiteralToken);
+                                N(SyntaxKind.NumericLiteralToken, "1");
+                            }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4323,24 +4357,25 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
+                            }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4357,32 +4392,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleMemberAccessExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.DotToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4399,32 +4435,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.ElementAccessExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.BracketedArgumentList);
                                 {
                                     N(SyntaxKind.OpenBracketToken);
-                                    N(SyntaxKind.CloseBracketToken);
+                                    M(SyntaxKind.CloseBracketToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4441,32 +4478,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.LessThanExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.LessThanToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4483,32 +4521,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.LessThanExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.LessThanToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "b");
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4525,33 +4564,34 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.GenericName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "b");
                                     }
                                     N(SyntaxKind.GreaterThanToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4568,38 +4608,39 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.GenericName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                                 N(SyntaxKind.TypeArgumentList);
                                 {
                                     N(SyntaxKind.LessThanToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "b");
                                     }
                                     N(SyntaxKind.CommaToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "c");
                                     }
                                     N(SyntaxKind.GreaterThanToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4616,41 +4657,42 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleMemberAccessExpression);
                             {
                                 N(SyntaxKind.GenericName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                     N(SyntaxKind.TypeArgumentList);
                                     {
                                         N(SyntaxKind.LessThanToken);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "b");
                                         }
                                         N(SyntaxKind.GreaterThanToken);
                                     }
                                 }
                                 N(SyntaxKind.DotToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4667,20 +4709,20 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleMemberAccessExpression);
                             {
                                 N(SyntaxKind.GenericName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                     N(SyntaxKind.TypeArgumentList);
                                     {
                                         N(SyntaxKind.LessThanToken);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "b");
                                         }
                                         N(SyntaxKind.GreaterThanToken);
                                     }
@@ -4688,20 +4730,21 @@ fixed int x[10];
                                 N(SyntaxKind.DotToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "c");
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4718,7 +4761,7 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
@@ -4727,13 +4770,13 @@ fixed int x[10];
                                 {
                                     N(SyntaxKind.GenericName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "a");
                                         N(SyntaxKind.TypeArgumentList);
                                         {
                                             N(SyntaxKind.LessThanToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "b");
                                             }
                                             N(SyntaxKind.GreaterThanToken);
                                         }
@@ -4741,26 +4784,27 @@ fixed int x[10];
                                     N(SyntaxKind.DotToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "c");
                                     }
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
                                     N(SyntaxKind.OpenParenToken);
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4777,32 +4821,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
                                     N(SyntaxKind.OpenParenToken);
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4819,7 +4864,7 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
@@ -4828,31 +4873,32 @@ fixed int x[10];
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "a");
                                     }
                                     N(SyntaxKind.DotToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "b");
                                     }
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
                                     N(SyntaxKind.OpenParenToken);
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4869,14 +4915,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -4885,23 +4931,24 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "c");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4918,14 +4965,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -4934,31 +4981,32 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "c");
                                         }
                                     }
                                     N(SyntaxKind.CommaToken);
-                                    N(SyntaxKind.Argument);
+                                    M(SyntaxKind.Argument);
                                     {
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -4975,14 +5023,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -4993,29 +5041,30 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                             N(SyntaxKind.ColonToken);
                                         }
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5032,14 +5081,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5050,34 +5099,35 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                             N(SyntaxKind.QuestionToken);
-                                            N(SyntaxKind.IdentifierName);
+                                            M(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.IdentifierToken);
                                             }
-                                            N(SyntaxKind.ColonToken);
-                                            N(SyntaxKind.IdentifierName);
+                                            M(SyntaxKind.ColonToken);
+                                            M(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.IdentifierToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5094,14 +5144,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5112,34 +5162,35 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "a");
                                             }
-                                            N(SyntaxKind.ColonToken);
-                                            N(SyntaxKind.IdentifierName);
+                                            M(SyntaxKind.ColonToken);
+                                            M(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.IdentifierToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5156,14 +5207,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5174,42 +5225,43 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.SimpleAssignmentExpression);
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "a");
                                                 }
                                                 N(SyntaxKind.EqualsToken);
-                                                N(SyntaxKind.IdentifierName);
+                                                M(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    M(SyntaxKind.IdentifierToken);
                                                 }
                                             }
-                                            N(SyntaxKind.ColonToken);
-                                            N(SyntaxKind.IdentifierName);
+                                            M(SyntaxKind.ColonToken);
+                                            M(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.IdentifierToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5226,14 +5278,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5244,55 +5296,56 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.SimpleAssignmentExpression);
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "a");
                                                 }
                                                 N(SyntaxKind.EqualsToken);
                                                 N(SyntaxKind.ConditionalExpression);
                                                 {
                                                     N(SyntaxKind.IdentifierName);
                                                     {
-                                                        N(SyntaxKind.IdentifierToken);
+                                                        N(SyntaxKind.IdentifierToken, "b");
                                                     }
                                                     N(SyntaxKind.QuestionToken);
-                                                    N(SyntaxKind.IdentifierName);
+                                                    M(SyntaxKind.IdentifierName);
                                                     {
-                                                        N(SyntaxKind.IdentifierToken);
+                                                        M(SyntaxKind.IdentifierToken);
                                                     }
-                                                    N(SyntaxKind.ColonToken);
-                                                    N(SyntaxKind.IdentifierName);
+                                                    M(SyntaxKind.ColonToken);
+                                                    M(SyntaxKind.IdentifierName);
                                                     {
-                                                        N(SyntaxKind.IdentifierToken);
+                                                        M(SyntaxKind.IdentifierToken);
                                                     }
                                                 }
                                             }
+                                            M(SyntaxKind.ColonToken);
+                                            M(SyntaxKind.IdentifierName);
+                                            {
+                                                M(SyntaxKind.IdentifierToken);
+                                            }
                                         }
                                     }
-                                    N(SyntaxKind.ColonToken);
-                                    N(SyntaxKind.IdentifierName);
-                                    {
-                                        N(SyntaxKind.IdentifierToken);
-                                    }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5309,14 +5362,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5324,17 +5377,18 @@ fixed int x[10];
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5351,14 +5405,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5367,23 +5421,24 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "a");
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5400,14 +5455,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5415,17 +5470,18 @@ fixed int x[10];
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
-                        }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
                         N(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5442,14 +5498,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5458,23 +5514,24 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "a");
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
-                        }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
                         N(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5491,14 +5548,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5509,29 +5566,30 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "x");
                                             }
                                             N(SyntaxKind.ColonToken);
                                         }
                                         N(SyntaxKind.NumericLiteralExpression);
                                         {
-                                            N(SyntaxKind.NumericLiteralToken);
+                                            N(SyntaxKind.NumericLiteralToken, "1");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5548,14 +5606,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5566,13 +5624,13 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "x");
                                             }
                                             N(SyntaxKind.ColonToken);
                                         }
                                         N(SyntaxKind.NumericLiteralExpression);
                                         {
-                                            N(SyntaxKind.NumericLiteralToken);
+                                            N(SyntaxKind.NumericLiteralToken, "1");
                                         }
                                     }
                                     N(SyntaxKind.CommaToken);
@@ -5582,7 +5640,7 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "y");
                                             }
                                             N(SyntaxKind.ColonToken);
                                         }
@@ -5590,34 +5648,35 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "a");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "b");
                                             }
                                             N(SyntaxKind.ColonToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5634,14 +5693,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleLambdaExpression);
                             {
                                 N(SyntaxKind.Parameter);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "u");
                                 }
                                 N(SyntaxKind.EqualsGreaterThanToken);
                                 N(SyntaxKind.Block);
@@ -5655,7 +5714,7 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.Parameter);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "v");
                                 }
                                 N(SyntaxKind.EqualsGreaterThanToken);
                                 N(SyntaxKind.Block);
@@ -5665,11 +5724,12 @@ fixed int x[10];
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5686,14 +5746,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleLambdaExpression);
                             {
                                 N(SyntaxKind.Parameter);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "u");
                                 }
                                 N(SyntaxKind.EqualsGreaterThanToken);
                                 N(SyntaxKind.InvocationExpression);
@@ -5705,19 +5765,19 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "d");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.SimpleLambdaExpression);
                                             {
                                                 N(SyntaxKind.Parameter);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "e");
                                                 }
                                                 N(SyntaxKind.EqualsGreaterThanToken);
                                                 N(SyntaxKind.NumericLiteralExpression);
                                                 {
-                                                    N(SyntaxKind.NumericLiteralToken);
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
                                                 }
                                             }
                                             N(SyntaxKind.ColonToken);
@@ -5725,12 +5785,12 @@ fixed int x[10];
                                             {
                                                 N(SyntaxKind.Parameter);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "f");
                                                 }
                                                 N(SyntaxKind.EqualsGreaterThanToken);
                                                 N(SyntaxKind.NumericLiteralExpression);
                                                 {
-                                                    N(SyntaxKind.NumericLiteralToken);
+                                                    N(SyntaxKind.NumericLiteralToken, "2");
                                                 }
                                             }
                                         }
@@ -5743,7 +5803,7 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.NumericLiteralExpression);
                                             {
-                                                N(SyntaxKind.NumericLiteralToken);
+                                                N(SyntaxKind.NumericLiteralToken, "3");
                                             }
                                         }
                                         N(SyntaxKind.CloseParenToken);
@@ -5755,20 +5815,21 @@ fixed int x[10];
                             {
                                 N(SyntaxKind.Parameter);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "c");
                                 }
                                 N(SyntaxKind.EqualsGreaterThanToken);
                                 N(SyntaxKind.NumericLiteralExpression);
                                 {
-                                    N(SyntaxKind.NumericLiteralToken);
+                                    N(SyntaxKind.NumericLiteralToken, "2");
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5785,37 +5846,38 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.ConditionalExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.QuestionToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
-                                N(SyntaxKind.ColonToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.ColonToken);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5832,30 +5894,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleAssignmentExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.EqualsToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5872,32 +5937,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleAssignmentExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.EqualsToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "b");
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5914,32 +5980,33 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.SimpleAssignmentExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.EqualsToken);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "b");
                                 }
                             }
                             N(SyntaxKind.ColonToken);
-                            N(SyntaxKind.IdentifierName);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -5956,14 +6023,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -5973,23 +6040,24 @@ fixed int x[10];
                                         N(SyntaxKind.OutKeyword);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "c");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6006,14 +6074,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6023,23 +6091,24 @@ fixed int x[10];
                                         N(SyntaxKind.RefKeyword);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "c");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6056,14 +6125,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6071,34 +6140,35 @@ fixed int x[10];
                                     N(SyntaxKind.Argument);
                                     {
                                         N(SyntaxKind.RefKeyword);
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.CommaToken);
                                     N(SyntaxKind.Argument);
                                     {
                                         N(SyntaxKind.OutKeyword);
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6115,14 +6185,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6130,34 +6200,35 @@ fixed int x[10];
                                     N(SyntaxKind.Argument);
                                     {
                                         N(SyntaxKind.RefKeyword);
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.CommaToken);
                                     N(SyntaxKind.Argument);
                                     {
                                         N(SyntaxKind.OutKeyword);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "c");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6174,14 +6245,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6193,20 +6264,21 @@ fixed int x[10];
                                             N(SyntaxKind.ThisKeyword);
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6223,14 +6295,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6244,24 +6316,27 @@ fixed int x[10];
                                                 N(SyntaxKind.ThisKeyword);
                                             }
                                             N(SyntaxKind.DotToken);
-                                            N(SyntaxKind.IdentifierName);
+                                            M(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.IdentifierToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6278,14 +6353,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6299,26 +6374,27 @@ fixed int x[10];
                                                 N(SyntaxKind.ThisKeyword);
                                             }
                                             N(SyntaxKind.LessThanToken);
-                                            N(SyntaxKind.IdentifierName);
+                                            M(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.IdentifierToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6335,14 +6411,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6358,24 +6434,25 @@ fixed int x[10];
                                             N(SyntaxKind.BracketedArgumentList);
                                             {
                                                 N(SyntaxKind.OpenBracketToken);
-                                                N(SyntaxKind.CloseBracketToken);
+                                                M(SyntaxKind.CloseBracketToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6392,14 +6469,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6411,28 +6488,29 @@ fixed int x[10];
                                             N(SyntaxKind.ThisKeyword);
                                         }
                                     }
-                                    N(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.CommaToken);
                                     N(SyntaxKind.Argument);
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "a");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6449,14 +6527,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6472,22 +6550,25 @@ fixed int x[10];
                                             N(SyntaxKind.ArgumentList);
                                             {
                                                 N(SyntaxKind.OpenParenToken);
-                                                N(SyntaxKind.CloseParenToken);
+                                                M(SyntaxKind.CloseParenToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6504,14 +6585,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6522,29 +6603,30 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "T");
                                             }
                                             N(SyntaxKind.BracketedArgumentList);
                                             {
                                                 N(SyntaxKind.OpenBracketToken);
-                                                N(SyntaxKind.CloseBracketToken);
+                                                M(SyntaxKind.CloseBracketToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6561,14 +6643,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6579,7 +6661,7 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "T");
                                             }
                                             N(SyntaxKind.BracketedArgumentList);
                                             {
@@ -6588,27 +6670,28 @@ fixed int x[10];
                                                 {
                                                     N(SyntaxKind.NumericLiteralExpression);
                                                     {
-                                                        N(SyntaxKind.NumericLiteralToken);
+                                                        N(SyntaxKind.NumericLiteralToken, "1");
                                                     }
                                                 }
-                                                N(SyntaxKind.CloseBracketToken);
+                                                M(SyntaxKind.CloseBracketToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6625,14 +6708,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6643,7 +6726,7 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "T");
                                             }
                                             N(SyntaxKind.BracketedArgumentList);
                                             {
@@ -6652,27 +6735,28 @@ fixed int x[10];
                                                 {
                                                     N(SyntaxKind.NumericLiteralExpression);
                                                     {
-                                                        N(SyntaxKind.NumericLiteralToken);
+                                                        N(SyntaxKind.NumericLiteralToken, "1");
                                                     }
                                                 }
                                                 N(SyntaxKind.CloseBracketToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6689,14 +6773,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6707,42 +6791,43 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "T");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.SimpleAssignmentExpression);
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "a");
                                                 }
                                                 N(SyntaxKind.EqualsToken);
-                                                N(SyntaxKind.IdentifierName);
+                                                M(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    M(SyntaxKind.IdentifierToken);
                                                 }
+                                            }
+                                            M(SyntaxKind.ColonToken);
+                                            M(SyntaxKind.IdentifierName);
+                                            {
+                                                M(SyntaxKind.IdentifierToken);
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.ColonToken);
-                                    N(SyntaxKind.IdentifierName);
-                                    {
-                                        N(SyntaxKind.IdentifierToken);
-                                    }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6759,14 +6844,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6775,21 +6860,24 @@ fixed int x[10];
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "T");
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6806,14 +6894,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6830,24 +6918,25 @@ fixed int x[10];
                                             N(SyntaxKind.DotToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "MaxValue");
                                             }
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6864,14 +6953,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6881,29 +6970,32 @@ fixed int x[10];
                                         N(SyntaxKind.RefKeyword);
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "a");
                                         }
                                     }
                                     N(SyntaxKind.CommaToken);
-                                    N(SyntaxKind.Argument);
+                                    M(SyntaxKind.Argument);
                                     {
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6920,47 +7012,48 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
                                     N(SyntaxKind.OpenParenToken);
-                                    N(SyntaxKind.Argument);
+                                    M(SyntaxKind.Argument);
                                     {
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
                                     N(SyntaxKind.CommaToken);
-                                    N(SyntaxKind.Argument);
+                                    M(SyntaxKind.Argument);
                                     {
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -6977,14 +7070,14 @@ fixed int x[10];
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "a");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -6995,14 +7088,14 @@ fixed int x[10];
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "T");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.ElementAccessExpression);
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "b");
                                                 }
                                                 N(SyntaxKind.BracketedArgumentList);
                                                 {
@@ -7011,7 +7104,7 @@ fixed int x[10];
                                                     {
                                                         N(SyntaxKind.NumericLiteralExpression);
                                                         {
-                                                            N(SyntaxKind.NumericLiteralToken);
+                                                            N(SyntaxKind.NumericLiteralToken, "1");
                                                         }
                                                     }
                                                     N(SyntaxKind.CloseBracketToken);
@@ -7022,7 +7115,7 @@ fixed int x[10];
                                             {
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "b");
                                                 }
                                                 N(SyntaxKind.BracketedArgumentList);
                                                 {
@@ -7031,7 +7124,7 @@ fixed int x[10];
                                                     {
                                                         N(SyntaxKind.NumericLiteralExpression);
                                                         {
-                                                            N(SyntaxKind.NumericLiteralToken);
+                                                            N(SyntaxKind.NumericLiteralToken, "2");
                                                         }
                                                     }
                                                     N(SyntaxKind.CloseBracketToken);
@@ -7042,17 +7135,18 @@ fixed int x[10];
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7071,14 +7165,14 @@ T ? f(a ? b : c)
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "f");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -7089,34 +7183,35 @@ T ? f(a ? b : c)
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "a");
                                             }
                                             N(SyntaxKind.QuestionToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "b");
                                             }
                                             N(SyntaxKind.ColonToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                         }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         /// <summary>
@@ -7136,14 +7231,14 @@ T ? f(a ? b : c)
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "m");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -7154,12 +7249,12 @@ T ? f(a ? b : c)
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "a");
                                             }
                                             N(SyntaxKind.LessThanToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "b");
                                             }
                                         }
                                     }
@@ -7170,12 +7265,12 @@ T ? f(a ? b : c)
                                         {
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "c");
                                             }
                                             N(SyntaxKind.GreaterThanToken);
                                             N(SyntaxKind.IdentifierName);
                                             {
-                                                N(SyntaxKind.IdentifierToken);
+                                                N(SyntaxKind.IdentifierToken, "d");
                                             }
                                         }
                                     }
@@ -7183,16 +7278,17 @@ T ? f(a ? b : c)
                                 }
                             }
                             N(SyntaxKind.ColonToken);
-                            N(SyntaxKind.IdentifierName);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7242,24 +7338,25 @@ T ? from
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "from");
+                            }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7278,7 +7375,7 @@ T ? from x
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.QueryExpression);
@@ -7288,36 +7385,39 @@ T ? from x
                                     N(SyntaxKind.FromKeyword);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "x");
                                     }
-                                    N(SyntaxKind.IdentifierToken);
-                                    N(SyntaxKind.InKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.InKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
-                                N(SyntaxKind.QueryBody);
+                                M(SyntaxKind.QueryBody);
                                 {
-                                    N(SyntaxKind.SelectClause);
+                                    M(SyntaxKind.SelectClause);
                                     {
-                                        N(SyntaxKind.SelectKeyword);
-                                        N(SyntaxKind.IdentifierName);
+                                        M(SyntaxKind.SelectKeyword);
+                                        M(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            M(SyntaxKind.IdentifierToken);
                                         }
                                     }
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7336,14 +7436,14 @@ T ? f(from
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "f");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -7352,23 +7452,24 @@ T ? f(from
                                     {
                                         N(SyntaxKind.IdentifierName);
                                         {
-                                            N(SyntaxKind.IdentifierToken);
+                                            N(SyntaxKind.IdentifierToken, "from");
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         /// <summary>
@@ -7390,14 +7491,14 @@ T ? f(from x
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "T");
                             }
                             N(SyntaxKind.QuestionToken);
                             N(SyntaxKind.InvocationExpression);
                             {
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "f");
                                 }
                                 N(SyntaxKind.ArgumentList);
                                 {
@@ -7411,42 +7512,43 @@ T ? f(from x
                                                 N(SyntaxKind.FromKeyword);
                                                 N(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    N(SyntaxKind.IdentifierToken, "x");
                                                 }
-                                                N(SyntaxKind.IdentifierToken);
-                                                N(SyntaxKind.InKeyword);
-                                                N(SyntaxKind.IdentifierName);
+                                                M(SyntaxKind.IdentifierToken);
+                                                M(SyntaxKind.InKeyword);
+                                                M(SyntaxKind.IdentifierName);
                                                 {
-                                                    N(SyntaxKind.IdentifierToken);
+                                                    M(SyntaxKind.IdentifierToken);
                                                 }
                                             }
-                                            N(SyntaxKind.QueryBody);
+                                            M(SyntaxKind.QueryBody);
                                             {
-                                                N(SyntaxKind.SelectClause);
+                                                M(SyntaxKind.SelectClause);
                                                 {
-                                                    N(SyntaxKind.SelectKeyword);
-                                                    N(SyntaxKind.IdentifierName);
+                                                    M(SyntaxKind.SelectKeyword);
+                                                    M(SyntaxKind.IdentifierName);
                                                     {
-                                                        N(SyntaxKind.IdentifierToken);
+                                                        M(SyntaxKind.IdentifierToken);
                                                     }
                                                 }
                                             }
                                         }
                                     }
-                                    N(SyntaxKind.CloseParenToken);
+                                    M(SyntaxKind.CloseParenToken);
                                 }
                             }
+                            M(SyntaxKind.ColonToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
                         }
-                        N(SyntaxKind.ColonToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         #endregion
@@ -7465,13 +7567,14 @@ T ? f(from x
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "from");
                         }
-                        N(SyntaxKind.SemicolonToken).IsMissing.ShouldBe(true);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7494,7 +7597,7 @@ T ? f(from x
                             N(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
@@ -7513,22 +7616,23 @@ T ? f(from x
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "from");
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "x");
                         }
                         N(SyntaxKind.CommaToken);
-                        N(SyntaxKind.VariableDeclarator);
+                        M(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.IdentifierToken);
                         }
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7570,25 +7674,26 @@ T ? f(from x
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "from");
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "x");
                             N(SyntaxKind.EqualsValueClause);
                             {
                                 N(SyntaxKind.EqualsToken);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
                         }
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7604,11 +7709,11 @@ T ? f(from x
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "from");
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "x");
                             N(SyntaxKind.BracketedArgumentList);
                             {
                                 N(SyntaxKind.OpenBracketToken);
@@ -7619,14 +7724,15 @@ T ? f(from x
                                         N(SyntaxKind.OmittedArraySizeExpressionToken);
                                     }
                                 }
-                                N(SyntaxKind.CloseBracketToken);
+                                M(SyntaxKind.CloseBracketToken);
                             }
                         }
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7639,18 +7745,19 @@ T ? f(from x
                 {
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "from");
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "c");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7664,27 +7771,28 @@ T ? f(from x
                 {
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "from");
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "a");
                     N(SyntaxKind.TypeParameterList);
                     {
                         N(SyntaxKind.LessThanToken);
-                        N(SyntaxKind.TypeParameter);
+                        M(SyntaxKind.TypeParameter);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.IdentifierToken);
                         }
-                        N(SyntaxKind.GreaterThanToken);
+                        M(SyntaxKind.GreaterThanToken);
                     }
-                    N(SyntaxKind.ParameterList);
+                    M(SyntaxKind.ParameterList);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7698,26 +7806,27 @@ T ? f(from x
                 {
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "from");
                     }
                     N(SyntaxKind.ExplicitInterfaceSpecifier);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
                         N(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
+                    M(SyntaxKind.IdentifierToken);
+                    M(SyntaxKind.ParameterList);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7731,26 +7840,27 @@ T ? f(from x
                 {
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "from");
                     }
                     N(SyntaxKind.ExplicitInterfaceSpecifier);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "a");
                         }
-                        N(SyntaxKind.DotToken);
+                        M(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
+                    M(SyntaxKind.IdentifierToken);
+                    M(SyntaxKind.ParameterList);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7764,26 +7874,27 @@ T ? f(from x
                 {
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "from");
                     }
                     N(SyntaxKind.ExplicitInterfaceSpecifier);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "global");
                         }
-                        N(SyntaxKind.DotToken);
+                        M(SyntaxKind.DotToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
+                    M(SyntaxKind.IdentifierToken);
+                    M(SyntaxKind.ParameterList);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.CloseParenToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
+                    M(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7796,17 +7907,18 @@ T ? f(from x
                 {
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "from");
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "c");
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7826,32 +7938,33 @@ T ? f(from x
                                 N(SyntaxKind.FromKeyword);
                                 N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    N(SyntaxKind.IdentifierToken, "c");
                                 }
-                                N(SyntaxKind.IdentifierToken);
-                                N(SyntaxKind.InKeyword);
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.IdentifierToken, "d");
+                                M(SyntaxKind.InKeyword);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
-                            N(SyntaxKind.QueryBody);
+                            M(SyntaxKind.QueryBody);
                             {
-                                N(SyntaxKind.SelectClause);
+                                M(SyntaxKind.SelectClause);
                                 {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.SelectKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7874,34 +7987,35 @@ T ? f(from x
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "x");
                                     }
                                     N(SyntaxKind.AsteriskToken);
                                 }
-                                N(SyntaxKind.IdentifierToken);
-                                N(SyntaxKind.InKeyword);
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.IdentifierToken, "a");
+                                M(SyntaxKind.InKeyword);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
-                            N(SyntaxKind.QueryBody);
+                            M(SyntaxKind.QueryBody);
                             {
-                                N(SyntaxKind.SelectClause);
+                                M(SyntaxKind.SelectClause);
                                 {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.SelectKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7924,34 +8038,35 @@ T ? f(from x
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "x");
                                     }
                                     N(SyntaxKind.QuestionToken);
                                 }
-                                N(SyntaxKind.IdentifierToken);
-                                N(SyntaxKind.InKeyword);
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.IdentifierToken, "a");
+                                M(SyntaxKind.InKeyword);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
-                            N(SyntaxKind.QueryBody);
+                            M(SyntaxKind.QueryBody);
                             {
-                                N(SyntaxKind.SelectClause);
+                                M(SyntaxKind.SelectClause);
                                 {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.SelectKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -7974,7 +8089,7 @@ T ? f(from x
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "x");
                                     }
                                     N(SyntaxKind.ArrayRankSpecifier);
                                     {
@@ -7986,30 +8101,31 @@ T ? f(from x
                                         N(SyntaxKind.CloseBracketToken);
                                     }
                                 }
-                                N(SyntaxKind.IdentifierToken);
-                                N(SyntaxKind.InKeyword);
-                                N(SyntaxKind.IdentifierName);
+                                N(SyntaxKind.IdentifierToken, "a");
+                                M(SyntaxKind.InKeyword);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
-                            N(SyntaxKind.QueryBody);
+                            M(SyntaxKind.QueryBody);
                             {
-                                N(SyntaxKind.SelectClause);
+                                M(SyntaxKind.SelectClause);
                                 {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.SelectKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -8027,30 +8143,31 @@ T ? f(from x
                             N(SyntaxKind.FromClause);
                             {
                                 N(SyntaxKind.FromKeyword);
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "goo");
                                 N(SyntaxKind.InKeyword);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
-                            N(SyntaxKind.QueryBody);
+                            M(SyntaxKind.QueryBody);
                             {
-                                N(SyntaxKind.SelectClause);
+                                M(SyntaxKind.SelectClause);
                                 {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.SelectKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -8072,38 +8189,39 @@ T ? f(from x
                                 {
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "goo");
                                     }
                                     N(SyntaxKind.DotToken);
                                     N(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        N(SyntaxKind.IdentifierToken, "bar");
                                     }
                                 }
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                                 N(SyntaxKind.InKeyword);
-                                N(SyntaxKind.IdentifierName);
+                                M(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.IdentifierToken);
                                 }
                             }
-                            N(SyntaxKind.QueryBody);
+                            M(SyntaxKind.QueryBody);
                             {
-                                N(SyntaxKind.SelectClause);
+                                M(SyntaxKind.SelectClause);
                                 {
-                                    N(SyntaxKind.SelectKeyword);
-                                    N(SyntaxKind.IdentifierName);
+                                    M(SyntaxKind.SelectKeyword);
+                                    M(SyntaxKind.IdentifierName);
                                     {
-                                        N(SyntaxKind.IdentifierToken);
+                                        M(SyntaxKind.IdentifierToken);
                                     }
                                 }
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         #endregion
@@ -8127,15 +8245,15 @@ T ? f(from x
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                             }
                             N(SyntaxKind.LessThanToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.GlobalStatement);
@@ -8146,19 +8264,20 @@ T ? f(from x
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "c");
                             }
                             N(SyntaxKind.DotToken);
-                            N(SyntaxKind.IdentifierName);
+                            M(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                M(SyntaxKind.IdentifierToken);
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -8178,15 +8297,15 @@ void goo() { }
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                             }
                             N(SyntaxKind.LessThanToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.MethodDeclaration);
@@ -8195,7 +8314,7 @@ void goo() { }
                     {
                         N(SyntaxKind.VoidKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "goo");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -8209,6 +8328,7 @@ void goo() { }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -8228,15 +8348,15 @@ void goo() { }
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                             }
                             N(SyntaxKind.LessThanToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.MethodDeclaration);
@@ -8245,7 +8365,7 @@ void goo() { }
                     {
                         N(SyntaxKind.VoidKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "goo");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -8259,6 +8379,7 @@ void goo() { }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -8278,15 +8399,15 @@ void goo() { }
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                             }
                             N(SyntaxKind.LessThanToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.MethodDeclaration);
@@ -8295,7 +8416,7 @@ void goo() { }
                     {
                         N(SyntaxKind.VoidKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "goo");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -8309,6 +8430,7 @@ void goo() { }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -8329,15 +8451,15 @@ void goo() { }
                         {
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "a");
                             }
                             N(SyntaxKind.LessThanToken);
                             N(SyntaxKind.IdentifierName);
                             {
-                                N(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "b");
                             }
                         }
-                        N(SyntaxKind.SemicolonToken);
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.MethodDeclaration);
@@ -8346,7 +8468,7 @@ void goo() { }
                     {
                         N(SyntaxKind.VoidKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "goo");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -8360,6 +8482,7 @@ void goo() { }
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
@@ -41,159 +41,250 @@ class C
                 N(SyntaxKind.ClassDeclaration);
                 {
                     N(SyntaxKind.ClassKeyword);
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "C");
                     N(SyntaxKind.OpenBraceToken);
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.OmittedTypeArgument); N(SyntaxKind.OmittedTypeArgumentToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.OmittedTypeArgument);
+                                    {
+                                        N(SyntaxKind.OmittedTypeArgumentToken);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "T");
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a2");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.OmittedTypeArgument); N(SyntaxKind.OmittedTypeArgumentToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.OmittedTypeArgument); N(SyntaxKind.OmittedTypeArgumentToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.OmittedTypeArgument);
+                                    {
+                                        N(SyntaxKind.OmittedTypeArgumentToken);
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.OmittedTypeArgument);
+                                    {
+                                        N(SyntaxKind.OmittedTypeArgumentToken);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a3");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "T");
+                                    }
+                                    M(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "U");
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a4");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.OmittedTypeArgument); N(SyntaxKind.OmittedTypeArgumentToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.OmittedTypeArgument); N(SyntaxKind.OmittedTypeArgumentToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.OmittedTypeArgument); N(SyntaxKind.OmittedTypeArgumentToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.OmittedTypeArgument);
+                                    {
+                                        N(SyntaxKind.OmittedTypeArgumentToken);
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.OmittedTypeArgument);
+                                    {
+                                        N(SyntaxKind.OmittedTypeArgumentToken);
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.OmittedTypeArgument);
+                                    {
+                                        N(SyntaxKind.OmittedTypeArgumentToken);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a5");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "T");
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a6");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "T");
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a7");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.GenericName);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.TypeArgumentList);
-                        N(SyntaxKind.LessThanToken);
                         {
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.GenericName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "A");
+                                N(SyntaxKind.TypeArgumentList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "T");
+                                    }
+                                    M(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "U");
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                    N(SyntaxKind.GreaterThanToken);
+                                }
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a8");
+                            }
                         }
-                        N(SyntaxKind.GreaterThanToken);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.CloseBraceToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
 
         [Fact]
@@ -558,215 +649,370 @@ class C
                 N(SyntaxKind.ClassDeclaration);
                 {
                     N(SyntaxKind.ClassKeyword);
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "C");
                     N(SyntaxKind.OpenBraceToken);
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.OmittedArraySizeExpression); N(SyntaxKind.OmittedArraySizeExpressionToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.OmittedArraySizeExpression);
+                                                {
+                                                    N(SyntaxKind.OmittedArraySizeExpressionToken);
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.OmittedArraySizeExpression); N(SyntaxKind.OmittedArraySizeExpressionToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.OmittedArraySizeExpression); N(SyntaxKind.OmittedArraySizeExpressionToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.OmittedArraySizeExpression);
+                                                {
+                                                    N(SyntaxKind.OmittedArraySizeExpressionToken);
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.OmittedArraySizeExpression);
+                                                {
+                                                    N(SyntaxKind.OmittedArraySizeExpressionToken);
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                                }
+                                                M(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "2");
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.OmittedArraySizeExpression); N(SyntaxKind.OmittedArraySizeExpressionToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.OmittedArraySizeExpression); N(SyntaxKind.OmittedArraySizeExpressionToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.OmittedArraySizeExpression); N(SyntaxKind.OmittedArraySizeExpressionToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.OmittedArraySizeExpression);
+                                                {
+                                                    N(SyntaxKind.OmittedArraySizeExpressionToken);
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.OmittedArraySizeExpression);
+                                                {
+                                                    N(SyntaxKind.OmittedArraySizeExpressionToken);
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.OmittedArraySizeExpression);
+                                                {
+                                                    N(SyntaxKind.OmittedArraySizeExpressionToken);
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                M(SyntaxKind.IdentifierName);
+                                                {
+                                                    M(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                M(SyntaxKind.IdentifierName);
+                                                {
+                                                    M(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.FieldDeclaration);
                     {
                         N(SyntaxKind.VariableDeclaration);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.ObjectKeyword);
-                        N(SyntaxKind.VariableDeclarator);
-                        N(SyntaxKind.IdentifierToken);
-                        N(SyntaxKind.EqualsValueClause);
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.ArrayCreationExpression);
-                        N(SyntaxKind.NewKeyword);
-                        N(SyntaxKind.ArrayType);
-                        N(SyntaxKind.PredefinedType);
-                        N(SyntaxKind.IntKeyword);
-                        N(SyntaxKind.ArrayRankSpecifier);
-                        N(SyntaxKind.OpenBracketToken);
                         {
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.NumericLiteralExpression); N(SyntaxKind.NumericLiteralToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
-                            N(SyntaxKind.CommaToken);
-                            N(SyntaxKind.IdentifierName); N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "a1");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.ArrayCreationExpression);
+                                    {
+                                        N(SyntaxKind.NewKeyword);
+                                        N(SyntaxKind.ArrayType);
+                                        {
+                                            N(SyntaxKind.PredefinedType);
+                                            {
+                                                N(SyntaxKind.IntKeyword);
+                                            }
+                                            N(SyntaxKind.ArrayRankSpecifier);
+                                            {
+                                                N(SyntaxKind.OpenBracketToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                                }
+                                                M(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.NumericLiteralExpression);
+                                                {
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                M(SyntaxKind.IdentifierName);
+                                                {
+                                                    M(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                M(SyntaxKind.IdentifierName);
+                                                {
+                                                    M(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.CloseBracketToken);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        N(SyntaxKind.CloseBracketToken);
                         N(SyntaxKind.SemicolonToken);
                     }
-
                     N(SyntaxKind.CloseBraceToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
+            EOF();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SuppressNullableWarningExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SuppressNullableWarningExpressionParsingTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
             {
                 N(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "o");
                 }
                 N(SyntaxKind.EqualsToken);
                 N(SyntaxKind.SimpleAssignmentExpression);
@@ -197,21 +197,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "o");
                         }
                         N(SyntaxKind.ExclamationEqualsToken);
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.IdentifierToken);
                         }
-                        N(SyntaxKind.EqualsToken);
-                        N(SyntaxKind.NullLiteralExpression);
-                        {
-                            N(SyntaxKind.NullKeyword);
-                        }
+                    }
+                    N(SyntaxKind.EqualsToken);
+                    N(SyntaxKind.NullLiteralExpression);
+                    {
+                        N(SyntaxKind.NullKeyword);
                     }
                 }
             }
+            EOF();
         }
 
         [Fact]


### PR DESCRIPTION
@dotnet/roslyn-compiler for review. Test-only change.