### PR TITLE
Make event backing fields accessible to third-party analyzers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -665,6 +665,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (Symbol member in members)
             {
+                if ((member as FieldSymbol)?.AssociatedSymbol is EventSymbol)
+                {
+                    continue;
+                }
+
                 // Do we need to exclude override members, or is that done later by overload resolution. It seems like
                 // not excluding them here can't lead to problems, because we will always find the overridden method as well.
                 SingleLookupResult resultOfThisMember = originalBinder.CheckViability(member, arity, options, accessThroughType, diagnose, ref useSiteDiagnostics, basesBeingResolved);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -270,20 +270,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                                         break;
 
                                     case SymbolKind.Property:
+                                    case SymbolKind.Event:
                                     case SymbolKind.Field:
                                         // NOTE: Dev11 does not add synthesized backing fields for properties,
                                         //       but adds backing fields for events, Roslyn adds both
                                         AddSymbolLocation(result, member);
-                                        break;
-
-                                    case SymbolKind.Event:
-                                        AddSymbolLocation(result, member);
-                                        //  event backing fields do not show up in GetMembers
-                                        FieldSymbol field = ((EventSymbol)member).AssociatedField;
-                                        if ((object)field != null)
-                                        {
-                                            AddSymbolLocation(result, field);
-                                        }
                                         break;
 
                                     default:

--- a/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
@@ -158,29 +158,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var hasGenerics = false;
             if (partialClosure.Add(type))
             {
-                foreach (var member in type.GetInstanceFieldsAndEvents())
+                foreach (var field in type.GetInstanceFields())
                 {
-                    // Only instance fields (including field-like events) affect the outcome.
-                    FieldSymbol field;
-                    switch (member.Kind)
-                    {
-                        case SymbolKind.Field:
-                            field = (FieldSymbol)member;
-                            Debug.Assert((object)(field.AssociatedSymbol as EventSymbol) == null,
-                                "Didn't expect to find a field-like event backing field in the member list.");
-                            break;
-                        case SymbolKind.Event:
-                            field = ((EventSymbol)member).AssociatedField;
-                            break;
-                        default:
-                            throw ExceptionUtilities.UnexpectedValue(member.Kind);
-                    }
-
-                    if ((object)field == null)
-                    {
-                        continue;
-                    }
-
                     TypeSymbol fieldType = field.NonPointerType();
                     if (fieldType is null)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -530,22 +530,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static bool IsFieldOrFieldLikeEvent(this Symbol member, out FieldSymbol field)
-        {
-            switch (member.Kind)
-            {
-                case SymbolKind.Field:
-                    field = (FieldSymbol)member;
-                    return true;
-                case SymbolKind.Event:
-                    field = ((EventSymbol)member).AssociatedField;
-                    return (object)field != null;
-                default:
-                    field = null;
-                    return false;
-            }
-        }
-
         internal static string GetMemberCallerName(this Symbol member)
         {
             if (member.Kind == SymbolKind.Method)

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -534,30 +534,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity);
 
         /// <summary>
-        /// Get all instance field and event members.
+        /// Get all instance fields. This includes backing fields for properties and field-like events.
         /// </summary>
         /// <remarks>
         /// For source symbols may be called while calculating
         /// <see cref="NamespaceOrTypeSymbol.GetMembersUnordered"/>.
         /// </remarks>
-        internal virtual IEnumerable<Symbol> GetInstanceFieldsAndEvents()
+        internal virtual IEnumerable<FieldSymbol> GetInstanceFields()
         {
-            return GetMembersUnordered().Where(IsInstanceFieldOrEvent);
+            return GetMembersUnordered().Where(IsInstanceField).Cast<FieldSymbol>();
         }
 
-        protected static Func<Symbol, bool> IsInstanceFieldOrEvent = symbol =>
-        {
-            if (!symbol.IsStatic)
-            {
-                switch (symbol.Kind)
-                {
-                    case SymbolKind.Field:
-                    case SymbolKind.Event:
-                        return true;
-                }
-            }
-            return false;
-        };
+        protected static Func<Symbol, bool> IsInstanceField = symbol => symbol is { IsStatic: false, Kind: SymbolKind.Field };
 
         /// <summary>
         /// Get this accessibility that was declared on this symbol. For symbols that do not have

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2469,7 +2469,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         continue;
                     }
 
-                    if (!field.CanBeReferencedByName)
+                    if (!(field.AssociatedSymbol is EventSymbol || field.CanBeReferencedByName))
                     {
                         continue;
                     }
@@ -2526,7 +2526,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         continue;
                     }
 
-                    if (!field.CanBeReferencedByName)
+                    if (!(field.AssociatedSymbol is EventSymbol || field.CanBeReferencedByName))
                     {
                         continue;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -618,12 +618,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         var sourceField = member as SourceFieldSymbol;
                         var isNewField = (object)sourceField != null && sourceField.IsNew;
 
-                        // We don't want to report diagnostics for field-like event backing fields (redundant),
-                        // but that shouldn't be an issue since they shouldn't be in the member list.
-                        Debug.Assert((object)sourceField == null || (object)sourceField.AssociatedSymbol == null ||
-                            sourceField.AssociatedSymbol.Kind != SymbolKind.Event);
-
-                        CheckNewModifier(member, isNewField, diagnostics);
+                        // We don't want to report diagnostics for field-like event backing fields (redundant).
+                        if (sourceField?.AssociatedSymbol?.Kind != SymbolKind.Event)
+                        {
+                            CheckNewModifier(member, isNewField, diagnostics);
+                        }
                         break;
                     case SymbolKind.NamedType:
                         CheckNewModifier(member, ((SourceMemberContainerTypeSymbol)member).IsNew, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1153,22 +1153,8 @@ next:;
             var members = this.GetMembersUnordered();
             for (var i = 0; i < members.Length; i++)
             {
-                var m = members[i];
-                if (!m.IsStatic)
-                {
-                    switch (m.Kind)
-                    {
-                        case SymbolKind.Field:
-                            return true;
-
-                        case SymbolKind.Event:
-                            if (((EventSymbol)m).AssociatedField != null)
-                            {
-                                return true;
-                            }
-                            break;
-                    }
-                }
+                if (members[i] is { IsStatic: false, Kind: SymbolKind.Field })
+                    return true;
             }
 
             return false;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -600,6 +600,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             }
 
                             var underlyingField = field is TupleElementFieldSymbol tupleElement ? tupleElement.UnderlyingField.OriginalDefinition : field.OriginalDefinition;
+                            if (underlyingField.AssociatedSymbol is EventSymbol)
+                            {
+                                members.Add(member);
+                                continue;
+                            }
+
                             int tupleFieldIndex = currentFieldsForElements.IndexOf(underlyingField, ReferenceEqualityComparer.Instance);
                             if (underlyingField is TupleErrorFieldSymbol)
                             {
@@ -1068,6 +1074,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         case SymbolKind.Method:
                         case SymbolKind.Property:
+                        case SymbolKind.Event:
                         case SymbolKind.NamedType:
                             map.Add(member.OriginalDefinition, member);
                             break;
@@ -1078,20 +1085,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 map[tupleUnderlyingField.OriginalDefinition] = member;
                             }
-                            break;
-
-                        case SymbolKind.Event:
-                            var underlyingEvent = (EventSymbol)member;
-                            var underlyingAssociatedField = underlyingEvent.AssociatedField;
-                            // The field is not part of the members list
-                            if ((object)underlyingAssociatedField != null)
-                            {
-                                Debug.Assert((object)underlyingAssociatedField.ContainingSymbol == TupleUnderlyingType);
-                                Debug.Assert(TupleUnderlyingType.GetMembers(underlyingAssociatedField.Name).IndexOf(underlyingAssociatedField) < 0);
-                                map.Add(underlyingAssociatedField.OriginalDefinition, new TupleFieldSymbol(TupleUnderlyingType, underlyingAssociatedField, -i - 1));
-                            }
-
-                            map.Add(underlyingEvent.OriginalDefinition, member);
                             break;
 
                         default:

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -2057,16 +2057,16 @@ public class Test
             {
                 var @class = moduleSymbol.GlobalNamespace.GetMember<NamedTypeSymbol>("Test");
 
-                var event1 = @class.GetMember<EventSymbol>("E1");
-                var event2 = @class.GetMember<EventSymbol>("E2");
-                var event3 = @class.GetMember<EventSymbol>("E3");
-                var event4 = @class.GetMember<EventSymbol>("E4");
-                var event5 = @class.GetMember<EventSymbol>("E5");
-                var event6 = @class.GetMember<EventSymbol>("E6");
-                var event7 = @class.GetMember<EventSymbol>("E7");
-                var event8 = @class.GetMember<EventSymbol>("E8");
-                var event9 = @class.GetMember<EventSymbol>("E9");
-                var event10 = @class.GetMember<EventSymbol>("E10");
+                var event1 = @class.GetEvent("E1");
+                var event2 = @class.GetEvent("E2");
+                var event3 = @class.GetEvent("E3");
+                var event4 = @class.GetEvent("E4");
+                var event5 = @class.GetEvent("E5");
+                var event6 = @class.GetEvent("E6");
+                var event7 = @class.GetEvent("E7");
+                var event8 = @class.GetEvent("E8");
+                var event9 = @class.GetEvent("E9");
+                var event10 = @class.GetEvent("E10");
 
                 var accessorsExpected = isFromSource ? new string[0] : new[] { "CompilerGeneratedAttribute" };
 
@@ -4612,7 +4612,7 @@ public struct S
             Assert.NotNull(idxsym);
             Assert.True(idxsym.HasSpecialName);
 
-            var etsym = typesym.GetMember("E") as EventSymbol;
+            var etsym = typesym.GetEvent("E");
             Assert.NotNull(etsym);
             Assert.True(etsym.HasSpecialName);
         }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Conditional.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Conditional.cs
@@ -174,7 +174,7 @@ public class Test
             attributesArrayBuilder.Add(propSetMethod.GetAttributes());
             attributesArrayBuilder.Add(propSetMethod.Parameters[0].GetAttributes());
 
-            var eventE = classZ.GetMember<EventSymbol>("e");
+            var eventE = classZ.GetEvent("e");
             attributesArrayBuilder.Add(eventE.GetAttributes());
             attributesArrayBuilder.Add(eventE.AddMethod.GetAttributes());
             attributesArrayBuilder.Add(eventE.RemoveMethod.GetAttributes());

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -4300,7 +4300,7 @@ public class B<T> :
                 type.GetMember<FieldSymbol>("Field").TypeWithAnnotations.ToTestDisplayString());
             Assert.Equal(
                 "System.EventHandler<(dynamic? _1, (System.Object _2, dynamic? _3), System.Object _4, dynamic? _5, System.Object _6, dynamic? _7, System.Object _8, dynamic? _9)>",
-                type.GetMember<EventSymbol>("Event").TypeWithAnnotations.ToTestDisplayString());
+                type.GetEvent("Event").TypeWithAnnotations.ToTestDisplayString());
             Assert.Equal(
                 "(dynamic? _1, (System.Object _2, dynamic? _3), System.Object _4, dynamic? _5, System.Object _6, dynamic? _7, System.Object _8, dynamic? _9) B<T>.Method((dynamic? _1, (System.Object _2, dynamic? _3), System.Object _4, dynamic? _5, System.Object _6, dynamic? _7, System.Object _8, dynamic? _9) arg)",
                 type.GetMember<MethodSymbol>("Method").ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -176,7 +176,7 @@ class Test
                 var property = type.GetMember<PEFieldSymbol>(GeneratedNames.MakeBackingFieldName("MyProp"));
                 Verify(property.Handle);
 
-                var eventField = (PEFieldSymbol)type.GetMember<PEEventSymbol>("MyEvent").AssociatedField;
+                var eventField = (PEFieldSymbol)type.GetEvent("MyEvent").AssociatedField;
                 Verify(eventField.Handle);
 
                 void Verify(EntityHandle token)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Synthesized.cs
@@ -232,7 +232,7 @@ abstract class C
                 Assert.Empty(peModule.GetCustomAttributesForToken(((PEMethodSymbol)q.GetMethod).Handle));
                 Assert.Empty(peModule.GetCustomAttributesForToken(((PEMethodSymbol)q.SetMethod).Handle));
 
-                var e = c.GetMember<EventSymbol>("E");
+                var e = c.GetEvent("E");
                 Assert.Equal("CompilerGeneratedAttribute", peModule.GetCustomAttributesForToken(((PEMethodSymbol)e.AddMethod).Handle).Single().AttributeClass.Name);
                 Assert.Equal("CompilerGeneratedAttribute", peModule.GetCustomAttributesForToken(((PEMethodSymbol)e.RemoveMethod).Handle).Single().AttributeClass.Name);
             });

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -372,7 +372,7 @@ class C
             {
                 // public static event Delegate1<(dynamic e1,
                 //                                ValueTuple<(dynamic e2, dynamic e3)> e4)> Event1;
-                var event1 = _derivedClass.GetMember<EventSymbol>("Event1");
+                var event1 = _derivedClass.GetEvent("Event1");
                 Assert.NotNull(event1);
 
                 ValidateTupleNameAttribute(event1.GetAttributes(),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7614,7 +7614,7 @@ class C : EventInterface
 Handler", references: WinRtRefs.Concat(new[] { ValueTupleRef, comp1.ToMetadataReference() }));
             comp2.VerifyDiagnostics();
 
-            Assert.True(comp2.Compilation.GetMember<IEventSymbol>("C.E").IsWindowsRuntimeEvent);
+            Assert.True(comp2.Compilation.GetEvent("C.E").IsWindowsRuntimeEvent);
         }
 
         [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
@@ -7677,7 +7677,7 @@ GetC
 Handler", references: WinRtRefs.Concat(new[] { ValueTupleRef, comp1.ToMetadataReference() }));
             comp2.VerifyDiagnostics();
 
-            Assert.True(comp2.Compilation.GetMember<IEventSymbol>("S.E").IsWindowsRuntimeEvent);
+            Assert.True(comp2.Compilation.GetEvent("S.E").IsWindowsRuntimeEvent);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -5410,7 +5410,7 @@ public class C
   // Code size       76 (0x4c)
   .maxstack  4
   IL_0000:  ldarg.0
-  IL_0001:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__4.<>p__0""
+  IL_0001:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__5.<>p__0""
   IL_0006:  brtrue.s   IL_002c
   IL_0008:  ldc.i4.0
   IL_0009:  ldtoken    ""System.Action""
@@ -5419,10 +5419,10 @@ public class C
   IL_0018:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_001d:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
   IL_0022:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0027:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__4.<>p__0""
-  IL_002c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__4.<>p__0""
+  IL_0027:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__5.<>p__0""
+  IL_002c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__5.<>p__0""
   IL_0031:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>>.Target""
-  IL_0036:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__4.<>p__0""
+  IL_0036:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>> C.<>o__5.<>p__0""
   IL_003b:  ldarg.0
   IL_003c:  ldfld      ""dynamic C.v""
   IL_0041:  callvirt   ""System.Action System.Func<System.Runtime.CompilerServices.CallSite, object, System.Action>.Invoke(System.Runtime.CompilerServices.CallSite, object)""

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenNullCoalescingAssignmentTests.cs
@@ -629,15 +629,15 @@ class C
   .maxstack  2
   IL_0000:  ldsfld     ""System.EventHandler C.E""
   IL_0005:  brtrue.s   IL_002b
-  IL_0007:  ldsfld     ""System.EventHandler C.<>c.<>9__3_0""
+  IL_0007:  ldsfld     ""System.EventHandler C.<>c.<>9__4_0""
   IL_000c:  dup
   IL_000d:  brtrue.s   IL_0026
   IL_000f:  pop
   IL_0010:  ldsfld     ""C.<>c C.<>c.<>9""
-  IL_0015:  ldftn      ""void C.<>c.<Main>b__3_0(object, System.EventArgs)""
+  IL_0015:  ldftn      ""void C.<>c.<Main>b__4_0(object, System.EventArgs)""
   IL_001b:  newobj     ""System.EventHandler..ctor(object, System.IntPtr)""
   IL_0020:  dup
-  IL_0021:  stsfld     ""System.EventHandler C.<>c.<>9__3_0""
+  IL_0021:  stsfld     ""System.EventHandler C.<>c.<>9__4_0""
   IL_0026:  stsfld     ""System.EventHandler C.E""
   IL_002b:  ret
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15491,6 +15491,7 @@ null
                 "System.Int32 (System.Int32, System.Int64).Item1",
                 "System.Int64 (System.Int32, System.Int64).Item2",
                 "(System.Int32, System.Int64)..ctor(System.Int32 item1, System.Int64 item2)",
+                "System.Action<System.Int32> (System.Int32, System.Int64).E1",
                 "void (System.Int32, System.Int64).E1.add",
                 "void (System.Int32, System.Int64).E1.remove",
                 "event System.Action<System.Int32> (System.Int32, System.Int64).E1",
@@ -15504,9 +15505,11 @@ null
                 "(System.Int32, System.Int64)..ctor()");
 
             AssertTupleTypeEquality(m1Tuple);
-            Assert.Equal(new string[] { "Item1", "Item2", ".ctor", "add_E1", "remove_E1", "E1", "_e2", "E2", "add_E2", "remove_E2", "RaiseE1", "RaiseE2", "Test" },
+            Assert.Equal(new string[] { "Item1", "Item2", ".ctor", "E1", "add_E1", "remove_E1", "_e2", "E2", "add_E2", "remove_E2", "RaiseE1", "RaiseE2", "Test" },
                          m1Tuple.MemberNames.ToArray());
-            Assert.Equal("event System.Action<System.Int32> (System.Int32, System.Int64).E1", m1Tuple.GetEarlyAttributeDecodingMembers("E1").Single().ToTestDisplayString());
+
+            Assert.Equal("System.Action<System.Int32> (System.Int32, System.Int64).E1", m1Tuple.GetEarlyAttributeDecodingMembers("E1").Single(m => m.Kind == SymbolKind.Field).ToTestDisplayString());
+            Assert.Equal("event System.Action<System.Int32> (System.Int32, System.Int64).E1", m1Tuple.GetEarlyAttributeDecodingMembers("E1").Single(m => m.Kind == SymbolKind.Event).ToTestDisplayString());
             Assert.Equal("event System.Action<System.Int64> (System.Int32, System.Int64).E2", m1Tuple.GetEarlyAttributeDecodingMembers("E2").Single().ToTestDisplayString());
 
             var m2Tuple = (NamedTypeSymbol)c.GetMember<MethodSymbol>("M2").ReturnType;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -12904,7 +12904,7 @@ partial class C
             var m10P2 = m10Tuple.GetMember<PropertySymbol>("P2");
             Assert.Equal("System.ObsoleteAttribute", m10P2.GetAttributes().Single().ToString());
 
-            var m10I1E1 = m10Tuple.GetMember<EventSymbol>("I1.E1");
+            var m10I1E1 = m10Tuple.GetEvent("I1.E1");
 
             Assert.True(m10I1E1.IsExplicitInterfaceImplementation);
             Assert.Equal("event System.Action I1.E1", m10I1E1.ExplicitInterfaceImplementations.Single().ToTestDisplayString());
@@ -12913,7 +12913,7 @@ partial class C
             Assert.True(m10I1E1.RemoveMethod.IsExplicitInterfaceImplementation);
             Assert.Equal("void I1.E1.remove", m10I1E1.RemoveMethod.ExplicitInterfaceImplementations.Single().ToTestDisplayString());
 
-            var m10E2 = m10Tuple.GetMember<EventSymbol>("E2");
+            var m10E2 = m10Tuple.GetEvent("E2");
             Assert.Equal("System.ObsoleteAttribute", m10E2.GetAttributes().Single().ToString());
         }
 
@@ -13894,7 +13894,7 @@ interface ITest2<T> : ValueTuple<int, int, int, int, int, int, int, T> where T :
 
             var test = comp.GetTypeByMetadataName("Test`1");
 
-            var e1Tuple = (INamedTypeSymbol)test.GetMember<IEventSymbol>("E1").Type;
+            var e1Tuple = (INamedTypeSymbol)test.GetEvent("E1").Type;
             Assert.False(e1Tuple.IsTupleType);
             Assert.Equal("System.ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, T>",
                          e1Tuple.ToTestDisplayString());
@@ -15515,7 +15515,7 @@ null
             AssertTupleTypeMembersEquality(m1Tuple, m2Tuple);
             AssertTupleTypeMembersEquality(m1Tuple, m3Tuple);
 
-            var m1E1 = m1Tuple.GetMember<EventSymbol>("E1");
+            var m1E1 = m1Tuple.GetEvent("E1");
             var m1E1Add = m1Tuple.GetMember<MethodSymbol>("add_E1");
             var m1E1Remove = m1Tuple.GetMember<MethodSymbol>("remove_E1");
 
@@ -15549,7 +15549,7 @@ null
             Assert.True(m1E1BackingField.IsImplicitlyDeclared);
             Assert.True(m1E1BackingField.TupleUnderlyingField.IsImplicitlyDeclared);
 
-            var m1E2 = m1Tuple.GetMember<EventSymbol>("E2");
+            var m1E2 = m1Tuple.GetEvent("E2");
             var m1E2Add = m1Tuple.GetMember<MethodSymbol>("add_E2");
             var m1E2Remove = m1Tuple.GetMember<MethodSymbol>("remove_E2");
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/EventTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/EventTests.cs
@@ -201,7 +201,7 @@ class C
         private static void ValidateEvent(ModuleSymbol module, bool isFromSource, bool isStatic, bool isFieldLike)
         {
             var @class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            var @event = @class.GetMember<EventSymbol>("E");
+            var @event = @class.GetEvent("E");
 
             Assert.Equal(SymbolKind.Event, @event.Kind);
             Assert.Equal(Accessibility.Public, @event.DeclaredAccessibility);
@@ -708,7 +708,7 @@ class C
                                             symbolValidator: module =>
                                                                 {
                                                                     var @class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                                                                    var @event = @class.GetMember<EventSymbol>("e");
+                                                                    var @event = @class.GetEvent("e");
 
                                                                     var addMethod = @event.AddMethod;
                                                                     Assert.False((addMethod.ImplementationAttributes & System.Reflection.MethodImplAttributes.Synchronized) == 0);
@@ -780,7 +780,7 @@ struct C
                                             symbolValidator: module =>
                                             {
                                                 var @class = module.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                                                var @event = @class.GetMember<EventSymbol>("e");
+                                                var @event = @class.GetEvent("e");
 
                                                 var addMethod = @event.AddMethod;
                                                 Assert.True((addMethod.ImplementationAttributes & System.Reflection.MethodImplAttributes.Synchronized) == 0);

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -3505,10 +3505,10 @@ using System;
                                                         "E",
                                                         "<H>k__BackingField", "H", "get_H", "set_H",
                                                         "<G>k__BackingField", "G", "get_G", "set_G",
-                                                        "add_L", "remove_L", "L",
+                                                        "L", "add_L", "remove_L", "L",
                                                         "D",
-                                                        "add_K", "remove_K", "K",
-                                                        "add_J", "remove_J", "J",
+                                                        "K", "add_K", "remove_K", "K",
+                                                        "J", "add_J", "remove_J", "J",
                                                         "O", "N", "M",
                                                         "F", "E", "D",
                                                         ".ctor", ".cctor"

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1754,7 +1754,8 @@ public class PublicClass
                 compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
+                new[] { "System.Action PublicClass.PublicEvent", "System.Action PublicClass.InternalEvent",
+                    "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
                     "void PublicClass.ProtectedInternalMethod()", "void PublicClass.PrivateProtectedMethod()",
                     "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",
@@ -1785,7 +1786,8 @@ public class PublicClass
                 compWithReal2.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
+                new[] { "System.Action PublicClass.PublicEvent", "System.Action PublicClass.InternalEvent",
+                    "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
                     "void PublicClass.ProtectedInternalMethod()", "void PublicClass.PrivateProtectedMethod()",
                     "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",
@@ -1813,7 +1815,8 @@ public class PublicClass
                 compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
+                new[] { "System.Action PublicClass.PublicEvent", "System.Action PublicClass.InternalEvent",
+                    "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
                     "void PublicClass.ProtectedInternalMethod()", "void PublicClass.PrivateProtectedMethod()",
                     "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -1142,7 +1142,7 @@ class B
 
             var diff1 = compilation1.EmitDifference(
                 generation0,
-                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<EventSymbol>("B.F"))));
+                ImmutableArray.Create(SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetEvent("B.F"))));
 
             // Verify delta metadata contains expected rows.
             using var md1 = diff1.GetMetadata();
@@ -1220,8 +1220,8 @@ class B
             var diff2 = compilation2.EmitDifference(
                 diff1.NextGeneration,
                 ImmutableArray.Create(
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetMember<EventSymbol>("A.G")),
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetMember<EventSymbol>("B.H"))));
+                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetEvent("A.G")),
+                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation2.GetEvent("B.H"))));
 
             // Verify delta metadata contains expected rows.
             using var md2 = diff2.GetMetadata();
@@ -1987,13 +1987,13 @@ interface I
             var compilation2 = compilation1.WithSource(source2);
 
             var x1 = compilation1.GetMember<FieldSymbol>("I.X");
-            var y1 = compilation1.GetMember<EventSymbol>("I.Y");
+            var y1 = compilation1.GetEvent("I.Y");
             var m1 = compilation1.GetMember<MethodSymbol>("I.M");
             var n1 = compilation1.GetMember<MethodSymbol>("I.N");
             var p1 = compilation1.GetMember<PropertySymbol>("I.P");
             var q1 = compilation1.GetMember<PropertySymbol>("I.Q");
-            var e1 = compilation1.GetMember<EventSymbol>("I.E");
-            var f1 = compilation1.GetMember<EventSymbol>("I.F");
+            var e1 = compilation1.GetEvent("I.E");
+            var f1 = compilation1.GetEvent("I.F");
             var j1 = compilation1.GetMember<NamedTypeSymbol>("I.J");
             var getP1 = compilation1.GetMember<MethodSymbol>("I.get_P");
             var setP1 = compilation1.GetMember<MethodSymbol>("I.set_P");
@@ -2196,7 +2196,7 @@ delegate void D();
                     SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<MethodSymbol>("C.M2")),
                     SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<FieldSymbol>("C.F2")),
                     SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<PropertySymbol>("C.P2")),
-                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetMember<EventSymbol>("C.E2"))));
+                    SemanticEdit.Create(SemanticEditKind.Insert, null, compilation1.GetEvent("C.E2"))));
 
             // Verify delta metadata contains expected rows.
             using var md1 = diff1.GetMetadata();

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -1244,22 +1244,22 @@ interface I
                 null);
 
             var x0 = compilation0.GetMember<FieldSymbol>("I.X");
-            var y0 = compilation0.GetMember<EventSymbol>("I.Y");
+            var y0 = compilation0.GetEvent("I.Y");
             var m0 = compilation0.GetMember<MethodSymbol>("I.M");
             var n0 = compilation0.GetMember<MethodSymbol>("I.N");
             var p0 = compilation0.GetMember<PropertySymbol>("I.P");
             var q0 = compilation0.GetMember<PropertySymbol>("I.Q");
-            var e0 = compilation0.GetMember<EventSymbol>("I.E");
-            var f0 = compilation0.GetMember<EventSymbol>("I.F");
+            var e0 = compilation0.GetEvent("I.E");
+            var f0 = compilation0.GetEvent("I.F");
 
             var x1 = compilation1.GetMember<FieldSymbol>("I.X");
-            var y1 = compilation1.GetMember<EventSymbol>("I.Y");
+            var y1 = compilation1.GetEvent("I.Y");
             var m1 = compilation1.GetMember<MethodSymbol>("I.M");
             var n1 = compilation1.GetMember<MethodSymbol>("I.N");
             var p1 = compilation1.GetMember<PropertySymbol>("I.P");
             var q1 = compilation1.GetMember<PropertySymbol>("I.Q");
-            var e1 = compilation1.GetMember<EventSymbol>("I.E");
-            var f1 = compilation1.GetMember<EventSymbol>("I.F");
+            var e1 = compilation1.GetEvent("I.E");
+            var f1 = compilation1.GetEvent("I.F");
 
             Assert.Same(x0, matcher.MapDefinition(x1));
             Assert.Same(y0, matcher.MapDefinition(y1));

--- a/src/Compilers/CSharp/Test/Emit/PrivateProtected.cs
+++ b/src/Compilers/CSharp/Test/Emit/PrivateProtected.cs
@@ -106,6 +106,8 @@ public class Base
                     case "this[]":
                     case "get_Item":
                         break;
+                    case "Event1" when member.Kind == SymbolKind.Field:
+                        break;
                     default:
                         Assert.Equal(Accessibility.ProtectedAndInternal, member.DeclaredAccessibility);
                         break;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
@@ -888,7 +888,7 @@ public class Derived : Base
             var baseEvent2 = baseClass.GetMembers("E").Cast<EventSymbol>().Where(hasCustomModifierCount(2)).Single();
 
             var derivedClass = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-            var derivedEvent = derivedClass.GetMember<EventSymbol>("E");
+            var derivedEvent = derivedClass.GetEvent("E");
 
             Assert.Equal(baseEvent1, derivedEvent.OverriddenEvent);
             Assert.NotEqual(baseEvent2, derivedEvent.OverriddenEvent);
@@ -971,7 +971,7 @@ public class Derived : Base
             var baseEvent2 = baseClass.GetMembers("E").Cast<EventSymbol>().Where(hasCustomModifierCount(2)).Single();
 
             var derivedClass = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-            var derivedEvent = derivedClass.GetMember<EventSymbol>("E");
+            var derivedEvent = derivedClass.GetEvent("E");
 
             Assert.Equal(baseEvent1, derivedEvent.OverriddenEvent);
             Assert.NotEqual(baseEvent2, derivedEvent.OverriddenEvent);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -6578,15 +6578,15 @@ class C : I
 
             var @interface = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("I");
             var interfaceEvents = new EventSymbol[numEvents];
-            interfaceEvents[0] = @interface.GetMember<EventSymbol>("E");
-            interfaceEvents[1] = @interface.GetMember<EventSymbol>("F");
-            interfaceEvents[2] = @interface.GetMember<EventSymbol>("G");
+            interfaceEvents[0] = @interface.GetEvent("E");
+            interfaceEvents[1] = @interface.GetEvent("F");
+            interfaceEvents[2] = @interface.GetEvent("G");
 
             var @class = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
             var classEvents = new EventSymbol[numEvents];
             classEvents[0] = @class.GetEvent("I.E");
-            classEvents[1] = @class.GetMember<EventSymbol>("F");
-            classEvents[2] = @class.GetMember<EventSymbol>("G");
+            classEvents[1] = @class.GetEvent("F");
+            classEvents[2] = @class.GetEvent("G");
 
             for (int i = 0; i < numEvents; i++)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -4701,13 +4701,7 @@ unsafe struct S
                 Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticFieldLikeEvent").WithArguments("S.StaticFieldLikeEvent"),
                 // (19,9): error CS0176: Member 'S.StaticCustomEvent' cannot be accessed with an instance reference; qualify it with a type name instead
                 //         p->StaticCustomEvent += null; //CS0176
-                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticCustomEvent").WithArguments("S.StaticCustomEvent"),
-                // (5,32): warning CS0067: The event 'S.StaticFieldLikeEvent' is never used
-                //     static event System.Action StaticFieldLikeEvent;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "StaticFieldLikeEvent").WithArguments("S.StaticFieldLikeEvent"),
-                // (4,25): warning CS0067: The event 'S.InstanceFieldLikeEvent' is never used
-                //     event System.Action InstanceFieldLikeEvent;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "InstanceFieldLikeEvent").WithArguments("S.InstanceFieldLikeEvent")
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "p->StaticCustomEvent").WithArguments("S.StaticCustomEvent")
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -1264,7 +1264,7 @@ class C
             var systemActionType = GetSystemActionType(comp);
             Assert.Equal(systemActionType, bindInfo.Type);
 
-            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E");
+            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetEvent("E");
             Assert.Equal(eventSymbol, bindInfo.Symbol);
         }
 
@@ -1292,7 +1292,7 @@ class C
             var systemActionType = GetSystemActionType(comp);
             Assert.Equal(systemActionType, bindInfo.Type);
 
-            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E");
+            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetEvent("E");
             Assert.Equal(eventSymbol, bindInfo.Symbol);
         }
 
@@ -1319,7 +1319,7 @@ class C
 
             Assert.Equal(SpecialType.System_Void, bindInfo.Type.SpecialType);
 
-            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E");
+            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetEvent("E");
             Assert.Equal(eventSymbol.AddMethod, bindInfo.Symbol);
         }
 
@@ -1346,7 +1346,7 @@ class C
 
             Assert.Equal(SpecialType.System_Void, bindInfo.Type.SpecialType);
 
-            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetMember<IEventSymbol>("E");
+            var eventSymbol = comp.GlobalNamespace.GetMember<INamedTypeSymbol>("C").GetEvent("E");
             Assert.Equal(eventSymbol.AddMethod, bindInfo.Symbol);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4652,8 +4652,8 @@ class Other
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Enclosing.Declaring.E"));
 
             var declaringType = compilation.GlobalNamespace.GetMember<ITypeSymbol>("Enclosing").GetMember<ITypeSymbol>("Declaring");
-            var fieldLikeEvent = declaringType.GetMember<IEventSymbol>("E");
-            var customEvent = declaringType.GetMember<IEventSymbol>("F");
+            var fieldLikeEvent = declaringType.GetEvent("E");
+            var customEvent = declaringType.GetEvent("F");
 
             int enclosingTypePosition = text.IndexOf("AAA", StringComparison.Ordinal);
             Assert.InRange(enclosingTypePosition, 0, text.Length);

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
@@ -101,7 +101,7 @@ class C
 }
 ";
             var comp = CreateCompilation(source);
-            var symbol = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<EventSymbol>("E");
+            var symbol = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetEvent("E");
             Assert.Equal(SymbolKind.Event, symbol.Kind);
             Assert.Equal("E:C.E", symbol.GetDocumentationCommentId());
         }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/EventDocumentationCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/EventDocumentationCommentTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestFieldLikeEvent()
         {
-            var eventSymbol = _widgetClass.GetMember<EventSymbol>("E");
+            var eventSymbol = _widgetClass.GetEvent("E");
             Assert.Equal("E:Acme.Widget.E", eventSymbol.GetDocumentationCommentId());
             Assert.Equal("M:Acme.Widget.add_E(System.Action)", eventSymbol.AddMethod.GetDocumentationCommentId());
             Assert.Equal("M:Acme.Widget.remove_E(System.Action)", eventSymbol.RemoveMethod.GetDocumentationCommentId());
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestCustomEvent()
         {
-            var eventSymbol = _widgetClass.GetMember<EventSymbol>("F");
+            var eventSymbol = _widgetClass.GetEvent("F");
             Assert.Equal("E:Acme.Widget.F", eventSymbol.GetDocumentationCommentId());
             Assert.Equal("M:Acme.Widget.add_F(System.Action)", eventSymbol.AddMethod.GetDocumentationCommentId());
             Assert.Equal("M:Acme.Widget.remove_F(System.Action)", eventSymbol.RemoveMethod.GetDocumentationCommentId());

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/IncludeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/IncludeTests.cs
@@ -11,13 +11,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class IncludeTests : CSharpTestBase
     {
         [Theory]
-        [InlineData("Field", "F:Acme.Widget.Field")]
-        [InlineData(WellKnownMemberNames.StaticConstructorName, "M:Acme.Widget.#cctor")]
-        [InlineData("Event", "E:Acme.Widget.Event")]
-        [InlineData("Property", "P:Acme.Widget.Property")]
-        [InlineData("Method", "M:Acme.Widget.Method")]
-        [InlineData("NamedType", "T:Acme.Widget.NamedType")]
-        public void TestDocumentationCaching(string symbolName, string documentationId)
+        [InlineData("Field", SymbolKind.Field, "F:Acme.Widget.Field")]
+        [InlineData(WellKnownMemberNames.StaticConstructorName, SymbolKind.Method, "M:Acme.Widget.#cctor")]
+        [InlineData("Event", SymbolKind.Event, "E:Acme.Widget.Event")]
+        [InlineData("Property", SymbolKind.Property, "P:Acme.Widget.Property")]
+        [InlineData("Method", SymbolKind.Method, "M:Acme.Widget.Method")]
+        [InlineData("NamedType", SymbolKind.NamedType, "T:Acme.Widget.NamedType")]
+        public void TestDocumentationCaching(string symbolName, SymbolKind symbolKind, string documentationId)
         {
             using var _ = new EnsureEnglishUICulture();
 
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var acmeNamespace = (NamespaceSymbol)compilation.GlobalNamespace.GetMembers("Acme").Single();
             var widgetClass = acmeNamespace.GetTypeMembers("Widget").Single();
 
-            var symbol = widgetClass.GetMembers(symbolName).Single();
+            var symbol = widgetClass.GetMembers(symbolName).Single(m => m.Kind == symbolKind);
             Assert.Equal(documentationId, symbol.GetDocumentationCommentId());
             Assert.Equal(
 $@"<member name=""{documentationId}"">

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -1869,7 +1869,7 @@ class C {
 
             Func<NamespaceSymbol, Symbol> findSymbol2 = global =>
                 global.GetMember<NamedTypeSymbol>("C").
-                GetMember<EventSymbol>("F");
+                GetEvent("F");
 
             var format = new SymbolDisplayFormat(
                 memberOptions:
@@ -1922,7 +1922,7 @@ class C {
 
             Func<NamespaceSymbol, Symbol> findSymbol2 = global =>
                 global.GetMember<NamedTypeSymbol>("C").
-                GetMember<EventSymbol>("F");
+                GetEvent("F");
 
             var format = new SymbolDisplayFormat(
                 memberOptions: SymbolDisplayMemberOptions.IncludeType,
@@ -4095,7 +4095,7 @@ class C
                 memberOptions: SymbolDisplayMemberOptions.IncludeContainingType | SymbolDisplayMemberOptions.IncludeType | SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeExplicitInterface);
 
             var comp = CreateEmptyCompilation(source, WinRtRefs, TestOptions.ReleaseWinMD);
-            var eventSymbol = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<EventSymbol>("E");
+            var eventSymbol = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetEvent("E");
             Assert.True(eventSymbol.IsWindowsRuntimeEvent);
 
             Verify(
@@ -4159,7 +4159,7 @@ namespace N
             var comp = CreateCompilation(source);
             var namespaceSymbol = comp.GlobalNamespace.GetMember<NamespaceSymbol>("N");
             var typeSymbol = namespaceSymbol.GetMember<NamedTypeSymbol>("C");
-            var eventSymbol = typeSymbol.GetMember<EventSymbol>("E");
+            var eventSymbol = typeSymbol.GetEvent("E");
 
             Verify(
                 namespaceSymbol.ToDisplayParts(memberFormat),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -2704,12 +2704,12 @@ class CL3
             var compilation = CreateCompilationWithILAndMscorlib40(source, ilSource, references: new[] { CSharpRef }, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Standard);
 
             var cl2 = compilation.GetTypeByMetadataName("CL2");
-            var test2 = cl2.GetMember<EventSymbol>("Test");
+            var test2 = cl2.GetEvent("Test");
             Assert.Equal("event System.Action<dynamic modopt(System.Runtime.CompilerServices.IsConst) []> CL2.Test",
                          test2.ToTestDisplayString());
 
             var cl3 = compilation.GetTypeByMetadataName("CL3");
-            var test3 = cl3.GetMember<EventSymbol>("Test");
+            var test3 = cl3.GetEvent("Test");
             Assert.Equal("event System.Action<System.Object modopt(System.Runtime.CompilerServices.IsConst) []> CL3.Test",
                          test3.ToTestDisplayString());
 
@@ -2798,12 +2798,12 @@ class CL3 : CL1
             var compilation = CreateCompilationWithILAndMscorlib40(source, ilSource, references: new[] { CSharpRef }, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Standard);
 
             var cl2 = compilation.GetTypeByMetadataName("CL2");
-            var test2 = cl2.GetMember<EventSymbol>("Test");
+            var test2 = cl2.GetEvent("Test");
             Assert.Equal("event System.Action<dynamic modopt(System.Runtime.CompilerServices.IsConst) []> CL2.Test",
                          test2.ToTestDisplayString());
 
             var cl3 = compilation.GetTypeByMetadataName("CL3");
-            var test3 = cl3.GetMember<EventSymbol>("Test");
+            var test3 = cl3.GetEvent("Test");
             Assert.Equal("event System.Action<System.Object modopt(System.Runtime.CompilerServices.IsConst) []> CL3.Test",
                          test3.ToTestDisplayString());
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -4764,7 +4764,7 @@ class Test2 : I1
         private static void ValidateEventImplementationTest1_101(ModuleSymbol m, bool haveAdd, bool haveRemove)
         {
             var i1 = m.GlobalNamespace.GetTypeMember("I1");
-            var e1 = i1.GetMember<EventSymbol>("E1");
+            var e1 = i1.GetEvent("E1");
             var addE1 = e1.AddMethod;
             var rmvE1 = e1.RemoveMethod;
 
@@ -4847,7 +4847,7 @@ class Test2 : I1
             var test2 = m.GlobalNamespace.GetTypeMember("Test2");
             Assert.Equal("I1", test2.InterfacesNoUseSiteDiagnostics().Single().ToTestDisplayString());
 
-            var e1 = test2.InterfacesNoUseSiteDiagnostics().Single().GetMember<EventSymbol>("E1");
+            var e1 = test2.InterfacesNoUseSiteDiagnostics().Single().GetEvent("E1");
             Assert.Same(e1, test2.FindImplementationForInterfaceMember(e1));
 
             if (haveAdd)
@@ -5253,8 +5253,8 @@ remove E8",
 
         private static void ValidateEventImplementation_201(ModuleSymbol m)
         {
-            var e7 = m.GlobalNamespace.GetMember<EventSymbol>("I1.E7");
-            var e8 = m.GlobalNamespace.GetMember<EventSymbol>("I1.E8");
+            var e7 = m.GlobalNamespace.GetEvent("I1.E7");
+            var e8 = m.GlobalNamespace.GetEvent("I1.E8");
 
             var derived = m.ContainingAssembly.GetTypeByMetadataName("Derived");
 
@@ -5375,8 +5375,8 @@ class Test : I1
 
             void Validate(ModuleSymbol m)
             {
-                var e7 = m.GlobalNamespace.GetMember<EventSymbol>("I1.E7");
-                var e8 = m.GlobalNamespace.GetMember<EventSymbol>("I1.E8");
+                var e7 = m.GlobalNamespace.GetEvent("I1.E7");
+                var e8 = m.GlobalNamespace.GetEvent("I1.E8");
 
                 var derived = m.ContainingAssembly.GetTypeByMetadataName("Derived");
 
@@ -5455,8 +5455,8 @@ class Test : I1
 
             void Validate(ModuleSymbol m)
             {
-                var e7 = m.GlobalNamespace.GetMember<EventSymbol>("I1.E7");
-                var e8 = m.GlobalNamespace.GetMember<EventSymbol>("I1.E8");
+                var e7 = m.GlobalNamespace.GetEvent("I1.E7");
+                var e8 = m.GlobalNamespace.GetEvent("I1.E8");
 
                 var derived = m.ContainingAssembly.GetTypeByMetadataName("Derived");
 
@@ -5548,7 +5548,7 @@ class Test2 : I1
             var i1 = derived.InterfacesNoUseSiteDiagnostics().Single();
             Assert.Equal("I1", i1.ToTestDisplayString());
 
-            var e7 = i1.GetMember<EventSymbol>("E7");
+            var e7 = i1.GetEvent("E7");
 
             Assert.True(e7.IsVirtual);
             Assert.False(e7.IsAbstract);
@@ -5655,7 +5655,7 @@ class Test2 : I2
             var i1 = compilation3.GetTypeByMetadataName("I1");
             Assert.Equal("I1", i1.ToTestDisplayString());
 
-            var e7 = i1.GetMember<EventSymbol>("E7");
+            var e7 = i1.GetEvent("E7");
 
             Assert.Null(test2.FindImplementationForInterfaceMember(e7));
 
@@ -5838,7 +5838,7 @@ class Test1 : I1
             var i1 = derived.InterfacesNoUseSiteDiagnostics().Single();
             Assert.Equal("I1", i1.ToTestDisplayString());
 
-            var e7 = i1.GetMember<EventSymbol>("E7");
+            var e7 = i1.GetEvent("E7");
 
             Assert.False(e7.IsVirtual);
             Assert.False(e7.IsAbstract);
@@ -23769,7 +23769,7 @@ public interface I1
         private static void ValidateSymbolsEventModifiers_01(CSharpCompilation compilation1)
         {
             var i1 = compilation1.GetTypeByMetadataName("I1");
-            var p01 = i1.GetMember<EventSymbol>("P01");
+            var p01 = i1.GetEvent("P01");
 
             Assert.True(p01.IsAbstract);
             Assert.False(p01.IsVirtual);
@@ -23794,7 +23794,7 @@ public interface I1
                 Assert.Equal(Accessibility.Public, accessor.DeclaredAccessibility);
             }
 
-            var p02 = i1.GetMember<EventSymbol>("P02");
+            var p02 = i1.GetEvent("P02");
             var p02get = p02.AddMethod;
 
             Assert.False(p02.IsAbstract);
@@ -23815,7 +23815,7 @@ public interface I1
             Assert.False(p02get.IsOverride);
             Assert.Equal(Accessibility.Protected, p02get.DeclaredAccessibility);
 
-            var p03 = i1.GetMember<EventSymbol>("P03");
+            var p03 = i1.GetEvent("P03");
             var p03set = p03.RemoveMethod;
 
             Assert.False(p03.IsAbstract);
@@ -23836,7 +23836,7 @@ public interface I1
             Assert.False(p03set.IsOverride);
             Assert.Equal(Accessibility.ProtectedOrInternal, p03set.DeclaredAccessibility);
 
-            var p04 = i1.GetMember<EventSymbol>("P04");
+            var p04 = i1.GetEvent("P04");
             var p04get = p04.AddMethod;
 
             Assert.False(p04.IsAbstract);
@@ -23857,7 +23857,7 @@ public interface I1
             Assert.False(p04get.IsOverride);
             Assert.Equal(Accessibility.Internal, p04get.DeclaredAccessibility);
 
-            var p05 = i1.GetMember<EventSymbol>("P05");
+            var p05 = i1.GetEvent("P05");
             var p05set = p05.RemoveMethod;
 
             Assert.False(p05.IsAbstract);
@@ -23878,7 +23878,7 @@ public interface I1
             Assert.False(p05set.IsOverride);
             Assert.Equal(Accessibility.Private, p05set.DeclaredAccessibility);
 
-            var p06 = i1.GetMember<EventSymbol>("P06");
+            var p06 = i1.GetEvent("P06");
             var p06get = p06.AddMethod;
 
             Assert.False(p06.IsAbstract);
@@ -23899,7 +23899,7 @@ public interface I1
             Assert.False(p06get.IsOverride);
             Assert.Equal(Accessibility.Public, p06get.DeclaredAccessibility);
 
-            var p07 = i1.GetMember<EventSymbol>("P07");
+            var p07 = i1.GetEvent("P07");
             var p07set = p07.RemoveMethod;
 
             Assert.False(p07.IsAbstract);
@@ -23920,7 +23920,7 @@ public interface I1
             Assert.False(p07set.IsOverride);
             Assert.Equal(Accessibility.Public, p07set.DeclaredAccessibility);
 
-            var p08 = i1.GetMember<EventSymbol>("P08");
+            var p08 = i1.GetEvent("P08");
             var p08get = p08.AddMethod;
 
             Assert.False(p08.IsAbstract);
@@ -23941,7 +23941,7 @@ public interface I1
             Assert.False(p08get.IsOverride);
             Assert.Equal(Accessibility.Public, p08get.DeclaredAccessibility);
 
-            var p09 = i1.GetMember<EventSymbol>("P09");
+            var p09 = i1.GetEvent("P09");
             var p09set = p09.RemoveMethod;
 
             Assert.False(p09.IsAbstract);
@@ -23962,7 +23962,7 @@ public interface I1
             Assert.False(p09set.IsOverride);
             Assert.Equal(Accessibility.Public, p09set.DeclaredAccessibility);
 
-            var p10 = i1.GetMember<EventSymbol>("P10");
+            var p10 = i1.GetEvent("P10");
             var p10get = p10.AddMethod;
 
             Assert.True(p10.IsAbstract);
@@ -23985,7 +23985,7 @@ public interface I1
 
             foreach (var name in new[] { "P11", "P12", "P13" })
             {
-                var p11 = i1.GetMember<EventSymbol>(name);
+                var p11 = i1.GetEvent(name);
 
                 Assert.False(p11.IsAbstract);
                 Assert.True(p11.IsVirtual);
@@ -24011,7 +24011,7 @@ public interface I1
                 }
             }
 
-            var p14 = i1.GetMember<EventSymbol>("P14");
+            var p14 = i1.GetEvent("P14");
 
             Assert.True(p14.IsAbstract);
             Assert.False(p14.IsVirtual);
@@ -24648,7 +24648,7 @@ public interface I1
         private static void ValidateEventModifiers_06(CSharpCompilation compilation1)
         {
             var i1 = compilation1.GetTypeByMetadataName("I1");
-            var p1 = i1.GetMember<EventSymbol>("P1");
+            var p1 = i1.GetEvent("P1");
 
             Assert.True(p1.IsAbstract);
             Assert.False(p1.IsVirtual);
@@ -24748,7 +24748,7 @@ set_P3", symbolValidator: Validate);
                                               (name: "P2", access: Accessibility.Internal),
                                               (name: "P3", access: Accessibility.Private)})
                 {
-                    var p1 = i1.GetMember<EventSymbol>(tuple.name);
+                    var p1 = i1.GetEvent(tuple.name);
 
                     Assert.False(p1.IsAbstract);
                     Assert.False(p1.IsVirtual);
@@ -24910,7 +24910,7 @@ class Test2 : I1
 
             var test1 = compilation1.GetTypeByMetadataName("Test1");
             var i1 = compilation1.GetTypeByMetadataName("I1");
-            var p1 = i1.GetMember<EventSymbol>("P1");
+            var p1 = i1.GetEvent("P1");
 
             Assert.True(p1.IsAbstract);
             Assert.False(p1.IsVirtual);
@@ -24937,7 +24937,7 @@ class Test2 : I1
                 Assert.Null(test1.FindImplementationForInterfaceMember(accessor));
             }
 
-            var p2 = i1.GetMember<EventSymbol>("P2");
+            var p2 = i1.GetEvent("P2");
 
             Assert.False(p2.IsAbstract);
             Assert.True(p2.IsVirtual);
@@ -24964,7 +24964,7 @@ class Test2 : I1
                 Assert.Null(test1.FindImplementationForInterfaceMember(accessor));
             }
 
-            var p3 = i1.GetMember<EventSymbol>("P3");
+            var p3 = i1.GetEvent("P3");
 
             Assert.False(p3.IsAbstract);
             Assert.False(p3.IsVirtual);
@@ -26256,7 +26256,7 @@ class Test1 : I1
 
             var test1 = compilation1.GetTypeByMetadataName("Test1");
             var i1 = compilation1.GetTypeByMetadataName("I1");
-            var p1 = i1.GetMember<EventSymbol>("P1");
+            var p1 = i1.GetEvent("P1");
             Assert.Null(test1.FindImplementationForInterfaceMember(p1));
             Assert.Null(test1.FindImplementationForInterfaceMember(p1.AddMethod));
             Assert.Null(test1.FindImplementationForInterfaceMember(p1.RemoveMethod));
@@ -28002,7 +28002,7 @@ set_P2",
                                               (name: "P2", access: Accessibility.ProtectedOrInternal),
                                               (name: "P3", access: Accessibility.ProtectedAndInternal)})
                 {
-                    var p1 = i1.GetMember<EventSymbol>(tuple.name);
+                    var p1 = i1.GetEvent(tuple.name);
 
                     Assert.False(p1.IsAbstract);
                     Assert.False(p1.IsVirtual);
@@ -39760,10 +39760,10 @@ class Test1 : I1
             void Validate1(ModuleSymbol m)
             {
                 var i1 = m.GlobalNamespace.GetTypeMember("I1");
-                var f1 = i1.GetMember<EventSymbol>("F1");
-                var f2 = i1.GetMember<EventSymbol>("F2");
-                var f3 = i1.GetMember<EventSymbol>("F3");
-                var f4 = i1.GetMember<EventSymbol>("F4");
+                var f1 = i1.GetEvent("F1");
+                var f2 = i1.GetEvent("F2");
+                var f3 = i1.GetEvent("F3");
+                var f4 = i1.GetEvent("F4");
 
                 Assert.True(f1.IsStatic);
                 Assert.True(f2.IsStatic);
@@ -39900,10 +39900,10 @@ class Test1 : I1
             void Validate1(ModuleSymbol m)
             {
                 var i1 = m.GlobalNamespace.GetTypeMember("I1");
-                var f1 = i1.GetMember<EventSymbol>("F1");
-                var f2 = i1.GetMember<EventSymbol>("F2");
-                var f3 = i1.GetMember<EventSymbol>("F3");
-                var f4 = i1.GetMember<EventSymbol>("F4");
+                var f1 = i1.GetEvent("F1");
+                var f2 = i1.GetEvent("F2");
+                var f3 = i1.GetEvent("F3");
+                var f4 = i1.GetEvent("F4");
 
                 Assert.True(f1.IsStatic);
                 Assert.True(f2.IsStatic);
@@ -55081,11 +55081,11 @@ class C1 : I1, Interface<int>
                     Assert.True(baseInterface.IsInterface);
                     Assert.True(i1.IsInterface);
 
-                    var i1Normal = i1.GetMember<EventSymbol>("Interface<System.Int32>.Normal");
-                    var i1WinRT = i1.GetMember<EventSymbol>("Interface<System.Int32>.WinRT");
+                    var i1Normal = i1.GetEvent("Interface<System.Int32>.Normal");
+                    var i1WinRT = i1.GetEvent("Interface<System.Int32>.WinRT");
 
-                    var baseInterfaceNormal = baseInterface.GetMember<EventSymbol>("Normal");
-                    var baseInterfaceWinRT = baseInterface.GetMember<EventSymbol>("WinRT");
+                    var baseInterfaceNormal = baseInterface.GetEvent("Normal");
+                    var baseInterfaceWinRT = baseInterface.GetEvent("WinRT");
 
                     Assert.False(baseInterfaceNormal.IsWindowsRuntimeEvent);
                     Assert.False(i1Normal.IsWindowsRuntimeEvent);
@@ -55150,7 +55150,7 @@ class C1 : I1
                 var i1 = m.GlobalNamespace.GetTypeMember("I1");
                 var c1 = m.GlobalNamespace.GetTypeMember("C1");
 
-                var i1WinRT = i1.GetMember<EventSymbol>("WinRT");
+                var i1WinRT = i1.GetEvent("WinRT");
 
                 Assert.True(i1WinRT.IsWindowsRuntimeEvent);
 
@@ -55207,9 +55207,9 @@ class C1 : I1, Interface
                 Assert.True(baseInterface.IsInterface);
                 Assert.True(i1.IsInterface);
 
-                var i1WinRT = i1.GetMember<EventSymbol>("Interface.WinRT");
+                var i1WinRT = i1.GetEvent("Interface.WinRT");
 
-                var baseInterfaceWinRT = baseInterface.GetMember<EventSymbol>("WinRT");
+                var baseInterfaceWinRT = baseInterface.GetEvent("WinRT");
 
                 Assert.True(baseInterfaceWinRT.IsWindowsRuntimeEvent);
                 Assert.True(i1WinRT.IsWindowsRuntimeEvent);
@@ -55497,7 +55497,7 @@ class Test4 : C1, I1
             var i1P1 = i1.GetMember<PropertySymbol>("P1");
             var i1P2 = i1.GetMember<PropertySymbol>("P2");
             var i1P3 = i1.GetMember<PropertySymbol>("P3");
-            var i1E1 = i1.GetMember<EventSymbol>("E1");
+            var i1E1 = i1.GetEvent("E1");
             var i2i1P1get = i2.GetMember<MethodSymbol>("I1.get_P1");
             var i2i1P2get = i2.GetMember<MethodSymbol>("I1.get_P2");
             var i2i1P2set = i2.GetMember<MethodSymbol>("I1.set_P2");
@@ -56385,7 +56385,7 @@ interface I3 : I2
             var i1P1 = i1.GetMember<PropertySymbol>("P1");
             var i1P2 = i1.GetMember<PropertySymbol>("P2");
             var i1P3 = i1.GetMember<PropertySymbol>("P3");
-            var i1E1 = i1.GetMember<EventSymbol>("E1");
+            var i1E1 = i1.GetEvent("E1");
             var i2i1P1get = i2.GetMember<MethodSymbol>("I1.get_P1");
             var i2i1P2get = i2.GetMember<MethodSymbol>("I1.get_P2");
             var i2i1P2set = i2.GetMember<MethodSymbol>("I1.set_P2");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ImplicitClassTests.cs
@@ -81,7 +81,7 @@ event System.Action e;
 
             c.VerifyDiagnostics();
 
-            var @event = c.ScriptClass.GetMember<EventSymbol>("e");
+            var @event = c.ScriptClass.GetEvent("e");
             Assert.False(@event.TypeWithAnnotations.IsDefault);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -1136,7 +1136,7 @@ class C : I
                     Assert.True(@interface.IsFromCompilation(compilation));
                 }
 
-                var interfaceEvent = @interface.GetMember<EventSymbol>("E");
+                var interfaceEvent = @interface.GetEvent("E");
                 var interfaceProperty = @interface.GetMember<PropertySymbol>("P");
                 var interfaceIndexer = @interface.Indexers.Single();
 
@@ -1160,7 +1160,7 @@ class C : I
                 Assert.False(classPropertyImpl.CanBeReferencedByName);
                 Assert.False(classIndexerImpl.CanBeReferencedByName);
 
-                var classEvent = @class.GetMember<EventSymbol>("E");
+                var classEvent = @class.GetEvent("E");
                 var classProperty = @class.GetMember<PropertySymbol>("P");
                 var classIndexer = @class.Indexers.Single();
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -56,7 +56,7 @@ interface Interface
             var baseIndexer = @base.Indexers.Single();
             Assert.Null(@base.FindImplementationForInterfaceMember(baseIndexer)); //containing type is not an interface
 
-            var baseEvent = @base.GetMember<EventSymbol>("Event");
+            var baseEvent = @base.GetEvent("Event");
             Assert.Null(@base.FindImplementationForInterfaceMember(baseEvent)); //containing type is not an interface
 
             var baseField = @base.GetMembers("Field").Single();
@@ -2211,7 +2211,7 @@ Explicit implementation
             var baseType = global.GetMember<NamedTypeSymbol>("Base");
             var derivedType = global.GetMember<NamedTypeSymbol>("Derived");
 
-            var interfaceEvent = @interface.GetMember<EventSymbol>("E");
+            var interfaceEvent = @interface.GetEvent("E");
             var interfaceAdder = interfaceEvent.AddMethod;
 
             var baseAdder = baseType.GetMembers().OfType<MethodSymbol>().

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadCustomModifiers.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadCustomModifiers.cs
@@ -225,10 +225,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
             var @class = globalNamespace.GetMember<NamedTypeSymbol>("EventCustomModifierCombinations");
 
-            Assert.True(@class.GetMember<EventSymbol>("Event11").Type.IsErrorType()); //Can't have modopt on event type
-            Assert.Equal(1, @class.GetMember<EventSymbol>("Event10").Type.CustomModifierCount());
-            Assert.True(@class.GetMember<EventSymbol>("Event01").Type.IsErrorType()); //Can't have modopt on event type
-            Assert.Equal(0, @class.GetMember<EventSymbol>("Event00").Type.CustomModifierCount());
+            Assert.True(@class.GetEvent("Event11").Type.IsErrorType()); //Can't have modopt on event type
+            Assert.Equal(1, @class.GetEvent("Event10").Type.CustomModifierCount());
+            Assert.True(@class.GetEvent("Event01").Type.IsErrorType()); //Can't have modopt on event type
+            Assert.Equal(0, @class.GetEvent("Event00").Type.CustomModifierCount());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
 
         private static void CheckInstanceAndStaticEvents(NamedTypeSymbol @class, string eventTypeDisplayString)
         {
-            var instanceEvent = @class.GetMember<EventSymbol>("InstanceEvent");
+            var instanceEvent = @class.GetEvent("InstanceEvent");
 
             Assert.Equal(SymbolKind.Event, instanceEvent.Kind);
             Assert.False(instanceEvent.IsStatic);
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             CheckAccessorShape(instanceEvent.AddMethod, instanceEvent);
             CheckAccessorShape(instanceEvent.RemoveMethod, instanceEvent);
 
-            var staticEvent = @class.GetMember<EventSymbol>("StaticEvent");
+            var staticEvent = @class.GetEvent("StaticEvent");
 
             Assert.Equal(SymbolKind.Event, staticEvent.Kind);
             Assert.True(staticEvent.IsStatic);
@@ -125,8 +125,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var globalNamespace = assemblies.ElementAt(1).GlobalNamespace;
 
             var @class = globalNamespace.GetMember<NamedTypeSymbol>("SignatureMismatch");
-            var mismatchedAddEvent = @class.GetMember<EventSymbol>("AddMismatch");
-            var mismatchedRemoveEvent = @class.GetMember<EventSymbol>("RemoveMismatch");
+            var mismatchedAddEvent = @class.GetEvent("AddMismatch");
+            var mismatchedRemoveEvent = @class.GetEvent("RemoveMismatch");
 
             Assert.NotEqual(mismatchedAddEvent.Type, mismatchedAddEvent.AddMethod.Parameters.Single().Type);
             Assert.True(mismatchedAddEvent.MustCallMethodsDirectly);
@@ -148,8 +148,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var globalNamespace = assemblies.ElementAt(1).GlobalNamespace;
 
             var @class = globalNamespace.GetMember<NamedTypeSymbol>("AccessorMissingParameter");
-            var noParamAddEvent = @class.GetMember<EventSymbol>("AddNoParam");
-            var noParamRemoveEvent = @class.GetMember<EventSymbol>("RemoveNoParam");
+            var noParamAddEvent = @class.GetEvent("AddNoParam");
+            var noParamRemoveEvent = @class.GetEvent("RemoveNoParam");
 
             Assert.Equal(0, noParamAddEvent.AddMethod.Parameters.Length);
             Assert.True(noParamAddEvent.MustCallMethodsDirectly);
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             var globalNamespace = assemblies.ElementAt(1).GlobalNamespace;
 
             var @class = globalNamespace.GetMember<NamedTypeSymbol>("NonDelegateEvent");
-            var nonDelegateEvent = @class.GetMember<EventSymbol>("NonDelegate");
+            var nonDelegateEvent = @class.GetEvent("NonDelegate");
 
             Assert.Equal(SpecialType.System_Int32, nonDelegateEvent.Type.SpecialType);
         }
@@ -438,7 +438,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Metadata.PE
             {
                 foreach (var mod2 in modList)
                 {
-                    var @event = type.GetMember<EventSymbol>(mod1.ToString() + mod2.ToString());
+                    var @event = type.GetEvent(mod1.ToString() + mod2.ToString());
                     var addMethod = @event.AddMethod;
                     var removeMethod = @event.RemoveMethod;
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/LoadingEvents.cs
@@ -465,7 +465,7 @@ public class C
             var comp = CreateCompilation("", new[] { reference }, TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
 
             var type = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            var @event = type.GetMember<PEEventSymbol>("E");
+            var @event = type.GetEvent("E");
             Assert.True(@event.HasAssociatedField);
 
             var field = @event.AssociatedField;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
@@ -2520,10 +2520,10 @@ class D : C
             var comp = CreateCompilation(source);
             var global = comp.GlobalNamespace;
 
-            var eventA = global.GetMember<NamedTypeSymbol>("A").GetMember<EventSymbol>("E");
-            var eventB = global.GetMember<NamedTypeSymbol>("B").GetMember<EventSymbol>("E");
-            var eventC = global.GetMember<NamedTypeSymbol>("C").GetMember<EventSymbol>("E");
-            var eventD = global.GetMember<NamedTypeSymbol>("D").GetMember<EventSymbol>("E");
+            var eventA = global.GetMember<NamedTypeSymbol>("A").GetEvent("E");
+            var eventB = global.GetMember<NamedTypeSymbol>("B").GetEvent("E");
+            var eventC = global.GetMember<NamedTypeSymbol>("C").GetEvent("E");
+            var eventD = global.GetMember<NamedTypeSymbol>("D").GetEvent("E");
 
             var ohmA = eventA.OverriddenOrHiddenMembers;
             var ohmB = eventB.OverriddenOrHiddenMembers;
@@ -3300,14 +3300,14 @@ public class C : B
 
             var events = new[]
             {
-                comp1.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetMember<EventSymbol>("E"),
+                comp1.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetEvent("E"),
 
-                comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetMember<EventSymbol>("E"),
-                comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("B").GetMember<EventSymbol>("E"),
+                comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetEvent("E"),
+                comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("B").GetEvent("E"),
 
-                comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetMember<EventSymbol>("E"),
-                comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("B").GetMember<EventSymbol>("E"),
-                comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<EventSymbol>("E"),
+                comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetEvent("E"),
+                comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("B").GetEvent("E"),
+                comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetEvent("E"),
             };
 
             AssertEx.All(events, e =>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
@@ -3058,7 +3058,7 @@ public sealed class C
                 //     public event D E;
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E"));
 
-            var @event = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<EventSymbol>("E");
+            var @event = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetEvent("E");
             Assert.True(@event.IsWindowsRuntimeEvent);
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DeclaringSyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DeclaringSyntaxNodeTests.cs
@@ -522,7 +522,7 @@ namespace N1 {
                     CheckDeclaringSyntaxNodesIncludingParameters(comp, memb, 1);
             }
 
-            var ev1 = c1.GetMembers("ev1").Single() as IEventSymbol;
+            var ev1 = c1.GetEvent("ev1");
             var prop3 = c1.GetMembers("Prop3").Single() as IPropertySymbol;
 
             foreach (ISymbol memb in c1.GetMembers())

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DeclaringSyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DeclaringSyntaxNodeTests.cs
@@ -30,15 +30,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols.Source
             else
             {
                 Assert.True(symbol.GetSymbol().IsFromCompilation((CSharpCompilation)compilation) || symbol.GetSymbol() is MergedNamespaceSymbol, "symbol with declaration should be in source, except for merged namespaces");
-                Assert.False(symbol.IsImplicitlyDeclared);
 
-                foreach (var node in declaringReferences.Select(d => d.GetSyntax()))
+                if (!((symbol as IFieldSymbol)?.AssociatedSymbol is IEventSymbol))
                 {
-                    // Make sure GetDeclaredSymbol gets back to the symbol for each node.
+                    Assert.False(symbol.IsImplicitlyDeclared);
 
-                    SyntaxTree tree = node.SyntaxTree;
-                    SemanticModel model = compilation.GetSemanticModel(tree);
-                    Assert.Equal(symbol.OriginalDefinition, model.GetDeclaredSymbol(node));
+                    foreach (var node in declaringReferences.Select(d => d.GetSyntax()))
+                    {
+                        // Make sure GetDeclaredSymbol gets back to the symbol for each node.
+
+                        SyntaxTree tree = node.SyntaxTree;
+                        SemanticModel model = compilation.GetSemanticModel(tree);
+                        Assert.Equal(symbol.OriginalDefinition, model.GetDeclaredSymbol(node));
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/EventTests.cs
@@ -74,7 +74,7 @@ class C
             var global = comp.GlobalNamespace;
             var @class = global.GetMember<NamedTypeSymbol>("C");
 
-            var @event = @class.GetMember<EventSymbol>("E");
+            var @event = @class.GetEvent("E");
 
             Assert.Equal(SymbolKind.Event, @event.Kind);
             Assert.Equal(Accessibility.Public, @event.DeclaredAccessibility);
@@ -113,7 +113,7 @@ class C
             var global = comp.GlobalNamespace;
             var @class = global.GetMember<NamedTypeSymbol>("C");
 
-            var @event = @class.GetMember<EventSymbol>("E");
+            var @event = @class.GetEvent("E");
 
             Assert.Equal(SymbolKind.Event, @event.Kind);
             Assert.Equal(Accessibility.Internal, @event.DeclaredAccessibility);
@@ -151,7 +151,7 @@ class C
             var global = comp.GlobalNamespace;
             var @class = global.GetMember<NamedTypeSymbol>("C");
 
-            var @event = @class.GetMember<EventSymbol>("E");
+            var @event = @class.GetEvent("E");
 
             Assert.Equal(SymbolKind.Event, @event.Kind);
             Assert.Equal(Accessibility.Protected, @event.DeclaredAccessibility);
@@ -186,7 +186,7 @@ class C
             var global = comp.GlobalNamespace;
             var @class = global.GetMember<NamedTypeSymbol>("C");
 
-            var @event = @class.GetMember<EventSymbol>("E");
+            var @event = @class.GetEvent("E");
 
             Assert.Equal(SymbolKind.Event, @event.Kind);
             Assert.Equal(Accessibility.Private, @event.DeclaredAccessibility);
@@ -319,7 +319,7 @@ class C
 ";
             var comp = CreateCompilation(text);
             NamedTypeSymbol type01 = comp.SourceModule.GlobalNamespace.GetTypeMembers("C").Single();
-            var fevent = type01.GetMembers("FieldLikeEvent").Single() as EventSymbol;
+            var fevent = type01.GetMembers("FieldLikeEvent").OfType<EventSymbol>().Single();
             Assert.NotNull(fevent.AddMethod);
             Assert.True(fevent.AddMethod.IsImplicitlyDeclared, "FieldLikeEvent AddAccessor");
             Assert.NotNull(fevent.AddMethod);
@@ -340,8 +340,8 @@ class A
             {
                 var peModule = (PEModuleSymbol)module;
                 var type = peModule.GlobalNamespace.GetMember<NamedTypeSymbol>("A");
-                var e1 = type.GetMember<EventSymbol>("E1");
-                var e2 = type.GetMember<EventSymbol>("E2");
+                var e1 = type.GetEvent("E1");
+                var e2 = type.GetEvent("E2");
                 var p = type.GetMember<PropertySymbol>("P");
 
                 Assert.Equal("System.Action<dynamic>", e1.Type.ToTestDisplayString());
@@ -601,8 +601,8 @@ public class CL2 : CL1
             {
                 var peModule = (PEModuleSymbol)module;
                 var type = peModule.GlobalNamespace.GetMember<NamedTypeSymbol>("CL2");
-                var e1 = type.GetMember<EventSymbol>("E1");
-                var e2 = type.GetMember<EventSymbol>("E2");
+                var e1 = type.GetEvent("E1");
+                var e2 = type.GetEvent("E2");
 
                 Assert.Equal("System.Action<System.Object>", e1.Type.ToTestDisplayString());
                 Assert.Equal("System.Action<System.Object>", e2.Type.ToTestDisplayString());
@@ -633,8 +633,8 @@ public class CL2 : CL1
             {
                 var peModule = (PEModuleSymbol)module;
                 var type = peModule.GlobalNamespace.GetMember<NamedTypeSymbol>("CL2");
-                var e1 = type.GetMember<EventSymbol>("E1");
-                var e2 = type.GetMember<EventSymbol>("E2");
+                var e1 = type.GetEvent("E1");
+                var e2 = type.GetEvent("E2");
 
                 Assert.Equal("System.Action<System.Object>", e1.Type.ToTestDisplayString());
                 Assert.Equal("System.Action<System.Object>", e2.Type.ToTestDisplayString());
@@ -825,7 +825,7 @@ class C
                 // (4,38): warning CS0067: The event 'C.E' is never used
                 //     public static event EventHandler E;
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 38));
-            var eventSymbol = compilation.GetMember<EventSymbol>("C.E");
+            var eventSymbol = compilation.GetEvent("C.E");
             Assert.False(eventSymbol.RequiresInstanceReceiver);
         }
 
@@ -841,7 +841,7 @@ class C
                 // (4,31): warning CS0067: The event 'C.E' is never used
                 //     public event EventHandler E;
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 31));
-            var eventSymbol = compilation.GetMember<EventSymbol>("C.E");
+            var eventSymbol = compilation.GetEvent("C.E");
             Assert.True(eventSymbol.RequiresInstanceReceiver);
         }
 
@@ -1879,9 +1879,9 @@ class C
                 Diagnostic(ErrorCode.ERR_BadAccess, "b.Event3 += null").WithArguments("Base.Event3.add"));
 
             var @class = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Base");
-            var event1 = @class.GetMember<EventSymbol>("Event1");
-            var event2 = @class.GetMember<EventSymbol>("Event2");
-            var event3 = @class.GetMember<EventSymbol>("Event3");
+            var event1 = @class.GetEvent("Event1");
+            var event2 = @class.GetEvent("Event2");
+            var event3 = @class.GetEvent("Event3");
 
             Assert.NotNull(event1.AddMethod);
             Assert.Equal(Accessibility.Private, event1.AddMethod.DeclaredAccessibility);
@@ -2277,19 +2277,19 @@ class Derived2 : Base
             var global = comp.GlobalNamespace;
 
             var @base = global.GetMember<NamedTypeSymbol>("Base");
-            var baseEvent = @base.GetMember<EventSymbol>("E");
+            var baseEvent = @base.GetEvent("E");
             var baseEventType = baseEvent.Type;
             Assert.Equal("System.Action<System.Int32 modopt(System.Int64) []>", baseEventType.ToTestDisplayString()); // Note modopt
 
             var derived1 = global.GetMember<NamedTypeSymbol>("Derived1");
-            var event1 = derived1.GetMember<EventSymbol>("E");
+            var event1 = derived1.GetEvent("E");
             Assert.Equal(baseEventType, event1.Type);
             Assert.Equal(baseEventType, event1.AssociatedField.Type);
             Assert.Equal(baseEventType, event1.AddMethod.ParameterTypesWithAnnotations.Single().Type);
             Assert.Equal(baseEventType, event1.RemoveMethod.ParameterTypesWithAnnotations.Single().Type);
 
             var derived2 = global.GetMember<NamedTypeSymbol>("Derived2");
-            var event2 = derived2.GetMember<EventSymbol>("E");
+            var event2 = derived2.GetEvent("E");
             Assert.Equal(baseEventType, event2.Type);
             Assert.Null(event2.AssociatedField);
             Assert.Equal(baseEventType, event2.AddMethod.ParameterTypesWithAnnotations.Single().Type);
@@ -2357,12 +2357,12 @@ class Derived2 : Base
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Derived1.E"));
 
             var derived1 = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived1");
-            var event1 = derived1.GetMember<EventSymbol>("E");
+            var event1 = derived1.GetEvent("E");
             Assert.Equal("myAdd", event1.AddMethod.Name);
             Assert.Equal("myRemove", event1.RemoveMethod.Name);
 
             var derived2 = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived2");
-            var event2 = derived2.GetMember<EventSymbol>("E");
+            var event2 = derived2.GetEvent("E");
             Assert.Equal("myAdd", event2.AddMethod.Name);
             Assert.Equal("myRemove", event2.RemoveMethod.Name);
         }
@@ -2403,12 +2403,12 @@ class Derived2 : Base
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Derived1.E"));
 
             var derived1 = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived1");
-            var event1 = derived1.GetMember<EventSymbol>("E");
+            var event1 = derived1.GetEvent("E");
             Assert.Equal("add_E", event1.AddMethod.Name);
             Assert.Equal("remove_E", event1.RemoveMethod.Name);
 
             var derived2 = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived2");
-            var event2 = derived2.GetMember<EventSymbol>("E");
+            var event2 = derived2.GetEvent("E");
             Assert.Equal("add_E", event2.AddMethod.Name);
             Assert.Equal("remove_E", event2.RemoveMethod.Name);
         }
@@ -2430,8 +2430,8 @@ public abstract class A
             var comp = CreateCompilation(source);
 
             var typeA = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("A");
-            var eventE = typeA.GetMember<EventSymbol>("E");
-            var eventF = typeA.GetMember<EventSymbol>("F");
+            var eventE = typeA.GetEvent("E");
+            var eventF = typeA.GetEvent("F");
 
             Assert.Null(eventE.AssociatedField);
             Assert.NotNull(eventF.AssociatedField); // Since it has an initializer.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -2970,5 +2970,21 @@ class C
             var property = compilation.GetMember<PropertySymbol>("C.P");
             Assert.True(property.RequiresInstanceReceiver);
         }
+
+        [Fact]
+        public void BackingFieldSymbolIsPresentInDeclaringType()
+        {
+            var source = @"
+class C
+{
+    public int P { get; }
+}";
+            var compilation = CreateCompilation(source).VerifyDiagnostics();
+            var declaringType = compilation.GetMember<ITypeSymbol>("C");
+
+            var fieldSymbol = Assert.Single(declaringType.GetMembers().OfType<IFieldSymbol>());
+
+            Assert.Same(compilation.GetMember<IPropertySymbol>("C.P"), fieldSymbol.AssociatedSymbol);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolDistinguisherTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolDistinguisherTests.cs
@@ -58,8 +58,8 @@ public class C
             Assert.Equal("C.F [file.cs(6)]", distinguisher.First.ToString());
             Assert.Equal("C.F [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", distinguisher.Second.ToString());
 
-            var sourceEvent = sourceType.GetMember<EventSymbol>("E");
-            var referencedEvent = referencedType.GetMember<EventSymbol>("E");
+            var sourceEvent = sourceType.GetEvent("E");
+            var referencedEvent = referencedType.GetEvent("E");
             distinguisher = new SymbolDistinguisher(comp, sourceEvent, referencedEvent);
             Assert.Equal("C.E [file.cs(7)]", distinguisher.First.ToString());
             Assert.Equal("C.E [Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]", distinguisher.Second.ToString());

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
@@ -754,8 +754,8 @@ public class B
                 expectedIncludeNullability: false
                 );
 
-            var event1 = (IEventSymbol)type1.GetMembers()[2];
-            var event2 = (IEventSymbol)type2.GetMembers()[2];
+            var event1 = (IEventSymbol)type1.GetMembers()[3];
+            var event2 = (IEventSymbol)type2.GetMembers()[3];
 
             VerifyEquality(event1, event2,
                 expectedDefault: true,

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -1604,8 +1604,7 @@ public struct S
             var nestedType = topType.GetTypeMembers("Nested").Single();
             var enumType = comp.SourceModule.GlobalNamespace.GetTypeMembers("E").Single();
             // ------------------------------
-            var mem = topType.GetMembers("efield").Single();
-            var deleType = (mem as EventSymbol).Type;
+            var deleType = topType.GetEvent("efield").Type;
             Assert.True(deleType.IsDelegateType());
             var memType = deleType.DelegateInvokeMethod().ReturnType;
             Assert.Same(comp.GetSpecialType(SpecialType.System_Nullable_T), memType.OriginalDefinition);
@@ -1619,7 +1618,7 @@ public struct S
             Assert.Same(enumType, memType.GetNullableUnderlyingType());
             Assert.Equal("E?", memType.ToDisplayString());
             // ------------------------------
-            mem = topType.GetMembers(WellKnownMemberNames.ImplicitConversionName).Single();
+            var mem = topType.GetMembers(WellKnownMemberNames.ImplicitConversionName).Single();
             memType = (mem as MethodSymbol).ReturnType;
             Assert.True(memType.IsNullableType());
             Assert.False(memType.CanBeConst());

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
@@ -2754,7 +2754,7 @@ public class abcdef{
             wns1 = wns1.GetMember<NamespaceSymbol>("UI");
             wns1 = wns1.GetMember<NamespaceSymbol>("Xaml");
             var itextrange = wns1.GetMember<PENamedTypeSymbol>("Application");
-            var @event = itextrange.GetMember<PEEventSymbol>("Suspending");
+            var @event = itextrange.GetEvent("Suspending");
 
             Assert.True(@event.IsWindowsRuntimeEvent, "Failed to detect winrt type event");
             Assert.True(!@event.MustCallMethodsDirectly, "Failed to override call methods directly");
@@ -3556,7 +3556,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             comp.VerifyDiagnostics();
 
             var type = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            var @event = type.GetMember<PEEventSymbol>("E");
+            var @event = type.GetEvent("E");
             Assert.True(@event.HasAssociatedField);
 
             var field = @event.AssociatedField;

--- a/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/Metadata/WinMdEventTests.cs
@@ -2839,8 +2839,8 @@ class C : Interface<int>
             comp.VerifyDiagnostics();
 
             var interfaceType = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Interface");
-            var interfaceNormalEvent = interfaceType.GetMember<EventSymbol>("Normal");
-            var interfaceWinRTEvent = interfaceType.GetMember<EventSymbol>("WinRT");
+            var interfaceNormalEvent = interfaceType.GetEvent("Normal");
+            var interfaceWinRTEvent = interfaceType.GetEvent("WinRT");
 
             Assert.IsType<PEEventSymbol>(interfaceNormalEvent);
             Assert.IsType<PEEventSymbol>(interfaceWinRTEvent);
@@ -2914,11 +2914,11 @@ interface I
                 comp.VerifyDiagnostics();
 
                 var @class = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                var classEvent = @class.GetMember<EventSymbol>("E");
+                var classEvent = @class.GetEvent("E");
 
                 // Specifically test interfaces because they follow a different code path.
                 var @interface = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("I");
-                var interfaceEvent = @interface.GetMember<EventSymbol>("E");
+                var interfaceEvent = @interface.GetEvent("E");
 
                 Assert.Equal(kind.IsWindowsRuntime(), classEvent.IsWindowsRuntimeEvent);
                 Assert.Equal(kind.IsWindowsRuntime(), interfaceEvent.IsWindowsRuntimeEvent);
@@ -2958,8 +2958,8 @@ class C : Interface
                 comp.VerifyDiagnostics();
 
                 var @class = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                var normalEvent = @class.GetMember<EventSymbol>("Normal");
-                var winRTEvent = @class.GetMember<EventSymbol>("WinRT");
+                var normalEvent = @class.GetEvent("Normal");
+                var winRTEvent = @class.GetEvent("WinRT");
 
                 Assert.False(normalEvent.IsWindowsRuntimeEvent);
                 Assert.True(winRTEvent.IsWindowsRuntimeEvent);
@@ -3034,8 +3034,8 @@ class OverrideAndImplIncorrectly : ReversedBase, Interface
 
                 {
                     var overrideNoImplClass = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("OverrideNoImpl");
-                    var normalEvent = overrideNoImplClass.GetMember<EventSymbol>("Normal");
-                    var winRTEvent = overrideNoImplClass.GetMember<EventSymbol>("WinRT");
+                    var normalEvent = overrideNoImplClass.GetEvent("Normal");
+                    var winRTEvent = overrideNoImplClass.GetEvent("WinRT");
 
                     Assert.False(normalEvent.IsWindowsRuntimeEvent);
                     Assert.True(winRTEvent.IsWindowsRuntimeEvent);
@@ -3043,8 +3043,8 @@ class OverrideAndImplIncorrectly : ReversedBase, Interface
 
                 {
                     var overrideAndImplCorrectlyClass = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("OverrideAndImplCorrectly");
-                    var normalEvent = overrideAndImplCorrectlyClass.GetMember<EventSymbol>("Normal");
-                    var winRTEvent = overrideAndImplCorrectlyClass.GetMember<EventSymbol>("WinRT");
+                    var normalEvent = overrideAndImplCorrectlyClass.GetEvent("Normal");
+                    var winRTEvent = overrideAndImplCorrectlyClass.GetEvent("WinRT");
 
                     Assert.False(normalEvent.IsWindowsRuntimeEvent);
                     Assert.True(winRTEvent.IsWindowsRuntimeEvent);
@@ -3052,8 +3052,8 @@ class OverrideAndImplIncorrectly : ReversedBase, Interface
 
                 {
                     var overrideAndImplIncorrectlyClass = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("OverrideAndImplIncorrectly");
-                    var normalEvent = overrideAndImplIncorrectlyClass.GetMember<EventSymbol>("Normal");
-                    var winRTEvent = overrideAndImplIncorrectlyClass.GetMember<EventSymbol>("WinRT");
+                    var normalEvent = overrideAndImplIncorrectlyClass.GetEvent("Normal");
+                    var winRTEvent = overrideAndImplIncorrectlyClass.GetEvent("WinRT");
 
                     // NB: reversed
                     Assert.True(normalEvent.IsWindowsRuntimeEvent);
@@ -3168,7 +3168,7 @@ class C : IWinRT, INormal
                     Diagnostic(ErrorCode.ERR_MixingWinRTEventWithRegular, "E").WithArguments("C.E", "INormal.E", "C.E", "INormal.E"));
 
                 var @class = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                var @event = @class.GetMember<EventSymbol>("E");
+                var @event = @class.GetEvent("E");
 
                 Assert.True(@event.IsWindowsRuntimeEvent); //Implemented at least one WinRT event.
             }
@@ -3195,7 +3195,7 @@ class C : INormal, IWinRT
                     Diagnostic(ErrorCode.ERR_MixingWinRTEventWithRegular, "E").WithArguments("C.E", "INormal.E", "C.E", "INormal.E"));
 
                 var @class = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                var @event = @class.GetMember<EventSymbol>("E");
+                var @event = @class.GetEvent("E");
 
                 Assert.True(@event.IsWindowsRuntimeEvent); //Implemented at least one WinRT event.
             }
@@ -3256,8 +3256,8 @@ class Derived : ReversedBase, Interface
                 Diagnostic(ErrorCode.ERR_MixingWinRTEventWithRegular, "Normal").WithArguments("Derived.Normal", "Interface.Normal", "Derived.Normal", "Interface.Normal"));
 
             var derivedClass = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Derived");
-            var normalEvent = derivedClass.GetMember<EventSymbol>("Normal");
-            var winRTEvent = derivedClass.GetMember<EventSymbol>("WinRT");
+            var normalEvent = derivedClass.GetEvent("Normal");
+            var winRTEvent = derivedClass.GetEvent("WinRT");
 
             // NB: reversed, since overriding beats implicitly implementing.
             Assert.True(normalEvent.IsWindowsRuntimeEvent);
@@ -3291,8 +3291,8 @@ class C
                     Diagnostic(ErrorCode.WRN_UnreferencedEvent, "F").WithArguments("C.F"));
 
                 var @class = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-                var customEvent = @class.GetMember<EventSymbol>("E");
-                var fieldLikeEvent = @class.GetMember<EventSymbol>("F");
+                var customEvent = @class.GetEvent("E");
+                var fieldLikeEvent = @class.GetEvent("F");
 
                 if (kind.IsWindowsRuntime())
                 {
@@ -3340,7 +3340,7 @@ class C
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E"));
 
             var @class = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
-            var @event = @class.GetMember<EventSymbol>("E");
+            var @event = @class.GetEvent("E");
             var field = @event.AssociatedField;
             var fieldType = (NamedTypeSymbol)field.Type;
             Assert.Equal(TypeKind.Error, fieldType.TypeKind);
@@ -3498,8 +3498,8 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             var compilation = CreateCompilationWithIL("", il, targetFramework: TargetFramework.Empty, references: WinRtRefs);
 
             var type = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("Events");
-            var instanceEvent = type.GetMember<EventSymbol>("Instance");
-            var staticEvent = type.GetMember<EventSymbol>("Static");
+            var instanceEvent = type.GetEvent("Instance");
+            var staticEvent = type.GetEvent("Static");
 
             Assert.True(instanceEvent.IsWindowsRuntimeEvent);
             Assert.False(instanceEvent.AddMethod.IsStatic);

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -285,7 +285,27 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         public static EventSymbol GetEvent(this NamedTypeSymbol symbol, string name)
         {
-            return (EventSymbol)symbol.GetMembers(name).Single();
+            return (EventSymbol)symbol.GetMembers(name).Single(m => m.Kind == SymbolKind.Event);
+        }
+
+        public static EventSymbol GetEvent(this CSharpCompilation compilation, string qualifiedName)
+        {
+            return compilation.GlobalNamespace.GetEvent(qualifiedName);
+        }
+
+        public static IEventSymbol GetEvent(this Compilation compilation, string qualifiedName)
+        {
+            return compilation.GlobalNamespace.GetEvent(qualifiedName);
+        }
+
+        public static EventSymbol GetEvent(this NamespaceOrTypeSymbol container, string qualifiedName)
+        {
+            return (EventSymbol)GetMembers(container, qualifiedName, lastContainer: out _).Single(m => m.Kind == SymbolKind.Event);
+        }
+
+        public static IEventSymbol GetEvent(this INamespaceOrTypeSymbol container, string qualifiedName)
+        {
+            return (IEventSymbol)GetMembers(container, qualifiedName, lastContainer: out _).Single(m => m.Kind == SymbolKind.Event);
         }
 
         public static MethodSymbol GetMethod(this NamedTypeSymbol symbol, string name)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -4574,7 +4574,7 @@ class Outer
             Dim method = outer.GetMembers("M").Single()
             Dim [property] = outer.GetMembers("P").Single()
             Dim field = outer.GetMembers("F").Single()
-            Dim [event] = outer.GetMembers("E").Single()
+            Dim [event] = outer.GetMembers("E").Single(Function(m) m.Kind <> SymbolKind.Field)
             Dim [delegate] = outer.GetMembers("D").Single()
             Dim [error] = outer.GetMembers("Error").Single()
 

--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyMetadataVsSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyMetadataVsSourceTests.cs
@@ -64,7 +64,7 @@ public class App : C
             var typesym = comp2.SourceModule.GlobalNamespace.GetTypeMembers("App").FirstOrDefault() as INamedTypeSymbol;
 
             // 'D'
-            var member01 = (typesym.GetMembers("myEvent").Single() as IEventSymbol).Type;
+            var member01 = typesym.GetMembers("myEvent").OfType<IEventSymbol>().Single().Type;
 
             // 'I'
             var member02 = (typesym.GetMembers("Prop").Single() as IPropertySymbol).Type;

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -187,6 +187,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                 {
                     var otherThingsNamedTheSame = renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name)
                                                            .Where(s => !s.Equals(renamedSymbol) &&
+                                                                       s.CanBeReferencedByName &&
                                                                        string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
 
                     IEnumerable<ISymbol> otherThingsNamedTheSameExcludeMethodAndParameterizedProperty;


### PR DESCRIPTION
Fixes #36259. Other than where I commented, all changes are meant to restore identical outcomes now that the event backing field comes along with the other fields for free. I seemed to remove a lot of workarounds.