### PR TITLE
Don't allow named arguments for implicit indexers

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2019.md
@@ -100,3 +100,4 @@ could be different than the one that compiler used to find.
 
 16. In *Visual Studio 2019 version 16.5* and language version 8.0 and later, the compiler will no longer accept `throw null` when there is no type `System.Exception`.
 
+17. https://github.com/dotnet/roslyn/issues/39852 Previously the compiler would allow an invocation of an implicit index or range indexer to specify any named argument. In *Visual Studio 2019 version 16.5* argument names are no longer permitted for these invocations.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7721,9 +7721,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (arguments.Names.Count > 0)
             {
                 diagnostics.Add(
-                    ErrorCode.ERR_ImplicitIndexerWithName,
-                    arguments.Names[0].GetLocation(),
-                    argIsRange ? nameof(Range) : nameof(Index));
+                    argIsRange
+                        ? ErrorCode.ERR_ImplicitRangeIndexerWithName 
+                        : ErrorCode.ERR_ImplicitIndexIndexerWithName,
+                    arguments.Names[0].GetLocation());
             }
             return true;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7722,7 +7722,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 diagnostics.Add(
                     argIsRange
-                        ? ErrorCode.ERR_ImplicitRangeIndexerWithName 
+                        ? ErrorCode.ERR_ImplicitRangeIndexerWithName
                         : ErrorCode.ERR_ImplicitIndexIndexerWithName,
                     arguments.Names[0].GetLocation());
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -7278,7 +7278,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (TryBindIndexOrRangeIndexer(
                     node,
                     expr,
-                    analyzedArguments.Arguments,
+                    analyzedArguments,
                     diagnostics,
                     out var patternIndexerAccess))
                 {
@@ -7452,7 +7452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (TryBindIndexOrRangeIndexer(
                         syntax,
                         receiverOpt,
-                        analyzedArguments.Arguments,
+                        analyzedArguments,
                         diagnostics,
                         out var patternIndexerAccess))
                     {
@@ -7552,7 +7552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool TryBindIndexOrRangeIndexer(
             SyntaxNode syntax,
             BoundExpression receiverOpt,
-            ArrayBuilder<BoundExpression> arguments,
+            AnalyzedArguments arguments,
             DiagnosticBag diagnostics,
             out BoundIndexOrRangePatternIndexerAccess patternIndexerAccess)
         {
@@ -7562,12 +7562,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // to this indexer that has an Index or Range type and that there is
             // a real receiver with a known type
 
-            if (arguments.Count != 1)
+            if (arguments.Arguments.Count != 1)
             {
                 return false;
             }
 
-            var argType = arguments[0].Type;
+            var argument = arguments.Arguments[0];
+
+            var argType = argument.Type;
             bool argIsIndex = TypeSymbol.Equals(argType,
                 Compilation.GetWellKnownType(WellKnownType.System_Index),
                 TypeCompareKind.ConsiderEverything);
@@ -7638,7 +7640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 receiverOpt,
                                 lengthOrCountProperty,
                                 property,
-                                BindToNaturalType(arguments[0], diagnostics),
+                                BindToNaturalType(argument, diagnostics),
                                 property.Type);
                             break;
                         }
@@ -7657,7 +7659,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         receiverOpt,
                         lengthOrCountProperty,
                         substring,
-                        BindToNaturalType(arguments[0], diagnostics),
+                        BindToNaturalType(argument, diagnostics),
                         substring.ReturnType);
                     checkWellKnown(WellKnownMember.System_Range__get_Start);
                     checkWellKnown(WellKnownMember.System_Range__get_End);
@@ -7698,7 +7700,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 receiverOpt,
                                 lengthOrCountProperty,
                                 method,
-                                BindToNaturalType(arguments[0], diagnostics),
+                                BindToNaturalType(argument, diagnostics),
                                 method.ReturnType);
                             checkWellKnown(WellKnownMember.System_Range__get_Start);
                             checkWellKnown(WellKnownMember.System_Range__get_End);
@@ -7716,6 +7718,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             _ = MessageID.IDS_FeatureIndexOperator.CheckFeatureAvailability(diagnostics, syntax);
             checkWellKnown(WellKnownMember.System_Index__GetOffset);
+            if (arguments.Names.Count > 0)
+            {
+                diagnostics.Add(
+                    ErrorCode.ERR_ImplicitIndexerWithName,
+                    arguments.Names[0].GetLocation(),
+                    argIsRange ? nameof(Range) : nameof(Index));
+            }
             return true;
 
             static void cleanup(LookupResult lookupResult, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5596,11 +5596,11 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Implicit {0} indexer cannot have a named argument..
+        ///   Looks up a localized string similar to Invocation of implicit Index Indexer cannot name the argument..
         /// </summary>
-        internal static string ERR_ImplicitIndexerWithName {
+        internal static string ERR_ImplicitIndexIndexerWithName {
             get {
-                return ResourceManager.GetString("ERR_ImplicitIndexerWithName", resourceCulture);
+                return ResourceManager.GetString("ERR_ImplicitIndexIndexerWithName", resourceCulture);
             }
         }
         
@@ -5673,6 +5673,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_ImplicitlyTypedVariableWithNoInitializer {
             get {
                 return ResourceManager.GetString("ERR_ImplicitlyTypedVariableWithNoInitializer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invocation of implicit Range Indexer cannot name the argument..
+        /// </summary>
+        internal static string ERR_ImplicitRangeIndexerWithName {
+            get {
+                return ResourceManager.GetString("ERR_ImplicitRangeIndexerWithName", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5596,6 +5596,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Implicit {0} indexer cannot have a named argument..
+        /// </summary>
+        internal static string ERR_ImplicitIndexerWithName {
+            get {
+                return ResourceManager.GetString("ERR_ImplicitIndexerWithName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No best type found for implicitly-typed array.
         /// </summary>
         internal static string ERR_ImplicitlyTypedArrayNoBestType {
@@ -7423,7 +7432,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos; or implement a suitable &apos;Dispose&apos; method..
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos;..
         /// </summary>
         internal static string ERR_NoConvToIDisp {
             get {
@@ -7432,7 +7441,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos; or implement a suitable &apos;Dispose&apos; method. Did you mean &apos;await using&apos; rather than &apos;using&apos;?.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: type used in a using statement must be implicitly convertible to &apos;System.IDisposable&apos;. Did you mean &apos;await using&apos; rather than &apos;using&apos;?.
         /// </summary>
         internal static string ERR_NoConvToIDispWrongAsync {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5927,7 +5927,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExternEventInitializer" xml:space="preserve">
     <value>'{0}': extern event cannot have initializer</value>
   </data>
-  <data name="ERR_ImplicitIndexerWithName" xml:space="preserve">
-    <value>Implicit {0} indexer cannot have a named argument.</value>
+  <data name="ERR_ImplicitIndexIndexerWithName" xml:space="preserve">
+    <value>Invocation of implicit Index Indexer cannot name the argument.</value>
+  </data>
+  <data name="ERR_ImplicitRangeIndexerWithName" xml:space="preserve">
+    <value>Invocation of implicit Range Indexer cannot name the argument.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5927,4 +5927,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExternEventInitializer" xml:space="preserve">
     <value>'{0}': extern event cannot have initializer</value>
   </data>
+  <data name="ERR_ImplicitIndexerWithName" xml:space="preserve">
+    <value>Implicit {0} indexer cannot have a named argument.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1738,6 +1738,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InternalError = 8751,
 
         ERR_ExternEventInitializer = 8760,
+        ERR_ImplicitIndexerWithName = 8761,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1605,6 +1605,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_UndecoratedCancellationTokenParameter = 8425,
         ERR_MultipleEnumeratorCancellationAttributes = 8426,
         ERR_VarianceInterfaceNesting = 8427,
+        ERR_ImplicitIndexIndexerWithName = 8428,
+        ERR_ImplicitRangeIndexerWithName = 8429,
         // available range
 
         #region diagnostics introduced for recursive patterns
@@ -1738,7 +1740,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InternalError = 8751,
 
         ERR_ExternEventInitializer = 8760,
-        ERR_ImplicitIndexerWithName = 8761,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -227,6 +227,11 @@
         <target state="translated">Operátor potlačení není v tomto kontextu povolený.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Argumenty s modifikátorem in se nedají použít v dynamicky odbavených výrazech.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -227,9 +227,14 @@
         <target state="translated">Operátor potlačení není v tomto kontextu povolený.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -227,6 +227,11 @@
         <target state="translated">Ein Unterdrückungsoperator ist in diesem Kontext unzulässig.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Argumente mit dem Modifizierer "in" können nicht in dynamisch verteilten Ausdrücken verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -227,9 +227,14 @@
         <target state="translated">Ein Unterdrückungsoperator ist in diesem Kontext unzulässig.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -227,9 +227,14 @@
         <target state="translated">No se permite el operador de supresión en este contexto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -227,6 +227,11 @@
         <target state="translated">No se permite el operador de supresión en este contexto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">No se pueden usar argumentos con el modificador "in" en expresiones distribuidas dinámicamente.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -227,9 +227,14 @@
         <target state="translated">L'opérateur de suppression n'est pas autorisé dans ce contexte</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -227,6 +227,11 @@
         <target state="translated">L'opérateur de suppression n'est pas autorisé dans ce contexte</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Impossible d'utiliser les arguments avec le modificateur 'in' dans les expressions faisant l'objet d'un dispatch dynamique.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -227,9 +227,14 @@
         <target state="translated">L'operatore di eliminazione non è consentito in questo contesto</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -227,6 +227,11 @@
         <target state="translated">L'operatore di eliminazione non è consentito in questo contesto</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Non è possibile usare argomenti con il modificatore 'in' nelle espressioni inviate in modo dinamico.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -227,6 +227,11 @@
         <target state="translated">このコンテキストでは抑制演算子が許可されていません</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">'in' 修飾子を持つ引数を、動的にディスパッチされる式で使用することはできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -227,9 +227,14 @@
         <target state="translated">このコンテキストでは抑制演算子が許可されていません</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -227,9 +227,14 @@
         <target state="translated">이 컨텍스트에서는 비표시 오류(Suppression) 연산자를 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -227,6 +227,11 @@
         <target state="translated">이 컨텍스트에서는 비표시 오류(Suppression) 연산자를 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">동적으로 디스패치된 식에서 'in' 한정자가 있는 인수를 사용할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -227,6 +227,11 @@
         <target state="translated">Operator pominięcia jest niedozwolony w tym kontekście</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Nie można używać argumentów z modyfikatorem „in” w wyrażeniach wysyłanych dynamicznie.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -227,9 +227,14 @@
         <target state="translated">Operator pominięcia jest niedozwolony w tym kontekście</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -227,9 +227,14 @@
         <target state="translated">O operador de supressão não é permitido neste contexto</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -227,6 +227,11 @@
         <target state="translated">O operador de supressão não é permitido neste contexto</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Os argumentos com o modificador 'in' não podem ser usados em expressões expedidas dinamicamente.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -227,6 +227,11 @@
         <target state="translated">Оператор подавления недопустим в данном контексте.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Аргументы с модификатором "in" невозможно использовать в динамически отправляемых выражениях.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -227,9 +227,14 @@
         <target state="translated">Оператор подавления недопустим в данном контексте.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -227,6 +227,11 @@
         <target state="translated">Gizleme işlecine bu bağlamda izin verilmez</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">'in' değiştiricisine sahip bağımsız değişkenler dinamik olarak dağıtılan ifadelerde kullanılamaz.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -227,9 +227,14 @@
         <target state="translated">Gizleme işlecine bu bağlamda izin verilmez</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -227,6 +227,11 @@
         <target state="translated">此上下文中不允许使用抑制运算符</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">带有 "in" 修饰符的参数不能用于动态调度的表达式。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -227,9 +227,14 @@
         <target state="translated">此上下文中不允许使用抑制运算符</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -227,6 +227,11 @@
         <target state="translated">此內容不允許隱藏項目運算子。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitIndexerWithName">
+        <source>Implicit {0} indexer cannot have a named argument.</source>
+        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">具有 'in' 修飾詞的引數不可用於動態分派的運算式。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -227,9 +227,14 @@
         <target state="translated">此內容不允許隱藏項目運算子。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_ImplicitIndexerWithName">
-        <source>Implicit {0} indexer cannot have a named argument.</source>
-        <target state="new">Implicit {0} indexer cannot have a named argument.</target>
+      <trans-unit id="ERR_ImplicitIndexIndexerWithName">
+        <source>Invocation of implicit Index Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Index Indexer cannot name the argument.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_ImplicitRangeIndexerWithName">
+        <source>Invocation of implicit Range Indexer cannot name the argument.</source>
+        <target state="new">Invocation of implicit Range Indexer cannot name the argument.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IndexAndRangeTests.cs
@@ -1561,19 +1561,31 @@ public class C
     public static void M(string text) 
     {
         _ = text[startIndex: 1..^1];
-        _ = new Span<char>(text.ToCharArray())[start: 1..^1];
         _ = text[range: 1..^1];
+        _ = text[notEvenTheCorrectName: 1..^1];
+        _ = new Span<char>(text.ToCharArray())[start: 1..^1];
+        _ = new Span<char>(text.ToCharArray())[range: 1..^1];
+        _ = new Span<char>(text.ToCharArray())[notEvenTheCorrectName: 1..^1];
     }
 }").VerifyDiagnostics(
-                    // (7,18): error CS8761: Implicit Range indexer cannot have a named argument.
+                    // (7,18): error CS8429: Invocation of implicit Range Indexer cannot name the argument.
                     //         _ = text[startIndex: 1..^1];
-                    Diagnostic(ErrorCode.ERR_ImplicitIndexerWithName, "startIndex").WithArguments("Range").WithLocation(7, 18),
-                    // (8,48): error CS8761: Implicit Range indexer cannot have a named argument.
-                    //         _ = new Span<char>(text.ToCharArray())[start: 1..^1];
-                    Diagnostic(ErrorCode.ERR_ImplicitIndexerWithName, "start").WithArguments("Range").WithLocation(8, 48),
-                    // (9,18): error CS8761: Implicit Range indexer cannot have a named argument.
+                    Diagnostic(ErrorCode.ERR_ImplicitRangeIndexerWithName, "startIndex").WithLocation(7, 18),
+                    // (8,18): error CS8429: Invocation of implicit Range Indexer cannot name the argument.
                     //         _ = text[range: 1..^1];
-                    Diagnostic(ErrorCode.ERR_ImplicitIndexerWithName, "range").WithArguments("Range").WithLocation(9, 18));
+                    Diagnostic(ErrorCode.ERR_ImplicitRangeIndexerWithName, "range").WithLocation(8, 18),
+                    // (9,18): error CS8429: Invocation of implicit Range Indexer cannot name the argument.
+                    //         _ = text[notEvenTheCorrectName: 1..^1];
+                    Diagnostic(ErrorCode.ERR_ImplicitRangeIndexerWithName, "notEvenTheCorrectName").WithLocation(9, 18),
+                    // (10,48): error CS8429: Invocation of implicit Range Indexer cannot name the argument.
+                    //         _ = new Span<char>(text.ToCharArray())[start: 1..^1];
+                    Diagnostic(ErrorCode.ERR_ImplicitRangeIndexerWithName, "start").WithLocation(10, 48),
+                    // (11,48): error CS8429: Invocation of implicit Range Indexer cannot name the argument.
+                    //         _ = new Span<char>(text.ToCharArray())[range: 1..^1];
+                    Diagnostic(ErrorCode.ERR_ImplicitRangeIndexerWithName, "range").WithLocation(11, 48),
+                    // (12,48): error CS8429: Invocation of implicit Range Indexer cannot name the argument.
+                    //         _ = new Span<char>(text.ToCharArray())[notEvenTheCorrectName: 1..^1];
+                    Diagnostic(ErrorCode.ERR_ImplicitRangeIndexerWithName, "notEvenTheCorrectName").WithLocation(12, 48));
         }
 
         [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
@@ -1586,51 +1598,145 @@ public class C
     public static void M(string text) 
     {
         _ = text[index: ^1];
+        _ = text[notEvenTheCorrectName: ^1];
         _ = new Span<char>(text.ToCharArray())[index: ^1];
+        _ = new Span<char>(text.ToCharArray())[notEvenTheCorrectName: ^1];
     }
 }").VerifyDiagnostics(
-                    // (7,18): error CS8761: Implicit Index indexer cannot have a named argument.
+                    // (7,18): error CS8428: Invocation of implicit Index Indexer cannot name the argument.
                     //         _ = text[index: ^1];
-                    Diagnostic(ErrorCode.ERR_ImplicitIndexerWithName, "index").WithArguments("Index").WithLocation(7, 18),
-                    // (8,48): error CS8761: Implicit Index indexer cannot have a named argument.
+                    Diagnostic(ErrorCode.ERR_ImplicitIndexIndexerWithName, "index").WithLocation(7, 18),
+                    // (8,18): error CS8428: Invocation of implicit Index Indexer cannot name the argument.
+                    //         _ = text[notEvenTheCorrectName: ^1];
+                    Diagnostic(ErrorCode.ERR_ImplicitIndexIndexerWithName, "notEvenTheCorrectName").WithLocation(8, 18),
+                    // (9,48): error CS8428: Invocation of implicit Index Indexer cannot name the argument.
                     //         _ = new Span<char>(text.ToCharArray())[index: ^1];
-                    Diagnostic(ErrorCode.ERR_ImplicitIndexerWithName, "index").WithArguments("Index").WithLocation(8, 48));
+                    Diagnostic(ErrorCode.ERR_ImplicitIndexIndexerWithName, "index").WithLocation(9, 48),
+                    // (10,48): error CS8428: Invocation of implicit Index Indexer cannot name the argument.
+                    //         _ = new Span<char>(text.ToCharArray())[notEvenTheCorrectName: ^1];
+                    Diagnostic(ErrorCode.ERR_ImplicitIndexIndexerWithName, "notEvenTheCorrectName").WithLocation(10, 48));
         }
 
         [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
-        public void AllowNamedArgumentsForRealRangeIndexer()
+        public void AllowNamedArgumentsForRealRangeIndexer1()
+        {
+            var comp = CreateCompilationWithIndexAndRange(@"
+using System;
+public class A
+{
+     public int this[Range range] => 42;
+}
+public class C 
+{
+    public static void Main() 
+    {
+        Console.Write(new A()[range: 1..^1]);
+    }
+}", options: TestOptions.ReleaseExe).VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput: "42");
+        }
+
+        [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
+        public void AllowNamedArgumentsForRealRangeIndexer2()
+        {
+            var comp = CreateCompilationWithIndexAndRange(@"
+using System;
+public class A
+{
+     public int this[Range param] => 42;
+}
+public class C 
+{
+    public static void Main() 
+    {
+        Console.Write(new A()[param: 1..^1]);
+    }
+}", options: TestOptions.ReleaseExe).VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput: "42");
+        }
+
+        [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
+        public void DontAllowIncorrectNamedArgumentsForRealRangeIndexer()
         {
             CreateCompilationWithIndexAndRange(@"
 using System;
 public class A
 {
-     public int this[Range range] => throw new Exception();
+     public int this[Range range] => 42;
 }
 public class C 
 {
-    public static void M(string text) 
+    public static void Main() 
     {
-        _ = new A()[range: 1..^1];
+        Console.Write(new A()[param: 1..^1]);
     }
-}").VerifyDiagnostics();
+}").VerifyDiagnostics(
+                    // (11,31): error CS1739: The best overload for 'this' does not have a parameter named 'param'
+                    //         Console.Write(new A()[param: 1..^1]);
+                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "param").WithArguments("this", "param").WithLocation(11, 31));
         }
 
         [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
-        public void AllowNamedArgumentsForRealIndexIndexer()
+        public void AllowNamedArgumentsForRealIndexIndexer1()
         {
-            CreateCompilationWithIndexAndRangeAndSpan(@"
+            var comp = CreateCompilationWithIndexAndRange(@"
 using System;
 public class A
 {
-     public int this[Index index] => throw new Exception();
+     public int this[Index index] => 42;
 }
 public class C 
 {
-    public static void M(string text) 
+    public static void Main() 
     {
-        _ = new A()[index: ^1];
+        Console.Write(new A()[index: ^1]);
     }
-}").VerifyDiagnostics();
+}", options: TestOptions.ReleaseExe).VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput: "42");
+        }
+
+        [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
+        public void AllowNamedArgumentsForRealIndexIndexer2()
+        {
+            var comp = CreateCompilationWithIndexAndRange(@"
+using System;
+public class A
+{
+     public int this[Index param] => 42;
+}
+public class C 
+{
+    public static void Main() 
+    {
+        Console.Write(new A()[param: ^1]);
+    }
+}", options: TestOptions.ReleaseExe).VerifyDiagnostics();
+
+            CompileAndVerify(comp, expectedOutput: "42");
+        }
+
+        [Fact, WorkItem(39852, "https://github.com/dotnet/roslyn/issues/39852")]
+        public void DontAllowIncorrectNamedArgumentsForRealIndexIndexer()
+        {
+            CreateCompilationWithIndexAndRange(@"
+using System;
+public class A
+{
+     public int this[Index index] => 42;
+}
+public class C 
+{
+    public static void Main() 
+    {
+        Console.Write(new A()[param: ^1]);
+    }
+}").VerifyDiagnostics(
+                    // (11,31): error CS1739: The best overload for 'this' does not have a parameter named 'param'
+                    //         Console.Write(new A()[param: ^1]);
+                    Diagnostic(ErrorCode.ERR_BadNamedArgument, "param").WithArguments("this", "param").WithLocation(11, 31));
         }
     }
 }


### PR DESCRIPTION
This fixes the compiler half of https://github.com/dotnet/roslyn/issues/39852

I'll fix the IDE half in a separate PR to simplify review, and because this is a breaking change where the IDE fix wont be.

Currently any argument name is allowed for an implicit Range or Index indexer. This disallows all names.
If the compiler team does decide to fix this, I assume it is best to fix it sooner rather than later.

It could be argued based on the spec that the names `range` and `index` should be allowed respectively, but seeing as they provide no useful information, I can't see the point of adding complexity to support them.