### PR TITLE
Move to the use site tracking for the purpose of recording used assemblies in VB

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1073,10 +1073,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 UseSiteInfo<AssemblySymbol> useSiteInfo = accessor.GetUseSiteInfo();
                 if (!object.Equals(useSiteInfo.DiagnosticInfo, propertySymbol.GetUseSiteInfo().DiagnosticInfo))
                 {
-                    if (diagnostics.Add(useSiteInfo, propertySyntax))
-                    {
-                        return true;
-                    }
+                    return diagnostics.Add(useSiteInfo, propertySyntax);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -623,12 +623,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return true;
                     }
 
-                    HashSet<DiagnosticInfo> useSiteDiagnostics = attributeTypeViabilityUseSiteInfo.Diagnostics;
+                    CompoundUseSiteInfo<AssemblySymbol> copyUseSiteInfo = attributeTypeViabilityUseSiteInfo;
                     attributeTypeViabilityUseSiteInfo = default;
 
-                    if (diagnose && !useSiteDiagnostics.IsNullOrEmpty())
+                    if (diagnose && copyUseSiteInfo.HasErrors)
                     {
-                        foreach (var info in useSiteDiagnostics)
+                        foreach (var info in copyUseSiteInfo.Diagnostics)
                         {
                             if (info.Severity == DiagnosticSeverity.Error)
                             {

--- a/src/Compilers/CSharp/Portable/Binder/BindingDiagnosticBag.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BindingDiagnosticBag.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    // PROTOTYPE(UsedAssemblyReferences): Consider if it makes sense to move this type into its own file
     internal static class BindingDiagnosticBagExtensions
     {
         internal static CSDiagnosticInfo Add(this CodeAnalysis.BindingDiagnosticBag diagnostics, ErrorCode code, Location location)
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static CSDiagnosticInfo Add(this CodeAnalysis.BindingDiagnosticBag diagnostics, ErrorCode code, Location location, ImmutableArray<Symbol> symbols, params object[] args)
         {
-            var info = new CSDiagnosticInfo(code, args, symbols, ImmutableArray<global::Microsoft.CodeAnalysis.Location>.Empty);
+            var info = new CSDiagnosticInfo(code, args, symbols, ImmutableArray<Location>.Empty);
             diagnostics.DiagnosticBag?.Add(new CSDiagnostic(info, location));
             return info;
         }
@@ -55,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                Debug.Assert(info.DiagnosticInfo == null || addDependencies); // It would be strange to drop diagnostics, but record dependencies
+                Debug.Assert(info.DiagnosticInfo == null); // It would be strange to drop diagnostics, but record dependencies
             }
 
             if (addDependencies)
@@ -90,12 +91,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static BindingDiagnosticBag GetInstance()
         {
             return new BindingDiagnosticBag(usePool: true);
-        }
-
-        // PROTOTYPE(UsedAssemblyReferences): Remove this overload once conversion operators are removed from the base type.
-        internal void AddRange(BindingDiagnosticBag other)
-        {
-            AddRange((BindingDiagnosticBag<AssemblySymbol>)other);
         }
 
         internal void AddDependencies(Symbol? symbol)
@@ -133,16 +128,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            addAssembliesUsedByNamespaceReference(ns);
+            addAssembliesUsedByNamespaceReferenceImpl(ns);
 
-            void addAssembliesUsedByNamespaceReference(NamespaceSymbol ns)
+            void addAssembliesUsedByNamespaceReferenceImpl(NamespaceSymbol ns)
             {
                 // Treat all assemblies contributing to this namespace symbol as used
                 if (ns.Extent.Kind == NamespaceKind.Compilation)
                 {
                     foreach (var constituent in ns.ConstituentNamespaces)
                     {
-                        AddAssembliesUsedByNamespaceReference(constituent);
+                        addAssembliesUsedByNamespaceReferenceImpl(constituent);
                     }
                 }
                 else

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -94,22 +94,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (!InferredReturnType.UseSiteDiagnostics.IsEmpty)
             {
-                if (useSiteInfo.Diagnostics == null)
-                {
-                    useSiteInfo.Diagnostics = new HashSet<DiagnosticInfo>();
-                }
-
-                useSiteInfo.Diagnostics.AddAll(InferredReturnType.UseSiteDiagnostics);
+                useSiteInfo.AddDiagnostics(InferredReturnType.UseSiteDiagnostics);
             }
 
             if (!InferredReturnType.Dependencies.IsEmpty)
             {
-                if (useSiteInfo.Dependencies == null)
-                {
-                    useSiteInfo.Dependencies = new HashSet<AssemblySymbol>();
-                }
-
-                useSiteInfo.Dependencies.AddAll(InferredReturnType.Dependencies);
+                useSiteInfo.AddDependencies(InferredReturnType.Dependencies);
             }
 
             if (nullableState == null)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2465,7 +2465,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (stage == CompilationStage.Compile || stage > CompilationStage.Compile && includeEarlierStages)
             {
-                var methodBodyDiagnostics = new BindingDiagnosticBag(DiagnosticBag.GetInstance(), new ConcurrentSet<AssemblySymbol>());
+                var methodBodyDiagnostics = new BindingDiagnosticBag(DiagnosticBag.GetInstance(),
+                                                                     builder.DependenciesBag is object ? new ConcurrentSet<AssemblySymbol>() : null);
                 GetDiagnosticsForAllMethodBodies(methodBodyDiagnostics, doLowering: false, cancellationToken);
                 builder.AddRange(methodBodyDiagnostics);
                 methodBodyDiagnostics.DiagnosticBag.Free();

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -656,9 +656,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             _diagnostics.Add(diagnostic.WithLocation(sourceLocation));
                         }
                     }
-
-                    _diagnostics.AddDependencies(bindingDiagnostics);
                 }
+
+                _diagnostics.AddDependencies(bindingDiagnostics);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -835,8 +835,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var discardedDiagnostics = BindingDiagnosticBag.GetInstance();
                 synthesizedAccessor.GenerateMethodBody(compilationState, discardedDiagnostics);
                 Debug.Assert(!discardedDiagnostics.HasAnyErrors());
-                discardedDiagnostics.DiagnosticBag.Clear();
-                _diagnostics.AddRangeAndFree(discardedDiagnostics);
+                _diagnostics.AddDependencies(discardedDiagnostics);
+                discardedDiagnostics.Free();
 
                 _moduleBeingBuiltOpt.AddSynthesizedDefinition(sourceProperty.ContainingType, synthesizedAccessor);
             }

--- a/src/Compilers/CSharp/Portable/Errors/DiagnosticBagExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Errors/DiagnosticBagExtensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool Add(
             this DiagnosticBag diagnostics,
             Location location,
-            HashSet<DiagnosticInfo> useSiteDiagnostics)
+            IReadOnlyCollection<DiagnosticInfo> useSiteDiagnostics)
         {
             if (useSiteDiagnostics.IsNullOrEmpty())
             {

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -225,46 +225,46 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override int ERR_EncUpdateFailedMissingAttribute => (int)ErrorCode.ERR_EncUpdateFailedMissingAttribute;
         public override int ERR_InvalidDebugInfo => (int)ErrorCode.ERR_InvalidDebugInfo;
 
-        public override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
+        protected override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;
             CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
             diagnostics.Add(ErrorCode.ERR_InvalidAttributeArgument, attributeArgumentSyntax.Location, node.GetErrorDisplayName());
         }
 
-        public override void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
+        protected override void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
         {
             var node = (AttributeSyntax)attributeSyntax;
             diagnostics.Add(ErrorCode.ERR_InvalidNamedArgument, node.ArgumentList.Arguments[namedArgumentIndex].Location, parameterName);
         }
 
-        public override void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex)
+        protected override void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex)
         {
             var node = (AttributeSyntax)attributeSyntax;
             diagnostics.Add(ErrorCode.ERR_ParameterNotValidForType, node.ArgumentList.Arguments[namedArgumentIndex].Location);
         }
 
-        public override void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
+        protected override void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;
             CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
             diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeNotValidForFields, attributeArgumentSyntax.Location, unmanagedTypeName);
         }
 
-        public override void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
+        protected override void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
             var node = (AttributeSyntax)attributeSyntax;
             CSharpSyntaxNode attributeArgumentSyntax = attribute.GetAttributeArgumentSyntax(parameterIndex, node);
             diagnostics.Add(ErrorCode.ERR_MarshalUnmanagedTypeOnlyValidForFields, attributeArgumentSyntax.Location, unmanagedTypeName);
         }
 
-        public override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)
+        protected override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)
         {
             var node = (AttributeSyntax)attributeSyntax;
             diagnostics.Add(ErrorCode.ERR_AttributeParameterRequired1, node.Name.Location, parameterName);
         }
 
-        public override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2)
+        protected override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2)
         {
             var node = (AttributeSyntax)attributeSyntax;
             diagnostics.Add(ErrorCode.ERR_AttributeParameterRequired2, node.Name.Location, parameterName1, parameterName2);

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -99,10 +99,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors = bag.HasAnyErrors();
             if (!hasErrors)
             {
-                bag.DiagnosticBag.Clear();
+                diagnostics.AddDependencies(bag);
+            }
+            else
+            {
+                diagnostics.AddRange(bag);
             }
 
-            diagnostics.AddRangeAndFree(bag);
+            bag.Free();
             return !hasErrors && _constructedSuccessfully;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -117,10 +117,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors = bag.HasAnyErrors();
             if (!hasErrors)
             {
-                bag.DiagnosticBag.Clear();
+                diagnostics.AddDependencies(bag);
+            }
+            else
+            {
+                diagnostics.AddRange(bag);
             }
 
-            diagnostics.AddRangeAndFree(bag);
+            bag.Free();
             return !hasErrors;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_UsedAssemblies.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_UsedAssemblies.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var setOfReferences = new HashSet<MetadataReference>(ReferenceEqualityComparer.Instance);
+            ImmutableDictionary<MetadataReference, ImmutableArray<MetadataReference>> mergedAssemblyReferencesMap = GetBoundReferenceManager().MergedAssemblyReferencesMap;
 
             foreach (var reference in References)
             {
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Symbol symbol = GetAssemblyOrModuleSymbol(reference);
                     if (symbol is object && usedAssemblies.Contains((AssemblySymbol)symbol) &&
                         setOfReferences.Add(reference) &&
-                        GetBoundReferenceManager().MergedAssemblyReferencesMap.TryGetValue(reference, out ImmutableArray<MetadataReference> merged))
+                        mergedAssemblyReferencesMap.TryGetValue(reference, out ImmutableArray<MetadataReference> merged))
                     {
                         // Include all "merged" references as well because they might "define" used extern aliases.
                         setOfReferences.AddAll(merged);

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -982,7 +982,7 @@ hasRelatedInterfaces:
             TypeParameterSymbol typeParameter,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder)
         {
-            if (!useSiteInfo.Dependencies.IsNullOrEmpty())
+            if (!useSiteInfo.HasErrors && !useSiteInfo.Dependencies.IsNullOrEmpty())
             {
                 ensureUseSiteDiagnosticsBuilder(ref useSiteDiagnosticsBuilder).Add(new TypeParameterDiagnosticInfo(typeParameter,
                                                                               useSiteInfo.Dependencies.Count == 1 ?

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1148,12 +1148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private UseSiteInfo<AssemblySymbol> GetCachedUseSiteInfo()
         {
-            if (_uncommonFields is null)
-            {
-                return new UseSiteInfo<AssemblySymbol>(PrimaryDependency);
-            }
-
-            return _uncommonFields._lazyCachedUseSiteInfo.ToUseSiteInfo(PrimaryDependency);
+            return (_uncommonFields?._lazyCachedUseSiteInfo ?? default).ToUseSiteInfo(PrimaryDependency);
         }
 
         private UseSiteInfo<AssemblySymbol> InitializeUseSiteDiagnostic(UseSiteInfo<AssemblySymbol> useSiteInfo)
@@ -1163,7 +1158,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return GetCachedUseSiteInfo();
             }
 
-            if (useSiteInfo.DiagnosticInfo is object || useSiteInfo.SecondaryDependencies?.IsEmpty == false)
+            if (useSiteInfo.DiagnosticInfo is object || !useSiteInfo.SecondaryDependencies.IsNullOrEmpty())
             {
                 useSiteInfo = AccessUncommonFields()._lazyCachedUseSiteInfo.InterlockedInitialize(PrimaryDependency, useSiteInfo);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -615,22 +615,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 bool inherited = (_containingSymbol.Kind == SymbolKind.Method) && ((MethodSymbol)_containingSymbol).IsOverride;
                 var bounds = this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited, currentCompilation: null,
                                                 diagnosticsBuilder: diagnostics, useSiteDiagnosticsBuilder: ref useSiteDiagnosticsBuilder);
+
+                if (useSiteDiagnosticsBuilder != null)
+                {
+                    diagnostics.AddRange(useSiteDiagnosticsBuilder);
+                }
+
                 AssemblySymbol primaryDependency = PrimaryDependency;
                 var useSiteInfo = new UseSiteInfo<AssemblySymbol>(primaryDependency);
 
-                if (diagnostics.Count > 0)
+                foreach (var diag in diagnostics)
                 {
-                    MergeUseSiteInfo(ref useSiteInfo, diagnostics[0].UseSiteInfo);
-                }
-                else if (useSiteDiagnosticsBuilder != null && useSiteDiagnosticsBuilder.Count > 0)
-                {
-                    foreach (var diag in useSiteDiagnosticsBuilder)
+                    MergeUseSiteInfo(ref useSiteInfo, diag.UseSiteInfo);
+                    if (useSiteInfo.DiagnosticInfo?.Severity == DiagnosticSeverity.Error)
                     {
-                        MergeUseSiteInfo(ref useSiteInfo, diag.UseSiteInfo);
-                        if (useSiteInfo.DiagnosticInfo?.Severity == DiagnosticSeverity.Error)
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2059,7 +2059,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void DecodeOneInternalsVisibleToAttribute(
             AttributeSyntax nodeOpt,
             CSharpAttributeData attrData,
-            DiagnosticBag diagnostics,
+            BindingDiagnosticBag diagnostics,
             int index,
             ref ConcurrentDictionary<string, ConcurrentDictionary<ImmutableArray<byte>, Tuple<Location, string>>> lazyInternalsVisibleToMap)
         {
@@ -2161,7 +2161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (attribute.IsTargetAttribute(this, AttributeDescription.InternalsVisibleToAttribute))
             {
-                DecodeOneInternalsVisibleToAttribute(arguments.AttributeSyntaxOpt, attribute, arguments.Diagnostics, index, ref _lazyInternalsVisibleToMap);
+                DecodeOneInternalsVisibleToAttribute(arguments.AttributeSyntaxOpt, attribute, (BindingDiagnosticBag)arguments.Diagnostics, index, ref _lazyInternalsVisibleToMap);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblySignatureKeyAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -955,15 +955,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return retVal;
             }
 
-            var secondaryDependencies = (result.SecondaryDependencies ?? ImmutableHashSet<AssemblySymbol>.Empty).Union(info.SecondaryDependencies ?? ImmutableHashSet<AssemblySymbol>.Empty);
-            var resultPrimaryDependency = result.PrimaryDependency ?? info.PrimaryDependency;
+            var secondaryDependencies = result.SecondaryDependencies;
+            var primaryDependency = result.PrimaryDependency;
 
-            if (resultPrimaryDependency != info.PrimaryDependency && info.PrimaryDependency is object)
-            {
-                secondaryDependencies = secondaryDependencies.Add(info.PrimaryDependency);
-            }
+            info.MergeDependencies(ref primaryDependency, ref secondaryDependencies);
 
-            result = new UseSiteInfo<AssemblySymbol>(diagnosticInfo, resultPrimaryDependency, secondaryDependencies);
+            result = new UseSiteInfo<AssemblySymbol>(diagnosticInfo, primaryDependency, secondaryDependencies);
             Debug.Assert(!retVal);
             return retVal;
         }

--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -12,14 +12,14 @@ using Microsoft.CodeAnalysis.Symbols;
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
-    /// This is base class for a bag used to accumulate various information as binding is performed.
+    /// This is base class for a bag used to accumulate information while binding is performed.
     /// Including diagnostic messages and dependencies in the form of "used" assemblies. 
     /// </summary>
-    internal class BindingDiagnosticBag
+    internal abstract class BindingDiagnosticBag // PROTOTYPE(UsedAssemblyReferences): Is there a better name for this and the derived types?
     {
         public readonly DiagnosticBag? DiagnosticBag;
 
-        public BindingDiagnosticBag(DiagnosticBag? diagnosticBag)
+        protected BindingDiagnosticBag(DiagnosticBag? diagnosticBag)
         {
             DiagnosticBag = diagnosticBag;
         }
@@ -50,31 +50,22 @@ namespace Microsoft.CodeAnalysis
         {
             DiagnosticBag?.Add(diag);
         }
-
-        // PROTOTYPE(UsedAssemblyReferences): Remove conversions once VB side is implemented.
-        public static implicit operator DiagnosticBag?(BindingDiagnosticBag from)
-        {
-            return from.DiagnosticBag;
-        }
-
-        public static implicit operator BindingDiagnosticBag(DiagnosticBag? from)
-        {
-            return new BindingDiagnosticBag(from);
-        }
     }
 
+    // PROTOTYPE(UsedAssemblyReferences): Mesure performace impact of collecting more information during binding by using this class.
     internal abstract class BindingDiagnosticBag<TAssemblySymbol> : BindingDiagnosticBag
         where TAssemblySymbol : class, IAssemblySymbolInternal
     {
         public readonly ICollection<TAssemblySymbol>? DependenciesBag;
 
-        public BindingDiagnosticBag(DiagnosticBag? diagnosticBag, ICollection<TAssemblySymbol>? dependenciesBag)
+        protected BindingDiagnosticBag(DiagnosticBag? diagnosticBag, ICollection<TAssemblySymbol>? dependenciesBag)
             : base(diagnosticBag)
         {
+            Debug.Assert(diagnosticBag?.GetType().IsValueType != true);
             DependenciesBag = dependenciesBag;
         }
 
-        public BindingDiagnosticBag(bool usePool)
+        protected BindingDiagnosticBag(bool usePool)
             : this(usePool ? DiagnosticBag.GetInstance() : new DiagnosticBag(), usePool ? PooledHashSet<TAssemblySymbol>.GetInstance() : new HashSet<TAssemblySymbol>())
         { }
 
@@ -102,20 +93,6 @@ namespace Microsoft.CodeAnalysis
             other.Free();
         }
 
-        // PROTOTYPE(UsedAssemblyReferences): Remove conversions once VB side is implemented.
-
-        [Obsolete("Implicit conversion from BindingDiagnosticBag<TAssemblySymbol> to DiagnosticBag is not supported.", error: true)]
-        public static implicit operator DiagnosticBag(BindingDiagnosticBag<TAssemblySymbol>? from)
-        {
-            throw new NotSupportedException();
-        }
-
-        [Obsolete("Implicit conversion from DiagnosticBag to BindingDiagnosticBag<TAssemblySymbol> is not supported.", error: true)]
-        public static implicit operator BindingDiagnosticBag<TAssemblySymbol>(DiagnosticBag? from)
-        {
-            throw new NotSupportedException();
-        }
-
         internal void Clear()
         {
             DiagnosticBag?.Clear();
@@ -128,10 +105,13 @@ namespace Microsoft.CodeAnalysis
             AddDependencies(other.Dependencies);
         }
 
-        internal void AddRange(BindingDiagnosticBag<TAssemblySymbol> other)
+        internal void AddRange(BindingDiagnosticBag<TAssemblySymbol>? other)
         {
-            AddRange(other.DiagnosticBag);
-            AddDependencies(other.DependenciesBag);
+            if (other is object)
+            {
+                AddRange(other.DiagnosticBag);
+                AddDependencies(other.DependenciesBag);
+            }
         }
 
         internal void AddRange(DiagnosticBag? bag)
@@ -152,7 +132,40 @@ namespace Microsoft.CodeAnalysis
 
         internal void AddDependencies(ICollection<TAssemblySymbol>? dependencies)
         {
-            if (dependencies?.Count > 0 && DependenciesBag is object)
+            if (!dependencies.IsNullOrEmpty() && DependenciesBag is object)
+            {
+                foreach (var candidate in dependencies)
+                {
+                    DependenciesBag.Add(candidate);
+                }
+            }
+        }
+
+        internal void AddDependencies(IReadOnlyCollection<TAssemblySymbol>? dependencies)
+        {
+            if (!dependencies.IsNullOrEmpty() && DependenciesBag is object)
+            {
+                foreach (var candidate in dependencies)
+                {
+                    DependenciesBag.Add(candidate);
+                }
+            }
+        }
+
+        internal void AddDependencies(ImmutableHashSet<TAssemblySymbol>? dependencies)
+        {
+            if (!dependencies.IsNullOrEmpty() && DependenciesBag is object)
+            {
+                foreach (var candidate in dependencies)
+                {
+                    DependenciesBag.Add(candidate);
+                }
+            }
+        }
+
+        internal void AddDependencies(ImmutableArray<TAssemblySymbol> dependencies)
+        {
+            if (!dependencies.IsDefaultOrEmpty && DependenciesBag is object)
             {
                 foreach (var candidate in dependencies)
                 {
@@ -177,10 +190,7 @@ namespace Microsoft.CodeAnalysis
 
         internal void AddDependencies(CompoundUseSiteInfo<TAssemblySymbol> useSiteInfo)
         {
-            if (DependenciesBag is object)
-            {
-                AddDependencies(useSiteInfo.Dependencies);
-            }
+            AddDependencies(useSiteInfo.Dependencies);
         }
 
         internal bool Add(SyntaxNode node, CompoundUseSiteInfo<TAssemblySymbol> useSiteInfo)
@@ -188,7 +198,12 @@ namespace Microsoft.CodeAnalysis
             return Add(node.Location, useSiteInfo);
         }
 
-        internal bool Add(Location location, CompoundUseSiteInfo<TAssemblySymbol> useSiteInfo)
+        internal bool AddDiagnostics(SyntaxNode node, CompoundUseSiteInfo<TAssemblySymbol> useSiteInfo)
+        {
+            return AddDiagnostics(node.Location, useSiteInfo);
+        }
+
+        internal bool AddDiagnostics(Location location, CompoundUseSiteInfo<TAssemblySymbol> useSiteInfo)
         {
             if (!useSiteInfo.Diagnostics.IsNullOrEmpty())
             {
@@ -220,7 +235,17 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            AddDependencies(useSiteInfo.Dependencies);
+            return false;
+        }
+
+        internal bool Add(Location location, CompoundUseSiteInfo<TAssemblySymbol> useSiteInfo)
+        {
+            if (AddDiagnostics(location, useSiteInfo))
+            {
+                return true;
+            }
+
+            AddDependencies(useSiteInfo);
             return false;
         }
 

--- a/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/Binding/BindingDiagnosticBag.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis
         }
     }
 
-    // PROTOTYPE(UsedAssemblyReferences): Mesure performace impact of collecting more information during binding by using this class.
+    // PROTOTYPE(UsedAssemblyReferences): Measure performance impact of collecting more information during binding by using this class.
     internal abstract class BindingDiagnosticBag<TAssemblySymbol> : BindingDiagnosticBag
         where TAssemblySymbol : class, IAssemblySymbolInternal
     {

--- a/src/Compilers/Core/Portable/Collections/CollectionsExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/CollectionsExtensions.cs
@@ -10,14 +10,14 @@ namespace Microsoft.CodeAnalysis
 {
     internal static class CollectionsExtensions
     {
-        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this ICollection<T>? hashSet)
+        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this ICollection<T>? collection)
         {
-            return hashSet == null || hashSet.Count == 0;
+            return collection == null || collection.Count == 0;
         }
 
-        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this IReadOnlyCollection<T>? hashSet)
+        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this IReadOnlyCollection<T>? collection)
         {
-            return hashSet == null || hashSet.Count == 0;
+            return collection == null || collection.Count == 0;
         }
 
         internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this ImmutableHashSet<T>? hashSet)

--- a/src/Compilers/Core/Portable/Collections/CollectionsExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/CollectionsExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal static class CollectionsExtensions
+    {
+        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this ICollection<T>? hashSet)
+        {
+            return hashSet == null || hashSet.Count == 0;
+        }
+
+        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this IReadOnlyCollection<T>? hashSet)
+        {
+            return hashSet == null || hashSet.Count == 0;
+        }
+
+        internal static bool IsNullOrEmpty<T>([NotNullWhen(returnValue: false)] this ImmutableHashSet<T>? hashSet)
+        {
+            return hashSet == null || hashSet.Count == 0;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis
             diagnostics.Add(CreateDiagnostic(ERR_OutputWriteFailed, Location.None, filePath, e.Message));
         }
 
-        public abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);
+        protected abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);
 
         public void ReportInvalidAttributeArgument(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public abstract void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName);
+        protected abstract void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName);
 
         public void ReportInvalidNamedArgument(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
         {
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public abstract void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex);
+        protected abstract void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex);
 
         public void ReportParameterNotValidForType(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex)
         {
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public abstract void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute);
+        protected abstract void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute);
 
         public void ReportMarshalUnmanagedTypeNotValidForFields(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
@@ -280,7 +280,8 @@ namespace Microsoft.CodeAnalysis
                 ReportMarshalUnmanagedTypeNotValidForFields(diagnosticBag, attributeSyntax, parameterIndex, unmanagedTypeName, attribute);
             }
         }
-        public abstract void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute);
+
+        protected abstract void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute);
 
         public void ReportMarshalUnmanagedTypeOnlyValidForFields(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
@@ -290,7 +291,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName);
+        protected abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName);
 
         public void ReportAttributeParameterRequired(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)
         {
@@ -300,7 +301,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2);
+        protected abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2);
 
         public void ReportAttributeParameterRequired(BindingDiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2)
         {

--- a/src/Compilers/Test/Utilities/CSharp/Extensions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/Extensions.cs
@@ -836,18 +836,31 @@ internal static class Extensions
     public static Conversion ClassifyConversionFromType(this ConversionsBase conversions, TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics, bool forCast = false)
     {
         CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
-        useSiteInfo.Diagnostics = useSiteDiagnostics;
         Conversion result = conversions.ClassifyConversionFromType(source, destination, ref useSiteInfo, forCast);
-        useSiteDiagnostics = useSiteInfo.Diagnostics;
+        AddDiagnosticInfos(ref useSiteDiagnostics, useSiteInfo);
         return result;
+    }
+
+    private static void AddDiagnosticInfos(ref HashSet<DiagnosticInfo> useSiteDiagnostics, CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+    {
+        if (useSiteInfo.Diagnostics is object)
+        {
+            if (useSiteDiagnostics is null)
+            {
+                useSiteDiagnostics = (HashSet<DiagnosticInfo>)useSiteInfo.Diagnostics;
+            }
+            else
+            {
+                useSiteDiagnostics.AddAll(useSiteInfo.Diagnostics);
+            }
+        }
     }
 
     public static Conversion ClassifyConversionFromExpression(this ConversionsBase conversions, BoundExpression sourceExpression, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics, bool forCast = false)
     {
         CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
-        useSiteInfo.Diagnostics = useSiteDiagnostics;
         Conversion result = conversions.ClassifyConversionFromExpression(sourceExpression, destination, ref useSiteInfo, forCast);
-        useSiteDiagnostics = useSiteInfo.Diagnostics;
+        AddDiagnosticInfos(ref useSiteDiagnostics, useSiteInfo);
         return result;
     }
 
@@ -863,9 +876,8 @@ internal static class Extensions
         ref HashSet<DiagnosticInfo> useSiteDiagnostics)
     {
         CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
-        useSiteInfo.Diagnostics = useSiteDiagnostics;
         binder.LookupSymbolsSimpleName(result, qualifierOpt, plainName, arity, basesBeingResolved, options, diagnose, ref useSiteInfo);
-        useSiteDiagnostics = useSiteInfo.Diagnostics;
+        AddDiagnosticInfos(ref useSiteDiagnostics, useSiteInfo);
     }
 
     public static ImmutableArray<Symbol> BindCref(this Microsoft.CodeAnalysis.CSharp.Binder binder, CrefSyntax syntax, out Symbol ambiguityWinner, DiagnosticBag diagnostics)

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -4,8 +4,10 @@ Imports System.Collections.Immutable
 Imports System.Reflection
 Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Symbols
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Xunit
 
 Friend Module Extensions
@@ -344,4 +346,81 @@ Friend Module Extensions
     Friend Function RefKind(this As ParameterSymbol) As RefKind
         Return DirectCast(this, IParameterSymbol).RefKind
     End Function
+
+    <Extension>
+    Friend Function ReduceExtensionMethod(this As MethodSymbol, instanceType As TypeSymbol) As MethodSymbol
+        Return this.ReduceExtensionMethod(instanceType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
+    End Function
+
+    <Extension>
+    Friend Function ReduceExtensionMethod(this As MethodSymbol, instanceType As TypeSymbol, proximity As Integer) As MethodSymbol
+        Return this.ReduceExtensionMethod(instanceType, proximity, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
+    End Function
+
+    <Extension>
+    Friend Function GetUseSiteErrorInfo(this As Symbol) As DiagnosticInfo
+        Return this.GetUseSiteInfo().DiagnosticInfo
+    End Function
+
+    <Extension>
+    Friend Sub Verify(this As ImmutableBindingDiagnostic(Of AssemblySymbol), ParamArray expected As DiagnosticDescription())
+        this.Diagnostics.Verify(expected)
+    End Sub
+
+    <Extension>
+    Friend Sub LookupMember(this As Binder,
+                            lookupResult As LookupResult,
+                            container As NamespaceOrTypeSymbol,
+                            name As String,
+                            arity As Integer,
+                            options As LookupOptions,
+                            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+        this.LookupMember(lookupResult, container, name, arity, options, useSiteInfo)
+        AddDiagnosticInfos(useSiteDiagnostics, useSiteInfo)
+    End Sub
+
+    Private Sub AddDiagnosticInfos(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo), useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
+        If useSiteInfo.Diagnostics IsNot Nothing Then
+            If useSiteDiagnostics Is Nothing Then
+                useSiteDiagnostics = DirectCast(useSiteInfo.Diagnostics, HashSet(Of DiagnosticInfo))
+            Else
+                useSiteDiagnostics.AddAll(useSiteInfo.Diagnostics)
+            End If
+        End If
+    End Sub
+
+    <Extension()>
+    Public Function IsBaseTypeOf(this As TypeSymbol, subType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+        Dim result = this.IsBaseTypeOf(subType, useSiteInfo)
+        AddDiagnosticInfos(useSiteDiagnostics, useSiteInfo)
+        Return result
+    End Function
+
+    <Extension()>
+    Public Function IsOrDerivedFrom(this As TypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+        Dim result = this.IsOrDerivedFrom(baseType, useSiteInfo)
+        AddDiagnosticInfos(useSiteDiagnostics, useSiteInfo)
+        Return result
+    End Function
+
+    <Extension>
+    Friend Sub Lookup(this As Binder,
+                      lookupResult As LookupResult,
+                      name As String,
+                      arity As Integer,
+                      options As LookupOptions,
+                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+        this.Lookup(lookupResult, name, arity, options, useSiteInfo)
+        AddDiagnosticInfos(useSiteDiagnostics, useSiteInfo)
+    End Sub
+
+    <Extension>
+    Friend Function GetBoundMethodBody(this As MethodSymbol, compilationState As TypeCompilationState, diagnostics As DiagnosticBag, <Out()> Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Return this.GetBoundMethodBody(compilationState, New BindingDiagnosticBag(diagnostics), methodBodyBinder)
+    End Function
+
 End Module

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -164,19 +164,19 @@ Friend Class MockNamedTypeSymbol
         End Get
     End Property
 
-    Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+    Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
         Throw New NotImplementedException()
     End Function
 
-    Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+    Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
         Throw New NotImplementedException()
     End Function
 
-    Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+    Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
         Throw New NotImplementedException()
     End Function
 
-    Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+    Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
         Throw New NotImplementedException()
     End Function
 

--- a/src/Compilers/VisualBasic/Portable/Binding/AttributeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/AttributeSemanticModel.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New AttributeSemanticModel(root, binder, parentSemanticModelOpt:=parentSemanticModel, speculatedPosition:=position)
         End Function
 
-        Friend Overrides Function Bind(binder As Binder, node As SyntaxNode, diagnostics As DiagnosticBag) As BoundNode
+        Friend Overrides Function Bind(binder As Binder, node As SyntaxNode, diagnostics As BindingDiagnosticBag) As BoundNode
             Debug.Assert(binder.IsSemanticModelBinder)
 
             Dim boundNode As BoundNode

--- a/src/Compilers/VisualBasic/Portable/Binding/BackstopBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BackstopBinder.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Overrides Function CheckAccessibility(sym As Symbol,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                      Optional accessThroughType As TypeSymbol = Nothing,
                                                      Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
             Throw ExceptionUtilities.Unreachable
@@ -91,24 +91,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Protected Overrides Function CreateBoundWithBlock(node As WithBlockSyntax, boundBlockBinder As Binder, diagnostics As DiagnosticBag) As BoundStatement
+        Protected Overrides Function CreateBoundWithBlock(node As WithBlockSyntax, boundBlockBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundStatement
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Friend Overrides Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Return ImmutableArray(Of Symbol).Empty
         End Function
 
-        Friend Overrides Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Return ImmutableArray(Of Symbol).Empty
         End Function
 
-        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Return ImmutableArray(Of Symbol).Empty
         End Function
 
         Protected Friend Overrides Function TryBindOmittedLeftForMemberAccess(node As MemberAccessExpressionSyntax,
-                                                                              diagnostics As DiagnosticBag,
+                                                                              diagnostics As BindingDiagnosticBag,
                                                                               accessingBinder As Binder,
                                                                               <Out> ByRef wholeMemberAccessExpressionBound As Boolean) As BoundExpression
             Return Nothing
@@ -116,16 +116,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Overrides Function TryBindOmittedLeftForDictionaryAccess(node As MemberAccessExpressionSyntax,
                                                                            accessingBinder As Binder,
-                                                                           diagnostics As DiagnosticBag) As BoundExpression
+                                                                           diagnostics As BindingDiagnosticBag) As BoundExpression
             Return Nothing
         End Function
 
-        Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As DiagnosticBag) As BoundExpression
+        Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return Nothing
         End Function
 
         Protected Friend Overrides Function TryBindOmittedLeftForXmlMemberAccess(node As XmlMemberAccessExpressionSyntax,
-                                                                                 diagnostics As DiagnosticBag,
+                                                                                 diagnostics As BindingDiagnosticBag,
                                                                                  accessingBinder As Binder) As BoundExpression
             Return Nothing
         End Function
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Public Overrides Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As DiagnosticBag) As LocalSymbol
+        Public Overrides Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As BindingDiagnosticBag) As LocalSymbol
             Throw ExceptionUtilities.Unreachable
         End Function
 
@@ -198,7 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Public Overrides Sub DisallowFurtherImplicitVariableDeclaration(diagnostics As DiagnosticBag)
+        Public Overrides Sub DisallowFurtherImplicitVariableDeclaration(diagnostics As BindingDiagnosticBag)
             ' No action needed.
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Binding/BasesBeingResolvedBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BasesBeingResolvedBinder.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Overrides Function CheckAccessibility(sym As Symbol,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                      Optional accessThroughType As TypeSymbol = Nothing,
                                                      Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
             ' Accessibility checking may involve looking at base types. We need to pass this accessibility
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 currentBasesBeingResolved = currentBasesBeingResolved.PrependImplementsBeingResolved(implementsBeingResolved)
             Next
 
-            Return m_containingBinder.CheckAccessibility(sym, useSiteDiagnostics, accessThroughType, currentBasesBeingResolved)
+            Return m_containingBinder.CheckAccessibility(sym, useSiteInfo, accessThroughType, currentBasesBeingResolved)
         End Function
     End Class
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -137,7 +137,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                           name As String,
                           arity As Integer,
                           options As LookupOptions,
-                          <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                          <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(name IsNot Nothing)
 
             Dim originalBinder As Binder = Me
@@ -150,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Do
                 currentResult.Clear()
-                currentBinder.LookupInSingleBinder(currentResult, name, arity, options, originalBinder, useSiteDiagnostics)
+                currentBinder.LookupInSingleBinder(currentResult, name, arity, options, originalBinder, useSiteInfo)
                 lookupResult.MergePrioritized(currentResult)
 
                 If lookupResult.StopFurtherLookup Then
@@ -206,7 +206,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     arity As Integer,
                                                     options As LookupOptions,
                                                     originalBinder As Binder,
-                                                    <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                    <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             lookupResult.Clear()
         End Sub
 
@@ -286,10 +286,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Overriding methods should consider <see cref="IgnoresAccessibility"/>.
         ''' </remarks>
         Public Overridable Function CheckAccessibility(sym As Symbol,
-                                                       <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                       <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                        Optional accessThroughType As TypeSymbol = Nothing,
                                                        Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
-            Return m_containingBinder.CheckAccessibility(sym, useSiteDiagnostics, accessThroughType, basesBeingResolved)
+            Return m_containingBinder.CheckAccessibility(sym, useSiteInfo, accessThroughType, basesBeingResolved)
         End Function
 
         ''' <summary>
@@ -298,10 +298,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' access with no qualifier).
         ''' </summary>
         Public Function IsAccessible(sym As Symbol,
-                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                      Optional accessThroughType As TypeSymbol = Nothing,
                                      Optional basesBeingResolved As BasesBeingResolved = Nothing) As Boolean
-            Return CheckAccessibility(sym, useSiteDiagnostics, accessThroughType, basesBeingResolved) = AccessCheckResult.Accessible
+            Return CheckAccessibility(sym, useSiteInfo, accessThroughType, basesBeingResolved) = AccessCheckResult.Accessible
         End Function
 
         ''' <summary>
@@ -422,27 +422,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="typeId">Type to get</param>
         ''' <param name="node">Where to report the error, if any.</param>
-        Public Function GetSpecialType(typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag) As NamedTypeSymbol
+        Public Function GetSpecialType(typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As BindingDiagnosticBag) As NamedTypeSymbol
             Dim reportedAnError As Boolean = False
-            Return GetSpecialType(SourceModule.ContainingAssembly, typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
+            Return GetSpecialType(Compilation, typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
         End Function
 
-        Public Shared Function GetSpecialType(assembly As AssemblySymbol, typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag) As NamedTypeSymbol
+        Public Shared Function GetSpecialType(compilation As VisualBasicCompilation, typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As BindingDiagnosticBag) As NamedTypeSymbol
             Dim reportedAnError As Boolean = False
-            Return GetSpecialType(assembly, typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
+            Return GetSpecialType(compilation, typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
         End Function
 
-        Public Function GetSpecialType(typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag, ByRef reportedAnError As Boolean, suppressUseSiteError As Boolean) As NamedTypeSymbol
-            Return GetSpecialType(SourceModule.ContainingAssembly, typeId, node, diagBag, reportedAnError, suppressUseSiteError)
+        Public Function GetSpecialType(typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As BindingDiagnosticBag, ByRef reportedAnError As Boolean, suppressUseSiteError As Boolean) As NamedTypeSymbol
+            Return GetSpecialType(Compilation, typeId, node, diagBag, reportedAnError, suppressUseSiteError)
         End Function
 
-        Public Shared Function GetSpecialType(assembly As AssemblySymbol, typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag, ByRef reportedAnError As Boolean, suppressUseSiteError As Boolean) As NamedTypeSymbol
-            Dim symbol As NamedTypeSymbol = assembly.GetSpecialType(typeId)
+        Public Shared Function GetSpecialType(compilation As VisualBasicCompilation, typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As BindingDiagnosticBag, ByRef reportedAnError As Boolean, suppressUseSiteError As Boolean) As NamedTypeSymbol
+            Dim symbol As NamedTypeSymbol = compilation.GetSpecialType(typeId)
 
             If diagBag IsNot Nothing Then
-                Dim info = GetUseSiteErrorForSpecialType(symbol, suppressUseSiteError)
-                If info IsNot Nothing Then
-                    ReportDiagnostic(diagBag, node, info)
+                Dim info = GetUseSiteInfoForSpecialType(symbol, suppressUseSiteError)
+                If ReportUseSite(diagBag, node, info) Then
                     reportedAnError = True
                 End If
             End If
@@ -450,13 +449,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return symbol
         End Function
 
-        Friend Shared Function GetUseSiteErrorForSpecialType(type As TypeSymbol, Optional suppressUseSiteError As Boolean = False) As DiagnosticInfo
-            Dim info As DiagnosticInfo = Nothing
+        Friend Shared Function GetUseSiteInfoForSpecialType(type As TypeSymbol, Optional suppressUseSiteInfo As Boolean = False) As UseSiteInfo(Of AssemblySymbol)
+            Dim info As UseSiteInfo(Of AssemblySymbol) = Nothing
             If type.TypeKind = TypeKind.Error AndAlso TypeOf type Is MissingMetadataTypeSymbol.TopLevel Then
                 Dim missing = DirectCast(type, MissingMetadataTypeSymbol.TopLevel)
-                info = ErrorFactory.ErrorInfo(ERRID.ERR_UndefinedType1, MetadataHelpers.BuildQualifiedName(missing.NamespaceName, missing.Name))
-            ElseIf Not suppressUseSiteError Then
-                info = type.GetUseSiteErrorInfo()
+                info = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UndefinedType1, MetadataHelpers.BuildQualifiedName(missing.NamespaceName, missing.Name)))
+            ElseIf Not suppressUseSiteInfo Then
+                info = type.GetUseSiteInfo()
             End If
             Return info
         End Function
@@ -465,33 +464,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' This is a layer on top of the Compilation version that generates a diagnostic if the well-known
         ''' type isn't found.
         ''' </summary>
-        Friend Function GetWellKnownType(type As WellKnownType, syntax As SyntaxNode, diagBag As DiagnosticBag) As NamedTypeSymbol
+        Friend Function GetWellKnownType(type As WellKnownType, syntax As SyntaxNode, diagBag As BindingDiagnosticBag) As NamedTypeSymbol
             Return GetWellKnownType(Me.Compilation, type, syntax, diagBag)
         End Function
 
-        Friend Shared Function GetWellKnownType(compilation As VisualBasicCompilation, type As WellKnownType, syntax As SyntaxNode, diagBag As DiagnosticBag) As NamedTypeSymbol
+        Friend Shared Function GetWellKnownType(compilation As VisualBasicCompilation, type As WellKnownType, syntax As SyntaxNode, diagBag As BindingDiagnosticBag) As NamedTypeSymbol
             Dim typeSymbol As NamedTypeSymbol = compilation.GetWellKnownType(type)
             Debug.Assert(typeSymbol IsNot Nothing)
 
-            Dim useSiteError = GetUseSiteErrorForWellKnownType(typeSymbol)
-            If useSiteError IsNot Nothing Then
-                ReportDiagnostic(diagBag, syntax, useSiteError)
-            End If
+            Dim useSiteInfo = GetUseSiteInfoForWellKnownType(typeSymbol)
+            ReportUseSite(diagBag, syntax, useSiteInfo)
 
             Return typeSymbol
         End Function
 
-        Friend Shared Function GetUseSiteErrorForWellKnownType(type As TypeSymbol) As DiagnosticInfo
-            Return type.GetUseSiteErrorInfo()
+        Friend Shared Function GetUseSiteInfoForWellKnownType(type As TypeSymbol) As UseSiteInfo(Of AssemblySymbol)
+            Return type.GetUseSiteInfo()
         End Function
 
-        Private Function GetInternalXmlHelperType(syntax As VisualBasicSyntaxNode, diagBag As DiagnosticBag) As NamedTypeSymbol
+        Private Function GetInternalXmlHelperType(syntax As VisualBasicSyntaxNode, diagBag As BindingDiagnosticBag) As NamedTypeSymbol
             Dim typeSymbol = GetInternalXmlHelperType()
 
-            Dim useSiteError = GetUseSiteErrorForWellKnownType(typeSymbol)
-            If useSiteError IsNot Nothing Then
-                ReportDiagnostic(diagBag, syntax, useSiteError)
-            End If
+            Dim useSiteInfo = GetUseSiteInfoForWellKnownType(typeSymbol)
+            ReportUseSite(diagBag, syntax, useSiteInfo)
 
             Return typeSymbol
         End Function
@@ -549,68 +544,72 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' This is a layer on top of the assembly version that generates a diagnostic if the well-known
         ''' member isn't found.
         ''' </summary>
-        Friend Function GetSpecialTypeMember(member As SpecialMember, syntax As SyntaxNode, diagnostics As DiagnosticBag) As Symbol
+        Friend Function GetSpecialTypeMember(member As SpecialMember, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag) As Symbol
             Return GetSpecialTypeMember(Me.ContainingMember.ContainingAssembly, member, syntax, diagnostics)
         End Function
 
-        Friend Shared Function GetSpecialTypeMember(assembly As AssemblySymbol, member As SpecialMember, syntax As SyntaxNode, diagnostics As DiagnosticBag) As Symbol
-            Dim useSiteError As DiagnosticInfo = Nothing
-            Dim specialMemberSymbol As Symbol = GetSpecialTypeMember(assembly, member, useSiteError)
-
-            If useSiteError IsNot Nothing Then
-                ReportDiagnostic(diagnostics, syntax, useSiteError)
-            End If
+        Friend Shared Function GetSpecialTypeMember(assembly As AssemblySymbol, member As SpecialMember, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag) As Symbol
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim specialMemberSymbol As Symbol = GetSpecialTypeMember(assembly, member, useSiteInfo)
+            ReportUseSite(diagnostics, syntax, useSiteInfo)
 
             Return specialMemberSymbol
         End Function
 
-        Friend Shared Function GetSpecialTypeMember(assembly As AssemblySymbol, member As SpecialMember, ByRef useSiteError As DiagnosticInfo) As Symbol
+        Friend Shared Function GetSpecialTypeMember(assembly As AssemblySymbol, member As SpecialMember, <Out> ByRef useSiteInfo As UseSiteInfo(Of AssemblySymbol)) As Symbol
             Dim specialMemberSymbol As Symbol = assembly.GetSpecialTypeMember(member)
 
             If specialMemberSymbol Is Nothing Then
                 Dim memberDescriptor As MemberDescriptor = SpecialMembers.GetDescriptor(member)
-                useSiteError = ErrorFactory.ErrorInfo(ERRID.ERR_MissingRuntimeHelper, memberDescriptor.DeclaringTypeMetadataName & "." & memberDescriptor.Name)
+                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_MissingRuntimeHelper, memberDescriptor.DeclaringTypeMetadataName & "." & memberDescriptor.Name))
             Else
-                useSiteError = If(specialMemberSymbol.GetUseSiteErrorInfo(), specialMemberSymbol.ContainingType.GetUseSiteErrorInfo())
+                useSiteInfo = GetUseSiteInfoForMemberAndContainingType(specialMemberSymbol)
             End If
 
             Return specialMemberSymbol
+        End Function
+
+        Friend Shared Function GetUseSiteInfoForMemberAndContainingType(member As Symbol) As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = member.GetUseSiteInfo()
+
+            If useSiteInfo.DiagnosticInfo Is Nothing Then
+                Symbol.MergeUseSiteInfo(useSiteInfo, member.ContainingType.GetUseSiteInfo(), highestPriorityUseSiteError:=0)
+            End If
+
+            Return useSiteInfo
         End Function
 
         ''' <summary>
         ''' This is a layer on top of the Compilation version that generates a diagnostic if the well-known
         ''' member isn't found.
         ''' </summary>
-        Friend Function GetWellKnownTypeMember(member As WellKnownMember, syntax As SyntaxNode, diagBag As DiagnosticBag) As Symbol
+        Friend Function GetWellKnownTypeMember(member As WellKnownMember, syntax As SyntaxNode, diagBag As BindingDiagnosticBag) As Symbol
             Return GetWellKnownTypeMember(Me.Compilation, member, syntax, diagBag)
         End Function
 
-        Friend Shared Function GetWellKnownTypeMember(compilation As VisualBasicCompilation, member As WellKnownMember, syntax As SyntaxNode, diagBag As DiagnosticBag) As Symbol
-            Dim useSiteError As DiagnosticInfo = Nothing
-            Dim memberSymbol As Symbol = GetWellKnownTypeMember(compilation, member, useSiteError)
-
-            If useSiteError IsNot Nothing Then
-                ReportDiagnostic(diagBag, syntax, useSiteError)
-            End If
+        Friend Shared Function GetWellKnownTypeMember(compilation As VisualBasicCompilation, member As WellKnownMember, syntax As SyntaxNode, diagBag As BindingDiagnosticBag) As Symbol
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim memberSymbol As Symbol = GetWellKnownTypeMember(compilation, member, useSiteInfo)
+            ReportUseSite(diagBag, syntax, useSiteInfo)
 
             Return memberSymbol
         End Function
 
-        Friend Shared Function GetWellKnownTypeMember(compilation As VisualBasicCompilation, member As WellKnownMember, ByRef useSiteError As DiagnosticInfo) As Symbol
+        Friend Shared Function GetWellKnownTypeMember(compilation As VisualBasicCompilation, member As WellKnownMember, <Out> ByRef useSiteInfo As UseSiteInfo(Of AssemblySymbol)) As Symbol
             Dim memberSymbol As Symbol = compilation.GetWellKnownTypeMember(member)
 
-            useSiteError = GetUseSiteErrorForWellKnownTypeMember(memberSymbol, member, compilation.Options.EmbedVbCoreRuntime)
+            useSiteInfo = GetUseSiteInfoForWellKnownTypeMember(memberSymbol, member, compilation.Options.EmbedVbCoreRuntime)
 
             Return memberSymbol
         End Function
 
-        Friend Shared Function GetUseSiteErrorForWellKnownTypeMember(memberSymbol As Symbol, member As WellKnownMember, embedVBRuntimeUsed As Boolean) As DiagnosticInfo
+        Friend Shared Function GetUseSiteInfoForWellKnownTypeMember(memberSymbol As Symbol, member As WellKnownMember, embedVBRuntimeUsed As Boolean) As UseSiteInfo(Of AssemblySymbol)
             If memberSymbol Is Nothing Then
                 Dim memberDescriptor As MemberDescriptor = WellKnownMembers.GetDescriptor(member)
 
-                Return GetDiagnosticForMissingRuntimeHelper(memberDescriptor.DeclaringTypeMetadataName, memberDescriptor.Name, embedVBRuntimeUsed)
+                Return New UseSiteInfo(Of AssemblySymbol)(GetDiagnosticForMissingRuntimeHelper(memberDescriptor.DeclaringTypeMetadataName, memberDescriptor.Name, embedVBRuntimeUsed))
             Else
-                Return If(memberSymbol.GetUseSiteErrorInfo(), memberSymbol.ContainingType.GetUseSiteErrorInfo())
+                Return GetUseSiteInfoForMemberAndContainingType(memberSymbol)
             End If
         End Function
 
@@ -778,7 +777,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Declare an implicit local variable. The type of the local is determined
         ''' by the type character (if any) on the variable.
         ''' </summary>
-        Public Overridable Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As DiagnosticBag) As LocalSymbol
+        Public Overridable Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As BindingDiagnosticBag) As LocalSymbol
             Debug.Assert(Not Me.AllImplicitVariableDeclarationsAreHandled)
             Return m_containingBinder.DeclareImplicitLocalVariable(nameSyntax, diagnostics)
         End Function
@@ -796,7 +795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Disallow additional local variable declaration and report delayed shadowing diagnostics.
         ''' </summary>
         ''' <remarks></remarks>
-        Public Overridable Sub DisallowFurtherImplicitVariableDeclaration(diagnostics As DiagnosticBag)
+        Public Overridable Sub DisallowFurtherImplicitVariableDeclaration(diagnostics As BindingDiagnosticBag)
             m_containingBinder.DisallowFurtherImplicitVariableDeclaration(diagnostics)
         End Sub
 
@@ -891,13 +890,51 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             diagBag.Add(diag)
         End Sub
 
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, syntax As SyntaxNodeOrToken, id As ERRID)
+            ReportDiagnostic(diagBag, syntax, ErrorFactory.ErrorInfo(id))
+        End Sub
+
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, syntax As SyntaxNodeOrToken, id As ERRID, ParamArray args As Object())
+            ReportDiagnostic(diagBag, syntax, ErrorFactory.ErrorInfo(id, args))
+        End Sub
+
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, syntax As SyntaxNodeOrToken, info As DiagnosticInfo)
+            Dim diag As New VBDiagnostic(info, syntax.GetLocation())
+            ReportDiagnostic(diagBag, diag)
+        End Sub
+
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, location As Location, id As ERRID)
+            ReportDiagnostic(diagBag, location, ErrorFactory.ErrorInfo(id))
+        End Sub
+
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, location As Location, id As ERRID, ParamArray args As Object())
+            ReportDiagnostic(diagBag, location, ErrorFactory.ErrorInfo(id, args))
+        End Sub
+
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, location As Location, info As DiagnosticInfo)
+            Dim diag As New VBDiagnostic(info, location)
+            ReportDiagnostic(diagBag, diag)
+        End Sub
+
+        Public Shared Sub ReportDiagnostic(diagBag As BindingDiagnosticBag, diag As Diagnostic)
+            diagBag.Add(diag)
+        End Sub
+
+        Public Shared Function ReportUseSite(diagBag As BindingDiagnosticBag, syntax As SyntaxNodeOrToken, useSiteInfo As UseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return diagBag.Add(useSiteInfo, syntax.GetLocation())
+        End Function
+
+        Public Shared Function ReportUseSite(diagBag As BindingDiagnosticBag, location As Location, useSiteInfo As UseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return diagBag.Add(useSiteInfo, location)
+        End Function
+
         ''' <summary>
         ''' Issue an error or warning for a symbol if it is Obsolete. If there is not enough
         ''' information to report diagnostics, then store the symbols so that diagnostics
         ''' can be reported at a later stage.
         ''' Also, check runtime support for the symbol.
         ''' </summary>
-        Friend Sub ReportDiagnosticsIfObsoleteOrNotSupportedByRuntime(diagnostics As DiagnosticBag, symbol As Symbol, node As SyntaxNode)
+        Friend Sub ReportDiagnosticsIfObsoleteOrNotSupportedByRuntime(diagnostics As BindingDiagnosticBag, symbol As Symbol, node As SyntaxNode)
             If Not Me.SuppressObsoleteDiagnostics Then
                 ReportDiagnosticsIfObsolete(diagnostics, Me.ContainingMember, symbol, node)
             End If
@@ -923,7 +960,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Friend Shared Sub ReportDiagnosticsIfObsolete(diagnostics As DiagnosticBag, context As Symbol, symbol As Symbol, node As SyntaxNode)
+        Friend Shared Sub ReportDiagnosticsIfObsolete(diagnostics As BindingDiagnosticBag, context As Symbol, symbol As Symbol, node As SyntaxNode)
             Dim kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(context, symbol)
 
             Dim info As DiagnosticInfo = Nothing
@@ -1013,22 +1050,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Some attributes are considered to be optional (e.g. the CompilerGeneratedAttribute). In this case the use site
         ''' errors will be ignored.
         ''' </summary>
-        Friend Function ReportUseSiteErrorForSynthesizedAttribute(
+        Friend Function ReportUseSiteInfoForSynthesizedAttribute(
             attributeCtor As WellKnownMember,
             syntax As VisualBasicSyntaxNode,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
-            Dim useSiteError As DiagnosticInfo = Nothing
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
 
-            Dim ctor As Symbol = GetWellKnownTypeMember(Me.Compilation, attributeCtor, useSiteError)
+            Dim ctor As Symbol = GetWellKnownTypeMember(Me.Compilation, attributeCtor, useSiteInfo)
 
             If Not WellKnownMembers.IsSynthesizedAttributeOptional(attributeCtor) Then
                 Debug.Assert(diagnostics IsNot Nothing)
 
-                If useSiteError IsNot Nothing Then
-                    ReportDiagnostic(diagnostics, syntax, useSiteError)
+                If ReportUseSite(diagnostics, syntax, useSiteInfo) Then
                     Return True
                 End If
+            Else
+                diagnostics.AddDependencies(useSiteInfo)
             End If
 
             Return False
@@ -1039,22 +1077,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Some attributes are considered to be optional (e.g. the CompilerGeneratedAttribute). In this case the use site
         ''' errors will be ignored.
         ''' </summary>
-        Friend Shared Function ReportUseSiteErrorForSynthesizedAttribute(
+        Friend Shared Function ReportUseSiteInfoForSynthesizedAttribute(
             attributeCtor As WellKnownMember,
             compilation As VisualBasicCompilation,
             location As Location,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
             Dim memberSymbol = compilation.GetWellKnownTypeMember(attributeCtor)
-            Dim useSiteError As DiagnosticInfo = GetUseSiteErrorForWellKnownTypeMember(memberSymbol, attributeCtor, compilation.Options.EmbedVbCoreRuntime)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = GetUseSiteInfoForWellKnownTypeMember(memberSymbol, attributeCtor, compilation.Options.EmbedVbCoreRuntime)
 
             If Not WellKnownMembers.IsSynthesizedAttributeOptional(attributeCtor) Then
                 Debug.Assert(diagnostics IsNot Nothing)
 
-                If useSiteError IsNot Nothing Then
-                    diagnostics.Add(New VBDiagnostic(useSiteError, location))
+                If diagnostics.Add(useSiteInfo, location) Then
                     Return True
                 End If
+            Else
+                diagnostics.AddDependencies(useSiteInfo)
             End If
 
             Return False

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_AnonymousTypes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_AnonymousTypes.vb
@@ -16,14 +16,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Partial Friend Class Binder
 
-        Private Function BindAnonymousObjectCreationExpression(node As AnonymousObjectCreationExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindAnonymousObjectCreationExpression(node As AnonymousObjectCreationExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return AnonymousTypeCreationBinder.BindAnonymousObjectInitializer(Me, node, node.Initializer, node.NewKeyword, diagnostics)
         End Function
 
         Private Function BindAnonymousObjectCreationExpression(node As VisualBasicSyntaxNode,
                                                                typeDescr As AnonymousTypeDescriptor,
                                                                initExpressions As ImmutableArray(Of BoundExpression),
-                                                               diagnostics As DiagnosticBag) As BoundExpression
+                                                               diagnostics As BindingDiagnosticBag) As BoundExpression
             '  Check for restricted types.
             For Each field As AnonymousTypeField In typeDescr.Fields
                 Dim restrictedType As TypeSymbol = Nothing
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                   owningSyntax As VisualBasicSyntaxNode,
                                                                   initializerSyntax As ObjectMemberInitializerSyntax,
                                                                   typeLocationToken As SyntaxToken,
-                                                                  diagnostics As DiagnosticBag) As BoundExpression
+                                                                  diagnostics As BindingDiagnosticBag) As BoundExpression
 
                 Dim fieldsCount = initializerSyntax.Initializers.Count
 
@@ -120,7 +120,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Private Sub New(containingBinder As Binder,
                             initializerSyntax As ObjectMemberInitializerSyntax,
-                            diagnostics As DiagnosticBag)
+                            diagnostics As BindingDiagnosticBag)
                 MyBase.New(containingBinder)
 
                 Dim objectType As TypeSymbol = GetSpecialType(SpecialType.System_Object, initializerSyntax, diagnostics)
@@ -206,7 +206,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Private Function BindInitializersAndCreateBoundNode(owningSyntax As VisualBasicSyntaxNode,
                                                                 initializerSyntax As ObjectMemberInitializerSyntax,
-                                                                diagnostics As DiagnosticBag,
+                                                                diagnostics As BindingDiagnosticBag,
                                                                 typeLocationToken As SyntaxToken) As BoundExpression
                 Dim fieldsCount As Integer = Me._fields.Length
 
@@ -376,7 +376,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 #Region "Binding of member access with omitted left like '.fieldName'"
 
             Protected Friend Overrides Function TryBindOmittedLeftForMemberAccess(node As MemberAccessExpressionSyntax,
-                                                                                  diagnostics As DiagnosticBag,
+                                                                                  diagnostics As BindingDiagnosticBag,
                                                                                   accessingBinder As Binder,
                                                                                   <Out> ByRef wholeMemberAccessExpressionBound As Boolean) As BoundExpression
                 wholeMemberAccessExpressionBound = True
@@ -460,14 +460,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return BadExpression(node, ErrorTypeSymbol.UnknownResultType)
             End Function
 
-            Protected Overrides Function TryBindOmittedLeftForDictionaryAccess(node As MemberAccessExpressionSyntax, accessingBinder As Binder, diagnostics As DiagnosticBag) As BoundExpression
+            Protected Overrides Function TryBindOmittedLeftForDictionaryAccess(node As MemberAccessExpressionSyntax, accessingBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundExpression
                 ' NOTE: since we don't have the symbol of the anonymous type, we use 
                 '       "<anonymous type>" literal to be consistent with Dev10
                 ReportDiagnostic(diagnostics, node, ERRID.ERR_NoDefaultNotExtend1, StringConstants.AnonymousTypeName)
                 Return BadExpression(node, ErrorTypeSymbol.UnknownResultType)
             End Function
 
-            Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As DiagnosticBag) As BoundExpression
+            Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundExpression
                 Return Nothing
             End Function
 #End Region

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Shared Function BindAttributeTypes(binders As ImmutableArray(Of Binder),
                                                   attributesToBind As ImmutableArray(Of AttributeSyntax),
                                                   ownerSymbol As Symbol,
-                                                  diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+                                                  diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Debug.Assert(binders.Any())
             Debug.Assert(attributesToBind.Any())
             Debug.Assert(ownerSymbol IsNot Nothing)
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Shared Function BindAttributeType(binder As Binder,
                                                  attribute As AttributeSyntax,
                                                  ownerSymbol As Symbol,
-                                                 diagnostics As DiagnosticBag) As NamedTypeSymbol
+                                                 diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             binder = New LocationSpecificBinder(VisualBasic.BindingLocation.Attribute, ownerSymbol, binder)
             Return DirectCast(binder.BindTypeSyntax(attribute.Name, diagnostics), NamedTypeSymbol)
         End Function
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         boundAttributeTypes As ImmutableArray(Of NamedTypeSymbol),
                                         attributeBuilder As VisualBasicAttributeData(),
                                         ownerSymbol As Symbol,
-                                        diagnostics As DiagnosticBag)
+                                        diagnostics As BindingDiagnosticBag)
             Debug.Assert(Not binders.IsEmpty)
             Debug.Assert(Not attributesToBind.IsEmpty)
             Debug.Assert(binders.Length = attributesToBind.Length)
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 #End Region
 
 #Region "Get Single Attribute"
-        Friend Function GetAttribute(node As AttributeSyntax, boundAttributeType As NamedTypeSymbol, diagnostics As DiagnosticBag) As SourceAttributeData
+        Friend Function GetAttribute(node As AttributeSyntax, boundAttributeType As NamedTypeSymbol, diagnostics As BindingDiagnosticBag) As SourceAttributeData
             Dim boundAttribute As boundAttribute = BindAttribute(node, boundAttributeType, diagnostics)
 
             Dim visitor As New AttributeExpressionVisitor(Me, boundAttribute.HasErrors)
@@ -109,7 +109,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #Region "Bind Single Attribute"
 
-        Friend Function BindAttribute(node As AttributeSyntax, diagnostics As DiagnosticBag) As BoundAttribute
+        Friend Function BindAttribute(node As AttributeSyntax, diagnostics As BindingDiagnosticBag) As BoundAttribute
             Dim namedType As NamedTypeSymbol = DirectCast(BindTypeSyntax(node.Name, diagnostics), NamedTypeSymbol)
 
             Return BindAttribute(node, namedType, diagnostics)
@@ -119,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     container As NamespaceOrTypeSymbol,
                     name As String,
                     options As LookupOptions,
-                    <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                    <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             Debug.Assert(lookupResult.IsClear)
             Debug.Assert(options.IsValid())
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             options = options Or LookupOptions.IgnoreExtensionMethods
 
-            Lookup(lookupResult, container, name & "Attribute", options, useSiteDiagnostics)
+            Lookup(lookupResult, container, name & "Attribute", options, useSiteInfo)
 
             ' If no result is found then do a second lookup without the attribute suffix. 
             ' The result is that namespace symbols or inaccessible symbols with the attribute 
@@ -138,7 +138,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If lookupResult.IsClear OrElse lookupResult.IsWrongArity Then
                 lookupResult.Clear()
-                Lookup(lookupResult, container, name, options, useSiteDiagnostics)
+                Lookup(lookupResult, container, name, options, useSiteInfo)
             End If
 
             If Not lookupResult.IsGood Then
@@ -147,23 +147,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Found a good symbol, now check that it is appropriate to use as an attribute.
-            CheckAttributeTypeViability(lookupResult)
+            CheckAttributeTypeViability(lookupResult, useSiteInfo)
         End Sub
 
         Private Sub Lookup(lookupResult As LookupResult,
              container As NamespaceOrTypeSymbol,
              name As String,
              options As LookupOptions,
-             <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+             <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             If container IsNot Nothing Then
-                LookupMember(lookupResult, container, name, 0, options, useSiteDiagnostics)
+                LookupMember(lookupResult, container, name, 0, options, useSiteInfo)
             Else
-                Lookup(lookupResult, name, 0, options, useSiteDiagnostics)
+                Lookup(lookupResult, name, 0, options, useSiteInfo)
             End If
         End Sub
 
-        Private Sub CheckAttributeTypeViability(lookupResult As LookupResult)
+        Private Sub CheckAttributeTypeViability(lookupResult As LookupResult, ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.HasSingleSymbol AndAlso lookupResult.IsGood)
 
             ' For error reporting, check the unwrapped symbol. However, return the unwrapped alias symbol if it is an alias.  
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Else
                 Dim namedType = DirectCast(symbol, NamedTypeSymbol)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim localUseSiteInfo = If(useSiteInfo.IsDiscarded, CompoundUseSiteInfo(Of AssemblySymbol).Discarded, Nothing)
 
                 ' type cannot be generic
                 If namedType.IsGenericType Then
@@ -196,11 +196,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     errorId = ERRID.ERR_AttributeMustBeClassNotStruct1
 
                     ' type must inherit from System.Attribute
-                ElseIf Not Compilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(namedType, useSiteDiagnostics) Then
+                ElseIf Not Compilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(namedType, localUseSiteInfo) Then
                     errorId = ERRID.ERR_AttributeMustInheritSysAttr
 
-                    If Not useSiteDiagnostics.IsNullOrEmpty() Then
-                        diagInfo = useSiteDiagnostics.First()
+                    If Not localUseSiteInfo.Diagnostics.IsNullOrEmpty() Then
+                        diagInfo = localUseSiteInfo.Diagnostics.First()
                     End If
 
                     ' type can not be "mustinherit"
@@ -210,6 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Else
                     ' Return the symbol from the lookup result. In the case of an alias, it will be the alias symbol not
                     ' the unwrapped symbol.  This is the convention for lookup methods.
+                    useSiteInfo.MergeAndClear(localUseSiteInfo)
                     Return
                 End If
 
@@ -224,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return
         End Sub
 
-        Friend Function BindAttribute(node As AttributeSyntax, type As NamedTypeSymbol, diagnostics As DiagnosticBag) As BoundAttribute
+        Friend Function BindAttribute(node As AttributeSyntax, type As NamedTypeSymbol, diagnostics As BindingDiagnosticBag) As BoundAttribute
 
             ' If attribute name bound to an error type with a single named type
             ' candidate symbol, we want to bind the attribute constructor
@@ -256,8 +257,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Not attributeTypeForBinding.IsErrorType() Then
 
                 ' Filter out inaccessible constructors 
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim accessibleConstructors = GetAccessibleConstructors(attributeTypeForBinding, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim accessibleConstructors = GetAccessibleConstructors(attributeTypeForBinding, useSiteInfo)
 
                 If accessibleConstructors.Length = 0 Then
                     ' TODO: we may want to fix the behavior of the Lookup result to contain more than one e.g. inaccessible symbol. 
@@ -267,7 +268,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' Having multiple bad symbols in a LookupResult was tried already by acasey, but getting this right is pretty
                     ' complicated and a performance hit (multiple diagnostics, ...).
 
-                    diagnostics.Add(node, useSiteDiagnostics)
+                    diagnostics.Add(node, useSiteInfo)
 
                     ' Avoid cascading diagnostics
                     If Not type.IsErrorType() Then
@@ -283,11 +284,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim constructorsGroup = New BoundMethodGroup(node.Name, Nothing, accessibleConstructors, LookupResultKind.Good, Nothing, QualificationKind.QualifiedViaTypeName)
 
                     Dim results As OverloadResolution.OverloadResolutionResult = OverloadResolution.MethodInvocationOverloadResolution(constructorsGroup, boundArguments, Nothing, Me, callerInfoOpt:=node.Name,
-                                                                                                                                       useSiteDiagnostics:=useSiteDiagnostics)
+                                                                                                                                       useSiteInfo:=useSiteInfo)
 
-                    If diagnostics.Add(node.Name, useSiteDiagnostics) Then
+                    If diagnostics.Add(node.Name, useSiteInfo) Then
                         ' Suppress additional diagnostics
-                        diagnostics = New DiagnosticBag()
+                        diagnostics = BindingDiagnosticBag.Discarded
                     End If
 
                     If Not results.BestResult.HasValue Then
@@ -298,7 +299,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             ' Create and report the diagnostic.
                             If results.Candidates.Length = 0 Then
                                 results = OverloadResolution.MethodInvocationOverloadResolution(constructorsGroup, boundArguments, Nothing, Me, includeEliminatedCandidates:=True, callerInfoOpt:=node.Name,
-                                                                                                useSiteDiagnostics:=useSiteDiagnostics)
+                                                                                                useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                             End If
 
                             ' Report overload resolution but do not use the bound node result. We always want to return a
@@ -375,7 +376,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindAttributeArguments(
             type As NamedTypeSymbol,
             argumentListOpt As ArgumentListSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
         ) As AnalyzedAttributeArguments
 
             Dim boundArguments As ImmutableArray(Of BoundExpression)
@@ -429,14 +430,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindAttributeNamedArgument(container As TypeSymbol,
                                                     namedArg As SimpleArgumentSyntax,
-                                                    diagnostics As DiagnosticBag) As BoundExpression
+                                                    diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(namedArg.IsNamed)
             ' Bind the named argument
             Dim result As LookupResult = LookupResult.GetInstance()
             Dim identifierName As IdentifierNameSyntax = namedArg.NameColonEquals.Name
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            LookupMember(result, container, identifierName.Identifier.ValueText, 0, LookupOptions.IgnoreExtensionMethods, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            LookupMember(result, container, identifierName.Identifier.ValueText, 0, LookupOptions.IgnoreExtensionMethods, useSiteInfo)
 
             ' Validating the expression is done when the bound expression is converted to a TypedConstant
             Dim rValue As BoundExpression = Me.BindValue(namedArg.Expression, diagnostics)
@@ -475,7 +476,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 hasErrors = True
                             End If
 
-                            If Not IsAccessible(setMethod, useSiteDiagnostics) Then
+                            If Not IsAccessible(setMethod, useSiteInfo) Then
                                 ReportDiagnostic(diagnostics, identifierName, ERRID.ERR_InaccessibleMember3,
                                                    propertySym.ContainingSymbol,
                                                    propertySym,
@@ -539,7 +540,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 rValue = MakeRValue(rValue, diagnostics)
             End If
 
-            diagnostics.Add(namedArg, useSiteDiagnostics)
+            diagnostics.Add(namedArg, useSiteInfo)
             result.Free()
 
             Dim namedArgExpr = New BoundAssignmentOperator(namedArg, lValue, rValue, True)
@@ -668,11 +669,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Get
             End Property
 
-            Public Function VisitPositionalArguments(arguments As ImmutableArray(Of BoundExpression), diag As DiagnosticBag) As ImmutableArray(Of TypedConstant)
+            Public Function VisitPositionalArguments(arguments As ImmutableArray(Of BoundExpression), diag As BindingDiagnosticBag) As ImmutableArray(Of TypedConstant)
                 Return VisitArguments(arguments, diag)
             End Function
 
-            Private Function VisitArguments(arguments As ImmutableArray(Of BoundExpression), diag As DiagnosticBag) As ImmutableArray(Of TypedConstant)
+            Private Function VisitArguments(arguments As ImmutableArray(Of BoundExpression), diag As BindingDiagnosticBag) As ImmutableArray(Of TypedConstant)
                 Dim builder As ArrayBuilder(Of TypedConstant) = Nothing
                 For Each exp In arguments
                     If builder Is Nothing Then
@@ -688,7 +689,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return builder.ToImmutableAndFree
             End Function
 
-            Public Function VisitNamedArguments(arguments As ImmutableArray(Of BoundExpression), diag As DiagnosticBag) As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
+            Public Function VisitNamedArguments(arguments As ImmutableArray(Of BoundExpression), diag As BindingDiagnosticBag) As ImmutableArray(Of KeyValuePair(Of String, TypedConstant))
                 Dim builder As ArrayBuilder(Of KeyValuePair(Of String, TypedConstant)) = Nothing
                 For Each namedArg In arguments
 
@@ -710,7 +711,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return builder.ToImmutableAndFree
             End Function
 
-            Private Function VisitNamedArgument(argument As BoundExpression, diag As DiagnosticBag) As Nullable(Of KeyValuePair(Of String, TypedConstant))
+            Private Function VisitNamedArgument(argument As BoundExpression, diag As BindingDiagnosticBag) As Nullable(Of KeyValuePair(Of String, TypedConstant))
                 Select Case argument.Kind
                     Case BoundKind.AssignmentOperator
                         Dim assignment = DirectCast(argument, BoundAssignmentOperator)
@@ -730,7 +731,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing
             End Function
 
-            Public Function VisitExpression(node As BoundExpression, diagBag As DiagnosticBag) As TypedConstant
+            Public Function VisitExpression(node As BoundExpression, diagBag As BindingDiagnosticBag) As TypedConstant
                 Do
                     If node.IsConstant Then
                         If _binder.IsValidTypeForAttributeArgument(node.Type) Then
@@ -812,7 +813,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Loop
             End Function
 
-            Private Function VisitGetType(node As BoundGetType, diagBag As DiagnosticBag) As TypedConstant
+            Private Function VisitGetType(node As BoundGetType, diagBag As BindingDiagnosticBag) As TypedConstant
                 Dim sourceType = node.SourceType
                 Dim getTypeArgument = sourceType.Type
 
@@ -834,7 +835,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return CreateTypedConstant(node.Type, getTypeArgument)
             End Function
 
-            Private Function VisitArrayCreation(node As BoundArrayCreation, diag As DiagnosticBag) As TypedConstant
+            Private Function VisitArrayCreation(node As BoundArrayCreation, diag As BindingDiagnosticBag) As TypedConstant
                 Dim type = DirectCast(node.Type, ArrayTypeSymbol)
 
                 Dim values As ImmutableArray(Of TypedConstant) = Nothing

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ConditionalAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ConditionalAccess.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
     Friend Partial Class Binder
 
-        Private Function BindConditionalAccessExpression(node As ConditionalAccessExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindConditionalAccessExpression(node As ConditionalAccessExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim placeholder As BoundRValuePlaceholder = Nothing
             Dim boundExpression As BoundExpression = BindConditionalAccessReceiver(node, diagnostics, placeholder)
 
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundConditionalAccess(node, boundExpression, placeholder, whenNotNull, Nothing)
         End Function
 
-        Private Function BindConditionalAccessReceiver(node As ConditionalAccessExpressionSyntax, diagnostics As DiagnosticBag, <Out> ByRef placeholder As BoundRValuePlaceholder) As BoundExpression
+        Private Function BindConditionalAccessReceiver(node As ConditionalAccessExpressionSyntax, diagnostics As BindingDiagnosticBag, <Out> ByRef placeholder As BoundRValuePlaceholder) As BoundExpression
             Dim boundExpression As BoundExpression
 
             If node.Expression Is Nothing Then
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Overridable Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax,
                                                                              accessingBinder As Binder,
-                                                                             diagnostics As DiagnosticBag) As BoundExpression
+                                                                             diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(Me.ContainingBinder IsNot Nothing)
             Return Me.ContainingBinder.TryBindOmittedLeftForConditionalAccess(node, accessingBinder, diagnostics)
         End Function
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If result Is Nothing Then
                 Dim placeholder As BoundRValuePlaceholder = Nothing
-                BindConditionalAccessReceiver(node, New DiagnosticBag(), placeholder)
+                BindConditionalAccessReceiver(node, BindingDiagnosticBag.Discarded, placeholder)
                 Return placeholder
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Constraints.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Constraints.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function BindTypeParameterConstraintClause(
             containingSymbol As Symbol,
             clause As TypeParameterConstraintClauseSyntax,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As ImmutableArray(Of TypeParameterConstraint)
             Debug.Assert((containingSymbol.Kind = SymbolKind.NamedType) OrElse (containingSymbol.Kind = SymbolKind.Method))
 
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             syntax As ConstraintSyntax,
             ByRef constraints As TypeParameterConstraintKind,
             constraintsBuilder As ArrayBuilder(Of TypeParameterConstraint),
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Debug.Assert((containingSymbol.Kind = SymbolKind.NamedType) OrElse (containingSymbol.Kind = SymbolKind.Method))
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindCastExpression(
              node As CastExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
          ) As BoundExpression
 
             Dim result As BoundExpression
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindCTypeExpression(
              node As CastExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
          ) As BoundExpression
 
             Debug.Assert(node.Keyword.Kind = SyntaxKind.CTypeKeyword)
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindDirectCastExpression(
              node As CastExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
          ) As BoundExpression
 
             Debug.Assert(node.Keyword.Kind = SyntaxKind.DirectCastKeyword)
@@ -69,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
              node As SyntaxNode,
              argument As BoundExpression,
              targetType As TypeSymbol,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Debug.Assert(argument.IsValue)
 
@@ -81,12 +81,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Classify conversion
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim conv As ConversionKind = Conversions.ClassifyDirectCastConversion(argument, targetType, Me, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim conv As ConversionKind = Conversions.ClassifyDirectCastConversion(argument, targetType, Me, useSiteInfo)
 
-            If diagnostics.Add(node, useSiteDiagnostics) Then
+            If diagnostics.Add(node, useSiteInfo) Then
                 ' Suppress any additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             If ReclassifyExpression(argument, SyntaxKind.DirectCastKeyword, node, conv, True, targetType, diagnostics) Then
@@ -161,7 +161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindTryCastExpression(
              node As CastExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
          ) As BoundExpression
 
             Debug.Assert(node.Keyword.Kind = SyntaxKind.TryCastKeyword)
@@ -176,7 +176,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
              node As SyntaxNode,
              argument As BoundExpression,
              targetType As TypeSymbol,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Debug.Assert(argument.IsValue)
 
@@ -191,12 +191,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim conv As ConversionKind
 
             If targetType.IsReferenceType Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                conv = Conversions.ClassifyTryCastConversion(argument, targetType, Me, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                conv = Conversions.ClassifyTryCastConversion(argument, targetType, Me, useSiteInfo)
 
-                If diagnostics.Add(node, useSiteDiagnostics) Then
+                If diagnostics.Add(node, useSiteInfo) Then
                     ' Suppress any additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
             Else
                 conv = Nothing
@@ -260,7 +260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindPredefinedCastExpression(
              node As PredefinedCastExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
          ) As BoundExpression
 
             Dim targetType As SpecialType
@@ -298,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As SyntaxNode,
             targetType As TypeSymbol,
             expression As BoundExpression,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional isOperandOfConditionalBranch As Boolean = False
         ) As BoundExpression
             Return ApplyConversion(node, targetType, expression, False, diagnostics, isOperandOfConditionalBranch:=isOperandOfConditionalBranch)
@@ -312,7 +312,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             targetType As TypeSymbol,
             argument As BoundExpression,
             isExplicit As Boolean,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional isOperandOfConditionalBranch As Boolean = False,
             Optional explicitSemanticForConcatArgument As Boolean = False
         ) As BoundExpression
@@ -339,7 +339,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If argument.HasErrors Then
                 ' Suppress any additional diagnostics produced by this function
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             ' Classify conversion
@@ -350,18 +350,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(Not isOperandOfConditionalBranch OrElse targetType.IsBooleanType())
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             If isOperandOfConditionalBranch AndAlso targetType.IsBooleanType() Then
                 Debug.Assert(Not isExplicit)
                 conv = Conversions.ClassifyConversionOfOperandOfConditionalBranch(argument, targetType, Me,
                                                                                   applyNullableIsTrueOperator,
                                                                                   isTrueOperator,
-                                                                                  useSiteDiagnostics)
+                                                                                  useSiteInfo)
 
-                If diagnostics.Add(node, useSiteDiagnostics) Then
+                If diagnostics.Add(node, useSiteInfo) Then
                     ' Suppress any additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
 
                 If isTrueOperator.BestResult.HasValue Then
@@ -390,11 +390,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     result = Binder.ApplyNullableIsTrueOperator(result, targetType)
                 End If
             Else
-                conv = Conversions.ClassifyConversion(argument, targetType, Me, useSiteDiagnostics)
+                conv = Conversions.ClassifyConversion(argument, targetType, Me, useSiteInfo)
 
-                If diagnostics.Add(node, useSiteDiagnostics) Then
+                If diagnostics.Add(node, useSiteInfo) Then
                     ' Suppress any additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
 
                 result = CreateConversionAndReportDiagnostic(node, argument, conv, isExplicit, targetType, diagnostics,
@@ -418,7 +418,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             convKind As KeyValuePair(Of ConversionKind, MethodSymbol),
             isExplicit As Boolean,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional copybackConversionParamName As String = Nothing,
             Optional explicitSemanticForConcatArgument As Boolean = False
         ) As BoundExpression
@@ -470,10 +470,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' If the conversion from the inferred element type to the source type of the user defined conversion is a narrowing conversion then
                 ' skip to the user defined conversion. Conversion errors on the individual elements will be reported when the array literal is reclassified.
-                If Not isExplicit AndAlso
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                reportArrayLiteralElementNarrowingConversion =
+                    Not isExplicit AndAlso
                     Conversions.IsNarrowingConversion(convKind.Key) AndAlso
-                    Conversions.IsNarrowingConversion(Conversions.ClassifyArrayLiteralConversion(DirectCast(argument, BoundArrayLiteral), sourceType, Me, Nothing)) Then
-                    reportArrayLiteralElementNarrowingConversion = True
+                    Conversions.IsNarrowingConversion(Conversions.ClassifyArrayLiteralConversion(DirectCast(argument, BoundArrayLiteral), sourceType, Me, useSiteInfo))
+
+                diagnostics.Add(argument.Syntax, useSiteInfo)
+
+                If reportArrayLiteralElementNarrowingConversion Then
                     GoTo DoneWithDiagnostics
                 End If
             End If
@@ -647,7 +652,22 @@ DoneWithDiagnostics:
             location As SyntaxNode,
             sourceType As TypeSymbol,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
+            justWarn As Boolean
+        ) As Boolean
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim result As Boolean = MakeVarianceConversionSuggestion(convKind, location, sourceType, targetType, diagnostics, useSiteInfo, justWarn)
+            diagnostics.AddDependencies(useSiteInfo)
+            Return result
+        End Function
+
+        Private Function MakeVarianceConversionSuggestion(
+            convKind As ConversionKind,
+            location As SyntaxNode,
+            sourceType As TypeSymbol,
+            targetType As TypeSymbol,
+            diagnostics As BindingDiagnosticBag,
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             justWarn As Boolean
         ) As Boolean
 
@@ -691,8 +711,7 @@ DoneWithDiagnostics:
 
                 If targetGenericDefinition.IsInterfaceType() Then
                     Dim matchingInterfaces As New HashSet(Of NamedTypeSymbol)()
-
-                    If IsOrInheritsFromOrImplementsInterface(sourceType, targetGenericDefinition, useSiteDiagnostics:=Nothing, matchingInterfaces:=matchingInterfaces) AndAlso
+                    If IsOrInheritsFromOrImplementsInterface(sourceType, targetGenericDefinition, useSiteInfo:=useSiteInfo, matchingInterfaces:=matchingInterfaces) AndAlso
                         matchingInterfaces.Count = 1 Then
                         sourceTypeArgument = matchingInterfaces(0).TypeArgumentsNoUseSiteDiagnostics(0)
                     End If
@@ -713,7 +732,7 @@ DoneWithDiagnostics:
                    Conversions.IsWideningConversion(Conversions.Classify_Reference_Array_TypeParameterConversion(sourceTypeArgument,
                                                                                                                  targetNamedType.TypeArgumentsNoUseSiteDiagnostics(0),
                                                                                                                  varianceCompatibilityClassificationDepth:=0,
-                                                                                                                 useSiteDiagnostics:=Nothing)) Then
+                                                                                                                 useSiteInfo:=useSiteInfo)) Then
                     Dim iEnumerable_T As NamedTypeSymbol = Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T)
 
                     If Not iEnumerable_T.IsErrorType() Then
@@ -769,7 +788,7 @@ DoneWithDiagnostics:
                 Case TypeKind.Interface
                     Dim matchingInterfaces As New HashSet(Of NamedTypeSymbol)()
 
-                    If IsOrInheritsFromOrImplementsInterface(sourceType, targetGenericDefinition, useSiteDiagnostics:=Nothing, matchingInterfaces:=matchingInterfaces) AndAlso
+                    If IsOrInheritsFromOrImplementsInterface(sourceType, targetGenericDefinition, useSiteInfo:=useSiteInfo, matchingInterfaces:=matchingInterfaces) AndAlso
                         matchingInterfaces.Count = 1 Then
                         matchingGenericInstantiation = matchingInterfaces(0)
                     Else
@@ -816,7 +835,7 @@ DoneWithDiagnostics:
                             Else
                                 conv = Conversions.Classify_Reference_Array_TypeParameterConversion(sourceArg, destinationArg,
                                                                                                     varianceCompatibilityClassificationDepth:=0,
-                                                                                                    useSiteDiagnostics:=Nothing)
+                                                                                                    useSiteInfo:=useSiteInfo)
 
                                 If Not Conversions.IsWideningConversion(conv) Then
                                     If Not Conversions.IsNarrowingConversion(conv) OrElse (conv And ConversionKind.VarianceConversionAmbiguity) = 0 Then
@@ -830,7 +849,7 @@ DoneWithDiagnostics:
                             Else
                                 conv = Conversions.Classify_Reference_Array_TypeParameterConversion(destinationArg, sourceArg,
                                                                                                     varianceCompatibilityClassificationDepth:=0,
-                                                                                                    useSiteDiagnostics:=Nothing)
+                                                                                                    useSiteInfo:=useSiteInfo)
 
                                 If Not Conversions.IsWideningConversion(conv) Then
                                     If (targetNamedType.IsDelegateType AndAlso destinationArg.IsReferenceType AndAlso sourceArg.IsReferenceType) OrElse
@@ -842,12 +861,12 @@ DoneWithDiagnostics:
                             End If
 
                         Case Else
-                            conv = Conversions.ClassifyDirectCastConversion(sourceArg, destinationArg, Nothing)
+                            conv = Conversions.ClassifyDirectCastConversion(sourceArg, destinationArg, useSiteInfo)
 
                             If Conversions.IsWideningConversion(conv) Then
                                 oneInvariantConvertibleDifference = typeParameters(i)
                             Else
-                                conv = Conversions.ClassifyDirectCastConversion(destinationArg, sourceArg, Nothing)
+                                conv = Conversions.ClassifyDirectCastConversion(destinationArg, sourceArg, useSiteInfo)
 
                                 If Conversions.IsWideningConversion(conv) Then
                                     oneInvariantReverseConvertibleDifference = typeParameters(i)
@@ -953,7 +972,7 @@ DoneWithDiagnostics:
             convKind As ConversionKind,
             isExplicit As Boolean,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundConversion
             Debug.Assert(Conversions.ConversionExists(convKind) AndAlso (convKind And ConversionKind.UserDefined) = 0)
 
@@ -1002,7 +1021,7 @@ DoneWithDiagnostics:
                                                   New BoundRelaxationLambda(tree, boundLambdaOpt, relaxationReceiverPlaceholderOpt).MakeCompilerGenerated()),
                                                targetType)
                 Else
-                    Debug.Assert(diagnostics.HasAnyErrors())
+                    Debug.Assert(diagnostics.DiagnosticBag Is Nothing OrElse diagnostics.HasAnyErrors())
                 End If
             End If
 
@@ -1035,7 +1054,6 @@ DoneWithDiagnostics:
         ) As BoundConvertedTupleElements
 
             If (convKind And ConversionKind.Tuple) <> 0 Then
-                Dim ignore = DiagnosticBag.GetInstance()
                 Dim sourceElementTypes = sourceType.GetNullableUnderlyingTypeOrSelf().GetElementTypesOfTupleOrCompatible()
                 Dim targetElementTypes = targetType.GetNullableUnderlyingTypeOrSelf().GetElementTypesOfTupleOrCompatible()
 
@@ -1045,10 +1063,8 @@ DoneWithDiagnostics:
                 For i As Integer = 0 To sourceElementTypes.Length - 1
                     Dim placeholder = New BoundRValuePlaceholder(tree, sourceElementTypes(i)).MakeCompilerGenerated()
                     placeholders.Add(placeholder)
-                    converted.Add(ApplyConversion(tree, targetElementTypes(i), placeholder, isExplicit, ignore))
+                    converted.Add(ApplyConversion(tree, targetElementTypes(i), placeholder, isExplicit, BindingDiagnosticBag.Discarded))
                 Next
-
-                ignore.Free()
 
                 Return New BoundConvertedTupleElements(tree, placeholders.ToImmutableAndFree(), converted.ToImmutableAndFree()).MakeCompilerGenerated()
             End If
@@ -1063,7 +1079,7 @@ DoneWithDiagnostics:
             isExplicit As Boolean,
             targetType As TypeSymbol,
             reportArrayLiteralElementNarrowingConversion As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundConversion
             Debug.Assert((convKind.Key And ConversionKind.UserDefined) <> 0 AndAlso convKind.Value IsNot Nothing AndAlso
                          convKind.Value.ParameterCount = 1 AndAlso Not convKind.Value.IsSub AndAlso
@@ -1079,12 +1095,13 @@ DoneWithDiagnostics:
 
             Dim intermediateConv As ConversionKind
             Dim inOutConversionFlags As Byte = 0
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             If argument.Kind = BoundKind.ArrayLiteral Then
                 ' For array literals, report Option Strict diagnostics for each element when reportArrayLiteralElementNarrowingConversion is true.
                 Dim arrayLiteral = DirectCast(argument, BoundArrayLiteral)
                 Dim arrayLiteralBinder = If(reportArrayLiteralElementNarrowingConversion, Me, conversionBinder)
-                intermediateConv = Conversions.ClassifyArrayLiteralConversion(arrayLiteral, inType, arrayLiteralBinder, Nothing)
+                intermediateConv = Conversions.ClassifyArrayLiteralConversion(arrayLiteral, inType, arrayLiteralBinder, useSiteInfo)
 
                 argument = arrayLiteralBinder.ReclassifyArrayLiteralExpression(SyntaxKind.CTypeKeyword, tree,
                                                             intermediateConv,
@@ -1093,7 +1110,7 @@ DoneWithDiagnostics:
                                                             inType, diagnostics)
                 originalArgumentType = inType
             Else
-                intermediateConv = Conversions.ClassifyPredefinedConversion(argument, inType, conversionBinder, Nothing)
+                intermediateConv = Conversions.ClassifyPredefinedConversion(argument, inType, conversionBinder, useSiteInfo)
 
                 If Not Conversions.IsIdentityConversion(intermediateConv) Then
 #If DEBUG Then
@@ -1108,7 +1125,7 @@ DoneWithDiagnostics:
                 End If
             End If
 
-            ReportUseSiteError(diagnostics, tree, convKind.Value)
+            ReportUseSite(diagnostics, tree, convKind.Value)
 
             ReportDiagnosticsIfObsoleteOrNotSupportedByRuntime(diagnostics, convKind.Value, tree)
 
@@ -1126,7 +1143,7 @@ DoneWithDiagnostics:
                                      suppressObjectClone:=True,
                                      type:=outType).MakeCompilerGenerated()
 
-            intermediateConv = Conversions.ClassifyPredefinedConversion(argument, targetType, conversionBinder, Nothing)
+            intermediateConv = Conversions.ClassifyPredefinedConversion(argument, targetType, conversionBinder, useSiteInfo)
 
             If Not Conversions.IsIdentityConversion(intermediateConv) Then
 #If DEBUG Then
@@ -1142,6 +1159,7 @@ DoneWithDiagnostics:
 
             argument = New BoundUserDefinedConversion(tree, argument, inOutConversionFlags, originalArgumentType).MakeCompilerGenerated()
 
+            diagnostics.Add(tree, useSiteInfo)
             Return New BoundConversion(tree, argument, convKind.Key, CheckOverflow, isExplicit, DirectCast(Nothing, ConstantValue), targetType)
         End Function
 
@@ -1166,7 +1184,7 @@ DoneWithDiagnostics:
             convKind As ConversionKind,
             isExplicit As Boolean,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
             Debug.Assert(argument.Kind <> BoundKind.GroupTypeInferenceLambda)
 
@@ -1275,7 +1293,7 @@ DoneWithDiagnostics:
             convKind As ConversionKind,
             isExplicit As Boolean,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Dim targetDelegateType As NamedTypeSymbol ' the target delegate type; if targetType is Expression(Of D), then this is D, otherwise targetType or Nothing.
@@ -1286,12 +1304,12 @@ DoneWithDiagnostics:
                 Dim anonymousDelegate As BoundExpression = ReclassifyUnboundLambdaExpression(unboundLambda, diagnostics)
 
 #If DEBUG Then
-                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) = unboundLambda.InferredAnonymousDelegate
+                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = unboundLambda.InferredAnonymousDelegate
 
                 Debug.Assert(anonymousDelegate.Type Is anonymousDelegateInfo.Key)
 
                 ' If we have errors for the inference, we know that there is no conversion.
-                If Not anonymousDelegateInfo.Value.IsDefault AndAlso anonymousDelegateInfo.Value.HasAnyErrors() Then
+                If Not anonymousDelegateInfo.Value.Diagnostics.IsDefault AndAlso anonymousDelegateInfo.Value.Diagnostics.HasAnyErrors() Then
                     Debug.Assert(Conversions.NoConversion(convKind) AndAlso (convKind And ConversionKind.DelegateRelaxationLevelMask) = 0)
                 Else
                     Debug.Assert(Conversions.NoConversion(convKind) OrElse
@@ -1321,18 +1339,16 @@ DoneWithDiagnostics:
                     If delegateInvoke Is Nothing Then
                         ReportDiagnostic(diagnostics, unboundLambda.Syntax, ERRID.ERR_LambdaNotDelegate1, targetDelegateType)
                         delegateInvoke = Nothing ' No conversion
-                    ElseIf ReportDelegateInvokeUseSiteError(diagnostics, unboundLambda.Syntax, targetDelegateType, delegateInvoke) Then
+                    ElseIf ReportDelegateInvokeUseSite(diagnostics, unboundLambda.Syntax, targetDelegateType, delegateInvoke) Then
                         delegateInvoke = Nothing ' No conversion
 
                     ElseIf unboundLambda.IsInferredDelegateForThisLambda(delegateInvoke.ContainingType) Then
-                        Dim inferenceDiagnostics As ImmutableArray(Of Diagnostic) = unboundLambda.InferredAnonymousDelegate.Value
+                        Dim inferenceDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol) = unboundLambda.InferredAnonymousDelegate.Value
 
-                        If Not inferenceDiagnostics.IsEmpty Then
-                            diagnostics.AddRange(inferenceDiagnostics)
+                        diagnostics.AddRange(inferenceDiagnostics)
 
-                            If inferenceDiagnostics.HasAnyErrors() Then
-                                delegateInvoke = Nothing ' No conversion
-                            End If
+                        If Not inferenceDiagnostics.Diagnostics.IsDefaultOrEmpty AndAlso inferenceDiagnostics.Diagnostics.HasAnyErrors() Then
+                            delegateInvoke = Nothing ' No conversion
                         End If
                     End If
 
@@ -1377,16 +1393,13 @@ DoneWithDiagnostics:
             Dim boundLambdaDiagnostics = boundLambda.Diagnostics
 
             Debug.Assert((convKind And ConversionKind.DelegateRelaxationLevelMask) >= boundLambda.DelegateRelaxation)
-            Debug.Assert(Conversions.ClassifyMethodConversionForLambdaOrAnonymousDelegate(delegateInvoke, boundLambda.LambdaSymbol, Nothing) = MethodConversionKind.Identity OrElse
+            Debug.Assert(Conversions.ClassifyMethodConversionForLambdaOrAnonymousDelegate(delegateInvoke, boundLambda.LambdaSymbol, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) = MethodConversionKind.Identity OrElse
                          ((convKind And ConversionKind.DelegateRelaxationLevelMask) <> ConversionKind.DelegateRelaxationLevelNone AndAlso
                           boundLambda.MethodConversionKind <> MethodConversionKind.Identity))
 
-            Dim reportedAnError As Boolean = False
+            Dim reportedAnError As Boolean = boundLambdaDiagnostics.Diagnostics.HasAnyErrors()
 
-            If boundLambdaDiagnostics.Any() Then
-                diagnostics.AddRange(boundLambdaDiagnostics)
-                reportedAnError = boundLambdaDiagnostics.HasAnyErrors()
-            End If
+            diagnostics.AddRange(boundLambdaDiagnostics)
 
             Dim relaxationLambdaOpt As BoundLambda = Nothing
 
@@ -1482,7 +1495,7 @@ DoneWithDiagnostics:
             convKind As ConversionKind,
             isExplicit As Boolean,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Debug.Assert(lambda.Type Is Nothing)
 
@@ -1501,7 +1514,7 @@ DoneWithDiagnostics:
 
                         If invoke Is Nothing Then
                             ReportDiagnostic(diagnostics, lambda.Syntax, ERRID.ERR_LambdaNotDelegate1, targetDelegateType)
-                        ElseIf Not ReportDelegateInvokeUseSiteError(diagnostics, lambda.Syntax, targetDelegateType, invoke) Then
+                        ElseIf Not ReportDelegateInvokeUseSite(diagnostics, lambda.Syntax, targetDelegateType, invoke) Then
 
                             ' Conversion could fail because we couldn't convert body of the lambda
                             ' to the target delegate type. We want to report that error instead of
@@ -1589,7 +1602,7 @@ DoneWithDiagnostics:
             Throw ExceptionUtilities.UnexpectedValue(conversionSemantics)
         End Function
 
-        Private Function ReclassifyInterpolatedStringExpression(conversionSemantics As SyntaxKind, tree As SyntaxNode, convKind As ConversionKind, isExplicit As Boolean, node As BoundInterpolatedStringExpression, targetType As TypeSymbol, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function ReclassifyInterpolatedStringExpression(conversionSemantics As SyntaxKind, tree As SyntaxNode, convKind As ConversionKind, isExplicit As Boolean, node As BoundInterpolatedStringExpression, targetType As TypeSymbol, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             If (convKind And ConversionKind.InterpolatedString) = ConversionKind.InterpolatedString Then
                 Debug.Assert(targetType.Equals(Compilation.GetWellKnownType(WellKnownType.System_IFormattable)) OrElse targetType.Equals(Compilation.GetWellKnownType(WellKnownType.System_FormattableString)))
@@ -1606,7 +1619,7 @@ DoneWithDiagnostics:
                        isExplicit As Boolean,
                        sourceTuple As BoundTupleLiteral,
                        destination As TypeSymbol,
-                       diagnostics As DiagnosticBag) As BoundExpression
+                       diagnostics As BindingDiagnosticBag) As BoundExpression
 
             ' We have a successful tuple conversion rather than producing a separate conversion node 
             ' which is a conversion on top of a tuple literal, tuple conversion is an element-wise conversion of arguments.
@@ -1676,7 +1689,7 @@ DoneWithDiagnostics:
             location As SyntaxNode,
             sourceType As TypeSymbol,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             If Conversions.IsNarrowingConversion(convKind) Then
                 Dim interfaceType As TypeSymbol = Nothing
@@ -1692,30 +1705,34 @@ DoneWithDiagnostics:
                     classType = DirectCast(sourceType, NamedTypeSymbol)
                 End If
 
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+
                 If classType IsNot Nothing AndAlso
                     interfaceType IsNot Nothing AndAlso
                     classType.IsNotInheritable AndAlso
                     Not classType.IsComImport() AndAlso
-                    Not Conversions.IsWideningConversion(Conversions.ClassifyDirectCastConversion(classType, interfaceType, Nothing)) Then
+                    Not Conversions.IsWideningConversion(Conversions.ClassifyDirectCastConversion(classType, interfaceType, useSiteInfo)) Then
                     ' Report specific warning if converting IEnumerable(Of XElement) to String.
-                    If (targetType.SpecialType = SpecialType.System_String) AndAlso IsIEnumerableOfXElement(sourceType, Nothing) Then
+                    If (targetType.SpecialType = SpecialType.System_String) AndAlso IsIEnumerableOfXElement(sourceType, useSiteInfo) Then
                         ReportDiagnostic(diagnostics, location, ERRID.WRN_UseValueForXmlExpression3, sourceType, targetType, sourceType)
                     Else
                         ReportDiagnostic(diagnostics, location, ERRID.WRN_InterfaceConversion2, sourceType, targetType)
                     End If
                 End If
+
+                diagnostics.AddDependencies(useSiteInfo)
             End If
         End Sub
 
-        Private Function IsIEnumerableOfXElement(type As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
-            Return type.IsOrImplementsIEnumerableOfXElement(Compilation, useSiteDiagnostics)
+        Private Function IsIEnumerableOfXElement(type As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return type.IsOrImplementsIEnumerableOfXElement(Compilation, useSiteInfo)
         End Function
 
         Private Sub ReportNoConversionError(
             location As SyntaxNode,
             sourceType As TypeSymbol,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional copybackConversionParamName As String = Nothing
         )
             If sourceType.IsArrayType() AndAlso targetType.IsArrayType() Then
@@ -1732,7 +1749,7 @@ DoneWithDiagnostics:
                     ReportDiagnostic(diagnostics, location, ERRID.ERR_TypeMismatch2, sourceType, targetType)
 
                 ElseIf Not (sourceElement.IsErrorType() OrElse targetElement.IsErrorType()) Then
-                    Dim elemConv = Conversions.ClassifyDirectCastConversion(sourceElement, targetElement, Nothing)
+                    Dim elemConv = Conversions.ClassifyDirectCastConversion(sourceElement, targetElement, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                     If Not Conversions.IsIdentityConversion(elemConv) AndAlso
                        (targetElement.IsObjectType() OrElse targetElement.SpecialType = SpecialType.System_ValueType) AndAlso
@@ -1766,7 +1783,7 @@ DoneWithDiagnostics:
                 ReportDiagnostic(diagnostics, location, ERRID.ERR_CopyBackTypeMismatch3,
                                  copybackConversionParamName, sourceType, targetType)
 
-            ElseIf sourceType.IsInterfaceType() AndAlso targetType.IsValueType() AndAlso IsIEnumerableOfXElement(sourceType, Nothing) Then
+            ElseIf sourceType.IsInterfaceType() AndAlso targetType.IsValueType() AndAlso IsIEnumerableOfXElement(sourceType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                 ReportDiagnostic(diagnostics, location, ERRID.ERR_TypeMismatchForXml3, sourceType, targetType, sourceType)
 
             Else

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
@@ -20,13 +20,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public ReadOnly DelegateConversions As ConversionKind
             Public ReadOnly Target As MethodSymbol
             Public ReadOnly MethodConversions As MethodConversionKind
-            Public ReadOnly Diagnostics As ImmutableArray(Of Diagnostic)
+            Public ReadOnly Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
 
             Public Sub New(
                 DelegateConversions As ConversionKind,
                 Target As MethodSymbol,
                 MethodConversions As MethodConversionKind,
-                Diagnostics As ImmutableArray(Of Diagnostic)
+                Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
             )
                 Me.DelegateConversions = DelegateConversions
                 Me.Target = Target
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="node">The AddressOf expression node.</param>
         ''' <param name="diagnostics">The diagnostics.</param><returns></returns>
-        Private Function BindAddressOfExpression(node As VisualBasicSyntaxNode, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindAddressOfExpression(node As VisualBasicSyntaxNode, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Dim addressOfSyntax = DirectCast(node, UnaryExpressionSyntax)
             Dim boundOperand = BindExpression(addressOfSyntax.Operand, isInvocationOrAddressOf:=True, diagnostics:=diagnostics, isOperandOfConditionalBranch:=False, eventContext:=False)
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             delegateType As TypeSymbol,
             argumentListOpt As ArgumentListSyntax,
             node As VisualBasicSyntaxNode,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Dim boundFirstArgument As BoundExpression = Nothing
@@ -159,10 +159,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             End If
 
-            Dim ignoredDiagnostics = DiagnosticBag.GetInstance
             Dim boundArguments(argumentCount - 1) As BoundExpression
             If boundFirstArgument IsNot Nothing Then
-                boundFirstArgument = MakeRValue(boundFirstArgument, ignoredDiagnostics)
+                boundFirstArgument = MakeRValueAndIgnoreDiagnostics(boundFirstArgument)
                 boundArguments(0) = boundFirstArgument
             End If
 
@@ -178,7 +177,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If expressionSyntax IsNot Nothing Then
-                    boundArguments(argumentIndex) = BindValue(expressionSyntax, ignoredDiagnostics)
+                    boundArguments(argumentIndex) = BindValue(expressionSyntax, BindingDiagnosticBag.Discarded)
                 Else
                     boundArguments(argumentIndex) = New BoundBadExpression(argumentSyntax,
                                                                            LookupResultKind.Empty,
@@ -188,8 +187,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                            hasErrors:=True)
                 End If
             Next
-
-            ignoredDiagnostics.Free()
 
             ' the default error message in delegate creations if the passed arguments are empty or not a addressOf
             ' should be ERRID.ERR_NoDirectDelegateConstruction1
@@ -220,7 +217,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ) As DelegateResolutionResult
             Debug.Assert(targetType IsNot Nothing)
 
-            Dim diagnostics = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
             Dim result As OverloadResolution.OverloadResolutionResult = Nothing
             Dim fromMethod As MethodSymbol = Nothing
 
@@ -245,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If delegateInvoke IsNot Nothing Then
 
-                    If ReportDelegateInvokeUseSiteError(diagnostics, syntaxTree, targetType, delegateInvoke) Then
+                    If ReportDelegateInvokeUseSite(diagnostics, syntaxTree, targetType, delegateInvoke) Then
                         methodConversions = methodConversions Or MethodConversionKind.Error_Unspecified
                     Else
 
@@ -336,8 +333,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New DelegateResolutionResult(delegateConversions, fromMethod, methodConversions, diagnostics.ToReadOnlyAndFree())
         End Function
 
-        Friend Shared Function ReportDelegateInvokeUseSiteError(
-            diagBag As DiagnosticBag,
+        Friend Shared Function ReportDelegateInvokeUseSite(
+            diagBag As BindingDiagnosticBag,
             syntax As SyntaxNode,
             delegateType As TypeSymbol,
             invoke As MethodSymbol
@@ -345,19 +342,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(delegateType IsNot Nothing)
             Debug.Assert(invoke IsNot Nothing)
 
-            Dim useSiteErrorInfo As DiagnosticInfo = invoke.GetUseSiteErrorInfo()
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = invoke.GetUseSiteInfo()
 
-            If useSiteErrorInfo IsNot Nothing Then
-                If useSiteErrorInfo.Code = ERRID.ERR_UnsupportedMethod1 Then
-                    ReportDiagnostic(diagBag, syntax, ERRID.ERR_UnsupportedMethod1, delegateType)
-                Else
-                    ReportDiagnostic(diagBag, syntax, useSiteErrorInfo)
-                End If
-
-                Return True
+            If useSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedMethod1 Then
+                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, delegateType))
             End If
 
-            Return False
+            Return diagBag.Add(useSiteInfo, syntax)
         End Function
 
         ''' <summary>
@@ -373,10 +364,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             addressOfExpression As BoundAddressOfOperator,
             toMethod As MethodSymbol,
             ignoreMethodReturnType As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As KeyValuePair(Of MethodSymbol, MethodConversionKind)
 
-            Dim argumentDiagnostics = DiagnosticBag.GetInstance
+            Dim argumentDiagnostics = BindingDiagnosticBag.GetInstance
             Dim couldTryZeroArgumentRelaxation As Boolean = True
 
             Dim matchingMethod As KeyValuePair(Of MethodSymbol, MethodConversionKind) = ResolveMethodForDelegateInvokeFullOrRelaxed(
@@ -390,7 +381,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' If there have been parameters and if there was no ambiguous match before, try zero argument relaxation.
             If matchingMethod.Key Is Nothing AndAlso couldTryZeroArgumentRelaxation Then
 
-                Dim zeroArgumentDiagnostics = DiagnosticBag.GetInstance
+                Dim zeroArgumentDiagnostics = BindingDiagnosticBag.GetInstance
                 Dim argumentMatchingMethod = matchingMethod
 
                 matchingMethod = ResolveMethodForDelegateInvokeFullOrRelaxed(
@@ -437,7 +428,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             addressOfExpression As BoundAddressOfOperator,
             toMethod As MethodSymbol,
             ignoreMethodReturnType As Boolean,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             useZeroArgumentRelaxation As Boolean,
             ByRef couldTryZeroArgumentRelaxation As Boolean
         ) As KeyValuePair(Of MethodSymbol, MethodConversionKind)
@@ -501,7 +492,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(resolutionBinder.OptionStrict = VisualBasic.OptionStrict.Off)
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             Dim resolutionResult = OverloadResolution.MethodInvocationOverloadResolution(
                 addressOfExpression.MethodGroup,
                 boundArguments,
@@ -512,13 +503,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 delegateReturnTypeReferenceBoundNode:=delegateReturnTypeReferenceBoundNode,
                 lateBindingIsAllowed:=False,
                 callerInfoOpt:=Nothing,
-                useSiteDiagnostics:=useSiteDiagnostics)
+                useSiteInfo:=useSiteInfo)
 
-            If diagnostics.Add(addressOfExpression.MethodGroup, useSiteDiagnostics) Then
+            If diagnostics.Add(addressOfExpression.MethodGroup, useSiteInfo) Then
                 couldTryZeroArgumentRelaxation = False
                 If addressOfExpression.MethodGroup.ResultKind <> LookupResultKind.Inaccessible Then
                     ' Suppress additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
             End If
 
@@ -546,7 +537,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     delegateReturnTypeReferenceBoundNode:=delegateReturnTypeReferenceBoundNode,
                     lateBindingIsAllowed:=False,
                     callerInfoOpt:=Nothing,
-                    useSiteDiagnostics:=useSiteDiagnostics)
+                    useSiteInfo:=useSiteInfo)
             End If
 
             Dim bestCandidates = ArrayBuilder(Of OverloadResolution.CandidateAnalysisResult).GetInstance()
@@ -585,7 +576,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If addressOfExpression.MethodGroup.ResultKind = LookupResultKind.Inaccessible Then
                     ReportDiagnostic(diagnostics, addressOfOperandSyntax,
                                      addressOfExpression.Binder.GetInaccessibleErrorInfo(
-                                         bestSymbols(0), useSiteDiagnostics:=Nothing))
+                                         bestSymbols(0)))
                 Else
                     Debug.Assert(addressOfExpression.MethodGroup.ResultKind = LookupResultKind.Good)
                 End If
@@ -628,7 +619,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             toMethod As MethodSymbol,
             ignoreMethodReturnType As Boolean,
             useZeroArgumentRelaxation As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As KeyValuePair(Of MethodSymbol, MethodConversionKind)
 
             Dim methodConversions As MethodConversionKind = MethodConversionKind.Identity
@@ -641,17 +632,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' determine conversions based on return type
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             Dim targetMethodSymbol = DirectCast(analysisResult.Candidate.UnderlyingSymbol, MethodSymbol)
 
             If Not ignoreMethodReturnType Then
                 methodConversions = methodConversions Or
                                     Conversions.ClassifyMethodConversionBasedOnReturn(targetMethodSymbol.ReturnType, targetMethodSymbol.ReturnsByRef,
-                                                                                      toMethod.ReturnType, toMethod.ReturnsByRef, useSiteDiagnostics)
+                                                                                      toMethod.ReturnType, toMethod.ReturnsByRef, useSiteInfo)
 
-                If diagnostics.Add(addressOfOperandSyntax, useSiteDiagnostics) Then
+                If diagnostics.Add(addressOfOperandSyntax, useSiteInfo) Then
                     ' Suppress additional diagnostics 
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
             End If
 
@@ -676,11 +667,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             Else
                 ' determine conversions based on arguments
-                methodConversions = methodConversions Or GetDelegateMethodConversionBasedOnArguments(analysisResult, toMethod, useSiteDiagnostics)
+                methodConversions = methodConversions Or GetDelegateMethodConversionBasedOnArguments(analysisResult, toMethod, useSiteInfo)
 
-                If diagnostics.Add(addressOfOperandSyntax, useSiteDiagnostics) Then
+                If diagnostics.Add(addressOfOperandSyntax, useSiteInfo) Then
                     ' Suppress additional diagnostics 
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
             End If
 
@@ -719,7 +710,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If addressOfExpression.MethodGroup.ResultKind = LookupResultKind.Inaccessible Then
                 ReportDiagnostic(diagnostics, addressOfOperandSyntax,
                                  addressOfExpression.Binder.GetInaccessibleErrorInfo(
-                                    analysisResult.Candidate.UnderlyingSymbol, useSiteDiagnostics:=Nothing))
+                                    analysisResult.Candidate.UnderlyingSymbol))
             Else
                 Debug.Assert(addressOfExpression.MethodGroup.ResultKind = LookupResultKind.Good)
             End If
@@ -731,7 +722,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             syntax As SyntaxNode,
             delegateType As NamedTypeSymbol,
             targetMethodSymbol As MethodSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             ' Option Strict On does not allow narrowing in implicit type conversion between method '{0}' and delegate "{1}".
             If targetMethodSymbol.ReducedFrom Is Nothing Then
@@ -755,7 +746,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             syntax As SyntaxNode,
             delegateType As NamedTypeSymbol,
             targetMethodSymbol As MethodSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             ' Option Strict On does not allow narrowing in implicit type conversion between method '{0}' and delegate "{1}".
             If targetMethodSymbol.ReducedFrom Is Nothing Then
@@ -783,7 +774,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function GetDelegateMethodConversionBasedOnArguments(
             bestResult As OverloadResolution.CandidateAnalysisResult,
             delegateInvoke As MethodSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
             Dim methodConversions As MethodConversionKind = MethodConversionKind.Identity
 
@@ -847,7 +838,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim conv = Conversions.ClassifyConversion(bestCandidate.Parameters(lastCommonIndex).Type,
                                                           delegateInvoke.Parameters(lastCommonIndex).Type,
-                                                          useSiteDiagnostics)
+                                                          useSiteInfo)
 
                 methodConversions = methodConversions Or
                                     Conversions.ClassifyMethodConversionBasedOnArgumentConversion(conv.Key,
@@ -931,7 +922,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             container As Symbol,
             token As SyntaxToken,
             flag As SourceParameterFlags,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As SourceParameterFlags
             ' 9.2.5.4: ParamArray parameters may not be specified in delegate or event declarations.
             If (flag And SourceParameterFlags.ParamArray) = SourceParameterFlags.ParamArray Then
@@ -974,7 +965,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             addressOfExpression As BoundAddressOfOperator,
             ByRef delegateResolutionResult As DelegateResolutionResult,
             targetType As TypeSymbol,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             isForHandles As Boolean,
             warnIfResultOfAsyncMethodIsDroppedDueToRelaxation As Boolean
         ) As BoundExpression
@@ -997,7 +988,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim resolvedTypeOrValueReceiver As BoundExpression = Nothing
             If receiver IsNot Nothing AndAlso
                 Not addressOfExpression.HasErrors AndAlso
-                Not delegateResolutionResult.Diagnostics.HasAnyErrors Then
+                Not delegateResolutionResult.Diagnostics.Diagnostics.HasAnyErrors Then
 
                 receiver = AdjustReceiverTypeOrValue(receiver, receiver.Syntax, targetMethod.IsShared, diagnostics, resolvedTypeOrValueReceiver)
             End If
@@ -1086,7 +1077,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             delegateRelaxation As ConversionKind,
             isZeroArgumentKnownToBeUsed As Boolean,
             warnIfResultOfAsyncMethodIsDroppedDueToRelaxation As Boolean,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             <Out()> ByRef relaxationReceiverPlaceholder As BoundRValuePlaceholder
         ) As BoundLambda
 
@@ -1156,7 +1147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             delegateRelaxation As ConversionKind,
             isZeroArgumentKnownToBeUsed As Boolean,
             warnIfResultOfAsyncMethodIsDroppedDueToRelaxation As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundLambda
             Debug.Assert(delegateInvoke.MethodKind = MethodKind.DelegateInvoke)
             Debug.Assert(methodGroup.Methods.Length = 1)
@@ -1294,7 +1285,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim boundLambda = New BoundLambda(syntaxNode,
                                           lambdaSymbol,
                                           lambdaBody,
-                                          ImmutableArray(Of Diagnostic).Empty,
+                                          ImmutableBindingDiagnostic(Of AssemblySymbol).Empty,
                                           Nothing,
                                           delegateRelaxation,
                                           MethodConversionKind.Identity)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Diagnostics.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Diagnostics.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Report a diagnostic, and also produce an error expression with error type.
         ''' </summary>
-        Public Shared Function ReportDiagnosticAndProduceBadExpression(diagBag As DiagnosticBag,
+        Public Shared Function ReportDiagnosticAndProduceBadExpression(diagBag As BindingDiagnosticBag,
                                                                        syntax As VisualBasicSyntaxNode,
                                                                        id As ERRID) As BoundExpression
             Return ReportDiagnosticAndProduceBadExpression(diagBag, syntax, ErrorFactory.ErrorInfo(id))
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Report a diagnostic, and also produce an error expression with error type.
         ''' </summary>
-        Public Shared Function ReportDiagnosticAndProduceBadExpression(diagBag As DiagnosticBag,
+        Public Shared Function ReportDiagnosticAndProduceBadExpression(diagBag As BindingDiagnosticBag,
                                                                   syntax As VisualBasicSyntaxNode,
                                                                   id As ERRID,
                                                                   ParamArray args As Object()) As BoundExpression
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Report a diagnostic, and also produce an error expression with error type.
         ''' </summary>
-        Public Shared Function ReportDiagnosticAndProduceBadExpression(diagBag As DiagnosticBag,
+        Public Shared Function ReportDiagnosticAndProduceBadExpression(diagBag As BindingDiagnosticBag,
                                                                   syntax As VisualBasicSyntaxNode,
                                                                   info As DiagnosticInfo,
                                                                   ParamArray nodes As BoundExpression()) As BoundExpression
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Report a diagnostic, and also produce an error expression with error type.
         ''' </summary>
-        Public Shared Function ReportDiagnosticAndProduceErrorTypeSymbol(diagBag As DiagnosticBag,
+        Public Shared Function ReportDiagnosticAndProduceErrorTypeSymbol(diagBag As BindingDiagnosticBag,
                                                                   syntax As VisualBasicSyntaxNode,
                                                                   id As ERRID,
                                                                   ParamArray args As Object()) As ErrorTypeSymbol
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Report a diagnostic, and also produce an error expression with error type.
         ''' </summary>
-        Public Shared Function ReportDiagnosticAndProduceErrorTypeSymbol(diagBag As DiagnosticBag,
+        Public Shared Function ReportDiagnosticAndProduceErrorTypeSymbol(diagBag As BindingDiagnosticBag,
                                                                   syntax As VisualBasicSyntaxNode,
                                                                   info As DiagnosticInfo) As ErrorTypeSymbol
             ReportDiagnostic(diagBag, syntax, info)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_DocumentationComments.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_DocumentationComments.vb
@@ -9,16 +9,16 @@ Imports System.Runtime.InteropServices
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class Binder
 
-        Friend Overridable Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
-            Return Me.ContainingBinder.BindInsideCrefAttributeValue(name, preserveAliases, diagnosticBag, useSiteDiagnostics)
+        Friend Overridable Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
+            Return Me.ContainingBinder.BindInsideCrefAttributeValue(name, preserveAliases, diagnosticBag, useSiteInfo)
         End Function
 
-        Friend Overridable Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
-            Return Me.ContainingBinder.BindInsideCrefAttributeValue(reference, preserveAliases, diagnosticBag, useSiteDiagnostics)
+        Friend Overridable Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
+            Return Me.ContainingBinder.BindInsideCrefAttributeValue(reference, preserveAliases, diagnosticBag, useSiteInfo)
         End Function
 
-        Friend Overridable Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
-            Return Me.ContainingBinder.BindXmlNameAttributeValue(identifier, useSiteDiagnostics)
+        Friend Overridable Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
+            Return Me.ContainingBinder.BindXmlNameAttributeValue(identifier, useSiteInfo)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function BindExpression(
             node As ExpressionSyntax,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Return BindExpression(node, False, False, False, diagnostics)
         End Function
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             isInvocationOrAddressOf As Boolean,
             isOperandOfConditionalBranch As Boolean,
             eventContext As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             If IsEarlyAttributeBinder AndAlso Not EarlyWellKnownAttributeBinder.CanBeValidAttributeArgument(node, Me) Then
@@ -305,7 +305,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Private Function BindTupleExpression(node As TupleExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindTupleExpression(node As TupleExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim arguments As SeparatedSyntaxList(Of SimpleArgumentSyntax) = node.Arguments
             Dim numElements As Integer = arguments.Count
 
@@ -383,7 +383,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundTupleLiteral(node, inferredType, elementNames, inferredPositions, boundArguments.ToImmutableAndFree(), tupleTypeOpt, hasErrors)
         End Function
 
-        Private Shared Function ExtractTupleElementNames(arguments As SeparatedSyntaxList(Of SimpleArgumentSyntax), diagnostics As DiagnosticBag) _
+        Private Shared Function ExtractTupleElementNames(arguments As SeparatedSyntaxList(Of SimpleArgumentSyntax), diagnostics As BindingDiagnosticBag) _
             As (elementNames As ImmutableArray(Of String), inferredPositions As ImmutableArray(Of Boolean), hasErrors As Boolean)
 
             Dim hasErrors = False
@@ -503,7 +503,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function GetTupleFieldType(expression As BoundExpression,
                                                   errorSyntax As VisualBasicSyntaxNode,
-                                                  diagnostics As DiagnosticBag,
+                                                  diagnostics As BindingDiagnosticBag,
                                                   ByRef hasNaturalType As Boolean) As TypeSymbol
             Dim expressionType As TypeSymbol = expression.Type
 
@@ -553,7 +553,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Shared Function CheckTupleMemberName(name As String, index As Integer, syntax As SyntaxNodeOrToken, diagnostics As DiagnosticBag, uniqueFieldNames As HashSet(Of String)) As Boolean
+        Private Shared Function CheckTupleMemberName(name As String, index As Integer, syntax As SyntaxNodeOrToken, diagnostics As BindingDiagnosticBag, uniqueFieldNames As HashSet(Of String)) As Boolean
             Dim reserved As Integer = TupleTypeSymbol.IsElementNameReserved(name)
             If reserved = 0 Then
                 Binder.ReportDiagnostic(diagnostics, syntax, ERRID.ERR_TupleReservedElementNameAnyPosition, name)
@@ -572,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return True
         End Function
 
-        Public Function BindNamespaceOrTypeExpression(node As TypeSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Public Function BindNamespaceOrTypeExpression(node As TypeSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim symbol = Me.BindNamespaceOrTypeOrAliasSyntax(node, diagnostics)
 
             Dim [alias] = TryCast(symbol, AliasSymbol)
@@ -580,7 +580,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 symbol = [alias].Target
 
                 '  check for use site errors
-                ReportUseSiteError(diagnostics, node, symbol)
+                ReportUseSite(diagnostics, node, symbol)
             End If
 
             Dim [type] = TryCast(symbol, TypeSymbol)
@@ -596,7 +596,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Public Function BindNamespaceOrTypeOrExpressionSyntaxForSemanticModel(node As ExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Public Function BindNamespaceOrTypeOrExpressionSyntaxForSemanticModel(node As ExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             If (node.Kind = SyntaxKind.PredefinedType) OrElse
                (((TypeOf node Is NameSyntax) OrElse node.Kind = SyntaxKind.ArrayType OrElse node.Kind = SyntaxKind.TupleType) AndAlso SyntaxFacts.IsInNamespaceOrTypeContext(node)) Then
                 Dim result As BoundExpression = Me.BindNamespaceOrTypeExpression(DirectCast(node, TypeSyntax), diagnostics)
@@ -609,7 +609,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim namespaceExpr = DirectCast(result, BoundNamespaceExpression)
 
                     If namespaceExpr.NamespaceSymbol.NamespaceKind = NamespaceKindNamespaceGroup Then
-                        Dim boundParent As BoundExpression = BindNamespaceOrTypeOrExpressionSyntaxForSemanticModel(DirectCast(node.Parent, QualifiedNameSyntax), New DiagnosticBag())
+                        Dim boundParent As BoundExpression = BindNamespaceOrTypeOrExpressionSyntaxForSemanticModel(DirectCast(node.Parent, QualifiedNameSyntax), BindingDiagnosticBag.Discarded)
 
                         Dim symbols = ArrayBuilder(Of Symbol).GetInstance()
 
@@ -617,7 +617,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         If symbols.Count = 0 Then
                             ' If we didn't get anything, let's bind normally and see if any symbol comes out.
-                            boundParent = BindExpression(DirectCast(node.Parent, QualifiedNameSyntax), New DiagnosticBag())
+                            boundParent = BindExpression(DirectCast(node.Parent, QualifiedNameSyntax), BindingDiagnosticBag.Discarded)
                             BindNamespaceOrTypeSyntaxForSemanticModelGetExpressionSymbols(boundParent, symbols)
                         End If
 
@@ -649,11 +649,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' This function is only needed for SemanticModel to perform binding for erroneous cases.
         ''' </summary>
-        Private Function BindQualifiedName(name As QualifiedNameSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindQualifiedName(name As QualifiedNameSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return Me.BindMemberAccess(name, BindExpression(name.Left, diagnostics), name.Right, eventContext:=False, diagnostics:=diagnostics)
         End Function
 
-        Private Function BindGetTypeExpression(node As GetTypeExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindGetTypeExpression(node As GetTypeExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' Create a special binder that allows unbound types
             Dim getTypeBinder = New GetTypeBinder(node.Type, Me)
 
@@ -675,11 +675,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundGetType(node, typeExpression, GetWellKnownType(WellKnownType.System_Type, node, diagnostics))
         End Function
 
-        Private Function BindNameOfExpression(node As NameOfExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindNameOfExpression(node As NameOfExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             ' Suppress diagnostics if argument has syntax errors
             If node.Argument.HasErrors Then
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             Dim value As String = Nothing
@@ -710,7 +710,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          If(node.Argument.Kind = SyntaxKind.SimpleMemberAccessExpression,
                                             DirectCast(node.Argument, MemberAccessExpressionSyntax).Name,
                                             node.Argument),
-                                         GetInaccessibleErrorInfo(group.Methods.First, useSiteDiagnostics:=Nothing))
+                                         GetInaccessibleErrorInfo(group.Methods.First))
 
                     ElseIf group.ResultKind = LookupResultKind.Good AndAlso group.TypeArgumentsOpt IsNot Nothing Then
                         ReportDiagnostic(diagnostics, group.TypeArgumentsOpt.Syntax, ERRID.ERR_MethodTypeArgsUnexpected)
@@ -725,14 +725,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          If(node.Argument.Kind = SyntaxKind.SimpleMemberAccessExpression,
                                             DirectCast(node.Argument, MemberAccessExpressionSyntax).Name,
                                             node.Argument),
-                                         GetInaccessibleErrorInfo(group.Properties.First, useSiteDiagnostics:=Nothing))
+                                         GetInaccessibleErrorInfo(group.Properties.First))
                     End If
             End Select
 
             Return New BoundNameOfOperator(node, argument, ConstantValue.Create(value), GetSpecialType(SpecialType.System_String, node, diagnostics))
         End Function
 
-        Private Shared Sub VerifyNameOfLookupResult(container As NamespaceOrTypeSymbol, member As SimpleNameSyntax, lookupResult As LookupResult, diagnostics As DiagnosticBag)
+        Private Shared Sub VerifyNameOfLookupResult(container As NamespaceOrTypeSymbol, member As SimpleNameSyntax, lookupResult As LookupResult, diagnostics As BindingDiagnosticBag)
             If lookupResult.HasDiagnostic Then
 
                 ' Ambiguous result is Ok
@@ -750,7 +750,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Function BindTypeOfExpression(node As TypeOfExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindTypeOfExpression(node As TypeOfExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Dim operand = BindRValue(node.Expression, diagnostics, isOperandOfConditionalBranch:=False)
             Dim operandType = operand.Type
@@ -773,12 +773,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ReportDiagnostic(diagnostics, node.Expression, ERRID.ERR_TypeOfRequiresReferenceType1, operandType)
 
             Else
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim convKind As ConversionKind = Conversions.ClassifyTryCastConversion(operandType, targetType, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim convKind As ConversionKind = Conversions.ClassifyTryCastConversion(operandType, targetType, useSiteInfo)
 
-                If diagnostics.Add(node, useSiteDiagnostics) Then
+                If diagnostics.Add(node, useSiteInfo) Then
                     ' Suppress any additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 ElseIf Not Conversions.ConversionExists(convKind) Then
                     ReportDiagnostic(diagnostics, node, ERRID.ERR_TypeOfExprAlwaysFalse2, operandType, targetType)
                 End If
@@ -798,7 +798,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend Function BindValue(
              node As ExpressionSyntax,
-             diagnostics As DiagnosticBag,
+             diagnostics As BindingDiagnosticBag,
              Optional isOperandOfConditionalBranch As Boolean = False
          ) As BoundExpression
             Dim expr = BindExpression(node, diagnostics:=diagnostics, isOperandOfConditionalBranch:=isOperandOfConditionalBranch, isInvocationOrAddressOf:=False, eventContext:=False)
@@ -809,7 +809,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function AdjustReceiverTypeOrValue(receiver As BoundExpression,
                               node As SyntaxNode,
                               isShared As Boolean,
-                              diagnostics As DiagnosticBag,
+                              diagnostics As BindingDiagnosticBag,
                               ByRef resolvedTypeOrValueExpression As BoundExpression) As BoundExpression
             Dim unused As QualificationKind
             Return AdjustReceiverTypeOrValue(receiver, node, isShared, True, diagnostics, unused, resolvedTypeOrValueExpression)
@@ -818,7 +818,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function AdjustReceiverTypeOrValue(receiver As BoundExpression,
                               node As SyntaxNode,
                               isShared As Boolean,
-                              diagnostics As DiagnosticBag,
+                              diagnostics As BindingDiagnosticBag,
                               ByRef qualKind As QualificationKind) As BoundExpression
             Dim unused As BoundExpression = Nothing
             Return AdjustReceiverTypeOrValue(receiver, node, isShared, False, diagnostics, qualKind, unused)
@@ -833,7 +833,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                               node As SyntaxNode,
                               isShared As Boolean,
                               clearIfShared As Boolean,
-                              diagnostics As DiagnosticBag,
+                              diagnostics As BindingDiagnosticBag,
                               ByRef qualKind As QualificationKind,
                               ByRef resolvedTypeOrValueExpression As BoundExpression) As BoundExpression
             If receiver Is Nothing Then
@@ -874,7 +874,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' RHS cannot be resolved (i.e. the RHS is an error or a late-bound
         ''' invocation/access).
         ''' </summary>
-        Private Shared Function AdjustReceiverAmbiguousTypeOrValue(receiver As BoundExpression, diagnostics As DiagnosticBag) As BoundExpression
+        Private Shared Function AdjustReceiverAmbiguousTypeOrValue(receiver As BoundExpression, diagnostics As BindingDiagnosticBag) As BoundExpression
             If receiver IsNot Nothing AndAlso receiver.Kind = BoundKind.TypeOrValueExpression Then
                 Dim typeOrValue = DirectCast(receiver, BoundTypeOrValueExpression)
                 diagnostics.AddRange(typeOrValue.Data.ValueDiagnostics)
@@ -884,7 +884,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return receiver
         End Function
 
-        Private Shared Function AdjustReceiverAmbiguousTypeOrValue(ByRef group As BoundMethodOrPropertyGroup, diagnostics As DiagnosticBag) As BoundExpression
+        Private Shared Function AdjustReceiverAmbiguousTypeOrValue(ByRef group As BoundMethodOrPropertyGroup, diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(group IsNot Nothing)
 
             Dim receiver = group.ReceiverOpt
@@ -923,7 +923,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function AdjustReceiverValue(receiver As BoundExpression,
                       node As SyntaxNode,
-                      diagnostics As DiagnosticBag) As BoundExpression
+                      diagnostics As BindingDiagnosticBag) As BoundExpression
 
             If Not receiver.IsValue() Then
                 receiver = MakeValue(receiver, diagnostics)
@@ -944,7 +944,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Function ReclassifyAsValue(
            expr As BoundExpression,
-           diagnostics As DiagnosticBag
+           diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             If expr.Kind = BoundKind.ConditionalAccess AndAlso expr.Type Is Nothing Then
                 Dim conditionalAccess = DirectCast(expr, BoundConditionalAccess)
@@ -1041,7 +1041,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Function TryDefaultInstanceProperty(typeExpr As BoundTypeExpression, diagnosticsBagFor_ERR_CantReferToMyGroupInsideGroupType1 As DiagnosticBag) As BoundExpression
+        Friend Function TryDefaultInstanceProperty(typeExpr As BoundTypeExpression, diagnosticsBagFor_ERR_CantReferToMyGroupInsideGroupType1 As BindingDiagnosticBag) As BoundExpression
 
             If Not IsDefaultInstancePropertyAllowed Then
                 Return Nothing
@@ -1107,7 +1107,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim ret = DirectCast(functionBlock.Statements(0), ReturnStatementSyntax)
-            Dim exprDiagnostics = DiagnosticBag.GetInstance()
+            Dim exprDiagnostics = BindingDiagnosticBag.GetInstance()
             Dim result As BoundExpression = (New DefaultInstancePropertyBinder(Me)).BindValue(ret.Expression, exprDiagnostics)
 
             If result.HasErrors OrElse exprDiagnostics.HasAnyErrors() Then
@@ -1215,7 +1215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function MakeValue(
            expr As BoundExpression,
-           diagnostics As DiagnosticBag
+           diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             If expr.Kind = BoundKind.Parenthesized Then
@@ -1264,18 +1264,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim getMethod = propertySymbol.GetMostDerivedGetMethod()
                             Debug.Assert(getMethod IsNot Nothing)
 
-                            If Not ReportUseSiteError(diagnostics, syntax, getMethod) Then
+                            If Not ReportUseSite(diagnostics, syntax, getMethod) Then
                                 Dim accessThroughType = GetAccessThroughType(propertyAccess.ReceiverOpt)
-                                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-                                If IsAccessible(getMethod, useSiteDiagnostics, accessThroughType) OrElse
-                                   Not IsAccessible(propertySymbol, useSiteDiagnostics, accessThroughType) Then
+                                If IsAccessible(getMethod, useSiteInfo, accessThroughType) OrElse
+                                   Not IsAccessible(propertySymbol, useSiteInfo, accessThroughType) Then
                                     hasError = False
                                 Else
                                     ReportDiagnostic(diagnostics, syntax, ERRID.ERR_NoAccessibleGet, CustomSymbolDisplayFormatter.ShortErrorName(propertySymbol))
                                 End If
 
-                                diagnostics.Add(syntax, useSiteDiagnostics)
+                                diagnostics.Add(syntax, useSiteInfo)
                             End If
                         End If
 
@@ -1321,7 +1321,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function BindRValue(
            node As ExpressionSyntax,
-           diagnostics As DiagnosticBag,
+           diagnostics As BindingDiagnosticBag,
            Optional isOperandOfConditionalBranch As Boolean = False
        ) As BoundExpression
             Dim expr = BindExpression(node, diagnostics:=diagnostics, isOperandOfConditionalBranch:=isOperandOfConditionalBranch, isInvocationOrAddressOf:=False, eventContext:=False)
@@ -1331,7 +1331,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Function MakeRValue(
            expr As BoundExpression,
-           diagnostics As DiagnosticBag
+           diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             If expr.Kind = BoundKind.Parenthesized AndAlso Not expr.IsNothingLiteral() Then
@@ -1405,15 +1405,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function MakeRValueAndIgnoreDiagnostics(
            expr As BoundExpression
         ) As BoundExpression
-            Dim ignoreErrors = DiagnosticBag.GetInstance()
-            expr = MakeRValue(expr, ignoreErrors)
-            ignoreErrors.Free()
+            expr = MakeRValue(expr, BindingDiagnosticBag.Discarded)
             Return expr
         End Function
 
         Friend Function ReclassifyExpression(
            expr As BoundExpression,
-           diagnostics As DiagnosticBag
+           diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             If expr.IsNothingLiteral() Then
                 ' This is a Nothing literal without a type.
@@ -1438,7 +1436,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If address.MethodGroup.ResultKind = LookupResultKind.Inaccessible Then
                         If address.MethodGroup.Methods.Length = 1 Then
-                            ReportDiagnostic(diagnostics, address.MethodGroup.Syntax, GetInaccessibleErrorInfo(address.MethodGroup.Methods(0), useSiteDiagnostics:=Nothing))
+                            ReportDiagnostic(diagnostics, address.MethodGroup.Syntax, GetInaccessibleErrorInfo(address.MethodGroup.Methods(0)))
                         Else
                             ReportDiagnostic(diagnostics, address.MethodGroup.Syntax, ERRID.ERR_NoViableOverloadCandidates1,
                                              address.MethodGroup.Methods(0).Name)
@@ -1474,7 +1472,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                           isExplicit As Boolean,
                                                           arrayLiteral As BoundArrayLiteral,
                                                           destination As TypeSymbol,
-                                                          diagnostics As DiagnosticBag) As BoundExpression
+                                                          diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Debug.Assert((conv And ConversionKind.UserDefined) = 0)
             Debug.Assert(Not (TypeOf destination Is ArrayLiteralTypeSymbol)) 'An array literal should never be reclassified as an array literal.
@@ -1490,10 +1488,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ReportNoConversionError(arrayLiteral.Syntax, arrayLiteral.InferredType, destination, diagnostics, Nothing)
                 End If
 
-                Dim ignoredDiagnostics = DiagnosticBag.GetInstance
                 ' Because we've already reported a no conversion error, ignore any diagnostics in ApplyImplicitConversion
-                Dim argument As BoundExpression = ApplyImplicitConversion(arrayLiteral.Syntax, arrayLiteral.InferredType, arrayLiteral, ignoredDiagnostics)
-                ignoredDiagnostics.Free()
+                Dim argument As BoundExpression = ApplyImplicitConversion(arrayLiteral.Syntax, arrayLiteral.InferredType, arrayLiteral, BindingDiagnosticBag.Discarded)
 
                 If conversionSemantics = SyntaxKind.CTypeKeyword Then
                     argument = New BoundConversion(tree, argument, conv, False, isExplicit, destination)
@@ -1579,7 +1575,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Function
 
-        Private Sub ReportArrayLiteralDiagnostics(arrayLiteral As BoundArrayLiteral, targetArrayType As ArrayTypeSymbol, diagnostics As DiagnosticBag)
+        Private Sub ReportArrayLiteralDiagnostics(arrayLiteral As BoundArrayLiteral, targetArrayType As ArrayTypeSymbol, diagnostics As BindingDiagnosticBag)
             If targetArrayType Is arrayLiteral.InferredType Then
                 ' Note, array type symbols do not preserve identity. If the target array is the same as the inferred array then we
                 ' assume that the target has inferred its type from the array literal.
@@ -1587,7 +1583,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Sub ReportArrayLiteralInferredTypeDiagnostics(arrayLiteral As BoundArrayLiteral, diagnostics As DiagnosticBag)
+        Private Sub ReportArrayLiteralInferredTypeDiagnostics(arrayLiteral As BoundArrayLiteral, diagnostics As BindingDiagnosticBag)
             Dim targetElementType = arrayLiteral.InferredType.ElementType
 
             If targetElementType.IsRestrictedType Then
@@ -1618,7 +1614,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Sub
 
-        Private Function ReclassifyArrayInitialization(arrayInitialization As BoundArrayInitialization, elementType As TypeSymbol, diagnostics As DiagnosticBag) As BoundArrayInitialization
+        Private Function ReclassifyArrayInitialization(arrayInitialization As BoundArrayInitialization, elementType As TypeSymbol, diagnostics As BindingDiagnosticBag) As BoundArrayInitialization
             Dim initializers = ArrayBuilder(Of BoundExpression).GetInstance
 
             ' Apply implicit conversion to the elements.
@@ -1655,7 +1651,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function ReclassifyTupleLiteralExpression(
            tupleLiteral As BoundTupleLiteral,
-           diagnostics As DiagnosticBag
+           diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Return ApplyImplicitConversion(tupleLiteral.Syntax,
@@ -1666,7 +1662,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function ReclassifyArrayLiteralExpression(
                                                          arrayLiteral As BoundArrayLiteral,
-                                                         diagnostics As DiagnosticBag
+                                                         diagnostics As BindingDiagnosticBag
                                                          ) As BoundExpression
             Return ApplyImplicitConversion(arrayLiteral.Syntax,
                                            arrayLiteral.InferredType,
@@ -1676,7 +1672,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function ReclassifyUnboundLambdaExpression(
            lambda As UnboundLambda,
-           diagnostics As DiagnosticBag
+           diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Return ApplyImplicitConversion(lambda.Syntax,
                                            lambda.InferredAnonymousDelegate.Key,
@@ -1687,7 +1683,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindAssignmentTarget(
             node As ExpressionSyntax,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Dim expression = BindExpression(node, diagnostics)
 
@@ -1697,7 +1693,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindAssignmentTarget(
             node As SyntaxNode,
             expression As BoundExpression,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             expression = ReclassifyAsValue(expression, diagnostics)
 
@@ -1770,7 +1766,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Shared Sub ReportAssignmentToRValue(expr As BoundExpression, diagnostics As DiagnosticBag)
+        Private Shared Sub ReportAssignmentToRValue(expr As BoundExpression, diagnostics As BindingDiagnosticBag)
             Dim err As ERRID
 
             If expr.IsConstant Then
@@ -1914,7 +1910,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return MethodKind.Ordinary ' Looks like a good default.
         End Function
 
-        Private Function BindTernaryConditionalExpression(node As TernaryConditionalExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindTernaryConditionalExpression(node As TernaryConditionalExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             '  bind arguments as values
             Dim boundConditionArg = BindBooleanExpression(node.Condition, diagnostics)
@@ -1981,7 +1977,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                    (candidate.IsNothingLiteral OrElse (candidate.Type IsNot Nothing AndAlso candidate.Type.AllowsCompileTimeOperations()))
         End Function
 
-        Private Function BindBinaryConditionalExpression(node As BinaryConditionalExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindBinaryConditionalExpression(node As BinaryConditionalExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             '  bind arguments
             Dim boundFirstArg = BindValue(node.FirstExpression, diagnostics)
@@ -2133,7 +2129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         constantValueOpt As ConstantValue,
                                         type As TypeSymbol,
                                         hasErrors As Boolean,
-                                        diagnostics As DiagnosticBag,
+                                        diagnostics As BindingDiagnosticBag,
                                         Optional explicitConversion As Boolean = False) As BoundExpression
 
             Dim convertedTestExpression As BoundExpression = Nothing
@@ -2170,7 +2166,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ''' <summary> Process the result of dominant type inference, generate diagnostics </summary>
         Private Function GenerateDiagnosticsForDominantTypeInferenceInIfExpression(dominantType As TypeSymbol, numCandidates As Integer,
-                                       node As ExpressionSyntax, diagnostics As DiagnosticBag) As Boolean
+                                       node As ExpressionSyntax, diagnostics As BindingDiagnosticBag) As Boolean
             Dim hasErrors As Boolean = False
             If dominantType Is Nothing Then
                 ReportDiagnostic(diagnostics, node, ERRID.ERR_IfNoType)
@@ -2319,7 +2315,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return CanAccessMeOrMyClass(implicitReference, errorId)
         End Function
 
-        Private Function BindMeExpression(node As MeExpressionSyntax, diagnostics As DiagnosticBag) As BoundMeReference
+        Private Function BindMeExpression(node As MeExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundMeReference
             Dim err As ERRID = Nothing
 
             If Not CanAccessMe(False, err) Then
@@ -2342,7 +2338,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result
         End Function
 
-        Private Function BindMyBaseExpression(node As MyBaseExpressionSyntax, diagnostics As DiagnosticBag) As BoundMyBaseReference
+        Private Function BindMyBaseExpression(node As MyBaseExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundMyBaseReference
             Dim err As ERRID = Nothing
 
             If Not CanAccessMyBase(False, err) Then
@@ -2354,7 +2350,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundMyBaseReference(node, If(Me.ContainingType IsNot Nothing, Me.ContainingType.BaseTypeNoUseSiteDiagnostics, ErrorTypeSymbol.UnknownResultType))
         End Function
 
-        Private Function BindMyClassExpression(node As MyClassExpressionSyntax, diagnostics As DiagnosticBag) As BoundMyClassReference
+        Private Function BindMyClassExpression(node As MyClassExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundMyClassReference
             Dim err As ERRID = Nothing
 
             If Not CanAccessMyClass(False, err) Then
@@ -2428,7 +2424,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' or the argument of an AddressOf, and the return value variable should not be bound to.
         Private Function BindSimpleName(node As SimpleNameSyntax,
                                         isInvocationOrAddressOf As Boolean,
-                                        diagnostics As DiagnosticBag,
+                                        diagnostics As BindingDiagnosticBag,
                                         Optional skipLocalsAndParameters As Boolean = False) As BoundExpression
             Dim name As String
             Dim typeArguments As TypeArgumentListSyntax
@@ -2473,9 +2469,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim arity As Integer = If(typeArguments IsNot Nothing, typeArguments.Arguments.Count, 0)
             Dim result As LookupResult = LookupResult.GetInstance()
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Me.Lookup(result, name, arity, options, useSiteDiagnostics)
-            diagnostics.Add(node, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Me.Lookup(result, name, arity, options, useSiteInfo)
+            diagnostics.Add(node, useSiteInfo)
 
             If Not result.IsGoodOrAmbiguous AndAlso
                Me.ImplicitVariableDeclarationAllowed AndAlso
@@ -2534,7 +2530,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         node As VisualBasicSyntaxNode,
                                         options As LookupOptions,
                                         typeArguments As TypeArgumentListSyntax,
-                                        diagnostics As DiagnosticBag) As BoundExpression
+                                        diagnostics As BindingDiagnosticBag) As BoundExpression
 
             ' An implicit Me is inserted if we found something in the immediate containing type.
             ' Note that validation of whether Me can actually be used in this case is deferred until after 
@@ -2603,7 +2599,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Private Function BindMemberAccess(node As MemberAccessExpressionSyntax, eventContext As Boolean, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindMemberAccess(node As MemberAccessExpressionSyntax, eventContext As Boolean, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim leftOpt = node.Expression
             Dim boundLeft As BoundExpression = Nothing
             Dim rightName As SimpleNameSyntax = node.Name
@@ -2645,7 +2641,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Me.BindMemberAccess(node, boundLeft, rightName, eventContext, diagnostics)
         End Function
 
-        Private Function BindLeftOfPotentialColorColorMemberAccess(parentNode As MemberAccessExpressionSyntax, leftOpt As ExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindLeftOfPotentialColorColorMemberAccess(parentNode As MemberAccessExpressionSyntax, leftOpt As ExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' handle for Color Color case:  
             '
             ' =======  11.6.1 Identical Type and Member Names
@@ -2690,13 +2686,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If leftOpt.Kind = SyntaxKind.IdentifierName Then
                 Dim node = DirectCast(leftOpt, SimpleNameSyntax)
-                Dim leftDiagnostics = DiagnosticBag.GetInstance()
+                Dim leftDiagnostics = BindingDiagnosticBag.GetInstance()
                 Dim boundLeft = Me.BindSimpleName(node, False, leftDiagnostics)
 
                 Dim boundValue = boundLeft
-                Dim propertyDiagnostics As DiagnosticBag = Nothing
+                Dim propertyDiagnostics As BindingDiagnosticBag = Nothing
                 If boundLeft.Kind = BoundKind.PropertyGroup Then
-                    propertyDiagnostics = DiagnosticBag.GetInstance()
+                    propertyDiagnostics = BindingDiagnosticBag.GetInstance()
                     boundValue = Me.AdjustReceiverValue(boundLeft, node, propertyDiagnostics)
                 End If
 
@@ -2724,7 +2720,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If leftType IsNot Nothing Then
                         Dim leftName = node.Identifier.ValueText
                         If CaseInsensitiveComparison.Equals(leftType.Name, leftName) AndAlso leftType.TypeKind <> TypeKind.TypeParameter Then
-                            Dim typeDiagnostics = New DiagnosticBag()
+                            Dim typeDiagnostics = New BindingDiagnosticBag()
                             Dim boundType = Me.BindNamespaceOrTypeExpression(node, typeDiagnostics)
                             If TypeSymbol.Equals(boundType.Type, leftType, TypeCompareKind.ConsiderEverything) Then
                                 Dim err As ERRID = Nothing
@@ -2735,7 +2731,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     Return boundType
                                 End If
 
-                                Dim valueDiagnostics = New DiagnosticBag()
+                                Dim valueDiagnostics = New BindingDiagnosticBag()
                                 valueDiagnostics.AddRangeAndFree(leftDiagnostics)
                                 If propertyDiagnostics IsNot Nothing Then
                                     valueDiagnostics.AddRangeAndFree(propertyDiagnostics)
@@ -2771,12 +2767,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' The method is protected, so that it can be called from other 
         ''' binders overriding TryBindMemberAccessWithLeftOmitted
         ''' </remarks>
-        Protected Function BindMemberAccess(node As VisualBasicSyntaxNode, left As BoundExpression, right As SimpleNameSyntax, eventContext As Boolean, diagnostics As DiagnosticBag) As BoundExpression
+        Protected Function BindMemberAccess(node As VisualBasicSyntaxNode, left As BoundExpression, right As SimpleNameSyntax, eventContext As Boolean, diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(node IsNot Nothing)
             Debug.Assert(left IsNot Nothing)
             Debug.Assert(right IsNot Nothing)
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             ' Check if 'left' is of type which is a class or struct and 'name' is "New"
             Dim leftTypeSymbol As TypeSymbol = left.Type
@@ -2807,10 +2803,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' Bind to method group representing available instance constructors
                         Dim namedLeftTypeSymbol = DirectCast(leftTypeSymbol, NamedTypeSymbol)
 
-                        Dim accessibleConstructors = GetAccessibleConstructors(namedLeftTypeSymbol, useSiteDiagnostics)
+                        Dim accessibleConstructors = GetAccessibleConstructors(namedLeftTypeSymbol, useSiteInfo)
 
-                        diagnostics.Add(node, useSiteDiagnostics)
-                        useSiteDiagnostics = Nothing
+                        diagnostics.Add(node, useSiteInfo)
+                        useSiteInfo = Nothing
 
                         If accessibleConstructors.IsEmpty Then
 
@@ -2874,7 +2870,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         options = options Or LookupOptions.AllowIntrinsicAliases
                     End If
 
-                    MemberLookup.Lookup(lookupResult, ns, rightName, rightArity, options, Me, useSiteDiagnostics) ' overload resolution filters methods by arity.
+                    MemberLookup.Lookup(lookupResult, ns, rightName, rightArity, options, Me, useSiteInfo) ' overload resolution filters methods by arity.
 
                     If lookupResult.HasSymbol Then
                         Return BindSymbolAccess(node, lookupResult, options, left, typeArguments, QualificationKind.QualifiedViaNamespace, diagnostics)
@@ -2893,7 +2889,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Return BadExpression(node, left, ErrorTypeSymbol.UnknownResultType)
                         End If
 
-                        LookupMember(lookupResult, type, rightName, rightArity, options, useSiteDiagnostics) ' overload resolution filters methods by arity.
+                        LookupMember(lookupResult, type, rightName, rightArity, options, useSiteInfo) ' overload resolution filters methods by arity.
 
                         If lookupResult.HasSymbol Then
                             Return BindSymbolAccess(node, lookupResult, options, left, typeArguments, QualificationKind.QualifiedViaTypeName, diagnostics)
@@ -2922,7 +2918,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         effectiveOptions = effectiveOptions Or LookupOptions.EventsOnly
                     End If
 
-                    LookupMember(lookupResult, type, rightName, rightArity, effectiveOptions, useSiteDiagnostics) ' overload resolution filters methods by arity.
+                    LookupMember(lookupResult, type, rightName, rightArity, effectiveOptions, useSiteInfo) ' overload resolution filters methods by arity.
 
                     If lookupResult.HasSymbol Then
                         Return BindSymbolAccess(node, lookupResult, effectiveOptions, left, typeArguments, QualificationKind.QualifiedViaValue, diagnostics)
@@ -2936,14 +2932,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Else
                         If type.IsInterfaceType() Then
                             ' In case IsExtensibleInterfaceNoUseSiteDiagnostics above failed because there were bad inherited interfaces.
-                            type.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                            type.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                         End If
 
                         Return ReportDiagnosticAndProduceBadExpression(diagnostics, node, ErrorFactory.ErrorInfo(ERRID.ERR_NameNotMember2, rightName, type), left)
                     End If
                 End If
             Finally
-                diagnostics.Add(node, useSiteDiagnostics)
+                diagnostics.Add(node, useSiteInfo)
                 lookupResult.Free()
             End Try
         End Function
@@ -2962,7 +2958,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' method returns bound node for the whole expression rather than only for omitted left part. 
         ''' </param>
         Protected Friend Overridable Function TryBindOmittedLeftForMemberAccess(node As MemberAccessExpressionSyntax,
-                                                                                diagnostics As DiagnosticBag,
+                                                                                diagnostics As BindingDiagnosticBag,
                                                                                 accessingBinder As Binder,
                                                                                 <Out> ByRef wholeMemberAccessExpressionBound As Boolean) As BoundExpression
             Debug.Assert(Me.ContainingBinder IsNot Nothing)
@@ -2970,7 +2966,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Protected Friend Overridable Function TryBindOmittedLeftForXmlMemberAccess(node As XmlMemberAccessExpressionSyntax,
-                                                                                   diagnostics As DiagnosticBag,
+                                                                                   diagnostics As BindingDiagnosticBag,
                                                                                    accessingBinder As Binder) As BoundExpression
             Debug.Assert(Me.ContainingBinder IsNot Nothing)
             Return Me.ContainingBinder.TryBindOmittedLeftForXmlMemberAccess(node, diagnostics, accessingBinder)
@@ -2993,7 +2989,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="diagnostics">diagnostic bag if errors are to be reported</param>
         ''' <returns>Returns the symbol's type or an ErrorTypeSymbol if the local is referenced before its definition or if the symbol is still being bound.</returns>
         ''' <remarks>This method safely returns a local symbol's type by checking for circular references or references before declaration.</remarks>
-        Private Function GetLocalSymbolType(localSymbol As LocalSymbol, node As VisualBasicSyntaxNode, Optional diagnostics As DiagnosticBag = Nothing) As TypeSymbol
+        Private Function GetLocalSymbolType(localSymbol As LocalSymbol, node As VisualBasicSyntaxNode, Optional diagnostics As BindingDiagnosticBag = Nothing) As TypeSymbol
             Dim localType As TypeSymbol = Nothing
             ' Check if local symbol is used before it's definition.
             ' Do span comparison first in order to optimize performance for non-error cases. 
@@ -3057,7 +3053,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                           receiver As BoundExpression,
                                           typeArgumentsOpt As TypeArgumentListSyntax,
                                           qualKind As QualificationKind,
-                                          diagnostics As DiagnosticBag) As BoundExpression
+                                          diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(lookupResult.HasSymbol)
 
             Dim hasError As Boolean = False ' Is there an ERROR (not a warning).
@@ -3151,7 +3147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not reportedLookupError Then
-                        ReportUseSiteError(diagnostics, node, eventSymbol)
+                        ReportUseSite(diagnostics, node, eventSymbol)
                     End If
 
                     If Not hasError Then
@@ -3193,7 +3189,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not reportedLookupError Then
-                        If Not ReportUseSiteError(diagnostics, node, fieldSymbol) Then
+                        If Not ReportUseSite(diagnostics, node, fieldSymbol) Then
                             CheckMemberTypeAccessibility(diagnostics, node, fieldSymbol)
                         End If
                     End If
@@ -3256,12 +3252,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
                     End If
 
-                    ' Debug.Assert(localSymbol.GetUseSiteErrorInfo() Is Nothing) ' Not true in the debugger.
+                    ' Debug.Assert(localSymbol.GetUseSiteInfo().DiagnosticInfo Is Nothing) ' Not true in the debugger.
                     Return New BoundLocal(node, localSymbol, localAccessType, hasErrors:=hasError)
 
                 Case SymbolKind.RangeVariable
                     Dim rangeVariable = DirectCast(lookupResult.SingleSymbol, RangeVariableSymbol)
-                    Debug.Assert(rangeVariable.GetUseSiteErrorInfo() Is Nothing)
+                    Debug.Assert(rangeVariable.GetUseSiteInfo().IsEmpty)
                     Return New BoundRangeVariable(node, rangeVariable, rangeVariable.Type, hasErrors:=hasError)
 
                 Case SymbolKind.Parameter
@@ -3273,7 +3269,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         VerifyTypeCharacterConsistency(asSimpleName, parameterType.GetEnumUnderlyingTypeOrSelf, diagnostics)
                     End If
 
-                    Debug.Assert(parameterSymbol.GetUseSiteErrorInfo() Is Nothing)
+                    Debug.Assert(parameterSymbol.GetUseSiteInfo().IsEmpty)
                     Return New BoundParameter(node, parameterSymbol, parameterType, hasErrors:=hasError)
 
                 Case SymbolKind.NamedType, SymbolKind.ErrorType
@@ -3305,7 +3301,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If Not reportedLookupError Then
-                        ReportUseSiteError(diagnostics, node, If(typeSymbol, lookupResult.SingleSymbol))
+                        ReportUseSite(diagnostics, node, If(typeSymbol, lookupResult.SingleSymbol))
                     End If
 
                     Dim type As TypeSymbol = DirectCast(lookupResult.SingleSymbol, TypeSymbol)
@@ -3320,30 +3316,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case SymbolKind.TypeParameter
                     ' Note: arity already checked by lookup process.
 
-                    Debug.Assert(lookupResult.SingleSymbol.GetUseSiteErrorInfo() Is Nothing)
+                    Debug.Assert(lookupResult.SingleSymbol.GetUseSiteInfo().IsEmpty)
                     Return New BoundTypeExpression(node, DirectCast(lookupResult.SingleSymbol, TypeSymbol), hasErrors:=hasError)
 
                 Case SymbolKind.Namespace
                     ' Note: arity already checked by lookup process.
 
-                    Debug.Assert(lookupResult.SingleSymbol.GetUseSiteErrorInfo() Is Nothing)
+                    Debug.Assert(lookupResult.SingleSymbol.GetUseSiteInfo().IsEmpty)
                     Return New BoundNamespaceExpression(node, receiver, DirectCast(lookupResult.SingleSymbol, NamespaceSymbol), hasErrors:=hasError)
 
                 Case SymbolKind.Alias
                     Dim [alias] = DirectCast(lookupResult.SingleSymbol, AliasSymbol)
 
-                    Debug.Assert([alias].GetUseSiteErrorInfo() Is Nothing)
+                    Debug.Assert([alias].GetUseSiteInfo().IsEmpty)
                     Dim symbol = [alias].Target
 
                     Select Case symbol.Kind
                         Case SymbolKind.NamedType, SymbolKind.ErrorType
                             If Not reportedLookupError Then
-                                ReportUseSiteError(diagnostics, node, symbol)
+                                ReportUseSite(diagnostics, node, symbol)
                             End If
 
                             Return New BoundTypeExpression(node, Nothing, [alias], DirectCast(symbol, TypeSymbol), hasErrors:=hasError)
                         Case SymbolKind.Namespace
-                            Debug.Assert(symbol.GetUseSiteErrorInfo() Is Nothing)
+                            Debug.Assert(symbol.GetUseSiteInfo().IsEmpty)
                             Return New BoundNamespaceExpression(node, Nothing, [alias], DirectCast(symbol, NamespaceSymbol), hasErrors:=hasError)
                         Case Else
                             Throw ExceptionUtilities.UnexpectedValue(symbol.Kind)
@@ -3486,7 +3482,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result
         End Function
 
-        Private Sub CheckMemberTypeAccessibility(diagnostics As DiagnosticBag, node As SyntaxNode, member As Symbol)
+        Private Sub CheckMemberTypeAccessibility(diagnostics As BindingDiagnosticBag, node As SyntaxNode, member As Symbol)
             ' We are not doing this check during lookup due to a performance impact it has on IDE scenarios.
             ' In any case, an accessible member with inaccessible type is beyond language spec, so we have
             ' some freedom how to deal with it.
@@ -3520,12 +3516,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Throw ExceptionUtilities.UnexpectedValue(member.Kind)
             End Select
 
-            If CheckAccessibility(memberType, Nothing, Nothing) <> AccessCheckResult.Accessible Then
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            If CheckAccessibility(memberType, useSiteInfo, accessThroughType:=Nothing) <> AccessCheckResult.Accessible Then
                 ReportDiagnostic(diagnostics, node,
                                  New BadSymbolDiagnostic(member,
                                                    ERRID.ERR_InaccessibleReturnTypeOfMember2,
                                                    CustomSymbolDisplayFormatter.WithContainingType(member)))
             End If
+
+            diagnostics.Add(node, useSiteInfo)
         End Sub
 
         Public Shared Function IsTopMostEnclosingLambdaAQueryLambda(containingMember As Symbol, stopAtContainer As Symbol) As Boolean
@@ -3549,11 +3548,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return topMostEnclosingLambdaIsQueryLambda
         End Function
 
-        Public Function BindLabel(node As LabelSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Public Function BindLabel(node As LabelSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim labelName As String = node.LabelToken.ValueText
 
             Dim result = LookupResult.GetInstance()
-            Me.Lookup(result, labelName, arity:=0, options:=LookupOptions.LabelsOnly, useSiteDiagnostics:=Nothing)
+            Me.Lookup(result, labelName, arity:=0, options:=LookupOptions.LabelsOnly, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
             Dim symbol As LabelSymbol = Nothing
             Dim hasErrors As Boolean = False
@@ -3586,7 +3585,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindTypeArguments(
             typeArgumentsOpt As TypeArgumentListSyntax,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundTypeArguments
 
             If typeArgumentsOpt Is Nothing Then
@@ -3612,7 +3611,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Report diagnostics relating to access shared/nonshared symbols. Returns true if an ERROR (but not a warning)
         ''' was reported. Also replaces receiver as a type with DefaultPropertyInstance when appropriate.
         ''' </summary>
-        Private Function CheckSharedSymbolAccess(node As SyntaxNode, isShared As Boolean, <[In], Out> ByRef receiver As BoundExpression, qualKind As QualificationKind, diagnostics As DiagnosticBag) As Boolean
+        Private Function CheckSharedSymbolAccess(node As SyntaxNode, isShared As Boolean, <[In], Out> ByRef receiver As BoundExpression, qualKind As QualificationKind, diagnostics As BindingDiagnosticBag) As Boolean
             If isShared Then
                 If qualKind = QualificationKind.QualifiedViaValue AndAlso receiver IsNot Nothing AndAlso
                         receiver.Kind <> BoundKind.TypeOrValueExpression AndAlso receiver.Kind <> BoundKind.MyBaseReference AndAlso
@@ -3692,12 +3691,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Protected Overridable Function TryBindOmittedLeftForDictionaryAccess(node As MemberAccessExpressionSyntax,
                                                                              accessingBinder As Binder,
-                                                                             diagnostics As DiagnosticBag) As BoundExpression
+                                                                             diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(Me.ContainingBinder IsNot Nothing)
             Return Me.ContainingBinder.TryBindOmittedLeftForDictionaryAccess(node, accessingBinder, diagnostics)
         End Function
 
-        Private Function BindDictionaryAccess(node As MemberAccessExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindDictionaryAccess(node As MemberAccessExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim leftOpt = node.Expression
             Dim left As BoundExpression
             If leftOpt Is Nothing Then
@@ -3748,10 +3747,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If type.IsInterfaceType Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                     ' In case IsExtensibleInterfaceNoUseSiteDiagnostics above failed because there were bad inherited interfaces.
-                    type.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                    diagnostics.Add(node, useSiteDiagnostics)
+                    type.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
+                    diagnostics.Add(node, useSiteInfo)
                 End If
 
                 Dim defaultPropertyGroup As BoundExpression = BindDefaultPropertyGroup(node, left, diagnostics)
@@ -3808,7 +3807,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ErrorTypeSymbol.UnknownResultType)
         End Function
 
-        Private Shared Sub ReportNoDefaultProperty(expr As BoundExpression, diagnostics As DiagnosticBag)
+        Private Shared Sub ReportNoDefaultProperty(expr As BoundExpression, diagnostics As BindingDiagnosticBag)
             Dim type = expr.Type
             Dim syntax = expr.Syntax
             Select Case type.TypeKind
@@ -3826,12 +3825,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Sub
 
-        Private Shared Sub ReportQualNotObjectRecord(expr As BoundExpression, diagnostics As DiagnosticBag)
+        Private Shared Sub ReportQualNotObjectRecord(expr As BoundExpression, diagnostics As BindingDiagnosticBag)
             ' "'!' requires its left operand to have a type parameter, class or interface type, but this operand has the type '{0}'."
             ReportDiagnostic(diagnostics, expr.Syntax, ERRID.ERR_QualNotObjectRecord1, expr.Type)
         End Sub
 
-        Private Shared Sub ReportDefaultMemberNotProperty(expr As BoundExpression, diagnostics As DiagnosticBag)
+        Private Shared Sub ReportDefaultMemberNotProperty(expr As BoundExpression, diagnostics As BindingDiagnosticBag)
             ' "Default member '{0}' is not a property."
             ' Note: The error argument is the expression type
             ' rather than the expression text used in Dev10.
@@ -3845,7 +3844,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return BadExpression(node, children.ToImmutableAndFree(), ErrorTypeSymbol.UnknownResultType)
         End Function
 
-        Private Shared Sub VerifyTypeCharacterConsistency(nodeOrToken As SyntaxNodeOrToken, type As TypeSymbol, typeChar As TypeCharacter, diagnostics As DiagnosticBag)
+        Private Shared Sub VerifyTypeCharacterConsistency(nodeOrToken As SyntaxNodeOrToken, type As TypeSymbol, typeChar As TypeCharacter, diagnostics As BindingDiagnosticBag)
             Dim typeCharacterString As String = Nothing
             Dim specialType As SpecialType = GetSpecialTypeForTypeCharacter(typeChar, typeCharacterString)
 
@@ -3863,7 +3862,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Shared Sub VerifyTypeCharacterConsistency(name As SimpleNameSyntax, type As TypeSymbol, diagnostics As DiagnosticBag)
+        Private Shared Sub VerifyTypeCharacterConsistency(name As SimpleNameSyntax, type As TypeSymbol, diagnostics As BindingDiagnosticBag)
             Dim typeChar As TypeCharacter = name.Identifier.GetTypeCharacter()
             If typeChar = TypeCharacter.None Then
                 Return
@@ -3885,7 +3884,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Function BindArrayAccess(node As InvocationExpressionSyntax, expr As BoundExpression, boundArguments As ImmutableArray(Of BoundExpression), argumentNames As ImmutableArray(Of String), diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindArrayAccess(node As InvocationExpressionSyntax, expr As BoundExpression, boundArguments As ImmutableArray(Of BoundExpression), argumentNames As ImmutableArray(Of String), diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(node IsNot Nothing)
             Debug.Assert(expr IsNot Nothing)
 
@@ -3956,7 +3955,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim noCommonType As Boolean = False
             Dim noCommonName As Boolean = False
 
-            Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
             For i As Integer = 0 To symbols.Length - 1
 
@@ -3996,7 +3995,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             symbolReference As VisualBasicSyntaxNode,
             s As Symbol,
             constantFieldsInProgress As SymbolsInProgress(Of FieldSymbol),
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As TypeSymbol
             Select Case s.Kind
                 Case SymbolKind.Method
@@ -4065,7 +4064,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         '''   new integer(n)(,) {...}
         '''   new integer() {...}
         ''' </summary>
-        Private Function BindArrayCreationExpression(node As ArrayCreationExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindArrayCreationExpression(node As ArrayCreationExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             ' Bind the type
             Dim baseType = BindTypeSyntax(node.Type, diagnostics)
@@ -4096,7 +4095,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function BindArrayLiteralExpression(node As CollectionInitializerSyntax,
-                                                    diagnostics As DiagnosticBag) As BoundExpression
+                                                    diagnostics As BindingDiagnosticBag) As BoundExpression
 
             ' Inspect the collection initializer to determine the literal's rank
             ' Per 11.1.1, the array literal is reclassified to a value whose type is an array of rank equal to the level of nesting is used.
@@ -4120,7 +4119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundArrayLiteral(node, hasDominantType, numberOfCandidates, inferredArrayType, sizes, arrayInitializer, Me)
         End Function
 
-        Private Function CreateArrayBounds(node As SyntaxNode, knownSizes() As DimensionSize, diagnostics As DiagnosticBag) As ImmutableArray(Of BoundExpression)
+        Private Function CreateArrayBounds(node As SyntaxNode, knownSizes() As DimensionSize, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of BoundExpression)
             Dim rank = knownSizes.Length
             Dim sizes = New BoundExpression(rank - 1) {}
             Dim Int32Type = GetSpecialType(SpecialType.System_Int32, node, diagnostics)
@@ -4173,7 +4172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindArrayInitializerList(node As CollectionInitializerSyntax,
                                                type As ArrayTypeSymbol,
                                                knownSizes As DimensionSize(),
-                                               diagnostics As DiagnosticBag) As BoundArrayInitialization
+                                               diagnostics As BindingDiagnosticBag) As BoundArrayInitialization
             Debug.Assert(type IsNot Nothing)
 
             Dim result = BindArrayInitializerList(node, type, knownSizes, 1, Nothing, diagnostics)
@@ -4195,7 +4194,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        <Out> ByRef hasDominantType As Boolean,
                                        <Out> ByRef numberOfCandidates As Integer,
                                        <Out> ByRef inferredElementType As TypeSymbol,
-                                       diagnostics As DiagnosticBag) As BoundArrayInitialization
+                                       diagnostics As BindingDiagnosticBag) As BoundArrayInitialization
 
             ' Infer the type for this array literal
 
@@ -4223,7 +4222,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                   knownSizes As DimensionSize(),
                                                   dimension As Integer,
                                                   allInitializers As ArrayBuilder(Of BoundExpression),
-                                                  diagnostics As DiagnosticBag) As BoundArrayInitialization
+                                                  diagnostics As BindingDiagnosticBag) As BoundArrayInitialization
             Debug.Assert(type IsNot Nothing OrElse allInitializers IsNot Nothing)
 
             Dim initializers = ArrayBuilder(Of BoundExpression).GetInstance
@@ -4310,7 +4309,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundArrayInitialization(node, initializers.ToImmutableAndFree(), arrayInitType)
         End Function
 
-        Private Sub CheckRangeArgumentLowerBound(rangeArgument As RangeArgumentSyntax, diagnostics As DiagnosticBag)
+        Private Sub CheckRangeArgumentLowerBound(rangeArgument As RangeArgumentSyntax, diagnostics As BindingDiagnosticBag)
             Dim lowerBound = BindValue(rangeArgument.LowerBound, diagnostics)
 
             ' This check was moved from the parser to the binder.  For backwards compatibility with Dev10, the constant must
@@ -4329,7 +4328,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="diagnostics">Where to put the errors</param>
         ''' <param name="knownSizes">The bounds if they are constants, if argument is not specified this info is not returned </param>
         Private Function BindArrayBounds(arrayBoundsOpt As ArgumentListSyntax,
-                                         diagnostics As DiagnosticBag,
+                                         diagnostics As BindingDiagnosticBag,
                                          Optional knownSizes As DimensionSize() = Nothing,
                                          Optional errorOnEmptyBound As Boolean = False) As ImmutableArray(Of BoundExpression)
 
@@ -4442,7 +4441,7 @@ lElseClause:
             Return boundArgumentsBuilder.ToImmutableAndFree
         End Function
 
-        Private Function BindLiteralConstant(node As LiteralExpressionSyntax, diagnostics As DiagnosticBag) As BoundLiteral
+        Private Function BindLiteralConstant(node As LiteralExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundLiteral
             Dim value = node.Token.Value
 
             Dim cv As ConstantValue
@@ -4471,7 +4470,7 @@ lElseClause:
         Friend Function InferDominantTypeOfExpressions(
             syntax As SyntaxNode,
             Expressions As ArrayBuilder(Of BoundExpression),
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             ByRef numCandidates As Integer,
             Optional ByRef errorReasons As InferenceErrorReasons = InferenceErrorReasons.Other
         ) As TypeSymbol
@@ -4572,12 +4571,12 @@ lElseClause:
             ' Note: if there were no candidate types in the list, this will fail with errorReason = NoneBest.
             errorReasons = InferenceErrorReasons.Other
             Dim results = ArrayBuilder(Of DominantTypeData).GetInstance()
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            typeList.FindDominantType(results, errorReasons, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            typeList.FindDominantType(results, errorReasons, useSiteInfo)
 
-            If diagnostics.Add(syntax, useSiteDiagnostics) Then
+            If diagnostics.Add(syntax, useSiteInfo) Then
                 ' Suppress additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             Dim dominantType As TypeSymbol
@@ -4633,7 +4632,7 @@ lElseClause:
 
         Private Function BindAwait(
             node As AwaitExpressionSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional bindAsStatement As Boolean = False
         ) As BoundExpression
 
@@ -4651,7 +4650,7 @@ lElseClause:
         Private Function BindAwait(
             node As VisualBasicSyntaxNode,
             operand As BoundExpression,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             bindAsStatement As Boolean
         ) As BoundExpression
 
@@ -4684,14 +4683,14 @@ lElseClause:
                 End If
             End If
 
-            Dim ignoreDiagnostics = DiagnosticBag.GetInstance()
+            Dim ignoreDiagnostics = BindingDiagnosticBag.GetInstance()
 
             ' Will accumulate all ignored diagnostics in case we want to add them
-            Dim allIgnoreDiagnostics = DiagnosticBag.GetInstance()
+            Dim allIgnoreDiagnostics = BindingDiagnosticBag.GetInstance()
 
             If operand.HasErrors Then
                 ' Disable error reporting going forward.
-                diagnostics = ignoreDiagnostics
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             Dim awaitableInstancePlaceholder = New BoundRValuePlaceholder(operand.Syntax, operand.Type).MakeCompilerGenerated()
@@ -4723,15 +4722,15 @@ lElseClause:
                 Debug.Assert(getResult.Type.IsObjectType())
                 getResult = DirectCast(getResult, BoundLateMemberAccess).SetAccessKind(If(bindAsStatement, LateBoundAccessKind.Call, LateBoundAccessKind.Get))
 
-                Debug.Assert(operand.Type.IsErrorType() OrElse ignoreDiagnostics.IsEmptyWithoutResolution())
+                Debug.Assert(operand.Type.IsErrorType() OrElse ignoreDiagnostics.DiagnosticBag.IsEmptyWithoutResolution())
             Else
                 Dim lookupResult As LookupResult = LookupResult.GetInstance()
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
                 ' 11.25 Await Operator
                 '
                 '1.	C contains an accessible instance or extension method named GetAwaiter which has no arguments and which returns some type E;
-                LookupMember(lookupResult, awaitableInstancePlaceholder.Type, WellKnownMemberNames.GetAwaiter, 0, LookupOptions.AllMethodsOfAnyArity, useSiteDiagnostics)
+                LookupMember(lookupResult, awaitableInstancePlaceholder.Type, WellKnownMemberNames.GetAwaiter, 0, LookupOptions.AllMethodsOfAnyArity, useSiteInfo)
 
                 Dim methodGroup As BoundMethodGroup = Nothing
 
@@ -4761,9 +4760,10 @@ lElseClause:
                     ' 3) method is not a Sub;
                     ' 4) result is not Object.
                     If getAwaiter.HasErrors OrElse
-                       DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics) OrElse
+                       DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics.DiagnosticBag) OrElse
                        getAwaiter.Kind <> BoundKind.Call OrElse
                        getAwaiter.Type.IsObjectType() Then
+
                         getAwaiter = Nothing
                     Else
                         allIgnoreDiagnostics.AddRange(ignoreDiagnostics)
@@ -4774,7 +4774,7 @@ lElseClause:
                         End If
                     End If
 
-                    Debug.Assert(getAwaiter Is Nothing OrElse Not DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics))
+                    Debug.Assert(getAwaiter Is Nothing OrElse Not DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics.DiagnosticBag))
                 End If
 
                 If getAwaiter IsNot Nothing AndAlso Not getAwaiter.Type.IsErrorType() Then
@@ -4783,7 +4783,7 @@ lElseClause:
 
                     lookupResult.Clear()
                     LookupMember(lookupResult, awaiterInstancePlaceholder.Type, WellKnownMemberNames.IsCompleted, 0,
-                                 LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods, useSiteDiagnostics)
+                                 LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods, useSiteInfo)
 
                     If lookupResult.Kind = LookupResultKind.Good AndAlso lookupResult.Symbols(0).Kind = SymbolKind.Property Then
                         Dim propertyGroup = New BoundPropertyGroup(node,
@@ -4808,9 +4808,10 @@ lElseClause:
                         ' 2) property doesn't have any parameters, optional parameters should be ruled out;
                         ' 3) result is Boolean.
                         If isCompleted.HasErrors OrElse
-                           DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics) OrElse
+                           DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics.DiagnosticBag) OrElse
                            isCompleted.Kind <> BoundKind.PropertyAccess OrElse
                            Not isCompleted.Type.IsBooleanType() Then
+
                             isCompleted = Nothing
                         Else
                             allIgnoreDiagnostics.AddRange(ignoreDiagnostics)
@@ -4822,13 +4823,13 @@ lElseClause:
                             End If
                         End If
 
-                        Debug.Assert(isCompleted Is Nothing OrElse Not DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics))
+                        Debug.Assert(isCompleted Is Nothing OrElse Not DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics.DiagnosticBag))
                     End If
 
                     ' 3.	E contains an accessible instance method named GetResult which takes no arguments;
                     lookupResult.Clear()
                     LookupMember(lookupResult, awaiterInstancePlaceholder.Type, WellKnownMemberNames.GetResult, 0,
-                                 LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods, useSiteDiagnostics)
+                                 LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods, useSiteInfo)
 
                     If lookupResult.Kind = LookupResultKind.Good AndAlso lookupResult.Symbols(0).Kind = SymbolKind.Method Then
                         methodGroup = CreateBoundMethodGroup(
@@ -4853,8 +4854,9 @@ lElseClause:
                         ' 1) a non-latebound call of an instance (extension methods ignored) method;
                         ' 2) method doesn't have any parameters, optional parameters should be ruled out;
                         If getResult.HasErrors OrElse
-                           DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics) OrElse
+                           DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics.DiagnosticBag) OrElse
                            getResult.Kind <> BoundKind.Call Then
+
                             getResult = Nothing
                         Else
                             allIgnoreDiagnostics.AddRange(ignoreDiagnostics)
@@ -4867,7 +4869,7 @@ lElseClause:
                             End If
                         End If
 
-                        Debug.Assert(getResult Is Nothing OrElse Not DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics))
+                        Debug.Assert(getResult Is Nothing OrElse Not DiagnosticBagHasErrorsOtherThanObsoleteOnes(ignoreDiagnostics.DiagnosticBag))
                     End If
 
                     ' 4.	E implements either System.Runtime.CompilerServices.INotifyCompletion or ICriticalNotifyCompletion.
@@ -4875,12 +4877,12 @@ lElseClause:
 
                     ' ICriticalNotifyCompletion inherits from INotifyCompletion, so a check for INotifyCompletion is sufficient.
                     If Not notifyCompletion.IsErrorType() AndAlso
-                       Not Conversions.IsWideningConversion(Conversions.ClassifyDirectCastConversion(getAwaiter.Type, notifyCompletion, useSiteDiagnostics)) Then
+                       Not Conversions.IsWideningConversion(Conversions.ClassifyDirectCastConversion(getAwaiter.Type, notifyCompletion, useSiteInfo)) Then
                         ReportDiagnostic(diagnostics, node, ERRID.ERR_DoesntImplementAwaitInterface2, getAwaiter.Type, notifyCompletion)
                     End If
                 End If
 
-                diagnostics.Add(node, useSiteDiagnostics)
+                diagnostics.Add(node, useSiteInfo)
                 lookupResult.Free()
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             symbol As SourceMemberContainerTypeSymbol,
             initializers As ImmutableArray(Of ImmutableArray(Of FieldOrPropertyInitializer)),
             scriptInitializerOpt As SynthesizedInteractiveInitializerMethod,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As ImmutableArray(Of BoundInitializer)
             Debug.Assert((scriptInitializerOpt IsNot Nothing) = symbol.IsScriptClass)
 
@@ -156,12 +156,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                             If fieldSymbol.Type.SpecialType = SpecialType.System_DateTime Then
                                 '  report proper diagnostics for System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor if needed
-                                initializerBinder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor,
+                                initializerBinder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor,
                                                                                             initializerNode,
                                                                                             diagnostics)
                             ElseIf fieldSymbol.Type.SpecialType = SpecialType.System_Decimal Then
                                 '  report proper diagnostics for System_Runtime_CompilerServices_DecimalConstantAttribute__ctor if needed
-                                initializerBinder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor,
+                                initializerBinder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor,
                                                                                             initializerNode,
                                                                                             diagnostics)
                             End If
@@ -201,7 +201,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindGlobalStatement(
             scriptInitializerOpt As SynthesizedInteractiveInitializerMethod,
             statementNode As StatementSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             isLast As Boolean) As BoundInitializer
 
             Dim boundStatement As BoundStatement = Me.BindStatement(statementNode, diagnostics)
@@ -225,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Sub BindArrayFieldImplicitInitializer(
             fieldSymbol As SourceFieldSymbol,
             boundInitializers As ArrayBuilder(Of BoundInitializer),
-            diagnostics As DiagnosticBag)
+            diagnostics As BindingDiagnosticBag)
 
             Debug.Assert(fieldSymbol.Syntax.Kind = SyntaxKind.ModifiedIdentifier)
             Debug.Assert(fieldSymbol.Type.Kind = SymbolKind.ArrayType)
@@ -260,7 +260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             fieldSymbols As ImmutableArray(Of FieldSymbol),
             equalsValueOrAsNewSyntax As SyntaxNode,
             boundInitializers As ArrayBuilder(Of BoundInitializer),
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional bindingForSemanticModel As Boolean = False
         )
             Debug.Assert(Not fieldSymbols.IsEmpty)
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             propertySymbols As ImmutableArray(Of PropertySymbol),
             initValueOrAsNewNode As SyntaxNode,
             boundInitializers As ArrayBuilder(Of BoundInitializer),
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Dim propertySymbol = DirectCast(propertySymbols.First, PropertySymbol)
             Dim syntaxNode As SyntaxNode = initValueOrAsNewNode
@@ -381,7 +381,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             equalsValueOrAsNewSyntax As SyntaxNode,
             targetType As TypeSymbol,
             asNewVariablePlaceholderOpt As BoundWithLValueExpressionPlaceholder,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Dim boundInitExpression As BoundExpression = Nothing
 
@@ -480,12 +480,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             fieldSymbol As FieldSymbol,
             equalsValueOrAsNewSyntax As VisualBasicSyntaxNode,
             isEnum As Boolean,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             <Out> ByRef constValue As ConstantValue
         ) As BoundExpression
             constValue = Nothing
             Dim boundInitValue As BoundExpression = Nothing
-            Dim initValueDiagnostics = DiagnosticBag.GetInstance
+            Dim initValueDiagnostics = BindingDiagnosticBag.GetInstance
 
             If equalsValueOrAsNewSyntax.Kind = SyntaxKind.EqualsValue Then
                 Dim equalsValueSyntax As EqualsValueSyntax = DirectCast(equalsValueOrAsNewSyntax, EqualsValueSyntax)
@@ -496,8 +496,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' the bound node in a BoundBadNode. The required diagnostics have already been reported in 
                 ' SourceFieldSymbol.Type
                 Dim asNewSyntax = DirectCast(equalsValueOrAsNewSyntax, AsNewClauseSyntax)
-                Dim ignoredDiagnostics = DiagnosticBag.GetInstance
-                Dim fieldType = If(fieldSymbol.HasDeclaredType, fieldSymbol.Type, GetSpecialType(SpecialType.System_Object, asNewSyntax, ignoredDiagnostics)) ' prevent recursion if field type is inferred.
+                Dim fieldType = If(fieldSymbol.HasDeclaredType, fieldSymbol.Type, GetSpecialType(SpecialType.System_Object, asNewSyntax, BindingDiagnosticBag.Discarded)) ' prevent recursion if field type is inferred.
                 Select Case asNewSyntax.NewExpression.Kind
                     Case SyntaxKind.ObjectCreationExpression
                         Dim objectCreationExpressionSyntax = DirectCast(asNewSyntax.NewExpression,
@@ -506,11 +505,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                       objectCreationExpressionSyntax.ArgumentList,
                                                                       fieldType,
                                                                       objectCreationExpressionSyntax,
-                                                                      ignoredDiagnostics,
+                                                                      BindingDiagnosticBag.Discarded,
                                                                       Nothing)
                     Case SyntaxKind.AnonymousObjectCreationExpression
                         boundInitValue = BindAnonymousObjectCreationExpression(
-                                                DirectCast(asNewSyntax.NewExpression, AnonymousObjectCreationExpressionSyntax), ignoredDiagnostics)
+                                                DirectCast(asNewSyntax.NewExpression, AnonymousObjectCreationExpressionSyntax), BindingDiagnosticBag.Discarded)
                     Case Else
                         Throw ExceptionUtilities.UnexpectedValue(asNewSyntax.NewExpression.Kind)
                 End Select
@@ -521,7 +520,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                         ImmutableArray.Create(boundInitValue),
                                                         fieldType,
                                                         hasErrors:=True)
-                ignoredDiagnostics.Free()
             End If
 
             If Not boundInitValue.HasErrors Then
@@ -550,9 +548,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' NOTE: only type diagnostics for "const s as StructureType = nothing"
 
                 If boundInitValueHasErrorsOrConstTypeIsWrong Then
-                    Dim discard = DiagnosticBag.GetInstance
-                    constValue = Me.GetExpressionConstantValueIfAny(boundInitValue, discard, ConstantContext.Default)
-                    discard.Free()
+                    constValue = Me.GetExpressionConstantValueIfAny(boundInitValue, BindingDiagnosticBag.Discarded, ConstantContext.Default)
                 Else
                     constValue = Me.GetExpressionConstantValueIfAny(boundInitValue, initValueDiagnostics, ConstantContext.Default)
                 End If
@@ -581,7 +577,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                 type As TypeSymbol,
                                                 name As ModifiedIdentifierSyntax,
                                                 equalsValueOpt As EqualsValueSyntax,
-                                                diagnostics As DiagnosticBag,
+                                                diagnostics As BindingDiagnosticBag,
                                                 <Out> ByRef constValue As ConstantValue) As BoundExpression
             constValue = Nothing
 
@@ -636,7 +632,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function BindParameterDefaultValue(
             targetType As TypeSymbol,
             equalsValueSyntax As EqualsValueSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             <Out> ByRef constValue As ConstantValue
         ) As BoundExpression
             constValue = Nothing

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_InterpolatedString.vb
@@ -11,7 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Partial Friend Class Binder
 
-        Private Function BindInterpolatedStringExpression(syntax As InterpolatedStringExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindInterpolatedStringExpression(syntax As InterpolatedStringExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Dim contentBuilder = ArrayBuilder(Of BoundNode).GetInstance()
 
@@ -31,11 +31,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Function
 
-        Private Function BindInterpolatedStringText(syntax As InterpolatedStringTextSyntax, diagnostics As DiagnosticBag) As BoundLiteral
+        Private Function BindInterpolatedStringText(syntax As InterpolatedStringTextSyntax, diagnostics As BindingDiagnosticBag) As BoundLiteral
             Return CreateStringLiteral(syntax, syntax.TextToken.ValueText, compilerGenerated:=False, diagnostics:=diagnostics)
         End Function
 
-        Private Function BindInterpolation(syntax As InterpolationSyntax, diagnostics As DiagnosticBag) As BoundInterpolation
+        Private Function BindInterpolation(syntax As InterpolationSyntax, diagnostics As BindingDiagnosticBag) As BoundInterpolation
 
             Dim expression = BindRValue(syntax.Expression, diagnostics)
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
@@ -13,16 +13,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindLambdaExpression(
              node As LambdaExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
          ) As BoundExpression
 
             Const asyncIterator As SourceMemberFlags = SourceMemberFlags.Async Or SourceMemberFlags.Iterator
 
             ' Decode the modifiers.
-            Dim modifiers As SourceMemberFlags = DecodeModifiers(node.SubOrFunctionHeader.Modifiers, asyncIterator, ERRID.ERR_InvalidLambdaModifier, Accessibility.Public, diagnostics).FoundFlags And asyncIterator
+            Dim modifiers As SourceMemberFlags = DecodeModifiers(node.SubOrFunctionHeader.Modifiers, asyncIterator, ERRID.ERR_InvalidLambdaModifier, Accessibility.Public, If(diagnostics.DiagnosticBag, New DiagnosticBag())).FoundFlags And asyncIterator
 
-            If (modifiers And asyncIterator) = asyncIterator Then
-                ReportModifierError(node.SubOrFunctionHeader.Modifiers, ERRID.ERR_InvalidAsyncIteratorModifiers, diagnostics, InvalidAsyncIterator)
+            If (modifiers And asyncIterator) = asyncIterator AndAlso diagnostics.DiagnosticBag IsNot Nothing Then
+                ReportModifierError(node.SubOrFunctionHeader.Modifiers, ERRID.ERR_InvalidAsyncIteratorModifiers, diagnostics.DiagnosticBag, InvalidAsyncIterator)
             End If
 
             Dim parameters As ImmutableArray(Of ParameterSymbol)
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function BuildBoundLambdaParameters(
             source As UnboundLambda,
             targetSignature As UnboundLambda.TargetSignature,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As ImmutableArray(Of BoundLambdaParameterSymbol)
 
             If source.Parameters.Length = 0 Then
@@ -153,7 +153,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(Me Is source.Binder)
 
             Dim maxRelaxationLevel As ConversionKind = ConversionKind.DelegateRelaxationLevelNone
-            Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
             Dim targetReturnType As TypeSymbol
 
             If source.ReturnType IsNot Nothing Then
@@ -206,12 +206,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                                returnsByRef:=False)
                     End If
 
-                    Dim typeInfo As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic)) = source.InferReturnType(targetForInference)
+                    Dim typeInfo As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = source.InferReturnType(targetForInference)
 
                     targetReturnType = typeInfo.Key
-                    If Not typeInfo.Value.IsEmpty Then
-                        diagnostics.AddRange(typeInfo.Value)
-                    End If
+                    diagnostics.AddRange(typeInfo.Value)
                 End If
             End If
 
@@ -232,10 +230,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     delegateRelaxation = ConversionKind.DelegateRelaxationLevelNone
                 Else
                     Dim seenReturnWithAValue As Boolean = False
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    delegateRelaxation = LambdaRelaxationVisitor.DetermineDelegateRelaxationLevel(lambdaSymbol, source.Flags = SourceMemberFlags.Iterator, block, seenReturnWithAValue, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    delegateRelaxation = LambdaRelaxationVisitor.DetermineDelegateRelaxationLevel(lambdaSymbol, source.Flags = SourceMemberFlags.Iterator, block, seenReturnWithAValue, useSiteInfo)
 
-                    diagnostics.Add(LambdaHeaderErrorNode(source), useSiteDiagnostics)
+                    diagnostics.Add(LambdaHeaderErrorNode(source), useSiteInfo)
 
                     ' Dev11#94373: we also need to track whether there were any returns with operands, since
                     ' turning "Async Function() : End Function" into a Func(Of Task(Of Integer)) is a delegate
@@ -252,12 +250,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If delegateRelaxation <> ConversionKind.DelegateRelaxationLevelInvalid Then
                 ' Figure out conversion kind.
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                methodConversions = Conversions.ClassifyMethodConversionForLambdaOrAnonymousDelegate(target, lambdaSymbol, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                methodConversions = Conversions.ClassifyMethodConversionForLambdaOrAnonymousDelegate(target, lambdaSymbol, useSiteInfo)
 
-                If diagnostics.Add(LambdaHeaderErrorNode(source), useSiteDiagnostics) Then
+                If diagnostics.Add(LambdaHeaderErrorNode(source), useSiteInfo) Then
                     ' Suppress additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
 
                 If Conversions.IsDelegateRelaxationSupportedFor(methodConversions) Then
@@ -300,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' the control flow of lambda expression bodies have not yet been analyzed. This will report unreachable code, ...
-            ControlFlowPass.Analyze(New FlowAnalysisInfo(Compilation, lambdaSymbol, block), diagnostics, True)
+            ControlFlowPass.Analyze(New FlowAnalysisInfo(Compilation, lambdaSymbol, block), diagnostics.DiagnosticBag, True)
 
             Dim hasAnyErrors = diagnostics.HasAnyErrors()
 
@@ -328,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private ReadOnly _isIterator As Boolean
             Private _delegateRelaxationLevel As ConversionKind = ConversionKind.DelegateRelaxationLevelNone
             Private _seenReturnWithAValue As Boolean
-            Private _useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            Private _useSiteDiagnostics As CompoundUseSiteInfo(Of AssemblySymbol)
 
             Private Sub New(lambdaSymbol As LambdaSymbol, isIterator As Boolean)
                 _lambdaSymbol = lambdaSymbol
@@ -340,13 +338,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 isIterator As Boolean,
                 lambdaBlock As BoundBlock,
                 <Out()> ByRef seenReturnWithAValue As Boolean,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As ConversionKind
                 Dim visitor As New LambdaRelaxationVisitor(lambdaSymbol, isIterator)
-                visitor._useSiteDiagnostics = useSiteDiagnostics
+                visitor._useSiteDiagnostics = useSiteInfo
                 visitor.VisitBlock(lambdaBlock)
                 seenReturnWithAValue = visitor._seenReturnWithAValue
-                useSiteDiagnostics = visitor._useSiteDiagnostics
+                useSiteInfo = visitor._useSiteDiagnostics
                 Return visitor._delegateRelaxationLevel
             End Function
 
@@ -409,7 +407,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindLambdaBody(
             lambdaSymbol As LambdaSymbol,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             ByRef lambdaBinder As LambdaBodyBinder
         ) As BoundBlock
             Dim implicitVariablesBinder As Binder = Nothing
@@ -484,9 +482,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' declarations are prohibited.
 
                         ' Bind local declaration, discard diagnostics
-                        Dim ignoredDiagnostics = DiagnosticBag.GetInstance()
-                        block = bodyBinder.BindBlock(lambdaSyntax, singleLineLambdaSyntax.Statements, ignoredDiagnostics).MakeCompilerGenerated()
-                        ignoredDiagnostics.Free()
+                        block = bodyBinder.BindBlock(lambdaSyntax, singleLineLambdaSyntax.Statements, BindingDiagnosticBag.Discarded).MakeCompilerGenerated()
 
                         ' Generate a diagnostic and a bad statement node
                         ReportDiagnostic(diagnostics, statement, ERRID.ERR_SubDisallowsStatement)
@@ -581,11 +577,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private ReadOnly _binder As Binder
-            Private ReadOnly _diagnostics As DiagnosticBag
+            Private ReadOnly _diagnostics As BindingDiagnosticBag
             Private _isInCatchFinallyOrSyncLock As Boolean
             Private _containsAwait As Boolean
 
-            Private Sub New(binder As Binder, diagnostics As DiagnosticBag)
+            Private Sub New(binder As Binder, diagnostics As BindingDiagnosticBag)
                 _diagnostics = diagnostics
                 _binder = binder
             End Sub
@@ -593,7 +589,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public Shared Shadows Function VisitBlock(
                 binder As Binder,
                 block As BoundBlock,
-                diagnostics As DiagnosticBag
+                diagnostics As BindingDiagnosticBag
             ) As Boolean
                 Debug.Assert(binder.IsInAsyncContext())
 
@@ -654,7 +650,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Class
 
 
-        Public Sub ReportLambdaParameterInferredToBeObject(unboundParam As UnboundLambdaParameterSymbol, diagnostics As DiagnosticBag)
+        Public Sub ReportLambdaParameterInferredToBeObject(unboundParam As UnboundLambdaParameterSymbol, diagnostics As BindingDiagnosticBag)
             If OptionStrict = OptionStrict.On Then
                 ReportDiagnostic(diagnostics, unboundParam.IdentifierSyntax, ERRID.ERR_StrictDisallowImplicitObjectLambda)
             ElseIf OptionStrict = OptionStrict.Custom Then
@@ -771,33 +767,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Friend Function InferAnonymousDelegateForLambda(source As UnboundLambda) As KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic))
+        Friend Function InferAnonymousDelegateForLambda(source As UnboundLambda) As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(Me Is source.Binder)
 
-            Dim diagnostics = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
             ' Using Void as return type, because BuildBoundLambdaParameters doesn't use it and it is as good as any other value.
             Dim targetSignature As New UnboundLambda.TargetSignature(ImmutableArray(Of ParameterSymbol).Empty, Compilation.GetSpecialType(SpecialType.System_Void), returnsByRef:=False)
             Dim parameters As ImmutableArray(Of BoundLambdaParameterSymbol) = BuildBoundLambdaParameters(source, targetSignature, diagnostics)
 
-            Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))
+            Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             returnTypeInfo = source.InferReturnType(New UnboundLambda.TargetSignature(StaticCast(Of ParameterSymbol).From(parameters), targetSignature.ReturnType, targetSignature.ReturnsByRef))
             Dim returnType As TypeSymbol = returnTypeInfo.Key
 
-            If Not returnTypeInfo.Value.IsDefaultOrEmpty Then
-                diagnostics.AddRange(returnTypeInfo.Value)
-            End If
+            diagnostics.AddRange(returnTypeInfo.Value)
 
             Dim delegateType As NamedTypeSymbol = ConstructAnonymousDelegateSymbol(source, parameters, returnType, diagnostics)
 
-            Return New KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic))(delegateType, diagnostics.ToReadOnlyAndFree())
+            Return New KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(delegateType, diagnostics.ToReadOnlyAndFree())
         End Function
 
         Private Function ConstructAnonymousDelegateSymbol(
             source As UnboundLambda,
             parameters As ImmutableArray(Of BoundLambdaParameterSymbol),
             returnType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As NamedTypeSymbol
             Debug.Assert(source.IsFunctionLambda = Not returnType.IsVoidType())
 
@@ -894,17 +888,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function InferFunctionLambdaReturnType(
             source As UnboundLambda,
             targetParameters As UnboundLambda.TargetSignature
-        ) As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))
+        ) As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(Me Is source.Binder AndAlso source.IsFunctionLambda AndAlso
                          source.ReturnType Is Nothing AndAlso targetParameters.ReturnType.IsVoidType())
 
             ' If both Async and Iterator are specified, we cannot really infer return type.
             If source.Flags = (SourceMemberFlags.Async Or SourceMemberFlags.Iterator) Then
                 ' No need to report any error because we complained about conflicting modifiers.
-                Return New KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))(LambdaSymbol.ReturnTypeIsUnknown, ImmutableArray(Of Diagnostic).Empty)
+                Return New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(LambdaSymbol.ReturnTypeIsUnknown, ImmutableBindingDiagnostic(Of AssemblySymbol).Empty)
             End If
 
-            Dim diagnostics = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
             ' Clone parameters. 
             Dim parameters As ImmutableArray(Of BoundLambdaParameterSymbol) = BuildBoundLambdaParameters(source, targetParameters, diagnostics)
@@ -913,7 +907,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim block As BoundBlock = BindLambdaBody(symbol, diagnostics, lambdaBinder:=Nothing)
 
             If block.HasErrors OrElse diagnostics.HasAnyErrors() Then
-                Return New KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))(LambdaSymbol.ReturnTypeIsUnknown, diagnostics.ToReadOnlyAndFree())
+                Return New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(LambdaSymbol.ReturnTypeIsUnknown, diagnostics.ToReadOnlyAndFree())
             End If
 
             diagnostics.Clear()
@@ -1010,7 +1004,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             returnExpressions.Free()
 
-            Return New KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))(lambdaReturnType, diagnostics.ToReadOnlyAndFree())
+            Return New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(lambdaReturnType, diagnostics.ToReadOnlyAndFree())
         End Function
 
         Private Shared Function LambdaHeaderErrorNode(source As UnboundLambda) As SyntaxNode
@@ -1129,8 +1123,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Sub LookupInSingleBinder(lookupResult As LookupResult, name As String, arity As Integer, options As LookupOptions, originalBinder As Binder,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
-            MyBase.LookupInSingleBinder(lookupResult, name, arity, options, originalBinder, useSiteDiagnostics)
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
+            MyBase.LookupInSingleBinder(lookupResult, name, arity, options, originalBinder, useSiteInfo)
 
             If (options And LookupOptions.LabelsOnly) = LookupOptions.LabelsOnly Then
                 If lookupResult.Kind = LookupResultKind.Empty Then

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Latebound.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            typeArguments As TypeArgumentListSyntax,
                                            receiver As BoundExpression,
                                            containerType As TypeSymbol,
-                                           diagnostics As DiagnosticBag) As BoundExpression
+                                           diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Dim boundTypeArguments As BoundTypeArguments = BindTypeArguments(typeArguments, diagnostics)
             Return BindLateBoundMemberAccess(node, name, boundTypeArguments, receiver, containerType, diagnostics)
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            boundTypeArguments As BoundTypeArguments,
                                            receiver As BoundExpression,
                                            containerType As TypeSymbol,
-                                           diagnostics As DiagnosticBag,
+                                           diagnostics As BindingDiagnosticBag,
                                            Optional suppressLateBindingResolutionDiagnostics As Boolean = False) As BoundExpression
 
             receiver = AdjustReceiverAmbiguousTypeOrValue(receiver, diagnostics)
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                    isDefaultMemberAccess As Boolean,
                                    arguments As ImmutableArray(Of BoundExpression),
                                    argumentNames As ImmutableArray(Of String),
-                                   diagnostics As DiagnosticBag) As BoundExpression
+                                   diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Dim memberName As String = If(isDefaultMemberAccess,
                                           Nothing,
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            receiver As BoundExpression,
                                            arguments As ImmutableArray(Of BoundExpression),
                                            argumentNames As ImmutableArray(Of String),
-                                           diagnostics As DiagnosticBag,
+                                           diagnostics As BindingDiagnosticBag,
                                            Optional suppressLateBindingResolutionDiagnostics As Boolean = False) As BoundExpression
 
             Debug.Assert(receiver IsNot Nothing AndAlso receiver.Kind <> BoundKind.TypeOrValueExpression)
@@ -229,7 +229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Sub CheckNamedArgumentsForLateboundInvocation(argumentNames As ImmutableArray(Of String),
                                                             arguments As ImmutableArray(Of BoundExpression),
-                                                            diagnostics As DiagnosticBag)
+                                                            diagnostics As BindingDiagnosticBag)
 
             Debug.Assert(Not arguments.IsDefault)
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -22,11 +22,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 name As String,
                                 arity As Integer,
                                 options As LookupOptions,
-                                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(options.IsValid())
 
             options = BinderSpecificLookupOptions(options)
-            MemberLookup.Lookup(lookupResult, container, name, arity, options, Me, useSiteDiagnostics)
+            MemberLookup.Lookup(lookupResult, container, name, arity, options, Me, useSiteInfo)
         End Sub
 
         Friend Sub LookupMember(lookupResult As LookupResult,
@@ -34,11 +34,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 name As String,
                                 arity As Integer,
                                 options As LookupOptions,
-                                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(options.IsValid())
 
             options = BinderSpecificLookupOptions(options)
-            MemberLookup.Lookup(lookupResult, container, name, arity, options, Me, useSiteDiagnostics)
+            MemberLookup.Lookup(lookupResult, container, name, arity, options, Me, useSiteInfo)
         End Sub
 
         Friend Sub LookupMember(lookupResult As LookupResult,
@@ -46,11 +46,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 name As String,
                                 arity As Integer,
                                 options As LookupOptions,
-                                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(options.IsValid())
 
             options = BinderSpecificLookupOptions(options)
-            MemberLookup.Lookup(lookupResult, container, name, arity, options, Me, useSiteDiagnostics)
+            MemberLookup.Lookup(lookupResult, container, name, arity, options, Me, useSiteInfo)
         End Sub
 
         Friend Sub LookupMemberImmediate(lookupResult As LookupResult,
@@ -58,11 +58,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 name As String,
                                 arity As Integer,
                                 options As LookupOptions,
-                                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(options.IsValid())
 
             options = BinderSpecificLookupOptions(options)
-            MemberLookup.LookupImmediate(lookupResult, container, name, arity, options, Me, useSiteDiagnostics)
+            MemberLookup.LookupImmediate(lookupResult, container, name, arity, options, Me, useSiteInfo)
         End Sub
 
         Friend Sub LookupExtensionMethods(
@@ -71,12 +71,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             name As String,
             arity As Integer,
             options As LookupOptions,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Debug.Assert(options.IsValid())
             Debug.Assert(lookupResult.IsClear)
             options = BinderSpecificLookupOptions(options)
-            MemberLookup.LookupForExtensionMethods(lookupResult, container, name, arity, options, Me, useSiteDiagnostics)
+            MemberLookup.LookupForExtensionMethods(lookupResult, container, name, arity, options, Me, useSiteInfo)
         End Sub
 
         Friend Sub LookupMemberInModules(lookupResult As LookupResult,
@@ -84,11 +84,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 name As String,
                                 arity As Integer,
                                 options As LookupOptions,
-                                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(options.IsValid())
 
             options = BinderSpecificLookupOptions(options)
-            MemberLookup.LookupInModules(lookupResult, container, name, arity, options, Me, useSiteDiagnostics)
+            MemberLookup.LookupInModules(lookupResult, container, name, arity, options, Me, useSiteInfo)
         End Sub
 
         Friend Sub AddMemberLookupSymbolsInfo(nameSet As LookupSymbolsInfo,
@@ -114,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        arity As Integer,
                                        options As LookupOptions,
                                        accessThroughType As TypeSymbol,
-                                       <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As SingleLookupResult
+                                       <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As SingleLookupResult
             Debug.Assert(sym IsNot Nothing)
 
             If Not sym.CanBeReferencedByNameIgnoringIllegalCharacters Then
@@ -216,7 +216,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If (options And LookupOptions.IgnoreAccessibility) = 0 Then
-                Dim accessCheckResult = CheckAccessibility(unwrappedSym, useSiteDiagnostics, If((options And LookupOptions.UseBaseReferenceAccessibility) <> 0, Nothing, accessThroughType))
+                Dim accessCheckResult = CheckAccessibility(unwrappedSym, useSiteInfo, If((options And LookupOptions.UseBaseReferenceAccessibility) <> 0, Nothing, accessThroughType))
                 ' Check if we are in 'MyBase' resolving mode and we need to ignore 'accessThroughType' to make protected members accessed
                 If accessCheckResult <> VisualBasic.AccessCheckResult.Accessible Then
                     Return SingleLookupResult.Inaccessible(sym, GetInaccessibleErrorInfo(sym))
@@ -230,11 +230,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Return SingleLookupResult.Good(sym)
-        End Function
-
-        Friend Function GetInaccessibleErrorInfo(sym As Symbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As DiagnosticInfo
-            CheckAccessibility(sym, useSiteDiagnostics) ' For diagnostics.
-            Return GetInaccessibleErrorInfo(sym)
         End Function
 
         Friend Function GetInaccessibleErrorInfo(sym As Symbol) As DiagnosticInfo
@@ -284,7 +279,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return False
             End If
 
-            Dim singleResult = CheckViability(sym, -1, options, accessThroughType, useSiteDiagnostics:=Nothing)
+            Dim singleResult = CheckViability(sym, -1, options, accessThroughType, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
             If (options And LookupOptions.MethodsOnly) <> 0 AndAlso
                sym.Kind <> SymbolKind.Method Then
@@ -337,11 +332,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                      arity As Integer,
                                      options As LookupOptions,
                                      binder As Binder,
-                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 If container.IsNamespace Then
-                    Lookup(lookupResult, DirectCast(container, NamespaceSymbol), name, arity, options, binder, useSiteDiagnostics)
+                    Lookup(lookupResult, DirectCast(container, NamespaceSymbol), name, arity, options, binder, useSiteInfo)
                 Else
-                    Lookup(lookupResult, DirectCast(container, TypeSymbol), name, arity, options, binder, useSiteDiagnostics)
+                    Lookup(lookupResult, DirectCast(container, TypeSymbol), name, arity, options, binder, useSiteInfo)
                 End If
             End Sub
 
@@ -370,11 +365,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                      arity As Integer,
                                      options As LookupOptions,
                                      binder As Binder,
-                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
                 Debug.Assert(lookupResult.IsClear)
 
-                LookupImmediate(lookupResult, container, name, arity, options, binder, useSiteDiagnostics)
+                LookupImmediate(lookupResult, container, name, arity, options, binder, useSiteInfo)
 
                 ' Result in the namespace takes precedence over results in containing modules.
                 If lookupResult.StopFurtherLookup Then
@@ -383,7 +378,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim currentResult = LookupResult.GetInstance()
 
-                LookupInModules(currentResult, container, name, arity, options, binder, useSiteDiagnostics)
+                LookupInModules(currentResult, container, name, arity, options, binder, useSiteInfo)
                 lookupResult.MergeAmbiguous(currentResult, s_ambiguousInModuleError)
 
                 currentResult.Free()
@@ -401,7 +396,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                      arity As Integer,
                                      options As LookupOptions,
                                      binder As Binder,
-                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
                 Debug.Assert(lookupResult.IsClear)
 
@@ -420,7 +415,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                             ' Intrinsic alias works only if type is available
                             If Not candidate.IsErrorType() Then
-                                lookupResult.MergeMembersOfTheSameNamespace(binder.CheckViability(candidate, arity, options, Nothing, useSiteDiagnostics), sourceModule, options)
+                                lookupResult.MergeMembersOfTheSameNamespace(binder.CheckViability(candidate, arity, options, Nothing, useSiteInfo), sourceModule, options)
                             End If
                         End If
                     End If
@@ -438,7 +433,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 #End If
 
-                    Dim currentResult As SingleLookupResult = binder.CheckViability(sym, arity, options, Nothing, useSiteDiagnostics)
+                    Dim currentResult As SingleLookupResult = binder.CheckViability(sym, arity, options, Nothing, useSiteInfo)
 
                     lookupResult.MergeMembersOfTheSameNamespace(currentResult, sourceModule, options)
                 Next
@@ -479,7 +474,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                      arity As Integer,
                                      options As LookupOptions,
                                      binder As Binder,
-                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
                 Debug.Assert(lookupResult.IsClear)
                 Dim firstModule As Boolean = True
@@ -492,7 +487,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Next, do a lookup in each contained module and merge the results.
                 For Each containedModule As NamedTypeSymbol In container.GetModuleMembers()
                     If firstModule Then
-                        Lookup(lookupResult, containedModule, name, arity, options, binder, useSiteDiagnostics)
+                        Lookup(lookupResult, containedModule, name, arity, options, binder, useSiteInfo)
                         firstModule = False
                     Else
                         If currentResult Is Nothing Then
@@ -501,7 +496,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             currentResult.Clear()
                         End If
 
-                        Lookup(currentResult, containedModule, name, arity, options, binder, useSiteDiagnostics)
+                        Lookup(currentResult, containedModule, name, arity, options, binder, useSiteInfo)
 
                         ' Symbols in source take priority over symbols in a referenced assembly.
                         If currentResult.StopFurtherLookup AndAlso currentResult.Symbols.Count > 0 AndAlso
@@ -569,21 +564,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       arity As Integer,
                                       options As LookupOptions,
                                       binder As Binder,
-                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 Debug.Assert(lookupResult.IsClear)
 
                 Select Case type.TypeKind
                     Case TypeKind.Class, TypeKind.Module, TypeKind.Structure, TypeKind.Delegate, TypeKind.Array, TypeKind.Enum
-                        LookupInClass(lookupResult, type, name, arity, options, type, binder, useSiteDiagnostics)
+                        LookupInClass(lookupResult, type, name, arity, options, type, binder, useSiteInfo)
 
                     Case TypeKind.Submission
-                        LookupInSubmissions(lookupResult, type, name, arity, options, binder, useSiteDiagnostics)
+                        LookupInSubmissions(lookupResult, type, name, arity, options, binder, useSiteInfo)
 
                     Case TypeKind.Interface
-                        LookupInInterface(lookupResult, DirectCast(type, NamedTypeSymbol), name, arity, options, binder, useSiteDiagnostics)
+                        LookupInInterface(lookupResult, DirectCast(type, NamedTypeSymbol), name, arity, options, binder, useSiteInfo)
 
                     Case TypeKind.TypeParameter
-                        LookupInTypeParameter(lookupResult, DirectCast(type, TypeParameterSymbol), name, arity, options, binder, useSiteDiagnostics)
+                        LookupInTypeParameter(lookupResult, DirectCast(type, TypeParameterSymbol), name, arity, options, binder, useSiteInfo)
 
                     Case TypeKind.Error
                         ' Error types have no members.
@@ -636,7 +631,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                              options As LookupOptions,
                                              accessThroughType As TypeSymbol,
                                              binder As Binder,
-                                             <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                             <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 Debug.Assert(result.IsClear)
 
                 Dim methodsOnly As Boolean = CheckAndClearMethodsOnlyOption(options)
@@ -648,7 +643,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Do
                     Dim hitNonoverloadingSymbol As Boolean = False
 
-                    LookupWithoutInheritance(currentResult, currentType, name, arity, options, accessThroughType, binder, useSiteDiagnostics)
+                    LookupWithoutInheritance(currentResult, currentType, name, arity, options, accessThroughType, binder, useSiteInfo)
                     If result.IsGoodOrAmbiguous AndAlso currentResult.IsGoodOrAmbiguous AndAlso Not LookupResult.CanOverload(result.Symbols(0), currentResult.Symbols(0)) Then
                         ' We hit another good symbol that can't overload this one. That doesn't affect the lookup result, but means we have to stop
                         ' looking for more members. See bug #14078 for example.
@@ -663,7 +658,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         FindWinRTMembers(result,
                                          namedType,
                                          binder,
-                                         useSiteDiagnostics,
+                                         useSiteInfo,
                                          lookupMembersNotDefaultProperties:=True,
                                          name:=name,
                                          arity:=arity,
@@ -694,7 +689,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If (options And LookupOptions.NoBaseClassLookup) <> 0 OrElse binder.IgnoreBaseClassesInLookup Then
                         currentType = Nothing
                     Else
-                        currentType = currentType.GetDirectBaseTypeWithDefinitionUseSiteDiagnostics(binder.BasesBeingResolved, useSiteDiagnostics)
+                        currentType = currentType.GetDirectBaseTypeWithDefinitionUseSiteDiagnostics(binder.BasesBeingResolved, useSiteInfo)
                     End If
 
                     If currentType Is Nothing Then
@@ -707,13 +702,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 currentResult.Free()
 
                 ClearLookupResultIfNotMethods(methodsOnly, result)
-                LookupForExtensionMethodsIfNeedTo(result, container, name, arity, options, binder, useSiteDiagnostics)
+                LookupForExtensionMethodsIfNeedTo(result, container, name, arity, options, binder, useSiteInfo)
             End Sub
 
             Public Delegate Sub WinRTLookupDelegate(iface As NamedTypeSymbol,
                                                      binder As Binder,
                                                      result As LookupResult,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             ''' <summary>
             ''' This function generalizes the idea of producing a set of non-conflicting
@@ -731,7 +726,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private Shared Sub FindWinRTMembers(result As LookupResult,
                                                 type As NamedTypeSymbol,
                                                 binder As Binder,
-                                                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                 lookupMembersNotDefaultProperties As Boolean,
                                                 Optional name As String = Nothing,
                                                 Optional arity As Integer = -1,
@@ -764,7 +759,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim tmp = LookupResult.GetInstance()
 
                 ' Dev11 searches all declared and undeclared base interfaces
-                For Each iface In type.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each iface In type.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     If IsWinRTProjectedInterface(iface, binder.Compilation) Then
                         If lookupMembersNotDefaultProperties Then
                             Debug.Assert(name IsNot Nothing)
@@ -775,13 +770,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      options,
                                                      iface,
                                                      binder,
-                                                     useSiteDiagnostics)
+                                                     useSiteInfo)
                         Else
                             LookupDefaultPropertyInSingleType(tmp,
                                                               iface,
                                                               iface,
                                                               binder,
-                                                              useSiteDiagnostics)
+                                                              useSiteInfo)
                         End If
                         ' only add viable members
                         If tmp.IsGood Then
@@ -859,7 +854,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                    arity As Integer,
                                                    options As LookupOptions,
                                                    binder As Binder,
-                                                   <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                   <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 Debug.Assert(result.IsClear)
                 Dim submissionSymbols = LookupResult.GetInstance()
                 Dim nonViable = LookupResult.GetInstance()
@@ -870,7 +865,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     submissionSymbols.Clear()
 
                     If submission.ScriptClass IsNot Nothing Then
-                        LookupWithoutInheritance(submissionSymbols, submission.ScriptClass, name, arity, options, submissionClass, binder, useSiteDiagnostics)
+                        LookupWithoutInheritance(submissionSymbols, submission.ScriptClass, name, arity, options, submissionClass, binder, useSiteInfo)
                     End If
 
                     ' TODO (tomat): import aliases
@@ -924,16 +919,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 nonViable.Free()
             End Sub
 
-            Public Shared Sub LookupDefaultProperty(result As LookupResult, container As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+            Public Shared Sub LookupDefaultProperty(result As LookupResult, container As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 Select Case container.TypeKind
                     Case TypeKind.Class, TypeKind.Module, TypeKind.Structure
-                        LookupDefaultPropertyInClass(result, DirectCast(container, NamedTypeSymbol), binder, useSiteDiagnostics)
+                        LookupDefaultPropertyInClass(result, DirectCast(container, NamedTypeSymbol), binder, useSiteInfo)
 
                     Case TypeKind.Interface
-                        LookupDefaultPropertyInInterface(result, DirectCast(container, NamedTypeSymbol), binder, useSiteDiagnostics)
+                        LookupDefaultPropertyInInterface(result, DirectCast(container, NamedTypeSymbol), binder, useSiteInfo)
 
                     Case TypeKind.TypeParameter
-                        LookupDefaultPropertyInTypeParameter(result, DirectCast(container, TypeParameterSymbol), binder, useSiteDiagnostics)
+                        LookupDefaultPropertyInTypeParameter(result, DirectCast(container, TypeParameterSymbol), binder, useSiteInfo)
 
                 End Select
             End Sub
@@ -942,13 +937,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 result As LookupResult,
                 type As NamedTypeSymbol,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Debug.Assert(type.IsClassType OrElse type.IsModuleType OrElse type.IsStructureType OrElse type.IsDelegateType)
                 Dim accessThroughType As NamedTypeSymbol = type
 
                 While type IsNot Nothing
-                    If LookupDefaultPropertyInSingleType(result, type, accessThroughType, binder, useSiteDiagnostics) Then
+                    If LookupDefaultPropertyInSingleType(result, type, accessThroughType, binder, useSiteInfo) Then
                         Return
                     End If
 
@@ -958,14 +953,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         FindWinRTMembers(result,
                                          type,
                                          binder,
-                                         useSiteDiagnostics,
+                                         useSiteInfo,
                                          lookupMembersNotDefaultProperties:=False)
                         If result.IsGood Then
                             Return
                         End If
                     End If
 
-                    type = type.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    type = type.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
                 End While
 
             End Sub
@@ -976,29 +971,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 result As LookupResult,
                 [interface] As NamedTypeSymbol,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Debug.Assert([interface].IsInterfaceType)
 
-                If LookupDefaultPropertyInSingleType(result, [interface], [interface], binder, useSiteDiagnostics) Then
+                If LookupDefaultPropertyInSingleType(result, [interface], [interface], binder, useSiteInfo) Then
                     Return
                 End If
 
                 For Each baseInterface In [interface].InterfacesNoUseSiteDiagnostics
-                    baseInterface.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                    baseInterface.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
 
-                    LookupDefaultPropertyInBaseInterface(result, baseInterface, binder, useSiteDiagnostics)
+                    LookupDefaultPropertyInBaseInterface(result, baseInterface, binder, useSiteInfo)
                     If result.HasDiagnostic Then
                         Return
                     End If
                 Next
             End Sub
 
-            Private Shared Sub LookupDefaultPropertyInTypeParameter(result As LookupResult, typeParameter As TypeParameterSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+            Private Shared Sub LookupDefaultPropertyInTypeParameter(result As LookupResult, typeParameter As TypeParameterSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 ' Look up in class constraint.
-                Dim constraintClass = typeParameter.GetClassConstraint(useSiteDiagnostics)
+                Dim constraintClass = typeParameter.GetClassConstraint(useSiteInfo)
                 If constraintClass IsNot Nothing Then
-                    LookupDefaultPropertyInClass(result, constraintClass, binder, useSiteDiagnostics)
+                    LookupDefaultPropertyInClass(result, constraintClass, binder, useSiteInfo)
                     If Not result.IsClear Then
                         Return
                     End If
@@ -1007,11 +1002,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Look up in interface constraints.
                 Dim lookIn As Queue(Of InterfaceInfo) = Nothing
                 Dim processed As HashSet(Of InterfaceInfo) = Nothing
-                AddInterfaceConstraints(typeParameter, lookIn, processed, useSiteDiagnostics)
+                AddInterfaceConstraints(typeParameter, lookIn, processed, useSiteInfo)
 
                 If lookIn IsNot Nothing Then
                     For Each baseInterface In lookIn
-                        LookupDefaultPropertyInBaseInterface(result, baseInterface.InterfaceType, binder, useSiteDiagnostics)
+                        LookupDefaultPropertyInBaseInterface(result, baseInterface.InterfaceType, binder, useSiteInfo)
                         If result.HasDiagnostic Then
                             Return
                         End If
@@ -1024,7 +1019,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 result As LookupResult,
                 type As NamedTypeSymbol,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 If type.IsErrorType() Then
                     Return
@@ -1035,7 +1030,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim tmpResult = LookupResult.GetInstance()
                 Try
-                    LookupDefaultPropertyInInterface(tmpResult, type, binder, useSiteDiagnostics)
+                    LookupDefaultPropertyInInterface(tmpResult, type, binder, useSiteInfo)
 
                     If Not tmpResult.HasSymbol Then
                         Return
@@ -1065,7 +1060,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 type As NamedTypeSymbol,
                 accessThroughType As TypeSymbol,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As Boolean
                 Dim defaultPropertyName = type.DefaultPropertyName
                 If String.IsNullOrEmpty(defaultPropertyName) Then
@@ -1082,7 +1077,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             options:=LookupOptions.Default,
                             accessThroughType:=accessThroughType,
                             binder:=binder,
-                            useSiteDiagnostics:=useSiteDiagnostics)
+                            useSiteInfo:=useSiteInfo)
 
                     Case TypeKind.Interface
                         Debug.Assert(accessThroughType Is type)
@@ -1093,7 +1088,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             arity:=0,
                             options:=LookupOptions.Default,
                             binder:=binder,
-                            useSiteDiagnostics:=useSiteDiagnostics)
+                            useSiteInfo:=useSiteInfo)
 
                     Case TypeKind.TypeParameter
                         Throw ExceptionUtilities.UnexpectedValue(type.TypeKind)
@@ -1129,7 +1124,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 arity As Integer,
                 options As LookupOptions,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 If result.IsGood AndAlso
                     ((options And LookupOptions.EagerlyLookupExtensionMethods) = 0 OrElse
@@ -1138,8 +1133,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim currentResult = LookupResult.GetInstance()
-                LookupForExtensionMethods(currentResult, container, name, arity, options, binder, useSiteDiagnostics)
-                MergeInternalXmlHelperValueIfNecessary(currentResult, container, name, arity, options, binder, useSiteDiagnostics)
+                LookupForExtensionMethods(currentResult, container, name, arity, options, binder, useSiteInfo)
+                MergeInternalXmlHelperValueIfNecessary(currentResult, container, name, arity, options, binder, useSiteInfo)
                 result.MergeOverloadedOrPrioritized(currentResult, checkIfCurrentHasOverloads:=False)
                 currentResult.Free()
             End Sub
@@ -1158,7 +1153,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 arity As Integer,
                 options As LookupOptions,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Debug.Assert(lookupResult.IsClear)
 
@@ -1194,15 +1189,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         If seenContainingTypes.Add(containingType) AndAlso
                            ((options And LookupOptions.IgnoreAccessibility) <> 0 OrElse
-                            AccessCheck.IsSymbolAccessible(containingType, binder.Compilation.Assembly, useSiteDiagnostics)) Then
+                            AccessCheck.IsSymbolAccessible(containingType, binder.Compilation.Assembly, useSiteInfo)) Then
 
                             ' Process all methods from the same type together.
                             Do
                                 ' Try to reduce this method and merge with the current result
-                                Dim reduced As MethodSymbol = methods(i).ReduceExtensionMethod(container, proximity)
+                                Dim reduced As MethodSymbol = methods(i).ReduceExtensionMethod(container, proximity, useSiteInfo)
 
                                 If reduced IsNot Nothing Then
-                                    lookupResult.MergeOverloadedOrPrioritizedExtensionMethods(binder.CheckViability(reduced, arity, options, reduced.ContainingType, useSiteDiagnostics))
+                                    lookupResult.MergeOverloadedOrPrioritizedExtensionMethods(binder.CheckViability(reduced, arity, options, reduced.ContainingType, useSiteInfo))
                                 End If
 
                                 i += 1
@@ -1236,7 +1231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 arity As Integer,
                 options As LookupOptions,
                 binder As Binder,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
 
                 If (arity <> 0) OrElse Not IdentifierComparison.Equals(name, StringConstants.ValueProperty) Then
@@ -1245,7 +1240,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim compilation = binder.Compilation
                 If (options And LookupOptions.NamespacesOrTypesOnly) <> 0 OrElse
-                   Not container.IsOrImplementsIEnumerableOfXElement(compilation, useSiteDiagnostics) Then
+                   Not container.IsOrImplementsIEnumerableOfXElement(compilation, useSiteInfo) Then
                     Return
                 End If
 
@@ -1257,7 +1252,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     singleResult = New SingleLookupResult(LookupResultKind.NotReferencable, Binder.GetErrorSymbol(name, useSiteError), useSiteError)
                 Else
                     Dim reduced = New ReducedExtensionPropertySymbol(DirectCast(symbol, PropertySymbol))
-                    singleResult = binder.CheckViability(reduced, arity, options, reduced.ContainingType, useSiteDiagnostics)
+                    singleResult = binder.CheckViability(reduced, arity, options, reduced.ContainingType, useSiteInfo)
                 End If
 
                 lookupResult.MergePrioritized(singleResult)
@@ -1274,7 +1269,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     LookupForExtensionMethods(lookup, container, name, 0,
                                               LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreAccessibility,
-                                              binder, useSiteDiagnostics:=Nothing)
+                                              binder, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                     If lookup.IsGood Then
                         For Each method As MethodSymbol In lookup.Symbols
@@ -1316,8 +1311,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Include "Value" for InternalXmlHelper.Value if necessary.
                 Dim compilation = binder.Compilation
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                If container.IsOrImplementsIEnumerableOfXElement(compilation, useSiteDiagnostics) AndAlso useSiteDiagnostics.IsNullOrEmpty Then
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                If container.IsOrImplementsIEnumerableOfXElement(compilation, useSiteInfo) AndAlso useSiteInfo.Diagnostics.IsNullOrEmpty Then
                     nameSet.AddSymbol(Nothing, StringConstants.ValueProperty, 0)
                 End If
             End Sub
@@ -1329,7 +1324,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         base As NamedTypeSymbol,
                         derived As NamedTypeSymbol,
                         basesBeingResolved As BasesBeingResolved,
-                        <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                        <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As Boolean
 
                 Debug.Assert(base.IsInterface)
@@ -1341,7 +1336,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' if we are not resolving bases we can just go through AllInterfaces list
                 If basesBeingResolved.InheritsBeingResolvedOpt Is Nothing Then
-                    For Each i In derived.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    For Each i In derived.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                         If TypeSymbol.Equals(i, base, TypeCompareKind.ConsiderEverything) Then
                             Return True
                         End If
@@ -1351,7 +1346,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 ' we are resolving bases so should use a private helper that relies only on Declared interfaces
-                Return IsDerivedInterface(base, derived, basesBeingResolved, New HashSet(Of Symbol), useSiteDiagnostics)
+                Return IsDerivedInterface(base, derived, basesBeingResolved, New HashSet(Of Symbol), useSiteInfo)
             End Function
 
             Private Shared Function IsDerivedInterface(
@@ -1359,7 +1354,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         derived As NamedTypeSymbol,
                         basesBeingResolved As BasesBeingResolved,
                         verified As HashSet(Of Symbol),
-                        <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                        <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As Boolean
 
                 Debug.Assert(Not TypeSymbol.Equals(base, derived, TypeCompareKind.ConsiderEverything), "should already be verified for equality")
@@ -1369,7 +1364,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 verified.Add(derived)
 
                 ' not afraid of cycles here as we will not verify same symbol twice
-                Dim interfaces = derived.GetDeclaredInterfacesWithDefinitionUseSiteDiagnostics(basesBeingResolved, useSiteDiagnostics)
+                Dim interfaces = derived.GetDeclaredInterfacesWithDefinitionUseSiteDiagnostics(basesBeingResolved, useSiteInfo)
 
                 If Not interfaces.IsDefaultOrEmpty Then
                     For Each i In interfaces
@@ -1387,7 +1382,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             i,
                             basesBeingResolved,
                             verified,
-                            useSiteDiagnostics) Then
+                            useSiteInfo) Then
 
                             Return True
                         End If
@@ -1429,7 +1424,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                          arity As Integer,
                          options As LookupOptions,
                          binder As Binder,
-                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Debug.Assert(lookupResult.IsClear)
 
@@ -1444,7 +1439,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim processed As New HashSet(Of InterfaceInfo)
                 processed.Add(info)
 
-                LookupInInterfaces(lookupResult, container, lookIn, processed, name, arity, options, binder, methodsOnly, useSiteDiagnostics)
+                LookupInInterfaces(lookupResult, container, lookIn, processed, name, arity, options, binder, methodsOnly, useSiteInfo)
 
                 ' If no viable or ambiguous results, look in Object.
                 If Not lookupResult.IsGoodOrAmbiguous AndAlso (options And LookupOptions.NoSystemObjectLookupForInterfaces) = 0 Then
@@ -1454,7 +1449,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     LookupInClass(currentResult,
                                   obj,
                                   name, arity, options Or LookupOptions.IgnoreExtensionMethods, obj, binder,
-                                  useSiteDiagnostics)
+                                  useSiteInfo)
 
                     If currentResult.IsGood Then
                         lookupResult.SetFrom(currentResult)
@@ -1464,7 +1459,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 ClearLookupResultIfNotMethods(methodsOnly, lookupResult)
-                LookupForExtensionMethodsIfNeedTo(lookupResult, container, name, arity, options, binder, useSiteDiagnostics)
+                LookupForExtensionMethodsIfNeedTo(lookupResult, container, name, arity, options, binder, useSiteInfo)
                 Return
             End Sub
 
@@ -1477,7 +1472,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                          options As LookupOptions,
                          binder As Binder,
                          methodsOnly As Boolean,
-                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Debug.Assert(lookupResult.IsClear)
 
@@ -1491,12 +1486,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Debug.Assert(processed.Contains(info))
 
                     Debug.Assert(currentResult.IsClear)
-                    LookupWithoutInheritance(currentResult, info.InterfaceType, name, arity, options, container, binder, useSiteDiagnostics)
+                    LookupWithoutInheritance(currentResult, info.InterfaceType, name, arity, options, container, binder, useSiteInfo)
 
                     ' if result does not shadow we will have bases to visit
                     If Not (currentResult.StopFurtherLookup AndAlso AnyShadows(currentResult)) Then
                         If (options And LookupOptions.NoBaseClassLookup) = 0 AndAlso Not binder.IgnoreBaseClassesInLookup Then
-                            AddBaseInterfacesToTheSearch(binder, info, lookIn, processed, useSiteDiagnostics)
+                            AddBaseInterfacesToTheSearch(binder, info, lookIn, processed, useSiteInfo)
                         End If
                     End If
 
@@ -1507,7 +1502,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If lookupResult.IsGood AndAlso currentResult.IsGood Then
                         ' We have _another_ viable result while lookupResult is already viable. Use special interface merging rules.
-                        MergeInterfaceLookupResults(lookupResult, currentResult, basesBeingResolved, leaveEventsOnly, useSiteDiagnostics)
+                        MergeInterfaceLookupResults(lookupResult, currentResult, basesBeingResolved, leaveEventsOnly, useSiteInfo)
                     Else
                         If currentResult.IsGood AndAlso leaveEventsOnly.HasValue Then
                             FilterSymbolsInLookupResult(currentResult, SymbolKind.Event, leaveInsteadOfRemoving:=leaveEventsOnly.Value)
@@ -1591,13 +1586,13 @@ ExitForFor:
                          arity As Integer,
                          options As LookupOptions,
                          binder As Binder,
-                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
                 Dim methodsOnly = CheckAndClearMethodsOnlyOption(options)
-                LookupInTypeParameterNoExtensionMethods(lookupResult, typeParameter, name, arity, options, binder, useSiteDiagnostics)
+                LookupInTypeParameterNoExtensionMethods(lookupResult, typeParameter, name, arity, options, binder, useSiteInfo)
 
                 ClearLookupResultIfNotMethods(methodsOnly, lookupResult)
-                LookupForExtensionMethodsIfNeedTo(lookupResult, typeParameter, name, arity, options, binder, useSiteDiagnostics)
+                LookupForExtensionMethodsIfNeedTo(lookupResult, typeParameter, name, arity, options, binder, useSiteInfo)
             End Sub
 
             Private Shared Sub LookupInTypeParameterNoExtensionMethods(result As LookupResult,
@@ -1606,7 +1601,7 @@ ExitForFor:
                          arity As Integer,
                          options As LookupOptions,
                          binder As Binder,
-                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 Debug.Assert((options And LookupOptions.MethodsOnly) = 0)
 
                 options = options Or LookupOptions.IgnoreExtensionMethods
@@ -1616,9 +1611,9 @@ ExitForFor:
                 ' which hides members in Object."
 
                 ' Look up in class constraint.
-                Dim constraintClass = typeParameter.GetClassConstraint(useSiteDiagnostics)
+                Dim constraintClass = typeParameter.GetClassConstraint(useSiteInfo)
                 If constraintClass IsNot Nothing Then
-                    LookupInClass(result, constraintClass, name, arity, options, constraintClass, binder, useSiteDiagnostics)
+                    LookupInClass(result, constraintClass, name, arity, options, constraintClass, binder, useSiteInfo)
                     If result.StopFurtherLookup Then
                         Return
                     End If
@@ -1627,14 +1622,14 @@ ExitForFor:
                 ' Look up in interface constraints.
                 Dim lookIn As Queue(Of InterfaceInfo) = Nothing
                 Dim processed As HashSet(Of InterfaceInfo) = Nothing
-                AddInterfaceConstraints(typeParameter, lookIn, processed, useSiteDiagnostics)
+                AddInterfaceConstraints(typeParameter, lookIn, processed, useSiteInfo)
 
                 If lookIn IsNot Nothing Then
                     ' §4.9.2: "If a member with the same name appears in more than one interface
                     ' constraint the member is unavailable (as in multiple interface inheritance)"
                     Dim interfaceResult = LookupResult.GetInstance()
                     Debug.Assert((options And LookupOptions.MethodsOnly) = 0)
-                    LookupInInterfaces(interfaceResult, typeParameter, lookIn, processed, name, arity, options, binder, False, useSiteDiagnostics)
+                    LookupInInterfaces(interfaceResult, typeParameter, lookIn, processed, name, arity, options, binder, False, useSiteInfo)
                     result.MergePrioritized(interfaceResult)
                     interfaceResult.Free()
                     If Not result.IsClear Then
@@ -1646,7 +1641,7 @@ ExitForFor:
                 If constraintClass Is Nothing Then
                     Debug.Assert(result.IsClear)
                     Dim baseType = GetTypeParameterBaseType(typeParameter)
-                    LookupInClass(result, baseType, name, arity, options, baseType, binder, useSiteDiagnostics)
+                    LookupInClass(result, baseType, name, arity, options, baseType, binder, useSiteInfo)
                 End If
             End Sub
 
@@ -1669,9 +1664,9 @@ ExitForFor:
             Private Shared Sub AddInterfaceConstraints(typeParameter As TypeParameterSymbol,
                                                        ByRef allInterfaces As Queue(Of InterfaceInfo),
                                                        ByRef processedInterfaces As HashSet(Of InterfaceInfo),
-                                                       <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                                                       <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
-                For Each constraintType In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each constraintType In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     Select Case constraintType.TypeKind
                         Case TypeKind.Interface
                             Dim newInfo As New InterfaceInfo(DirectCast(constraintType, NamedTypeSymbol), False)
@@ -1687,7 +1682,7 @@ ExitForFor:
                             End If
 
                         Case TypeKind.TypeParameter
-                            AddInterfaceConstraints(DirectCast(constraintType, TypeParameterSymbol), allInterfaces, processedInterfaces, useSiteDiagnostics)
+                            AddInterfaceConstraints(DirectCast(constraintType, TypeParameterSymbol), allInterfaces, processedInterfaces, useSiteInfo)
                     End Select
                 Next
             End Sub
@@ -1707,7 +1702,7 @@ ExitForFor:
                                         newResult As LookupResult,
                                         BasesBeingResolved As BasesBeingResolved,
                                         leaveEventsOnly As Boolean?,
-                                        <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                                        <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
 
                 Debug.Assert(knownResult.Kind = newResult.Kind)
@@ -1754,7 +1749,7 @@ ExitForFor:
                         If IsDerivedInterface(base:=newSymbolContainer,
                                                  derived:=knownSymbolContainer,
                                                  basesBeingResolved:=BasesBeingResolved,
-                                                 useSiteDiagnostics:=useSiteDiagnostics) Then
+                                                 useSiteInfo:=useSiteInfo) Then
 
                             ' if currently known is more derived and shadows the new one
                             ' it shadows all the new ones and we are done
@@ -1769,7 +1764,7 @@ ExitForFor:
                         ElseIf IsDerivedInterface(base:=knownSymbolContainer,
                                              derived:=newSymbolContainer,
                                              basesBeingResolved:=BasesBeingResolved,
-                                             useSiteDiagnostics:=useSiteDiagnostics) Then
+                                             useSiteInfo:=useSiteInfo) Then
 
                             ' if new is more derived and shadows
                             ' the current one should be dropped
@@ -1849,7 +1844,7 @@ ExitForFor:
                                currentInfo As InterfaceInfo,
                                lookIn As Queue(Of InterfaceInfo),
                                processed As HashSet(Of InterfaceInfo),
-                               <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                               <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
                 Dim interfaces As ImmutableArray(Of NamedTypeSymbol) = currentInfo.InterfaceType.GetDirectBaseInterfacesNoUseSiteDiagnostics(binder.BasesBeingResolved)
 
@@ -1876,7 +1871,7 @@ ExitForFor:
                             Continue For
                         End If
 
-                        i.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                        i.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
 
                         Dim newInfo As New InterfaceInfo(i, inComInterfaceContext, descendants)
                         If processed.Add(newInfo) Then
@@ -1997,7 +1992,7 @@ ExitForFor:
                                                                 processed As HashSet(Of InterfaceInfo),
                                                                 options As LookupOptions,
                                                                 binder As Binder)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim useSiteInfo = CompoundUseSiteInfo(Of AssemblySymbol).Discarded
 
                 Do
                     Dim currentType As InterfaceInfo = lookIn.Dequeue
@@ -2007,7 +2002,7 @@ ExitForFor:
                     ' Go to base type, unless that would case infinite recursion or the options or the binder
                     ' disallows it.
                     If (options And LookupOptions.NoBaseClassLookup) = 0 AndAlso Not binder.IgnoreBaseClassesInLookup Then
-                        AddBaseInterfacesToTheSearch(binder, currentType, lookIn, processed, useSiteDiagnostics)
+                        AddBaseInterfacesToTheSearch(binder, currentType, lookIn, processed, useSiteInfo)
                     End If
 
                 Loop While lookIn.Count <> 0
@@ -2035,7 +2030,7 @@ ExitForFor:
                 options = options Or LookupOptions.IgnoreExtensionMethods
 
                 ' Look up in class constraint.
-                Dim constraintClass = typeParameter.GetClassConstraint(Nothing)
+                Dim constraintClass = typeParameter.GetClassConstraint(CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                 If constraintClass IsNot Nothing Then
                     AddLookupSymbolsInfoInClass(nameSet, constraintClass, options, binder)
                 End If
@@ -2043,7 +2038,7 @@ ExitForFor:
                 ' Look up in interface constraints.
                 Dim lookIn As Queue(Of InterfaceInfo) = Nothing
                 Dim processed As HashSet(Of InterfaceInfo) = Nothing
-                AddInterfaceConstraints(typeParameter, lookIn, processed, useSiteDiagnostics:=Nothing)
+                AddInterfaceConstraints(typeParameter, lookIn, processed, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                 If lookIn IsNot Nothing Then
                     AddLookupSymbolsInfoInInterfaces(nameSet, typeParameter, lookIn, processed, options, binder)
@@ -2068,7 +2063,7 @@ ExitForFor:
                                                        options As LookupOptions,
                                                        accessThroughType As TypeSymbol,
                                                        binder As Binder,
-                                                       <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                                                       <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Dim members As ImmutableArray(Of Symbol) = ImmutableArray(Of Symbol).Empty
 
@@ -2090,7 +2085,7 @@ ExitForFor:
                     Dim imported As Boolean = container.ContainingModule IsNot binder.SourceModule
 
                     For Each sym In members
-                        lookupResult.MergeMembersOfTheSameType(binder.CheckViability(sym, arity, options, accessThroughType, useSiteDiagnostics), imported)
+                        lookupResult.MergeMembersOfTheSameType(binder.CheckViability(sym, arity, options, accessThroughType, useSiteInfo), imported)
                     Next
                 End If
             End Sub
@@ -2140,7 +2135,7 @@ ExitForFor:
 
             Private Shared Function GetTypeParameterBaseType(typeParameter As TypeParameterSymbol) As NamedTypeSymbol
                 ' The default base type should only be used if there is no explicit class constraint.
-                Debug.Assert(typeParameter.GetClassConstraint(Nothing) Is Nothing)
+                Debug.Assert(typeParameter.GetClassConstraint(CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Is Nothing)
                 Return typeParameter.ContainingAssembly.GetSpecialType(If(typeParameter.HasValueTypeConstraint, SpecialType.System_ValueType, SpecialType.System_Object))
             End Function
         End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend Partial Class Binder
         Private Function BindObjectCreationExpression(
             node As ObjectCreationExpressionSyntax,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             DisallowNewOnTupleType(node.Type, diagnostics)
@@ -26,9 +26,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                    extendedErrorType.CandidateSymbols(0).Kind = SymbolKind.NamedType Then
                     ' Continue binding with candidate symbol as the target type, but suppress any additional diagnostics
                     type = DirectCast(extendedErrorType.CandidateSymbols(0), TypeSymbol)
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 Else
-                    Dim argumentDiagnostics = DiagnosticBag.GetInstance()
+                    Dim argumentDiagnostics = BindingDiagnosticBag.GetInstance()
                     Dim boundArguments As ImmutableArray(Of BoundExpression) = Nothing
                     Dim argumentNames As ImmutableArray(Of String) = Nothing
                     Dim argumentNamesLocations As ImmutableArray(Of Location) = Nothing
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return BindObjectCreationExpression(node.Type, node.ArgumentList, type, node, diagnostics, Nothing)
         End Function
 
-        Private Shared Sub DisallowNewOnTupleType(type As TypeSyntax, diagnostics As DiagnosticBag)
+        Private Shared Sub DisallowNewOnTupleType(type As TypeSyntax, diagnostics As BindingDiagnosticBag)
             If type.Kind = SyntaxKind.TupleType Then
                 diagnostics.Add(ERRID.ERR_NewWithTupleTypeSyntax, type.Location)
             End If
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             argumentListOpt As ArgumentListSyntax,
             type0 As TypeSymbol,
             node As ObjectCreationExpressionSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             asNewVariablePlaceholderOpt As BoundWithLValueExpressionPlaceholder
         ) As BoundExpression
 
@@ -94,14 +94,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             For Each constructor In ctors
                                 If constructor.ParameterCount = 0 Then
                                     '  the first parameterless constructor will do the job
-                                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                                    If IsAccessible(constructor, useSiteDiagnostics) Then
+                                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                                    If IsAccessible(constructor, useSiteInfo) Then
                                         ' if not accessible, just clear symbol information
                                         constructorSymbol = constructor
-                                        ReportUseSiteError(diagnostics, node, constructorSymbol)
+                                        ReportUseSite(diagnostics, node, constructorSymbol)
                                     End If
 
-                                    diagnostics.Add(node, useSiteDiagnostics)
+                                    diagnostics.Add(node, useSiteInfo)
                                     Exit For
                                 End If
                             Next
@@ -156,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             syntax As SyntaxNode,
             type As TypeSymbol,
             arguments As ImmutableArray(Of BoundExpression),
-            diagnostics As DiagnosticBag) As BoundExpression
+            diagnostics As BindingDiagnosticBag) As BoundExpression
             Return BindObjectCreationExpression(
                 typeNode:=syntax,
                 argumentListOpt:=Nothing,
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             boundArguments As ImmutableArray(Of BoundExpression),
             argumentNames As ImmutableArray(Of String),
             objectInitializerExpressionOpt As BoundObjectInitializerExpressionBase,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             callerInfoOpt As VisualBasicSyntaxNode
         ) As BoundExpression
 
@@ -247,9 +247,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 End If
 
                                 ' Check accessibility
-                                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                                Dim isInAccessible As Boolean = (Me.CheckAccessibility(namedCoClass, useSiteDiagnostics) <> AccessCheckResult.Accessible)
-                                diagnostics.Add(node, useSiteDiagnostics)
+                                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                                Dim isInAccessible As Boolean = (Me.CheckAccessibility(namedCoClass, useSiteInfo) <> AccessCheckResult.Accessible)
+                                diagnostics.Add(node, useSiteInfo)
 
                                 If isInAccessible Then
                                     ' CoClass is inaccessible
@@ -348,10 +348,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim constructorsGroup As BoundMethodGroup = Nothing
 
             If type IsNot Nothing AndAlso Not type.IsInterface Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim constructors As ImmutableArray(Of MethodSymbol) = GetAccessibleConstructors(type, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim constructors As ImmutableArray(Of MethodSymbol) = GetAccessibleConstructors(type, useSiteInfo)
 
-                diagnostics.Add(node, useSiteDiagnostics)
+                diagnostics.Add(node, useSiteInfo)
 
                 Dim groupResultKind As LookupResultKind = LookupResultKind.Good
 
@@ -373,7 +373,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 ' Suppress any additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             If constructorsGroup Is Nothing Then
@@ -386,18 +386,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' We rely on the asserted condition when we are merging/changing result kinds below. 
                 Debug.Assert(constructorsGroup.ResultKind = LookupResultKind.Good OrElse constructorsGroup.ResultKind = LookupResultKind.Inaccessible)
 
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                 Dim results As OverloadResolution.OverloadResolutionResult = OverloadResolution.MethodInvocationOverloadResolution(constructorsGroup,
                                                                                                                                    boundArguments,
                                                                                                                                    argumentNames,
                                                                                                                                    Me,
                                                                                                                                    callerInfoOpt,
-                                                                                                                                   useSiteDiagnostics)
+                                                                                                                                   useSiteInfo)
 
-                If diagnostics.Add(node, useSiteDiagnostics) Then
+                If diagnostics.Add(node, useSiteInfo) Then
                     If constructorsGroup.ResultKind <> LookupResultKind.Inaccessible Then
                         ' Suppress additional diagnostics
-                        diagnostics = New DiagnosticBag()
+                        diagnostics = BindingDiagnosticBag.Discarded
                     End If
                 End If
 
@@ -406,7 +406,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' Create and report the diagnostic.
                     If results.Candidates.Length = 0 Then
                         results = OverloadResolution.MethodInvocationOverloadResolution(constructorsGroup, boundArguments, argumentNames, Me, includeEliminatedCandidates:=True, callerInfoOpt:=callerInfoOpt,
-                                                                                        useSiteDiagnostics:=useSiteDiagnostics)
+                                                                                        useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                     End If
 
                     ' NOTE: current services implementation expects all diagnostics to be associated with type node, not with a node itself
@@ -512,7 +512,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             coClass As NamedTypeSymbol,
             boundArguments As ImmutableArray(Of BoundExpression),
             initializerOpt As BoundObjectInitializerExpressionBase,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Dim hasErrors = False
 
@@ -548,7 +548,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             syntaxNode As ObjectCreationExpressionSyntax,
             initializedObjectType As TypeSymbol,
             asNewVariablePlaceholderOpt As BoundWithLValueExpressionPlaceholder,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundObjectInitializerExpressionBase
 
             If syntaxNode.Initializer Is Nothing Then
@@ -576,7 +576,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             objectCreationSyntax As ObjectCreationExpressionSyntax,
             initializedObjectType As TypeSymbol,
             asNewVariablePlaceholderOpt As BoundWithLValueExpressionPlaceholder,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundObjectInitializerExpression
 
             Dim memberInitializerSyntax = DirectCast(objectCreationSyntax.Initializer, ObjectMemberInitializerSyntax)
@@ -635,7 +635,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' The temporary error messages should only be shown if binding the member access itself failed, or the bound
             ' member access is usable for the initialization (non shared, writable field or property).
             ' Otherwise more specific diagnostics will be shown .
-            Dim memberBindingDiagnostics = DiagnosticBag.GetInstance
+            Dim memberBindingDiagnostics = BindingDiagnosticBag.GetInstance
 
             For Each fieldInitializer In memberInitializerSyntax.Initializers
                 ' NamedFieldInitializerSyntax is derived from FieldInitializerSyntax, which has this optional keyword as a member
@@ -742,7 +742,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindCollectionInitializer(
             objectCreationSyntax As ObjectCreationExpressionSyntax,
             initializedObjectType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCollectionInitializerExpression
 
             Dim collectionInitializerSyntax = DirectCast(objectCreationSyntax.Initializer, ObjectCollectionInitializerSyntax)
@@ -752,7 +752,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim unusedExpression As BoundExpression = Nothing
             Dim unusedLValuePlaceholder As BoundLValuePlaceholder = Nothing
             Dim unusedRValuePlaceholder As BoundRValuePlaceholder = Nothing
-            Dim temporaryDiagnostics = DiagnosticBag.GetInstance
+            Dim temporaryDiagnostics = BindingDiagnosticBag.GetInstance
             Dim matchesDesignPattern As Boolean = False
 
             ' From Dev10:
@@ -783,13 +783,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 matchesDesignPattern = True
 
             Else
-                Dim ienumerableUseSiteDiagnostics = DiagnosticBag.GetInstance
+                Dim ienumerableUseSiteDiagnostics = BindingDiagnosticBag.GetInstance
                 Dim ienumerable = GetSpecialType(SpecialType.System_Collections_IEnumerable,
                                                  objectCreationSyntax,
                                                  ienumerableUseSiteDiagnostics)
 
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                If IsOrInheritsFromOrImplementsInterface(collectionType, ienumerable, useSiteDiagnostics) Then
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                If IsOrInheritsFromOrImplementsInterface(collectionType, ienumerable, useSiteInfo) Then
                     diagnostics.AddRange(ienumerableUseSiteDiagnostics)
                     matchesDesignPattern = True
 
@@ -799,7 +799,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                      ErrorFactory.ErrorInfo(ERRID.ERR_NotACollection1, collectionType.Name))
                 End If
 
-                diagnostics.Add(collectionInitializerSyntax, useSiteDiagnostics)
+                diagnostics.Add(collectionInitializerSyntax, useSiteInfo)
 
                 ienumerableUseSiteDiagnostics.Free()
             End If
@@ -867,7 +867,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             topLevelInitializer As ExpressionSyntax,
             placeholder As BoundWithLValueExpressionPlaceholder,
             result As LookupResult,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Dim arguments = ArrayBuilder(Of BoundExpression).GetInstance
@@ -943,7 +943,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Protected Friend Overrides Function TryBindOmittedLeftForMemberAccess(
             node As MemberAccessExpressionSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             accessingBinder As Binder,
             ByRef wholeMemberAccessExpressionBound As Boolean
         ) As BoundExpression
@@ -951,7 +951,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return _receiver
         End Function
 
-        Protected Friend Overrides Function TryBindOmittedLeftForXmlMemberAccess(node As XmlMemberAccessExpressionSyntax, diagnostics As DiagnosticBag, accessingBinder As Binder) As BoundExpression
+        Protected Friend Overrides Function TryBindOmittedLeftForXmlMemberAccess(node As XmlMemberAccessExpressionSyntax, diagnostics As BindingDiagnosticBag, accessingBinder As Binder) As BoundExpression
             Return _receiver
         End Function
 
@@ -961,13 +961,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Protected Overrides Function TryBindOmittedLeftForDictionaryAccess(
                     node As MemberAccessExpressionSyntax,
                     accessingBinder As Binder,
-                    diagnostics As DiagnosticBag
+                    diagnostics As BindingDiagnosticBag
                 ) As BoundExpression
 
             Return _receiver
         End Function
 
-        Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As DiagnosticBag) As BoundExpression
+        Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return Nothing
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindIsExpression(
              node As BinaryExpressionSyntax,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Debug.Assert(node.Kind = SyntaxKind.IsExpression OrElse node.Kind = SyntaxKind.IsNotExpression)
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
              right As BoundExpression,
              node As SyntaxNode,
              [isNot] As Boolean,
-             diagnostics As DiagnosticBag
+             diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             left = MakeRValue(left, diagnostics)
             right = MakeRValue(right, diagnostics)
@@ -62,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             targetArgument As BoundExpression,
             otherArgument As BoundExpression,
             [isNot] As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Dim targetArgumentType As TypeSymbol = targetArgument.Type
@@ -117,7 +117,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindBinaryOperator(
             node As BinaryExpressionSyntax,
             isOperandOfConditionalBranch As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             ' Some tools, such as ASP .NET, generate expressions containing thousands
             ' of string concatenations. For this reason, for string concatenations,
@@ -198,7 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             operatorTokenKind As SyntaxKind,
             preliminaryOperatorKind As BinaryOperatorKind,
             isOperandOfConditionalBranch As Boolean,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional isSelectCase As Boolean = False
         ) As BoundExpression
 
@@ -209,7 +209,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If (left.HasErrors OrElse right.HasErrors) Then
                 ' Suppress any additional diagnostics by overriding DiagnosticBag.
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             ' Deal with NOTHING literal as an input.
@@ -221,7 +221,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If (left.HasErrors OrElse right.HasErrors) Then
                 ' Suppress any additional diagnostics by overriding DiagnosticBag.
                 If diagnostics Is originalDiagnostics Then
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
             End If
 
@@ -253,16 +253,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' and the common operand type.
             Dim intrinsicOperatorType As SpecialType = SpecialType.None
             Dim userDefinedOperator As OverloadResolution.OverloadResolutionResult = Nothing
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             Dim operatorKind As BinaryOperatorKind = OverloadResolution.ResolveBinaryOperator(preliminaryOperatorKind, left, right, Me,
                                                                                               True,
                                                                                               intrinsicOperatorType,
                                                                                               userDefinedOperator,
-                                                                                              useSiteDiagnostics)
+                                                                                              useSiteInfo)
 
-            If diagnostics.Add(node, useSiteDiagnostics) Then
+            If diagnostics.Add(node, useSiteInfo) Then
                 ' Suppress additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             If operatorKind = BinaryOperatorKind.UserDefined Then
@@ -369,7 +369,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                (forceToBooleanType IsNot Nothing AndAlso forceToBooleanType.GetNullableUnderlyingTypeOrSelf().IsErrorType()) Then
                 ' Suppress any additional diagnostics by overriding DiagnosticBag.
                 If diagnostics Is originalDiagnostics Then
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
             End If
 
@@ -394,7 +394,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' Suppress any additional diagnostics by overriding DiagnosticBag.
                     If diagnostics Is originalDiagnostics Then
-                        diagnostics = New DiagnosticBag()
+                        diagnostics = BindingDiagnosticBag.Discarded
                     End If
                 End If
             ElseIf OptionStrict = VisualBasic.OptionStrict.Custom Then 'warn if option strict is off
@@ -535,7 +535,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' concatenation requires that nullable nulls are treated as null strings. 
         ''' Note that conversion is treated as explicit conversion.
         ''' </summary>
-        Private Function ForceLiftToEmptyString(left As BoundExpression, stringType As TypeSymbol, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function ForceLiftToEmptyString(left As BoundExpression, stringType As TypeSymbol, diagnostics As BindingDiagnosticBag) As BoundExpression
             Debug.Assert(stringType.IsStringType)
 
             Dim nothingStr = New BoundLiteral(left.Syntax, ConstantValue.Nothing, stringType).MakeCompilerGenerated()
@@ -556,7 +556,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             left As BoundExpression,
             right As BoundExpression,
             <[In]> ByRef userDefinedOperator As OverloadResolution.OverloadResolutionResult,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundUserDefinedBinaryOperator
             Debug.Assert(userDefinedOperator.Candidates.Length > 0)
 
@@ -622,7 +622,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             left As BoundExpression,
             right As BoundExpression,
             <[In]> ByRef bitwiseOperator As OverloadResolution.OverloadResolutionResult,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundUserDefinedShortCircuitingOperator
             Debug.Assert(opKind = BinaryOperatorKind.AndAlso OrElse opKind = BinaryOperatorKind.OrElse)
             Debug.Assert(bitwiseOperator.Candidates.Length > 0)
@@ -660,10 +660,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                  SyntaxFacts.GetText(If(opKind = BinaryOperatorKind.AndAlso,
                                                         SyntaxKind.AndAlsoKeyword, SyntaxKind.OrElseKeyword)))
 
-                Dim discardedDiagnostics = DiagnosticBag.GetInstance()
                 bitwise = BindUserDefinedNonShortCircuitingBinaryOperator(node, bitwiseKind, left, right, bitwiseOperator,
-                                                                          discardedDiagnostics) ' Ignore any additional diagnostics.
-                discardedDiagnostics.Free()
+                                                                          BindingDiagnosticBag.Discarded) ' Ignore any additional diagnostics.
                 hasErrors = True
                 GoTo Done
             End If
@@ -673,17 +671,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Find IsTrue/IsFalse operator
             Dim leftCheckOperator As OverloadResolution.OverloadResolutionResult
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             If opKind = BinaryOperatorKind.AndAlso Then
-                leftCheckOperator = OverloadResolution.ResolveIsFalseOperator(leftPlaceholder, Me, useSiteDiagnostics)
+                leftCheckOperator = OverloadResolution.ResolveIsFalseOperator(leftPlaceholder, Me, useSiteInfo)
             Else
-                leftCheckOperator = OverloadResolution.ResolveIsTrueOperator(leftPlaceholder, Me, useSiteDiagnostics)
+                leftCheckOperator = OverloadResolution.ResolveIsTrueOperator(leftPlaceholder, Me, useSiteInfo)
             End If
 
-            If diagnostics.Add(node, useSiteDiagnostics) Then
+            If diagnostics.Add(node, useSiteInfo) Then
                 ' Suppress additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             If Not leftCheckOperator.BestResult.HasValue Then
@@ -692,10 +690,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                  SyntaxFacts.GetText(If(opKind = BinaryOperatorKind.AndAlso, SyntaxKind.IsFalseKeyword, SyntaxKind.IsTrueKeyword)),
                                  SyntaxFacts.GetText(If(opKind = BinaryOperatorKind.AndAlso, SyntaxKind.AndAlsoKeyword, SyntaxKind.OrElseKeyword)))
 
-                Dim discardedDiagnostics = DiagnosticBag.GetInstance()
                 bitwise = BindUserDefinedNonShortCircuitingBinaryOperator(node, bitwiseKind, left, right, bitwiseOperator,
-                                                                          discardedDiagnostics) ' Ignore any additional diagnostics.
-                discardedDiagnostics.Free()
+                                                                          BindingDiagnosticBag.Discarded) ' Ignore any additional diagnostics.
                 leftPlaceholder = Nothing
                 hasErrors = True
                 GoTo Done
@@ -710,7 +706,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                  left.Type, right.Type)
 
                 hasErrors = True
-                diagnostics = New DiagnosticBag() ' Ignore any additional diagnostics.
+                diagnostics = BindingDiagnosticBag.Discarded ' Ignore any additional diagnostics.
                 bitwise = BindUserDefinedNonShortCircuitingBinaryOperator(node, bitwiseKind, left, right, bitwiseOperator, diagnostics)
             Else
                 ' Convert the operands to the operator type.
@@ -768,7 +764,7 @@ Done:
             operatorTokenKind As SyntaxKind,
             operand As BoundExpression,
             preliminaryOperatorKind As BinaryOperatorKind,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             ReportDiagnostic(diagnostics, operand.Syntax,
                              ErrorFactory.ErrorInfo(
@@ -783,7 +779,7 @@ Done:
         Private Function SubstituteDBNullWithNothingString(
             ByRef dbNullOperand As BoundExpression,
             otherOperandType As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As TypeSymbol
             Dim stringType As TypeSymbol
 
@@ -810,7 +806,7 @@ Done:
             rightType As TypeSymbol,
             specialType As SpecialType,
             makeNullable As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As TypeSymbol
             Debug.Assert(specialType <> Microsoft.CodeAnalysis.SpecialType.None)
             Debug.Assert(Not makeNullable OrElse leftType.IsNullableType() OrElse rightType.IsNullableType())
@@ -934,7 +930,7 @@ Done:
             right As BoundExpression,
             operatorTokenKind As SyntaxKind,
             operatorKind As BinaryOperatorKind,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Dim leftType = left.Type
             Dim rightType = right.Type
@@ -949,15 +945,15 @@ Done:
             Dim operatorTokenText = SyntaxFacts.GetText(operatorTokenKind)
 
             If OverloadResolution.UseUserDefinedBinaryOperators(operatorKind, leftType, rightType) AndAlso
-                Not leftType.CanContainUserDefinedOperators(useSiteDiagnostics:=Nothing) AndAlso Not rightType.CanContainUserDefinedOperators(useSiteDiagnostics:=Nothing) AndAlso
+                Not leftType.CanContainUserDefinedOperators(useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) AndAlso Not rightType.CanContainUserDefinedOperators(useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) AndAlso
                 (operatorKind = BinaryOperatorKind.Equals OrElse operatorKind = BinaryOperatorKind.NotEquals) AndAlso
                 leftType.IsReferenceType() AndAlso rightType.IsReferenceType() Then
                 ReportDiagnostic(diagnostics, syntax, ERRID.ERR_ReferenceComparison3, operatorTokenText, leftType, rightType)
 
-            ElseIf IsIEnumerableOfXElement(leftType, Nothing) Then
+            ElseIf IsIEnumerableOfXElement(leftType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                 ReportDiagnostic(diagnostics, syntax, ERRID.ERR_BinaryOperandsForXml4, operatorTokenText, leftType, rightType, leftType)
 
-            ElseIf IsIEnumerableOfXElement(rightType, Nothing) Then
+            ElseIf IsIEnumerableOfXElement(rightType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                 ReportDiagnostic(diagnostics, syntax, ERRID.ERR_BinaryOperandsForXml4, operatorTokenText, leftType, rightType, rightType)
 
             Else
@@ -978,7 +974,7 @@ Done:
             operatorKind As BinaryOperatorKind,
             ByRef left As BoundExpression,
             ByRef right As BoundExpression,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Debug.Assert((operatorKind And BinaryOperatorKind.OpMask) = operatorKind AndAlso operatorKind <> 0)
 
@@ -1103,7 +1099,7 @@ Done:
             End If
         End Sub
 
-        Private Function BindUnaryOperator(node As UnaryExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindUnaryOperator(node As UnaryExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
 
             Dim operand As BoundExpression = BindValue(node.Operand, diagnostics)
             Dim preliminaryOperatorKind As UnaryOperatorKind = OverloadResolution.MapUnaryOperatorKind(node.Kind)
@@ -1120,17 +1116,17 @@ Done:
 
             If operand.HasErrors Then
                 ' Suppress any additional diagnostics by overriding DiagnosticBag.
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             Dim intrinsicOperatorType As SpecialType = SpecialType.None
             Dim userDefinedOperator As OverloadResolution.OverloadResolutionResult = Nothing
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim operatorKind As UnaryOperatorKind = OverloadResolution.ResolveUnaryOperator(preliminaryOperatorKind, operand, Me, intrinsicOperatorType, userDefinedOperator, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim operatorKind As UnaryOperatorKind = OverloadResolution.ResolveUnaryOperator(preliminaryOperatorKind, operand, Me, intrinsicOperatorType, userDefinedOperator, useSiteInfo)
 
-            If diagnostics.Add(node, useSiteDiagnostics) Then
+            If diagnostics.Add(node, useSiteInfo) Then
                 ' Suppress additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             If operatorKind = UnaryOperatorKind.UserDefined Then
@@ -1211,7 +1207,7 @@ Done:
             opKind As UnaryOperatorKind,
             operand As BoundExpression,
             <[In]> ByRef userDefinedOperator As OverloadResolution.OverloadResolutionResult,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundUserDefinedUnaryOperator
             Debug.Assert(userDefinedOperator.Candidates.Length > 0)
 
@@ -1249,7 +1245,7 @@ Done:
         Private Shared Sub ReportUndefinedOperatorError(
             syntax As UnaryExpressionSyntax,
             operand As BoundExpression,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             If operand.Type.IsErrorType() Then
                 Return ' Let's not report more errors.

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_SelectCase.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_SelectCase.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #Region "Bind select case statement"
 
-        Private Function BindSelectBlock(node As SelectBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindSelectBlock(node As SelectBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node IsNot Nothing)
 
             ' Bind select expression
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim expression = BindSelectExpression(selectExprStatementSyntax.Expression, diagnostics)
 
             If expression.HasErrors Then
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             Dim exprPlaceHolder = New BoundRValuePlaceholder(selectExprStatementSyntax.Expression, expression.Type)
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             exitLabel:=selectBinder.GetExitLabel(SyntaxKind.ExitSelectStatement))
         End Function
 
-        Private Function BindSelectExpression(node As ExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindSelectExpression(node As ExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' SPEC: A Select Case statement executes statements based on the value of an expression.
             ' SPEC: The expression must be classified as a value.
 
@@ -101,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             selectExpression As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
             ByRef recommendSwitchTable As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As ImmutableArray(Of BoundCaseBlock)
 
             If Not caseBlocks.IsEmpty() Then
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As CaseBlockSyntax,
             selectExpression As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCaseBlock
 
             Dim caseStatement As BoundCaseStatement = BindCaseStatement(node.CaseStatement, selectExpression, convertCaseElements, diagnostics)
@@ -138,7 +138,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As CaseStatementSyntax,
             selectExpressionOpt As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCaseStatement
 
             Dim caseClauses As ImmutableArray(Of BoundCaseClause)
@@ -164,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As CaseClauseSyntax,
             selectExpressionOpt As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCaseClause
             Select Case node.Kind
                 Case SyntaxKind.CaseEqualsClause, SyntaxKind.CaseNotEqualsClause,
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As RelationalCaseClauseSyntax,
             selectExpressionOpt As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCaseClause
             ' SPEC:     A Case clause may take two forms.
             ' SPEC:     One form is an optional Is keyword, a comparison operator, and an expression.
@@ -235,7 +235,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As SimpleCaseClauseSyntax,
             selectExpressionOpt As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCaseClause
             ' SPEC:     The other form is an expression optionally followed by the keyword To and
             ' SPEC:     a second expression. Both expressions are converted to the type of the
@@ -267,7 +267,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As RangeCaseClauseSyntax,
             selectExpressionOpt As BoundRValuePlaceholder,
             convertCaseElements As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundCaseClause
             ' SPEC:     The other form is an expression optionally followed by the keyword To and
             ' SPEC:     a second expression. Both expressions are converted to the type of the
@@ -315,7 +315,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             operatorKind As BinaryOperatorKind,
             convertCaseElements As Boolean,
             ByRef conditionOpt As BoundExpression,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             Dim caseExpr As BoundExpression = BindValue(expressionSyntax, diagnostics)
@@ -372,7 +372,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             selectExpression As BoundRValuePlaceholder,
             caseBlockBuilder As ArrayBuilder(Of BoundCaseBlock),
             ByRef generateSwitchTable As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As ImmutableArray(Of BoundCaseBlock)
             Debug.Assert(Not selectExpression.HasErrors)
 
@@ -449,7 +449,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return caseBlockBuilder.ToImmutableAndFree()
         End Function
 
-        Private Function ComputeCaseClauseCondition(caseClause As BoundCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As DiagnosticBag) As BoundCaseClause
+        Private Function ComputeCaseClauseCondition(caseClause As BoundCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As BindingDiagnosticBag) As BoundCaseClause
             Select Case caseClause.Kind
                 Case BoundKind.RelationalCaseClause
                     Return ComputeRelationalCaseClauseCondition(DirectCast(caseClause, BoundRelationalCaseClause), conditionOpt, selectExpression, diagnostics)
@@ -465,7 +465,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Function ComputeRelationalCaseClauseCondition(boundClause As BoundRelationalCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As DiagnosticBag) As BoundCaseClause
+        Private Function ComputeRelationalCaseClauseCondition(boundClause As BoundRelationalCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As BindingDiagnosticBag) As BoundCaseClause
             Dim syntax = DirectCast(boundClause.Syntax, RelationalCaseClauseSyntax)
 
             ' Exactly one of the operand or condition must be non-null
@@ -483,7 +483,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return boundClause.Update(boundClause.OperatorKind, valueOpt:=Nothing, conditionOpt:=conditionOpt)
         End Function
 
-        Private Function ComputeSimpleCaseClauseCondition(boundClause As BoundSimpleCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As DiagnosticBag) As BoundCaseClause
+        Private Function ComputeSimpleCaseClauseCondition(boundClause As BoundSimpleCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As BindingDiagnosticBag) As BoundCaseClause
             ' Exactly one of the value or condition must be non-null
             Debug.Assert(boundClause.ConditionOpt IsNot Nothing Xor boundClause.ValueOpt IsNot Nothing)
 
@@ -499,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return boundClause.Update(valueOpt:=Nothing, conditionOpt:=conditionOpt)
         End Function
 
-        Private Function ComputeRangeCaseClauseCondition(boundClause As BoundRangeCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As DiagnosticBag) As BoundCaseClause
+        Private Function ComputeRangeCaseClauseCondition(boundClause As BoundRangeCaseClause, <Out()> ByRef conditionOpt As BoundExpression, selectExpression As BoundRValuePlaceholder, diagnostics As BindingDiagnosticBag) As BoundCaseClause
             Dim syntax = boundClause.Syntax
 
             ' Exactly one of the LowerBoundOpt or LowerBoundConditionOpt must be non-null
@@ -548,7 +548,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         ' Helper method to determine if we must rewrite the select case statement as an IF list or a SWITCH table
-        Private Function RecommendSwitchTable(selectExpr As BoundRValuePlaceholder, caseBlocks As ArrayBuilder(Of BoundCaseBlock), diagnostics As DiagnosticBag) As Boolean
+        Private Function RecommendSwitchTable(selectExpr As BoundRValuePlaceholder, caseBlocks As ArrayBuilder(Of BoundCaseBlock), diagnostics As BindingDiagnosticBag) As Boolean
             ' We can rewrite select case statement as an IF list or a SWITCH table
             ' This function determines which method to use.
             ' The conditions for choosing the SWITCH table are:
@@ -654,7 +654,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ' Function reports WRN_SelectCaseInvalidRange for any invalid select case range.
         ' Returns True if an invalid range was found, False otherwise.
-        Private Function ReportInvalidSelectCaseRange(caseBlocks As ArrayBuilder(Of BoundCaseBlock), diagnostics As DiagnosticBag) As Boolean
+        Private Function ReportInvalidSelectCaseRange(caseBlocks As ArrayBuilder(Of BoundCaseBlock), diagnostics As BindingDiagnosticBag) As Boolean
             For Each caseBlock In caseBlocks
                 For Each caseClause In caseBlock.CaseStatement.CaseClauses
                     Select Case caseClause.Kind

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' The dispatcher method that handles syntax nodes for all stand-alone statements.
         ''' </summary>
-        Public Overridable Function BindStatement(node As StatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Public Overridable Function BindStatement(node As StatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node IsNot Nothing)
             Select Case node.Kind
                 Case SyntaxKind.SimpleAssignmentStatement,
@@ -262,7 +262,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundBadStatement(node, ImmutableArray(Of BoundNode).Empty, hasErrors:=True)
         End Function
 
-        Private Function BindStandAloneCaseStatement(caseStatement As CaseStatementSyntax, diagnostics As DiagnosticBag) As BoundBadStatement
+        Private Function BindStandAloneCaseStatement(caseStatement As CaseStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundBadStatement
             ' Valid Case statement within Select Case statement is handled in BindSelectBlock.
             ' We should reach here only for invalid Case statements which are not inside any SelectBlock.
             ' Parser must have already reported error ERRID.ERR_CaseNoSelect or ERRID.ERR_SubRequiresSingleStatement.
@@ -286,7 +286,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundBadStatement(caseStatement, children.ToImmutableAndFree(), hasErrors:=True)
         End Function
 
-        Private Function BindMethodBlock(methodBlock As MethodBlockBaseSyntax, diagnostics As DiagnosticBag) As BoundBlock
+        Private Function BindMethodBlock(methodBlock As MethodBlockBaseSyntax, diagnostics As BindingDiagnosticBag) As BoundBlock
             Dim statements As ArrayBuilder(Of BoundStatement) = ArrayBuilder(Of BoundStatement).GetInstance
             Dim locals As ImmutableArray(Of LocalSymbol) = ImmutableArray(Of LocalSymbol).Empty
 
@@ -422,7 +422,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
             Private ReadOnly _binder As Binder
-            Private ReadOnly _diagnostics As DiagnosticBag
+            Private ReadOnly _diagnostics As BindingDiagnosticBag
             Private _containsOnError As Boolean ' The block contains an [On Error] statement. 
             Private _containsTry As Boolean ' The block contains a Try block.
             Private _containsResume As Boolean ' The block contains a [Resume [...]] or an [On Error Resume Next] statement. And this is a syntax node for the first of them.
@@ -435,7 +435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private _containsAwait As Boolean
             Private ReadOnly _tryOnErrorResume As New ArrayBuilder(Of BoundStatement)
 
-            Private Sub New(binder As Binder, diagnostics As DiagnosticBag)
+            Private Sub New(binder As Binder, diagnostics As BindingDiagnosticBag)
                 _diagnostics = diagnostics
                 _binder = binder
             End Sub
@@ -443,7 +443,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public Shared Shadows Sub VisitBlock(
                 binder As Binder,
                 block As BoundBlock,
-                diagnostics As DiagnosticBag,
+                diagnostics As BindingDiagnosticBag,
                 <Out> ByRef containsAwait As Boolean,
                 <Out> ByRef containsOnError As Boolean,
                 <Out> ByRef containsResume As Boolean,
@@ -601,7 +601,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Function
         End Class
 
-        Private Shared Sub ReportNameConfictsBetweenStaticLocals(methodBlockBinder As Binder, diagnostics As DiagnosticBag)
+        Private Shared Sub ReportNameConfictsBetweenStaticLocals(methodBlockBinder As Binder, diagnostics As BindingDiagnosticBag)
             Dim currentBinder As Binder = methodBlockBinder
             Dim bodyBinder As MethodBodyBinder
 
@@ -666,7 +666,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <remarks> Currently set to 32 because of COM+ array type limits </remarks>
         Public Const ArrayRankLimit = 32
 
-        Private Function BindRedimStatement(node As ReDimStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindRedimStatement(node As ReDimStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim operands = ArrayBuilder(Of BoundRedimClause).GetInstance()
             Dim hasPreserveClause = node.Kind = SyntaxKind.ReDimPreserveStatement
 
@@ -759,7 +759,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundRedimStatement(node, operands.ToImmutableAndFree())
         End Function
 
-        Private Function BindEraseStatement(node As EraseStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindEraseStatement(node As EraseStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim clauses = ArrayBuilder(Of BoundAssignmentOperator).GetInstance()
 
             For Each operand As ExpressionSyntax In node.Expressions
@@ -792,7 +792,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundEraseStatement(node, clauses.ToImmutableAndFree())
         End Function
 
-        Private Function BindGoToStatement(node As GoToStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindGoToStatement(node As GoToStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim symbol As LabelSymbol = Nothing
 
             Dim boundLabelExpression As BoundExpression = BindExpression(node.Label, diagnostics)
@@ -815,7 +815,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Private Function IsValidLabelForGoto(label As LabelSymbol, labelSyntax As LabelSyntax, diagnostics As DiagnosticBag) As Boolean
+        Private Function IsValidLabelForGoto(label As LabelSymbol, labelSyntax As LabelSyntax, diagnostics As BindingDiagnosticBag) As Boolean
             Dim hasError As Boolean = False
 
             Dim labelParent = DirectCast(label.LabelName.Parent, VisualBasicSyntaxNode)
@@ -890,14 +890,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return False
         End Function
 
-        Private Function BindLabelStatement(node As LabelStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindLabelStatement(node As LabelStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim labelToken As SyntaxToken = node.LabelToken
             Dim labelName = labelToken.ValueText
 
             ' A label symbol will always be found because all labels without syntax errors are put into the 
             ' label map in the blockbasebinder.
             Dim result = LookupResult.GetInstance()
-            Lookup(result, labelName, 0, LookupOptions.LabelsOnly, useSiteDiagnostics:=Nothing)
+            Lookup(result, labelName, 0, LookupOptions.LabelsOnly, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             Debug.Assert(result.HasSingleSymbol AndAlso result.IsGood)
 
             Dim symbol = DirectCast(result.SingleSymbol, SourceLabelSymbol)
@@ -920,7 +920,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="syntax">The syntax list of the modifiers.</param>
         ''' <param name="diagBag">returns True if any errors are reported</param>
-        Private Sub DecodeLocalModifiersAndReportErrors(syntax As SyntaxTokenList, diagBag As DiagnosticBag)
+        Private Sub DecodeLocalModifiersAndReportErrors(syntax As SyntaxTokenList, diagBag As BindingDiagnosticBag)
 
             Const localModifiersMask = SourceMemberFlags.Const Or SourceMemberFlags.Dim Or SourceMemberFlags.Static
             Dim foundModifiers As SourceMemberFlags = Nothing
@@ -965,7 +965,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ElseIf (foundModifiers And SourceMemberFlags.Static) <> 0 Then
 
                 ' 'Static' keyword is only allowed in class methods, but not in structure methods
-                If Me.ContainingType IsNot Nothing AndAlso Me.ContainingType.TypeKind = TYPEKIND.Structure Then
+                If Me.ContainingType IsNot Nothing AndAlso Me.ContainingType.TypeKind = TypeKind.Structure Then
                     '  Local variables within methods of structures cannot be declared 'Static'
                     ReportDiagnostic(diagBag, firstStatic, ERRID.ERR_BadStaticLocalInStruct)
                 ElseIf Me.IsInLambda Then
@@ -977,7 +977,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Sub
 
-        Private Function BindLocalDeclaration(node As LocalDeclarationStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindLocalDeclaration(node As LocalDeclarationStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
 
             DecodeLocalModifiersAndReportErrors(node.Modifiers, diagnostics)
 
@@ -990,7 +990,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindVariableDeclarators(
             declarators As SeparatedSyntaxList(Of VariableDeclaratorSyntax),
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As ImmutableArray(Of BoundLocalDeclarationBase)
 
             Dim builder = ArrayBuilder(Of BoundLocalDeclarationBase).GetInstance()
@@ -1080,7 +1080,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             name As ModifiedIdentifierSyntax,
             asClauseOpt As AsClauseSyntax,
             equalsValueOpt As EqualsValueSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             Optional skipAsNewInitializer As Boolean = False
         ) As BoundLocalDeclaration
 
@@ -1266,7 +1266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     equalsValueOpt As EqualsValueSyntax,
                                     <Out()> ByRef valueExpression As BoundExpression,
                                     <Out()> ByRef asClauseType As TypeSymbol,
-                                    diagnostics As DiagnosticBag) As TypeSymbol
+                                    diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             valueExpression = Nothing
 
@@ -1378,7 +1378,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If inferredType IsNot Nothing Then
                         ' Infer the type from the expression. When the identifier has modifiers, the expression type
                         ' and the modifiers need to be compatible. Without modifiers just use the expression type.
-                        Dim localDiagnostics As DiagnosticBag = If(inferFrom.HasErrors, New DiagnosticBag(), diagnostics)
+                        Dim localDiagnostics = If(inferFrom.HasErrors, BindingDiagnosticBag.Discarded, diagnostics)
 
                         If modifiedIdentifierOpt IsNot Nothing Then
                             type = InferVariableType(type, modifiedIdentifierOpt, valueSyntax, inferredType, inferFrom, typeDiagnostic, localDiagnostics)
@@ -1430,7 +1430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                  <Out()> ByRef fromValueExpression As BoundExpression,
                                  <Out()> ByRef toValueExpression As BoundExpression,
                                  <Out()> ByRef stepValueExpression As BoundExpression,
-                                 diagnostics As DiagnosticBag) As TypeSymbol
+                                 diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             fromValueExpression = Nothing
             toValueExpression = Nothing
@@ -1512,7 +1512,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                          <Out()> ByRef collectionPlaceholder As BoundRValuePlaceholder,
                          <Out()> ByRef needToDispose As Boolean,
                          <Out()> ByRef isOrInheritsFromOrImplementsIDisposable As Boolean,
-                         diagnostics As DiagnosticBag) As TypeSymbol
+                         diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             collectionExpression = Nothing
             currentType = Nothing
@@ -1582,7 +1582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            valueType As TypeSymbol,
                                            valueExpression As BoundExpression,
                                            getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
-                                           diagnostics As DiagnosticBag) As TypeSymbol
+                                           diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             Dim nameIsArrayType = IsArrayType(name)
             Dim nameHasNullable = name.Nullable.Node IsNot Nothing
@@ -1714,7 +1714,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         'TODO: override in MethodBodySemanticModel similarly to BindVariableDeclaration.
         Friend Overridable Function BindCatchVariableDeclaration(name As IdentifierNameSyntax,
                                                     asClause As AsClauseSyntax,
-                                                    diagnostics As DiagnosticBag) As BoundLocal
+                                                    diagnostics As BindingDiagnosticBag) As BoundLocal
 
             Dim identifier = name.Identifier
             Dim symbol As LocalSymbol = GetLocalForDeclaration(identifier)
@@ -1733,7 +1733,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     type As TypeSymbol,
                                     nameSyntax As VisualBasicSyntaxNode,
                                     identifier As SyntaxToken,
-                                    diagnostics As DiagnosticBag)
+                                    diagnostics As BindingDiagnosticBag)
 
             Dim localForFunctionValue = GetLocalForFunctionValue()
             Dim name = identifier.ValueText
@@ -1746,7 +1746,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Else
                 Dim result = LookupResult.GetInstance()
-                Lookup(result, identifier.ValueText, 0, Nothing, useSiteDiagnostics:=Nothing)
+                Lookup(result, identifier.ValueText, 0, Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                 ' A local symbol will always be found because all local declarations are put into the 
                 ' local map in the blockbasebinder. 
@@ -1792,7 +1792,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             symbol As Symbol,
             nameSyntax As SyntaxNodeOrToken,
             identifier As SyntaxNodeOrToken,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Debug.Assert(symbol.Kind = SymbolKind.Local OrElse symbol.Kind = SymbolKind.RangeVariable OrElse
                          (symbol.Kind = SymbolKind.Parameter AndAlso
@@ -1809,13 +1809,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Do
 
-                Dim namedTypeBinder = TryCast(container, namedTypeBinder)
+                Dim namedTypeBinder = TryCast(container, NamedTypeBinder)
                 If namedTypeBinder IsNot Nothing Then
                     Exit Do
                 End If
 
                 result.Clear()
-                container.LookupInSingleBinder(result, name, 0, Nothing, Me, useSiteDiagnostics:=Nothing)
+                container.LookupInSingleBinder(result, name, 0, Nothing, Me, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                 If result.HasSingleSymbol Then
 
@@ -1873,7 +1873,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 End If
 
-                Dim implicitVariableBinder = TryCast(container, implicitVariableBinder)
+                Dim implicitVariableBinder = TryCast(container, ImplicitVariableBinder)
                 If implicitVariableBinder IsNot Nothing AndAlso Not implicitVariableBinder.AllImplicitVariableDeclarationsAreHandled Then
                     ' If an implicit local comes into being later, then report an error here.
                     If symbol.Kind = SymbolKind.Parameter Then
@@ -1893,7 +1893,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             result.Free()
         End Sub
 
-        Friend Function AdjustAssignmentTarget(node As SyntaxNode, op1 As BoundExpression, diagnostics As DiagnosticBag, ByRef isError As Boolean) As BoundExpression
+        Friend Function AdjustAssignmentTarget(node As SyntaxNode, op1 As BoundExpression, diagnostics As BindingDiagnosticBag, ByRef isError As Boolean) As BoundExpression
             Select Case op1.Kind
                 Case BoundKind.XmlMemberAccess
                     Dim memberAccess = DirectCast(op1, BoundXmlMemberAccess)
@@ -1925,19 +1925,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If setMethod IsNot Nothing Then
                             ReportDiagnosticsIfObsoleteOrNotSupportedByRuntime(diagnostics, setMethod, node)
 
-                            If ReportUseSiteError(diagnostics, op1.Syntax, setMethod) Then
+                            If ReportUseSite(diagnostics, op1.Syntax, setMethod) Then
                                 isError = True
                             Else
                                 Dim accessThroughType = GetAccessThroughType(propertyAccess.ReceiverOpt)
-                                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-                                If Not IsAccessible(setMethod, useSiteDiagnostics, accessThroughType) AndAlso
-                                   IsAccessible(propertySymbol, useSiteDiagnostics, accessThroughType) Then
+                                If Not IsAccessible(setMethod, useSiteInfo, accessThroughType) AndAlso
+                                   IsAccessible(propertySymbol, useSiteInfo, accessThroughType) Then
                                     ReportDiagnostic(diagnostics, node, ERRID.ERR_NoAccessibleSet, CustomSymbolDisplayFormatter.ShortErrorName(propertySymbol))
                                     isError = True
                                 End If
 
-                                diagnostics.Add(node, useSiteDiagnostics)
+                                diagnostics.Add(node, useSiteInfo)
                             End If
                         End If
                     End If
@@ -1959,7 +1959,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Function BindAssignment(node As SyntaxNode, op1 As BoundExpression, op2 As BoundExpression, diagnostics As DiagnosticBag) As BoundAssignmentOperator
+        Private Function BindAssignment(node As SyntaxNode, op1 As BoundExpression, op2 As BoundExpression, diagnostics As BindingDiagnosticBag) As BoundAssignmentOperator
 
             Dim isError As Boolean = False
             op1 = AdjustAssignmentTarget(node, op1, diagnostics, isError)
@@ -1983,7 +1983,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             right As BoundExpression,
             operatorTokenKind As SyntaxKind,
             operatorKind As BinaryOperatorKind,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundAssignmentOperator
 
             Dim isError As Boolean = False
@@ -2009,7 +2009,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If isError Then
                 ' Suppress all additional diagnostics. This ensures that we still generate the appropriate tree shape
                 ' even in error scenarios
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             placeholder = New BoundCompoundAssignmentTargetPlaceholder(left.Syntax, targetType).MakeCompilerGenerated()
@@ -2025,7 +2025,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Binds a list of statements and puts in a scope.
         ''' </summary>
-        Friend Function BindBlock(syntax As SyntaxNode, stmtList As SyntaxList(Of StatementSyntax), diagnostics As DiagnosticBag) As BoundBlock
+        Friend Function BindBlock(syntax As SyntaxNode, stmtList As SyntaxList(Of StatementSyntax), diagnostics As BindingDiagnosticBag) As BoundBlock
             Dim stmtListBinder = Me.GetBinder(stmtList)
             Return BindBlock(syntax, stmtList, diagnostics, stmtListBinder)
         End Function
@@ -2033,7 +2033,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Binds a list of statements and puts in a scope.
         ''' </summary>
-        Friend Function BindBlock(syntax As SyntaxNode, stmtList As SyntaxList(Of StatementSyntax), diagnostics As DiagnosticBag, stmtListBinder As Binder) As BoundBlock
+        Friend Function BindBlock(syntax As SyntaxNode, stmtList As SyntaxList(Of StatementSyntax), diagnostics As BindingDiagnosticBag, stmtListBinder As Binder) As BoundBlock
             Dim boundStatements(stmtList.Count - 1) As BoundStatement
             Dim locals As ArrayBuilder(Of LocalSymbol) = Nothing
 
@@ -2085,7 +2085,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Sub
 
-        Private Function BindAssignmentStatement(node As AssignmentStatementSyntax, diagnostics As DiagnosticBag) As BoundExpressionStatement
+        Private Function BindAssignmentStatement(node As AssignmentStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundExpressionStatement
             Debug.Assert(node IsNot Nothing)
 
             Dim op1 As BoundExpression = Me.BindAssignmentTarget(node.Left, diagnostics)
@@ -2151,7 +2151,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundExpressionStatement(node, expr.MakeCompilerGenerated())
         End Function
 
-        Private Function BindMidAssignmentStatement(node As AssignmentStatementSyntax, diagnostics As DiagnosticBag) As BoundExpressionStatement
+        Private Function BindMidAssignmentStatement(node As AssignmentStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundExpressionStatement
             Debug.Assert(node IsNot Nothing AndAlso node.Kind = SyntaxKind.MidAssignmentStatement AndAlso node.Left.Kind = SyntaxKind.MidExpression)
 
             Dim midExpression = DirectCast(node.Left, MidExpressionSyntax)
@@ -2222,8 +2222,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                                   hasErrors:=isError).MakeCompilerGenerated())
         End Function
 
-        Private Function BindAddRemoveHandlerStatement(node As AddRemoveHandlerStatementSyntax, diagnostics As DiagnosticBag) As BoundAddRemoveHandlerStatement
-            Dim eventSymbol As eventSymbol = Nothing
+        Private Function BindAddRemoveHandlerStatement(node As AddRemoveHandlerStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundAddRemoveHandlerStatement
+            Dim eventSymbol As EventSymbol = Nothing
             Dim actualEventAccess As BoundEventAccess = Nothing
             Dim eventAccess As BoundExpression = BindEventAccess(node.EventExpression, diagnostics, actualEventAccess, eventSymbol)
 
@@ -2291,26 +2291,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         hasErrors = True
                     Else
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                         Dim accessThroughType = GetAccessThroughType(actualEventAccess.ReceiverOpt)
-                        If Not Me.IsAccessible(method, useSiteDiagnostics, accessThroughType) Then
+                        If Not Me.IsAccessible(method, useSiteInfo, accessThroughType) Then
                             Debug.Assert(eventSymbol.DeclaringCompilation IsNot Me.Compilation)
                             ReportDiagnostic(diagnostics, node.EventExpression, GetInaccessibleErrorInfo(method))
                         End If
 
-                        diagnostics.Add(node.EventExpression, useSiteDiagnostics)
+                        diagnostics.Add(node.EventExpression, useSiteInfo)
 
                         Dim badShape As Boolean = False
-                        Dim useSiteError As DiagnosticInfo = Nothing
 
                         ' Decrease noise in diagnostics, if event is "bad", we already complained about it. 
-                        If eventSymbol.GetUseSiteErrorInfo() Is Nothing Then
-                            useSiteError = method.GetUseSiteErrorInfo()
-                        End If
+                        If eventSymbol.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso
+                           ReportUseSite(diagnostics, node.EventExpression, method.GetUseSiteInfo()) Then
 
-                        If useSiteError IsNot Nothing Then
                             Debug.Assert(eventSymbol.DeclaringCompilation IsNot Me.Compilation)
-                            ReportDiagnostic(diagnostics, node.EventExpression, useSiteError)
                             hasErrors = True
 
                         ElseIf method.ParameterCount <> 1 OrElse method.Parameters(0).IsByRef Then
@@ -2351,7 +2347,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function BindEventAccess(node As ExpressionSyntax,
-                                         diagnostics As DiagnosticBag,
+                                         diagnostics As BindingDiagnosticBag,
                                          <Out()> ByRef actualEventAccess As BoundEventAccess,
                                          <Out()> ByRef eventSymbol As EventSymbol) As BoundExpression
 
@@ -2370,9 +2366,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If notQualifiedSyntax.Kind <> SyntaxKind.IdentifierName Then
                 ReportDiagnostic(diagnostics, notQualifiedSyntax, ERRID.ERR_AddOrRemoveHandlerEvent)
 
-                Dim ignoreDiagnostics = DiagnosticBag.GetInstance()
-                Dim errorRecovery As BoundExpression = BindRValue(node, ignoreDiagnostics)
-                ignoreDiagnostics.Free()
+                Dim errorRecovery As BoundExpression = BindRValue(node, BindingDiagnosticBag.Discarded)
 
                 Return errorRecovery
             End If
@@ -2384,7 +2378,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' when binding a simple name event we know that it must be a member since methods do not declare events
             If notParenthesizedSyntax.Kind = SyntaxKind.IdentifierName Then
-                Dim simpleNameSyntax As simpleNameSyntax = DirectCast(notParenthesizedSyntax, IdentifierNameSyntax)
+                Dim simpleNameSyntax As SimpleNameSyntax = DirectCast(notParenthesizedSyntax, IdentifierNameSyntax)
                 result = BindSimpleName(simpleNameSyntax, False, diagnostics, skipLocalsAndParameters:=True)
             Else
                 result = BindExpression(node, isInvocationOrAddressOf:=False, isOperandOfConditionalBranch:=False, eventContext:=True, diagnostics:=diagnostics)
@@ -2419,7 +2413,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result
         End Function
 
-        Private Function BindRaiseEventStatement(node As RaiseEventStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindRaiseEventStatement(node As RaiseEventStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim hasErrors = False
 
             Dim target As BoundExpression = BindSimpleName(node.Name, False, diagnostics, skipLocalsAndParameters:=True)
@@ -2448,14 +2442,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If eventSym.HasAssociatedField Then
                 ' field is not nothing when event IsFieldLike
                 Dim eventField = eventSym.AssociatedField
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-                If Not IsAccessible(eventField, useSiteDiagnostics, Me.ContainingType) Then
+                If Not IsAccessible(eventField, useSiteInfo, Me.ContainingType) Then
                     ReportDiagnostic(diagnostics, node.Name, ERRID.ERR_CantRaiseBaseEvent)
                     hasErrors = True
                 End If
 
-                diagnostics.Add(node.Name, useSiteDiagnostics)
+                diagnostics.Add(node.Name, useSiteInfo)
 
                 Debug.Assert(TypeSymbol.Equals(targetAsEvent.Type, eventField.Type, TypeCompareKind.ConsiderEverything) OrElse eventSym.IsWindowsRuntimeEvent, "non-WinRT event should have the same type as its backing field")
 
@@ -2482,7 +2476,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 fireMethod = eventType.DelegateInvokeMethod
 
-                If ReportUseSiteError(diagnostics, node.Name, fireMethod) Then
+                If ReportUseSite(diagnostics, node.Name, fireMethod) Then
                     hasErrors = True
                 End If
 
@@ -2503,7 +2497,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return New BoundBadStatement(node, StaticCast(Of BoundNode).From(boundArguments).Add(target), True)
                 End If
 
-                If ReportUseSiteError(diagnostics, node.Name, fireMethod) Then
+                If ReportUseSite(diagnostics, node.Name, fireMethod) Then
                     hasErrors = True
                 End If
 
@@ -2568,7 +2562,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundRaiseEventStatement(node, eventSym, invocation, hasErrors)
         End Function
 
-        Private Function BindExpressionStatement(statement As ExpressionStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindExpressionStatement(statement As ExpressionStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
 
             Dim expression = statement.Expression
 
@@ -2592,7 +2586,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundExpressionStatement(statement, boundExpression)
         End Function
 
-        Private Sub WarnOnUnobservedCallThatReturnsAnAwaitable(statement As ExpressionStatementSyntax, boundExpression As BoundExpression, diagnostics As DiagnosticBag)
+        Private Sub WarnOnUnobservedCallThatReturnsAnAwaitable(statement As ExpressionStatementSyntax, boundExpression As BoundExpression, diagnostics As BindingDiagnosticBag)
             If boundExpression.Kind = BoundKind.ConditionalAccess Then
                 WarnOnUnobservedCallThatReturnsAnAwaitable(statement, DirectCast(boundExpression, BoundConditionalAccess).AccessExpression, diagnostics)
                 Return
@@ -2630,18 +2624,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If Not warn Then
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                     ' 2. 
-                    If IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncAction, useSiteDiagnostics:=Nothing) OrElse
-                       IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncActionWithProgress_T, useSiteDiagnostics:=Nothing) OrElse
-                       IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncOperation_T, useSiteDiagnostics:=Nothing) OrElse
-                       IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncOperationWithProgress_T2, useSiteDiagnostics:=Nothing) Then
+                    If IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncAction, useSiteInfo:=useSiteInfo) OrElse
+                       IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncActionWithProgress_T, useSiteInfo:=useSiteInfo) OrElse
+                       IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncOperation_T, useSiteInfo:=useSiteInfo) OrElse
+                       IsOrInheritsFromOrImplementsInterface(boundExpression.Type, WellKnownType.Windows_Foundation_IAsyncOperationWithProgress_T2, useSiteInfo:=useSiteInfo) Then
+                        diagnostics.AddDependencies(useSiteInfo)
                         warn = True
 
                     ElseIf IsInAsyncContext() Then
                         ' 3.
-                        Dim diagBag = DiagnosticBag.GetInstance()
+                        Dim diagBag = BindingDiagnosticBag.GetInstance()
 
                         If Not BindAwait(statement, boundExpression, diagBag, bindAsStatement:=True).HasErrors AndAlso Not diagBag.HasAnyErrors Then
+                            diagnostics.AddDependencies(diagBag)
                             warn = True
                         End If
 
@@ -2655,28 +2652,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Function IsOrInheritsFromOrImplementsInterface(derivedType As TypeSymbol, interfaceType As WellKnownType, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Private Function IsOrInheritsFromOrImplementsInterface(derivedType As TypeSymbol, interfaceType As WellKnownType, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Dim type As NamedTypeSymbol = Compilation.GetWellKnownType(interfaceType)
             Return Not type.IsErrorType() AndAlso type.IsInterfaceType() AndAlso
-                   IsOrInheritsFromOrImplementsInterface(derivedType, type, useSiteDiagnostics)
+                   IsOrInheritsFromOrImplementsInterface(derivedType, type, useSiteInfo)
         End Function
 
-        Private Function BindPrintStatement(printStmt As PrintStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindPrintStatement(printStmt As PrintStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim boundExpression As BoundExpression = BindRValue(printStmt.Expression, diagnostics)
             Return New BoundExpressionStatement(printStmt, boundExpression)
         End Function
 
-        Private Function BindCallStatement(callStmt As CallStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindCallStatement(callStmt As CallStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim boundInvocation As BoundExpression = BindInvocationExpressionAsStatement(callStmt.Invocation, diagnostics)
 
             Return New BoundExpressionStatement(callStmt, boundInvocation)
         End Function
 
-        Private Function BindInvocationExpressionAsStatement(expression As ExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindInvocationExpressionAsStatement(expression As ExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return ReclassifyInvocationExpressionAsStatement(BindExpression(expression, diagnostics), diagnostics)
         End Function
 
-        Friend Function ReclassifyInvocationExpressionAsStatement(boundInvocation As BoundExpression, diagnostics As DiagnosticBag) As BoundExpression
+        Friend Function ReclassifyInvocationExpressionAsStatement(boundInvocation As BoundExpression, diagnostics As BindingDiagnosticBag) As BoundExpression
             Select Case boundInvocation.Kind
                 Case BoundKind.PropertyAccess
                     boundInvocation = MakeRValue(boundInvocation, diagnostics)
@@ -2714,7 +2711,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return boundInvocation
         End Function
 
-        Private Function BindSingleLineIfStatement(node As SingleLineIfStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindSingleLineIfStatement(node As SingleLineIfStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node IsNot Nothing)
 
             Dim condition As BoundExpression
@@ -2730,7 +2727,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundIfStatement(node, condition, consequence, alternative)
         End Function
 
-        Private Function BindMultiLineIfBlock(node As MultiLineIfBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindMultiLineIfBlock(node As MultiLineIfBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node IsNot Nothing)
 
             ' We need to bind the conditions and blocks in lexical order (so that Option Explicit binding
@@ -2771,7 +2768,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return currentAlternative
         End Function
 
-        Private Function BindDoLoop(node As DoLoopBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindDoLoop(node As DoLoopBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node IsNot Nothing)
 
             Dim topCondition As BoundExpression = Nothing
@@ -2806,7 +2803,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             hasErrors:=topCondition IsNot Nothing AndAlso bottomCondition IsNot Nothing)
         End Function
 
-        Private Function BindWhileBlock(node As WhileBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindWhileBlock(node As WhileBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node IsNot Nothing)
 
             ' Bind condition
@@ -2824,7 +2821,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             exitLabel:=loopBodyBinder.GetExitLabel(SyntaxKind.ExitWhileStatement))
         End Function
 
-        Public Function BindForToBlock(node As ForOrForEachBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Public Function BindForToBlock(node As ForOrForEachBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             ' For statement has its own binding scope since it may introduce iteration variable
             ' that is visible through the entire For block. It also needs to support Continue/Exit
             ' Interestingly, control variable is in scope when Limit and Step or the collection are bound,
@@ -2854,7 +2851,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                   diagnostics)
         End Function
 
-        Public Function BindForEachBlock(node As ForOrForEachBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Public Function BindForEachBlock(node As ForOrForEachBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             ' For statement has its own binding scope since it may introduce iteration variable
             ' that is visible through the entire For block. It also needs to support Continue/Exit
             ' Interestingly, control variable is in scope when Limit and Step or the collection are bound,
@@ -2899,7 +2896,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            <Out()> ByRef declaredOrInferredLocalOpt As LocalSymbol,
                                            <Out()> ByRef controlVariable As BoundExpression,
                                            <Out()> ByRef isInferredLocal As Boolean,
-                                           diagnostics As DiagnosticBag) As Boolean
+                                           diagnostics As BindingDiagnosticBag) As Boolean
             ' Bind control variable
 
             ' There are two forms of control variables -
@@ -2945,9 +2942,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim identifier = DirectCast(controlVariableSyntax, IdentifierNameSyntax).Identifier
                     Dim name = identifier.ValueText
                     Dim result As LookupResult = LookupResult.GetInstance
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Lookup(result, name, 0, LookupOptions.AllMethodsOfAnyArity, useSiteDiagnostics)
-                    diagnostics.Add(node, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Lookup(result, name, 0, LookupOptions.AllMethodsOfAnyArity, useSiteInfo)
+                    diagnostics.Add(node, useSiteInfo)
 
                     ' If a local symbol is found then check whether this local corresponds to this identifier.  If it does then
                     ' this is local is an inferred local for the for block.  This local does not have a type yet. Return the 
@@ -2999,7 +2996,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As ForOrForEachBlockSyntax,
             <Out()> ByRef nextVariables As ImmutableArray(Of BoundExpression),
             <Out()> ByRef loopBody As BoundBlock,
-            diagnostics As DiagnosticBag)
+            diagnostics As BindingDiagnosticBag)
 
             ' Bind the body of the loop.
             loopBody = BindBlock(node, node.Statements, diagnostics).MakeCompilerGenerated()
@@ -3064,7 +3061,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             controlVariableOpt As BoundExpression,
             isInferredLocal As Boolean,
             hasErrors As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundForStatement
             Dim forStatement = DirectCast(node.ForOrForEachStatement, ForStatementSyntax)
 
@@ -3152,12 +3149,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim booleanType = GetSpecialType(SpecialType.System_Boolean, node, diagnostics)
 
             Dim udfOperators As BoundForToUserDefinedOperators = Nothing
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             ' normalize initValue, limit and step to the common type
             If Not hasErrors Then
                 If Not (initialValue.HasErrors OrElse limit.HasErrors OrElse stepValue.HasErrors) AndAlso
-                   targetType.CanContainUserDefinedOperators(useSiteDiagnostics) Then
+                   targetType.CanContainUserDefinedOperators(useSiteInfo) Then
                     ' Bind user-defined operators that we need.
                     Dim syntax As VisualBasicSyntaxNode = node.ForOrForEachStatement
 
@@ -3178,7 +3175,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If greaterThanOrEqual IsNot Nothing Then
                         ' Suppress errors if we already reported them for LessThanOrEqual.
                         greaterThanOrEqual = ApplyImplicitConversion(syntax, booleanType, greaterThanOrEqual,
-                                                                     If(lessThanOrEqual IsNot Nothing AndAlso lessThanOrEqual.HasErrors, New DiagnosticBag(), diagnostics),
+                                                                     If(lessThanOrEqual IsNot Nothing AndAlso lessThanOrEqual.HasErrors, BindingDiagnosticBag.Discarded, diagnostics),
                                                                      isOperandOfConditionalBranch:=True).MakeCompilerGenerated()
                     End If
 
@@ -3193,7 +3190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             End If
 
-            diagnostics.Add(node, useSiteDiagnostics)
+            diagnostics.Add(node, useSiteInfo)
 
             hasErrors = hasErrors OrElse
                         targetType.IsErrorType OrElse
@@ -3231,20 +3228,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             opCode As BinaryOperatorKind,
             left As BoundExpression,
             right As BoundExpression,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundUserDefinedBinaryOperator
 
             Debug.Assert(opCode = BinaryOperatorKind.Add OrElse opCode = BinaryOperatorKind.Subtract OrElse opCode = BinaryOperatorKind.LessThanOrEqual OrElse opCode = BinaryOperatorKind.GreaterThanOrEqual)
 
             Dim isRelational As Boolean = (opCode = BinaryOperatorKind.LessThanOrEqual OrElse opCode = BinaryOperatorKind.GreaterThanOrEqual)
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             Dim userDefinedOperator As OverloadResolution.OverloadResolutionResult = OverloadResolution.ResolveUserDefinedBinaryOperator(left, right, opCode, Me, includeEliminatedCandidates:=False,
-                                                                                                                                         useSiteDiagnostics:=useSiteDiagnostics)
+                                                                                                                                         useSiteInfo:=useSiteInfo)
 
-            If diagnostics.Add(syntax, useSiteDiagnostics) Then
+            If diagnostics.Add(syntax, useSiteInfo) Then
                 ' Suppress additional diagnostics
-                diagnostics = New DiagnosticBag()
+                diagnostics = BindingDiagnosticBag.Discarded
             End If
 
             If userDefinedOperator.ResolutionIsLateBound OrElse Not userDefinedOperator.BestResult.HasValue Then
@@ -3282,7 +3279,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' Verify that control variable can actually be used as a control variable
         Private Shared Function IsValidForControlVariableType(node As ForOrForEachBlockSyntax,
                                     targetType As TypeSymbol,
-                                    diagnostics As DiagnosticBag) As Boolean
+                                    diagnostics As BindingDiagnosticBag) As Boolean
 
             ' if it's a nullable type, simply unwrap it (no recursion needed because nullables cannot be nested)
             If targetType.IsNullableType Then
@@ -3297,16 +3294,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End If
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-            If targetType.IsIntrinsicOrEnumType OrElse Not targetType.CanContainUserDefinedOperators(useSiteDiagnostics) Then
-                diagnostics.Add(DirectCast(node.ForOrForEachStatement, ForStatementSyntax).ControlVariable, useSiteDiagnostics)
+            If targetType.IsIntrinsicOrEnumType OrElse Not targetType.CanContainUserDefinedOperators(useSiteInfo) Then
+                diagnostics.Add(DirectCast(node.ForOrForEachStatement, ForStatementSyntax).ControlVariable, useSiteInfo)
                 ReportDiagnostic(diagnostics, DirectCast(node.ForOrForEachStatement, ForStatementSyntax).ControlVariable, ERRID.ERR_ForLoopType1, targetType)
 
                 Return False
             End If
 
-            diagnostics.Add(DirectCast(node.ForOrForEachStatement, ForStatementSyntax).ControlVariable, useSiteDiagnostics)
+            diagnostics.Add(DirectCast(node.ForOrForEachStatement, ForStatementSyntax).ControlVariable, useSiteInfo)
 
             Return True
         End Function
@@ -3316,7 +3313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             declaredOrInferredLocalOpt As LocalSymbol,
             controlVariableOpt As BoundExpression,
             isInferredLocal As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundForEachStatement
             Dim forEachStatement = DirectCast(node.ForOrForEachStatement, ForEachStatementSyntax)
 
@@ -3413,7 +3410,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     '
                     ' invalid in strict mode.
 
-                    If Conversions.IsIdentityConversion(Conversions.ClassifyConversion(elementType, currentType, useSiteDiagnostics:=Nothing).Key) Then
+                    If Conversions.IsIdentityConversion(Conversions.ClassifyConversion(elementType, currentType, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key) Then
                         boundCurrentPlaceholder = New BoundRValuePlaceholder(collectionSyntax, elementType)
                         boundElement = boundCurrentPlaceholder
                     Else
@@ -3427,7 +3424,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If boundElement Is boundCurrentPlaceholder OrElse
-                       Not Conversions.IsIdentityConversion(Conversions.ClassifyConversion(controlVariableType, elementType, useSiteDiagnostics:=Nothing).Key) Then
+                       Not Conversions.IsIdentityConversion(Conversions.ClassifyConversion(controlVariableType, elementType, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key) Then
                         boundCurrentConversion = ApplyConversion(collectionSyntax,
                                                                  controlVariableType,
                                                                  boundElement,
@@ -3467,12 +3464,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' was not Nothing.
 
                     ' create TryCast
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim conversionKind As ConversionKind = Conversions.ClassifyTryCastConversion(enumeratorType, idisposableType, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim conversionKind As ConversionKind = Conversions.ClassifyTryCastConversion(enumeratorType, idisposableType, useSiteInfo)
 
-                    If diagnostics.Add(collectionSyntax, useSiteDiagnostics) Then
+                    If diagnostics.Add(collectionSyntax, useSiteInfo) Then
                         ' Suppress additional diagnostics
-                        diagnostics = New DiagnosticBag()
+                        diagnostics = BindingDiagnosticBag.Discarded
                     End If
 
                     boundDisposeCast = New BoundTryCast(collectionSyntax, boundEnumeratorPlaceholder.MakeRValue(), conversionKind, idisposableType, Nothing)
@@ -3514,7 +3511,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="variableDeclarator">The variable declarator.</param>
         ''' <param name="diagnostics">The diagnostics.</param><returns></returns>
-        Private Shared Function VerifyForControlVariableDeclaration(variableDeclarator As VariableDeclaratorSyntax, diagnostics As DiagnosticBag) As Boolean
+        Private Shared Function VerifyForControlVariableDeclaration(variableDeclarator As VariableDeclaratorSyntax, diagnostics As BindingDiagnosticBag) As Boolean
             ' Check variable declaration syntax if present
             Debug.Assert(variableDeclarator.Names.Count = 1, "should be exactly one control variable")
             Dim identifier = variableDeclarator.Names(0)
@@ -3548,7 +3545,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function TryBindLoopControlVariable(
             controlVariableSyntax As VisualBasicSyntaxNode,
             <Out()> ByRef controlVariable As BoundExpression,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
             Debug.Assert(controlVariableSyntax.Kind <> SyntaxKind.VariableDeclarator)
 
@@ -3584,7 +3581,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="controlVariable">The control variable.</param>
         ''' <param name="diagnostics">The diagnostics.</param><returns></returns>
-        Private Function VerifyForLoopControlReference(controlVariable As BoundExpression, diagnostics As DiagnosticBag) As Boolean
+        Private Function VerifyForLoopControlReference(controlVariable As BoundExpression, diagnostics As BindingDiagnosticBag) As Boolean
 
             Dim isLValue As Boolean
             ' A property reference is not allowed as the control variable of any
@@ -3620,7 +3617,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private Sub New()
             End Sub
 
-            Public Shared Function SeenAwaitIn(node As BoundNode, diagnostics As DiagnosticBag) As Boolean
+            Public Shared Function SeenAwaitIn(node As BoundNode, diagnostics As BindingDiagnosticBag) As Boolean
                 Dim visitor = New SeenAwaitVisitor()
                 Try
                     visitor.Visit(node)
@@ -3676,7 +3673,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             <Out()> ByRef collectionPlaceholder As BoundRValuePlaceholder,
             <Out()> ByRef needToDispose As Boolean,
             <Out()> ByRef isOrInheritsFromOrImplementsIDisposable As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
 
             currentType = Nothing
@@ -3707,7 +3704,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' because it is more efficient.
 
             Dim interfaceSpecialType As SpecialType = SpecialType.None
-            Dim detailedDiagnostics = DiagnosticBag.GetInstance
+            Dim detailedDiagnostics = BindingDiagnosticBag.GetInstance
 
             If MatchesForEachCollectionDesignPattern(collectionType, collection,
                                                      currentType,
@@ -3727,16 +3724,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 isEnumerable = True
             Else
                 ' using a temporary diagnostic bag to only report use site errors for IEnumerable or IEnumerable(Of T) if they are used.
-                Dim ienumerableUseSiteDiagnostics = DiagnosticBag.GetInstance
+                Dim ienumerableUseSiteDiagnostics = BindingDiagnosticBag.GetInstance
                 Dim genericIEnumerable = GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T, collectionSyntax, ienumerableUseSiteDiagnostics)
                 Dim matchingInterfaces As New HashSet(Of NamedTypeSymbol)(EqualsIgnoringComparer.InstanceIgnoringTupleNames)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
                 If Not collection.IsNothingLiteral AndAlso
                    Not collectionType.IsArrayType AndAlso
-                   IsOrInheritsFromOrImplementsInterface(collectionType, genericIEnumerable, useSiteDiagnostics, matchingInterfaces) Then
+                   IsOrInheritsFromOrImplementsInterface(collectionType, genericIEnumerable, useSiteInfo, matchingInterfaces) Then
 
-                    diagnostics.Add(collectionSyntax, useSiteDiagnostics)
+                    diagnostics.Add(collectionSyntax, useSiteInfo)
 
                     Debug.Assert(matchingInterfaces.Count > 0)
                     isEnumerable = True
@@ -3770,11 +3767,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Dim ienumerable = GetSpecialType(SpecialType.System_Collections_IEnumerable, collectionSyntax, ienumerableUseSiteDiagnostics)
                     If ((collection.IsNothingLiteral OrElse collectionType.IsObjectType) AndAlso Me.OptionStrict <> OptionStrict.On) OrElse
-                       (Not collection.IsNothingLiteral AndAlso Not collectionType.IsArrayType AndAlso IsOrInheritsFromOrImplementsInterface(collectionType, ienumerable, useSiteDiagnostics, matchingInterfaces)) Then
+                       (Not collection.IsNothingLiteral AndAlso Not collectionType.IsArrayType AndAlso IsOrInheritsFromOrImplementsInterface(collectionType, ienumerable, useSiteInfo, matchingInterfaces)) Then
 
                         Debug.Assert(collection.IsNothingLiteral OrElse collectionType.IsObjectType OrElse (TypeSymbol.Equals(matchingInterfaces.First, ienumerable, TypeCompareKind.ConsiderEverything) AndAlso matchingInterfaces.Count = 1))
 
-                        diagnostics.Add(collectionSyntax, useSiteDiagnostics)
+                        diagnostics.Add(collectionSyntax, useSiteInfo)
 
                         isEnumerable = True
                         targetCollectionType = ienumerable
@@ -3787,7 +3784,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Else
                         Debug.Assert(collectionType IsNot Nothing OrElse collection.IsNothingLiteral AndAlso Me.OptionStrict = OptionStrict.On)
 
-                        diagnostics.Add(collectionSyntax, useSiteDiagnostics)
+                        diagnostics.Add(collectionSyntax, useSiteInfo)
 
                         If collection.IsNothingLiteral Then
                             ' in case of option strict on we need to reclassify the nothing literal
@@ -3840,7 +3837,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         specialTypeMember = GetSpecialTypeMember(SpecialMember.System_Collections_Generic_IEnumerable_T__GetEnumerator,
                                                                  collectionSyntax,
                                                                  diagnostics)
-                        If specialTypeMember IsNot Nothing AndAlso specialTypeMember.GetUseSiteErrorInfo Is Nothing AndAlso Not targetCollectionType.IsErrorType Then
+                        If specialTypeMember IsNot Nothing AndAlso specialTypeMember.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso Not targetCollectionType.IsErrorType Then
                             member = DirectCast(targetCollectionType, SubstitutedNamedType).GetMemberForDefinition(specialTypeMember)
                         Else
                             member = Nothing
@@ -3851,7 +3848,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       diagnostics)
                     End If
 
-                    If member IsNot Nothing AndAlso member.GetUseSiteErrorInfo Is Nothing Then
+                    Dim membertUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = If(member?.GetUseSiteInfo(), New UseSiteInfo(Of AssemblySymbol)())
+
+                    If member IsNot Nothing AndAlso membertUseSiteInfo.DiagnosticInfo Is Nothing Then
+                        diagnostics.AddDependencies(membertUseSiteInfo)
                         collectionPlaceholder = New BoundRValuePlaceholder(collectionSyntax,
                                                                            If(collectionType IsNot Nothing AndAlso collectionType.IsStringType, collectionType, collection.Type))
                         Dim methodOrPropertyGroup As BoundMethodOrPropertyGroup
@@ -3875,7 +3875,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         member = GetSpecialTypeMember(SpecialMember.System_Collections_IEnumerator__MoveNext,
                                                       collectionSyntax,
                                                       diagnostics)
-                        If member IsNot Nothing AndAlso member.GetUseSiteErrorInfo Is Nothing Then
+                        membertUseSiteInfo = If(member?.GetUseSiteInfo(), New UseSiteInfo(Of AssemblySymbol)())
+                        If member IsNot Nothing AndAlso membertUseSiteInfo.DiagnosticInfo Is Nothing Then
+                            diagnostics.AddDependencies(membertUseSiteInfo)
                             methodOrPropertyGroup = New BoundMethodGroup(collectionSyntax,
                                                                          Nothing,
                                                                          ImmutableArray.Create(DirectCast(member, MethodSymbol)),
@@ -3896,7 +3898,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                      collectionSyntax,
                                                                      diagnostics)
 
-                            If specialTypeMember IsNot Nothing AndAlso specialTypeMember.GetUseSiteErrorInfo Is Nothing AndAlso Not enumeratorType.IsErrorType Then
+                            If specialTypeMember IsNot Nothing AndAlso specialTypeMember.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso Not enumeratorType.IsErrorType Then
                                 member = DirectCast(enumeratorType, SubstitutedNamedType).GetMemberForDefinition(specialTypeMember)
                             Else
                                 member = Nothing
@@ -3907,7 +3909,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                           diagnostics)
                         End If
 
-                        If member IsNot Nothing AndAlso member.GetUseSiteErrorInfo Is Nothing Then
+                        membertUseSiteInfo = If(member?.GetUseSiteInfo(), New UseSiteInfo(Of AssemblySymbol)())
+                        If member IsNot Nothing AndAlso membertUseSiteInfo.DiagnosticInfo Is Nothing Then
+                            diagnostics.AddDependencies(membertUseSiteInfo)
                             methodOrPropertyGroup = New BoundPropertyGroup(collectionSyntax,
                                                                            ImmutableArray.Create(DirectCast(member, PropertySymbol)),
                                                                            LookupResultKind.Good,
@@ -3945,10 +3949,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Not boundGetEnumeratorCall.HasErrors AndAlso Not boundGetEnumeratorCall.Type.IsErrorType Then
 
                     Dim getEnumeratorReturnType = boundGetEnumeratorCall.Type
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim conversionKind = Conversions.ClassifyDirectCastConversion(getEnumeratorReturnType, idisposable, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim conversionKind = Conversions.ClassifyDirectCastConversion(getEnumeratorReturnType, idisposable, useSiteInfo)
 
-                    diagnostics.Add(collectionSyntax, useSiteDiagnostics)
+                    diagnostics.Add(collectionSyntax, useSiteInfo)
 
                     isOrInheritsFromOrImplementsIDisposable = Conversions.IsWideningConversion(conversionKind)
 
@@ -4016,9 +4020,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             <Out()> ByRef boundMoveNextCall As BoundExpression,
             <Out()> ByRef boundCurrentAccess As BoundExpression,
             <Out()> ByRef collectionPlaceholder As BoundRValuePlaceholder,
-            temporaryDiagnostics As DiagnosticBag
+            temporaryDiagnostics As BindingDiagnosticBag
         ) As Boolean
-            Debug.Assert(temporaryDiagnostics.IsEmptyWithoutResolution)
+            Debug.Assert(temporaryDiagnostics.DiagnosticBag.IsEmptyWithoutResolution)
 
             currentType = Nothing
             boundGetEnumeratorCall = Nothing
@@ -4168,7 +4172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function CreateBoundInvocationExpressionFromMethodOrPropertyGroup(
             syntax As SyntaxNode,
             methodOrPropertyGroup As BoundMethodOrPropertyGroup,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As BoundExpression
             Dim boundCall = BindInvocationExpression(syntax, syntax,
                                                      TypeCharacter.None,
@@ -4220,15 +4224,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             symbolChecker As Func(Of Symbol, Boolean),
             result As LookupResult,
             syntax As SyntaxNode,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
             result.Clear()
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            LookupMember(result, container, name, 0, LookupOptions.AllMethodsOfAnyArity, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            LookupMember(result, container, name, 0, LookupOptions.AllMethodsOfAnyArity, useSiteInfo)
 
-            diagnostics.Add(syntax, useSiteDiagnostics)
-            useSiteDiagnostics = Nothing
+            diagnostics.Add(syntax, useSiteInfo)
+            useSiteInfo = Nothing
 
             If result.IsGood Then
                 For Each candidateSymbol In result.Symbols
@@ -4247,9 +4251,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            name,
                                            0,
                                            LookupOptions.AllMethodsOfAnyArity,
-                                           useSiteDiagnostics)
+                                           useSiteInfo)
 
-                    diagnostics.Add(syntax, useSiteDiagnostics)
+                    diagnostics.Add(syntax, useSiteInfo)
 
                     If result.IsGood Then
                         For Each candidateSymbol In result.Symbols
@@ -4279,7 +4283,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="derivedType">The possible derived type.</param>
         ''' <param name="interfaceType">Type of the interface.</param>
-        ''' <param name="useSiteDiagnostics"/> 
+        ''' <param name="useSiteInfo"/> 
         ''' <param name="matchingInterfaces">A list of matching interfaces.</param>
         ''' <returns>
         '''   <c>true</c> if derivedType is, inherits from or implements the interface; otherwise, <c>false</c>.
@@ -4287,7 +4291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Shared Function IsOrInheritsFromOrImplementsInterface(
             derivedType As TypeSymbol,
             interfaceType As NamedTypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional matchingInterfaces As HashSet(Of NamedTypeSymbol) = Nothing
         ) As Boolean
 
@@ -4304,14 +4308,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' if it has a value type constraint, check if system.valuetype satisfies the requirements
                 If derivedTypeParameter.HasValueTypeConstraint Then
                     Dim valueTypeSymbol = interfaceType.ContainingAssembly.GetSpecialType(SpecialType.System_ValueType)
-                    If IsOrInheritsFromOrImplementsInterface(valueTypeSymbol, interfaceType, useSiteDiagnostics, matchingInterfaces) AndAlso matchingInterfaces Is Nothing Then
+                    If IsOrInheritsFromOrImplementsInterface(valueTypeSymbol, interfaceType, useSiteInfo, matchingInterfaces) AndAlso matchingInterfaces Is Nothing Then
                         Return True
                     End If
                 End If
 
                 ' check if any interface constraint has the appropriate relation to the base type
-                For Each typeConstraint In derivedTypeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                    If IsOrInheritsFromOrImplementsInterface(typeConstraint, interfaceType, useSiteDiagnostics, matchingInterfaces) AndAlso matchingInterfaces Is Nothing Then
+                For Each typeConstraint In derivedTypeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
+                    If IsOrInheritsFromOrImplementsInterface(typeConstraint, interfaceType, useSiteInfo, matchingInterfaces) AndAlso matchingInterfaces Is Nothing Then
                         Return True
                     End If
                 Next
@@ -4326,7 +4330,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 ' implements or inherits interface
-                For Each interfaceOfDerived In derivedType.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each interfaceOfDerived In derivedType.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     If TypeSymbol.Equals(interfaceOfDerived.OriginalDefinition, interfaceType, TypeCompareKind.ConsiderEverything) Then
                         If matchingInterfaces Is Nothing Then
                             Return True
@@ -4354,12 +4358,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Public Function BindWithBlock(node As WithBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Public Function BindWithBlock(node As WithBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim binder As Binder = Me.GetBinder(DirectCast(node, VisualBasicSyntaxNode))
             Return binder.CreateBoundWithBlock(node, binder, diagnostics)
         End Function
 
-        Protected Overridable Function CreateBoundWithBlock(node As WithBlockSyntax, boundBlockBinder As Binder, diagnostics As DiagnosticBag) As BoundStatement
+        Protected Overridable Function CreateBoundWithBlock(node As WithBlockSyntax, boundBlockBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundStatement
             Return Me.ContainingBinder.CreateBoundWithBlock(node, boundBlockBinder, diagnostics)
         End Function
 
@@ -4383,7 +4387,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         '''          list_of_statements
         '''      end using
         '''</summary>
-        Public Function BindUsingBlock(node As UsingBlockSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Public Function BindUsingBlock(node As UsingBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim usingBinder = Me.GetBinder(node)
             Debug.Assert(usingBinder IsNot Nothing)
 
@@ -4509,7 +4513,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             localSymbol As LocalSymbol,
             iDisposable As TypeSymbol,
             placeholderInfo As Dictionary(Of TypeSymbol, ValueTuple(Of BoundRValuePlaceholder, BoundExpression, BoundExpression)),
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Dim declarationType As TypeSymbol = localSymbol.Type
 
@@ -4545,16 +4549,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             resourceType As TypeSymbol,
             placeholderInfo As Dictionary(Of TypeSymbol, ValueTuple(Of BoundRValuePlaceholder, BoundExpression, BoundExpression)),
             iDisposable As TypeSymbol,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             If Not placeholderInfo.ContainsKey(resourceType) Then
                 ' TODO: add late binding, see statementsemantics.cpp lines 6765++
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim conversionKind = Conversions.ClassifyDirectCastConversion(resourceType, iDisposable, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim conversionKind = Conversions.ClassifyDirectCastConversion(resourceType, iDisposable, useSiteInfo)
 
-                If diagnostics.Add(syntaxNode, useSiteDiagnostics) Then
+                If diagnostics.Add(syntaxNode, useSiteInfo) Then
                     ' Suppress additional diagnostics
-                    diagnostics = New DiagnosticBag()
+                    diagnostics = BindingDiagnosticBag.Discarded
                 End If
 
                 Dim isValidDispose = Conversions.IsWideningConversion(conversionKind)
@@ -4588,7 +4592,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ''' <summary>Check the given type of and report WRN_MutableGenericStructureInUsing if needed.</summary>
         ''' <remarks>This function should only be called for a type of a using variable.</remarks>
-        Private Sub ReportMutableStructureConstraintsInUsing(type As TypeSymbol, symbolName As String, syntaxNode As SyntaxNode, diagnostics As DiagnosticBag)
+        Private Sub ReportMutableStructureConstraintsInUsing(type As TypeSymbol, symbolName As String, syntaxNode As SyntaxNode, diagnostics As BindingDiagnosticBag)
             ' Dev10 #666593: Warn if the type of the variable is not a reference type or an immutable structure.
             If Not type.IsReferenceType Then
                 If type.IsTypeParameter Then
@@ -4672,7 +4676,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="node">The node.</param>
         ''' <param name="diagnostics">The diagnostics.</param><returns></returns>
-        Public Function BindSyncLockBlock(node As SyncLockBlockSyntax, diagnostics As DiagnosticBag) As BoundSyncLockStatement
+        Public Function BindSyncLockBlock(node As SyncLockBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundSyncLockStatement
 
             ' bind the expression
             Dim lockExpression As BoundExpression = BindRValue(node.SyncLockStatement.Expression, diagnostics)
@@ -4689,7 +4693,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundSyncLockStatement(node, lockExpression, boundBody)
         End Function
 
-        Public Function BindTryBlock(node As TryBlockSyntax, diagnostics As DiagnosticBag) As BoundTryStatement
+        Public Function BindTryBlock(node As TryBlockSyntax, diagnostics As BindingDiagnosticBag) As BoundTryStatement
             Debug.Assert(node IsNot Nothing)
 
             Dim tryBlock As BoundBlock = BindBlock(node, node.Statements, diagnostics).MakeCompilerGenerated()
@@ -4711,7 +4715,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundTryStatement(node, tryBlock, catchBlocks, finallyBlockOpt, tryBinder.GetExitLabel(SyntaxKind.ExitTryStatement))
         End Function
 
-        Public Function BindCatchBlocks(catchClauses As SyntaxList(Of CatchBlockSyntax), diagnostics As DiagnosticBag) As ImmutableArray(Of BoundCatchBlock)
+        Public Function BindCatchBlocks(catchClauses As SyntaxList(Of CatchBlockSyntax), diagnostics As BindingDiagnosticBag) As ImmutableArray(Of BoundCatchBlock)
             Dim n As Integer = catchClauses.Count
             If n = 0 Then
                 Return ImmutableArray(Of BoundCatchBlock).Empty
@@ -4728,7 +4732,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return catchBlocks.ToImmutableAndFree
         End Function
 
-        Private Function BindCatchBlock(node As CatchBlockSyntax, previousBlocks As ArrayBuilder(Of BoundCatchBlock), diagnostics As DiagnosticBag) As BoundCatchBlock
+        Private Function BindCatchBlock(node As CatchBlockSyntax, previousBlocks As ArrayBuilder(Of BoundCatchBlock), diagnostics As BindingDiagnosticBag) As BoundCatchBlock
 
             ' we need to compute the following parts
             Dim catchLocal As LocalSymbol = Nothing
@@ -4778,18 +4782,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' type of the catch variable must derive from Exception
                         Debug.Assert(exceptionType IsNot Nothing)
 
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
                         If exceptionType.IsErrorType() Then
                             hasError = True
-                        ElseIf Not exceptionType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Exception, Compilation, useSiteDiagnostics) Then
+                        ElseIf Not exceptionType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Exception, Compilation, useSiteInfo) Then
                             ReportDiagnostic(diagnostics,
                                              If(asClauseOpt IsNot Nothing, asClauseOpt.Type, name),
                                              ERRID.ERR_CatchNotException1,
                                              exceptionType)
                             hasError = True
-                            diagnostics.Add(If(asClauseOpt IsNot Nothing, asClauseOpt.Type, name), useSiteDiagnostics)
                         End If
+
+                        diagnostics.Add(If(asClauseOpt IsNot Nothing, asClauseOpt.Type, name), useSiteInfo)
                     End If
                 End If
             Else
@@ -4802,7 +4807,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If Not hasError Then
-                Debug.Assert(exceptionType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Exception, Compilation, Nothing))
+                Debug.Assert(exceptionType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Exception, Compilation, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
 
                 For Each previousBlock In previousBlocks
                     If previousBlock.ExceptionFilterOpt IsNot Nothing Then
@@ -4826,10 +4831,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Exit For
                         End If
 
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                        Dim isBaseType As Boolean = exceptionType.IsOrDerivedFrom(previousType, useSiteDiagnostics)
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim isBaseType As Boolean = exceptionType.IsOrDerivedFrom(previousType, useSiteInfo)
 
-                        diagnostics.Add(declaration, useSiteDiagnostics)
+                        diagnostics.Add(declaration, useSiteInfo)
 
                         If isBaseType Then
                             ReportDiagnostic(diagnostics, declaration, ERRID.WRN_OverlappingCatch, exceptionType, previousType)
@@ -4849,7 +4854,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
 
-        Private Function BindExitStatement(node As ExitStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindExitStatement(node As ExitStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim targetLabel As LabelSymbol = GetExitLabel(node.Kind)
 
             If targetLabel Is Nothing Then
@@ -4875,7 +4880,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Function
 
-        Private Function BindContinueStatement(node As ContinueStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindContinueStatement(node As ContinueStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim targetLabel As LabelSymbol = GetContinueLabel(node.Kind)
 
             If targetLabel Is Nothing Then
@@ -4895,7 +4900,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Function
 
-        Private Function BindBooleanExpression(node As ExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindBooleanExpression(node As ExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' 11.19 Boolean Expressions
             Dim expr As BoundExpression = Me.BindValue(node, diagnostics, isOperandOfConditionalBranch:=True)
             Dim boolSymbol As NamedTypeSymbol = GetSpecialType(SpecialType.System_Boolean, node, diagnostics)
@@ -4940,7 +4945,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return methodReturnType
         End Function
 
-        Private Function BindReturn(originalSyntax As ReturnStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindReturn(originalSyntax As ReturnStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim expressionSyntax As expressionSyntax = originalSyntax.Expression
 
             ' UNDONE - Handle ERRID_ReturnFromEventMethod
@@ -5004,17 +5009,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' and the return expression can't be converted to T but is identical to Task<T>,
                         ' then don't give the normal error message about "there is no conversion from T to Task<T>"
                         ' and instead say "Since this is async, the return expression must be 'T' rather than 'Task<T>'."
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                         If isAsync AndAlso Not retType.IsErrorType() AndAlso methodReturnType.Equals(arg.Type) AndAlso
                             methodReturnType.OriginalDefinition.Equals(Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T)) AndAlso
-                            Not Conversions.ConversionExists(Conversions.ClassifyConversion(arg, retType, Me, useSiteDiagnostics).Key) Then
+                            Not Conversions.ConversionExists(Conversions.ClassifyConversion(arg, retType, Me, useSiteInfo).Key) Then
 
-                            If Not diagnostics.Add(arg, useSiteDiagnostics) Then
+                            If Not diagnostics.Add(arg, useSiteInfo) Then
                                 ReportDiagnostic(diagnostics, arg.Syntax, ERRID.ERR_BadAsyncReturnOperand1, retType)
                             End If
 
                             arg = MakeRValueAndIgnoreDiagnostics(arg)
                         Else
+                            diagnostics.Add(arg, useSiteInfo)
                             arg = ApplyImplicitConversion(arg.Syntax, retType, arg, diagnostics)
                         End If
                     End If
@@ -5038,7 +5044,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetCurrentYieldType(node As YieldStatementSyntax,
-                                             diagnostics As DiagnosticBag) As TypeSymbol
+                                             diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             Dim method As MethodSymbol = TryCast(Me.ContainingMember, MethodSymbol)
 
@@ -5080,7 +5086,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return ErrorTypeSymbol.UnknownResultType
         End Function
 
-        Private Function BindYield(originalSyntax As YieldStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindYield(originalSyntax As YieldStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim expressionSyntax As expressionSyntax = originalSyntax.Expression
             Dim arg As BoundExpression = Me.BindValue(expressionSyntax, diagnostics)
 
@@ -5116,7 +5122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundYieldStatement(originalSyntax, arg)
         End Function
 
-        Private Function BindThrow(node As ThrowStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindThrow(node As ThrowStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim expressionSyntax As expressionSyntax = node.Expression
             Dim hasError As Boolean = False
 
@@ -5163,13 +5169,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim exceptionType = value.Type
                 If Not exceptionType.IsErrorType Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-                    If Not exceptionType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Exception, Compilation, useSiteDiagnostics) Then
+                    If Not exceptionType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Exception, Compilation, useSiteInfo) Then
                         hasError = True
                         ReportDiagnostic(diagnostics, node, ERRID.ERR_CantThrowNonException, exceptionType)
-                        diagnostics.Add(node, useSiteDiagnostics)
                     End If
+
+                    diagnostics.Add(node, useSiteInfo)
                 Else
                     hasError = True
                 End If
@@ -5178,7 +5185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Private Function BindError(node As ErrorStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindError(node As ErrorStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             Dim value As BoundExpression = ApplyImplicitConversion(node.ErrorNumber,
                                                                    GetSpecialType(SpecialType.System_Int32, node.ErrorNumber, diagnostics),
                                                                    BindValue(node.ErrorNumber, diagnostics),
@@ -5187,7 +5194,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundThrowStatement(node, value)
         End Function
 
-        Private Function BindResumeStatement(node As ResumeStatementSyntax, diagnostics As DiagnosticBag) As BoundResumeStatement
+        Private Function BindResumeStatement(node As ResumeStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundResumeStatement
 
             If IsInLambda Then
                 ReportDiagnostic(diagnostics, node, ERRID.ERR_MultilineLambdasCannotContainOnError)
@@ -5222,7 +5229,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Function BindOnErrorStatement(node As StatementSyntax, diagnostics As DiagnosticBag) As BoundOnErrorStatement
+        Private Function BindOnErrorStatement(node As StatementSyntax, diagnostics As BindingDiagnosticBag) As BoundOnErrorStatement
 
             If IsInLambda Then
                 ReportDiagnostic(diagnostics, node, ERRID.ERR_MultilineLambdasCannotContainOnError)
@@ -5265,7 +5272,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundStopStatement(stopStatementSyntax)
         End Function
 
-        Private Function BindEndStatement(endStatementSyntax As StopOrEndStatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Private Function BindEndStatement(endStatementSyntax As StopOrEndStatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             If Not Compilation.Options.OutputKind.IsApplication() Then
                 ReportDiagnostic(diagnostics, endStatementSyntax, ERRID.ERR_EndDisallowedInDllProjects)
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' If the identifier has a type character, report an error on it.
         ''' </summary>
         Public Shared Sub DisallowTypeCharacter(identifier As SyntaxToken,
-                                         diagBag As DiagnosticBag,
+                                         diagBag As BindingDiagnosticBag,
                                          Optional errid As ERRID = ERRID.ERR_TypecharNotallowed)
             If (identifier.GetTypeCharacter() <> TypeCharacter.None) Then
                 ReportDiagnostic(diagBag, identifier, errid)
@@ -256,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function DecodeParameterModifiers(container As Symbol,
                                                  modifiers As SyntaxTokenList,
                                                  checkModifier As CheckParameterModifierDelegate,
-                                                 diagBag As DiagnosticBag) As SourceParameterFlags
+                                                 diagBag As BindingDiagnosticBag) As SourceParameterFlags
             Dim flags As SourceParameterFlags = Nothing
 
             ' Go through each modifiers, accumulating flags of what we've seen and reporting errors.
@@ -288,7 +288,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function CreateNullableOf(typeArgument As TypeSymbol,
                                          syntax As VisualBasicSyntaxNode,
                                          syntaxTypeArgument As VisualBasicSyntaxNode,
-                                         diagBag As DiagnosticBag) As NamedTypeSymbol
+                                         diagBag As BindingDiagnosticBag) As NamedTypeSymbol
             ' Get the Nullable type
             Dim nullableType As NamedTypeSymbol = DirectCast(GetSpecialType(SpecialType.System_Nullable_T, syntax, diagBag), NamedTypeSymbol)
 
@@ -306,7 +306,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 For Each pair In diagnosticsBuilder
-                    diagBag.Add(pair.DiagnosticInfo, syntaxTypeArgument.GetLocation())
+                    diagBag.Add(pair.UseSiteInfo, syntaxTypeArgument.GetLocation())
                 Next
                 diagnosticsBuilder.Free()
             End If
@@ -319,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Function ApplyArrayRankSpecifiersToType(elementType As TypeSymbol,
                                       arrayModifierSyntax As SyntaxList(Of ArrayRankSpecifierSyntax),
-                                      diagnostics As DiagnosticBag) As TypeSymbol
+                                      diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             Dim currentType As TypeSymbol = elementType
 
@@ -344,7 +344,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function ApplyArrayRankSpecifiersAndBoundsToType(elementType As TypeSymbol,
                                       arrayModifierSyntax As SyntaxList(Of ArrayRankSpecifierSyntax),
                                       arrayBoundsOpt As ArgumentListSyntax,
-                                      diagnostics As DiagnosticBag) As TypeSymbol
+                                      diagnostics As BindingDiagnosticBag) As TypeSymbol
 
             Dim currentType As TypeSymbol = elementType
 
@@ -376,7 +376,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function CreateArrayOf(elementType As TypeSymbol,
                                       arrayModifierSyntax As SyntaxList(Of ArrayRankSpecifierSyntax),
                                       arrayBoundsOpt As ArgumentListSyntax,
-                                      diagnostics As DiagnosticBag) As ArrayTypeSymbol
+                                      diagnostics As BindingDiagnosticBag) As ArrayTypeSymbol
 
             Debug.Assert(arrayModifierSyntax.Count > 0 OrElse
                                   arrayBoundsOpt IsNot Nothing)
@@ -478,7 +478,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      asClauseSyntaxOpt As AsClauseSyntax,
                                                      initializerSyntaxOpt As VisualBasicSyntaxNode,
                                                      getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
-                                                     diagBag As DiagnosticBag,
+                                                     diagBag As BindingDiagnosticBag,
                                                      Optional decoderContext As ModifiedIdentifierTypeDecoderContext = ModifiedIdentifierTypeDecoderContext.None
         ) As TypeSymbol
             Dim baseType As TypeSymbol = DecodeIdentifierType(modifiedIdentifier.Identifier, asClauseOrValueType, getRequireTypeDiagnosticInfoFunc, diagBag, decoderContext)
@@ -568,7 +568,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      initializerSyntaxOpt As EqualsValueSyntax,
                                                      getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
                                                      <Out()> ByRef asClauseType As TypeSymbol,
-                                                     diagBag As DiagnosticBag,
+                                                     diagBag As BindingDiagnosticBag,
                                                      Optional decoderContext As ModifiedIdentifierTypeDecoderContext = Nothing
         ) As TypeSymbol
 
@@ -600,7 +600,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      asClauseOpt As AsClauseSyntax,
                                                      initializerSyntaxOpt As EqualsValueSyntax,
                                                      getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
-                                                     diagBag As DiagnosticBag,
+                                                     diagBag As BindingDiagnosticBag,
                                                      Optional decoderContext As ModifiedIdentifierTypeDecoderContext = Nothing
         ) As TypeSymbol
 
@@ -621,7 +621,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                              asClauseOpt As AsClauseSyntax,
                                              getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
                                              ByRef asClauseType As TypeSymbol,
-                                             diagBag As DiagnosticBag) As TypeSymbol
+                                             diagBag As BindingDiagnosticBag) As TypeSymbol
 
             If asClauseOpt IsNot Nothing Then
                 asClauseType = BindTypeSyntax(asClauseOpt.Type, diagBag)
@@ -643,7 +643,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function DecodeIdentifierType(identifier As SyntaxToken,
                                              asClauseOpt As AsClauseSyntax,
                                              getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
-                                             diagBag As DiagnosticBag) As TypeSymbol
+                                             diagBag As BindingDiagnosticBag) As TypeSymbol
             Dim asClauseType As TypeSymbol = Nothing
             Return DecodeIdentifierType(identifier, asClauseOpt, getRequireTypeDiagnosticInfoFunc, asClauseType, diagBag)
         End Function
@@ -659,7 +659,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function DecodeIdentifierType(identifier As SyntaxToken,
                                              asClauseType As TypeSymbol,
                                              getRequireTypeDiagnosticInfoFunc As Func(Of DiagnosticInfo),
-                                             diagBag As DiagnosticBag,
+                                             diagBag As BindingDiagnosticBag,
                                              Optional decoderContext As ModifiedIdentifierTypeDecoderContext = ModifiedIdentifierTypeDecoderContext.None
         ) As TypeSymbol
             Dim typeCharacterType As TypeSymbol = Nothing
@@ -808,7 +808,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function DecodeParameterListOfDelegateDeclaration(
             container As Symbol,
             syntaxOpt As ParameterListSyntax,
-            diagBag As DiagnosticBag
+            diagBag As BindingDiagnosticBag
         ) As ImmutableArray(Of ParameterSymbol)
 
             If syntaxOpt Is Nothing Then
@@ -849,7 +849,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             isFromLambda As Boolean,
                                             modifiers As SourceMemberFlags,
                                             syntaxOpt As ParameterListSyntax,
-                                            diagBag As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+                                            diagBag As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
             Debug.Assert(Not (container.Kind = SymbolKind.Method AndAlso DirectCast(container, MethodSymbol).MethodKind = MethodKind.DelegateInvoke))
 
             If syntaxOpt Is Nothing Then
@@ -913,7 +913,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared ReadOnly s_checkOperatorParameterModifierCallback As CheckParameterModifierDelegate = AddressOf CheckOperatorParameterModifier
 
-        Private Shared Function CheckOperatorParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As DiagnosticBag) As SourceParameterFlags
+        Private Shared Function CheckOperatorParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As BindingDiagnosticBag) As SourceParameterFlags
             If (flag And SourceParameterFlags.ByRef) <> 0 Then
                 diagnostics.Add(ERRID.ERR_ByRefIllegal1, token.GetLocation(), container.GetKindText())
                 flag = flag And (Not SourceParameterFlags.ByRef)
@@ -939,7 +939,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="syntaxOpt">Optional parameter list syntax</param>
         Public Function DecodePropertyParameterList(container As PropertySymbol,
                                             syntaxOpt As ParameterListSyntax,
-                                            diagBag As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+                                            diagBag As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
             If syntaxOpt Is Nothing Then
                 Return ImmutableArray(Of ParameterSymbol).Empty
             End If
@@ -976,7 +976,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Shared ReadOnly s_checkPropertyParameterModifierCallback As CheckParameterModifierDelegate = AddressOf CheckPropertyParameterModifier
 
-        Private Shared Function CheckPropertyParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As DiagnosticBag) As SourceParameterFlags
+        Private Shared Function CheckPropertyParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As BindingDiagnosticBag) As SourceParameterFlags
             If flag = SourceParameterFlags.ByRef Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_ByRefIllegal1, location, container.GetKindText(), token.ToString())
@@ -985,7 +985,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return flag
         End Function
 
-        Private Shared Function CheckReservedParameterName(reservedName As String, syntax As ParameterSyntax, errorId As ERRID, diagnostics As DiagnosticBag) As Boolean
+        Private Shared Function CheckReservedParameterName(reservedName As String, syntax As ParameterSyntax, errorId As ERRID, diagnostics As BindingDiagnosticBag) As Boolean
             Dim identifier = syntax.Identifier
             Dim name = identifier.Identifier.ValueText
             If IdentifierComparison.Equals(reservedName, name) Then
@@ -1002,7 +1002,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                  nParams As Integer,
                                                  syntax As ParameterSyntax,
                                                  parameter As ParameterSymbol,
-                                                 diagnostics As DiagnosticBag)
+                                                 diagnostics As BindingDiagnosticBag)
             Dim name = parameter.Name
             For i = 0 To nParams - 1
                 If IdentifierComparison.Equals(params(i).Name, name) Then
@@ -1013,7 +1013,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Next
         End Sub
 
-        Friend Delegate Function CheckParameterModifierDelegate(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As DiagnosticBag) As SourceParameterFlags
+        Friend Delegate Function CheckParameterModifierDelegate(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As BindingDiagnosticBag) As SourceParameterFlags
 
         Public Sub DecodeParameterList(container As Symbol,
                                             isFromLambda As Boolean,
@@ -1021,7 +1021,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             syntax As SeparatedSyntaxList(Of ParameterSyntax),
                                             params As ArrayBuilder(Of ParameterSymbol),
                                             checkModifier As CheckParameterModifierDelegate,
-                                            diagBag As DiagnosticBag)
+                                            diagBag As BindingDiagnosticBag)
 
             Dim count As Integer = syntax.Count
             Dim ordinal = params.Count
@@ -1287,7 +1287,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="diagnostics">The diagnostics.</param>
         ''' <returns>ConstantValue if the bound expression is compile time constant and can be used 
         ''' for const field/local initializations or enum member initializations. Nothing if not</returns>
-        Public Function GetExpressionConstantValueIfAny(boundExpression As BoundExpression, diagnostics As DiagnosticBag, context As ConstantContext) As ConstantValue
+        Public Function GetExpressionConstantValueIfAny(boundExpression As BoundExpression, diagnostics As BindingDiagnosticBag, context As ConstantContext) As ConstantValue
             Dim nonConstantDetected As Boolean = False
             Do
                 If boundExpression.Kind = BoundKind.Local Then
@@ -1379,7 +1379,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return False
         End Function
 
-        Private Function CheckConversionForConstantExpression(conv As BoundExpression, operand As BoundExpression, diagnostics As DiagnosticBag, context As ConstantContext) As ConstantValue
+        Private Function CheckConversionForConstantExpression(conv As BoundExpression, operand As BoundExpression, diagnostics As BindingDiagnosticBag, context As ConstantContext) As ConstantValue
             If conv.HasErrors Then
                 Return Nothing
             End If
@@ -1455,9 +1455,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Else
                         ' Let's convert to the underlying type of the Nullable.
                         ' All diagnostics about this conversion have already been reported, so we can treat it as an explicit conversion and ignore any errors/warnings.
-                        Dim ignoreDiagnostics = DiagnosticBag.GetInstance()
-                        Dim conversionToUnderlying As BoundExpression = ApplyConversion(operand.Syntax, conversionType.GetNullableUnderlyingType(), operand, isExplicit:=True, diagnostics:=ignoreDiagnostics)
-                        ignoreDiagnostics.Free()
+                        Dim conversionToUnderlying As BoundExpression = ApplyConversion(operand.Syntax, conversionType.GetNullableUnderlyingType(), operand, isExplicit:=True, diagnostics:=BindingDiagnosticBag.Discarded)
 
                         nestedConstValue = conversionToUnderlying.ConstantValueOpt
                         If nestedConstValue IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_WithBlock.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_WithBlock.vb
@@ -100,7 +100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            expressionPlaceholder As BoundValuePlaceholderBase,
                            draftSubstitute As BoundExpression,
                            draftInitializers As ImmutableArray(Of BoundExpression),
-                           diagnostics As DiagnosticBag)
+                           diagnostics As BindingDiagnosticBag)
 
                 Debug.Assert(originalExpression IsNot Nothing)
                 Debug.Assert(expressionPlaceholder IsNot Nothing AndAlso (expressionPlaceholder.Kind = BoundKind.WithLValueExpressionPlaceholder OrElse expressionPlaceholder.Kind = BoundKind.WithRValueExpressionPlaceholder))
@@ -122,7 +122,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public ReadOnly ExpressionPlaceholder As BoundValuePlaceholderBase
 
             ''' <summary> Diagnostics produced while binding the expression </summary>
-            Public ReadOnly Diagnostics As DiagnosticBag
+            Public ReadOnly Diagnostics As BindingDiagnosticBag
 
             ''' <summary> 
             ''' Draft initializers for With statement, is based on initial binding tree 
@@ -201,7 +201,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Me._withBlockInfo Is Nothing Then
                 ' Because we cannot guarantee that diagnostics will be freed we 
                 ' don't allocate this diagnostics bag from a pool
-                Dim diagnostics As New DiagnosticBag()
+                Dim diagnostics As New BindingDiagnosticBag()
 
                 ' Bind the expression as a value
                 Dim boundExpression As BoundExpression = Me.ContainingBinder.BindValue(Me.Expression, diagnostics)
@@ -289,7 +289,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #Region "With block binding"
 
-        Protected Overrides Function CreateBoundWithBlock(node As WithBlockSyntax, boundBlockBinder As Binder, diagnostics As DiagnosticBag) As BoundStatement
+        Protected Overrides Function CreateBoundWithBlock(node As WithBlockSyntax, boundBlockBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundStatement
             Debug.Assert(node Is Me._withBlockSyntax)
 
             ' Bind With statement expression
@@ -322,7 +322,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #If DEBUG Then
 
-        Public Overrides Function BindStatement(node As StatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+        Public Overrides Function BindStatement(node As StatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
             AssertExpressionIsNotFromStatementExpression(node)
             Return MyBase.BindStatement(node, diagnostics)
         End Function
@@ -334,7 +334,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 #End If
 
-        Private Sub PrepareBindingOfOmittedLeft(node As VisualBasicSyntaxNode, diagnostics As DiagnosticBag, accessingBinder As Binder)
+        Private Sub PrepareBindingOfOmittedLeft(node As VisualBasicSyntaxNode, diagnostics As BindingDiagnosticBag, accessingBinder As Binder)
             AssertExpressionIsNotFromStatementExpression(node)
             Debug.Assert((node.Kind = SyntaxKind.SimpleMemberAccessExpression) OrElse
                          (node.Kind = SyntaxKind.DictionaryAccessExpression) OrElse
@@ -357,7 +357,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Protected Friend Overrides Function TryBindOmittedLeftForMemberAccess(node As MemberAccessExpressionSyntax,
-                                                                              diagnostics As DiagnosticBag,
+                                                                              diagnostics As BindingDiagnosticBag,
                                                                               accessingBinder As Binder,
                                                                               <Out> ByRef wholeMemberAccessExpressionBound As Boolean) As BoundExpression
             PrepareBindingOfOmittedLeft(node, diagnostics, accessingBinder)
@@ -368,18 +368,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Overrides Function TryBindOmittedLeftForDictionaryAccess(node As MemberAccessExpressionSyntax,
                                                                            accessingBinder As Binder,
-                                                                           diagnostics As DiagnosticBag) As BoundExpression
+                                                                           diagnostics As BindingDiagnosticBag) As BoundExpression
             PrepareBindingOfOmittedLeft(node, diagnostics, accessingBinder)
             Return Me._withBlockInfo.ExpressionPlaceholder
         End Function
 
-        Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As DiagnosticBag) As BoundExpression
+        Protected Overrides Function TryBindOmittedLeftForConditionalAccess(node As ConditionalAccessExpressionSyntax, accessingBinder As Binder, diagnostics As BindingDiagnosticBag) As BoundExpression
             PrepareBindingOfOmittedLeft(node, diagnostics, accessingBinder)
             Return Me._withBlockInfo.ExpressionPlaceholder
         End Function
 
         Protected Friend Overrides Function TryBindOmittedLeftForXmlMemberAccess(node As XmlMemberAccessExpressionSyntax,
-                                                                                 diagnostics As DiagnosticBag,
+                                                                                 diagnostics As BindingDiagnosticBag,
                                                                                  accessingBinder As Binder) As BoundExpression
             PrepareBindingOfOmittedLeft(node, diagnostics, accessingBinder)
             Return Me._withBlockInfo.ExpressionPlaceholder

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindXmlComment(
                                        syntax As XmlCommentSyntax,
                                        rootInfoOpt As XmlElementRootInfo,
-                                       diagnostics As DiagnosticBag) As BoundExpression
+                                       diagnostics As BindingDiagnosticBag) As BoundExpression
             If rootInfoOpt Is Nothing Then
                 diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
             End If
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlComment(syntax, str, objectCreation, objectCreation.Type)
         End Function
 
-        Private Function BindXmlDocument(syntax As XmlDocumentSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlDocument(syntax As XmlDocumentSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
 
             Dim declaration = BindXmlDeclaration(syntax.Declaration, diagnostics)
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlDocument(syntax, declaration, childNodes, rewriterInfo, objectCreation.Type, rewriterInfo.HasErrors)
         End Function
 
-        Private Function BindXmlDeclaration(syntax As XmlDeclarationSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlDeclaration(syntax As XmlDeclarationSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim version = BindXmlDeclarationOption(syntax, syntax.Version, diagnostics)
             Dim encoding = BindXmlDeclarationOption(syntax, syntax.Encoding, diagnostics)
             Dim standalone = BindXmlDeclarationOption(syntax, syntax.Standalone, diagnostics)
@@ -63,7 +63,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlDeclaration(syntax, version, encoding, standalone, objectCreation, objectCreation.Type)
         End Function
 
-        Private Function BindXmlDeclarationOption(syntax As XmlDeclarationSyntax, optionSyntax As XmlDeclarationOptionSyntax, diagnostics As DiagnosticBag) As BoundLiteral
+        Private Function BindXmlDeclarationOption(syntax As XmlDeclarationSyntax, optionSyntax As XmlDeclarationOptionSyntax, diagnostics As BindingDiagnosticBag) As BoundLiteral
             If optionSyntax Is Nothing Then
                 Return CreateStringLiteral(syntax, Nothing, compilerGenerated:=True, diagnostics:=diagnostics)
             Else
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Private Function BindXmlProcessingInstruction(syntax As XmlProcessingInstructionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlProcessingInstruction(syntax As XmlProcessingInstructionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim target = CreateStringLiteral(syntax, GetXmlName(syntax.Name), compilerGenerated:=True, diagnostics:=diagnostics)
             Dim data = CreateStringLiteral(syntax, GetXmlString(syntax.TextTokens), compilerGenerated:=True, diagnostics:=diagnostics)
             Dim objectCreation = BindObjectCreationExpression(
@@ -86,14 +86,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindXmlEmptyElement(
                                             syntax As XmlEmptyElementSyntax,
                                             rootInfoOpt As XmlElementRootInfo,
-                                            diagnostics As DiagnosticBag) As BoundExpression
+                                            diagnostics As BindingDiagnosticBag) As BoundExpression
             Return BindXmlElement(syntax, syntax.Name, syntax.Attributes, Nothing, rootInfoOpt, diagnostics)
         End Function
 
         Private Function BindXmlElement(
                                        syntax As XmlElementSyntax,
                                        rootInfoOpt As XmlElementRootInfo,
-                                       diagnostics As DiagnosticBag) As BoundExpression
+                                       diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim startTag = syntax.StartTag
             Return BindXmlElement(syntax, startTag.Name, startTag.Attributes, syntax.Content, rootInfoOpt, diagnostics)
         End Function
@@ -104,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        attributes As SyntaxList(Of XmlNodeSyntax),
                                        content As SyntaxList(Of XmlNodeSyntax),
                                        rootInfoOpt As XmlElementRootInfo,
-                                       diagnostics As DiagnosticBag) As BoundExpression
+                                       diagnostics As BindingDiagnosticBag) As BoundExpression
             If rootInfoOpt Is Nothing Then
                 diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
 
@@ -144,7 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                               otherAttributes As ArrayBuilder(Of XmlNodeSyntax),
                                                               content As SyntaxList(Of XmlNodeSyntax),
                                                               rootInfo As XmlElementRootInfo,
-                                                              diagnostics As DiagnosticBag) As BoundExpression
+                                                              diagnostics As BindingDiagnosticBag) As BoundExpression
             ' Any expression type is allowed as long as there is an appropriate XElement
             ' constructor for that argument type. In particular, this allows expressions of type
             ' XElement since XElement includes New(other As XElement). This is consistent with
@@ -216,7 +216,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      objectCreation As BoundExpression,
                                                      childNodes As ImmutableArray(Of BoundExpression),
                                                      rootInfoOpt As XmlElementRootInfo,
-                                                     diagnostics As DiagnosticBag) As BoundXmlContainerRewriterInfo
+                                                     diagnostics As BindingDiagnosticBag) As BoundXmlContainerRewriterInfo
             If (childNodes.Length = 0) AndAlso
                 ((rootInfoOpt Is Nothing) OrElse (rootInfoOpt.ImportedNamespaces.Count = 0)) Then
                 Return New BoundXmlContainerRewriterInfo(objectCreation)
@@ -346,7 +346,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                 namespacesPlaceholder As BoundRValuePlaceholder,
                                                                 <Out()> ByRef xmlnsAttributesPlaceholder As BoundRValuePlaceholder,
                                                                 <Out()> ByRef removeNamespacesGroup As BoundMethodOrPropertyGroup,
-                                                                diagnostics As DiagnosticBag) As BoundExpression
+                                                                diagnostics As BindingDiagnosticBag) As BoundExpression
 
             If xmlnsAttributesPlaceholder Is Nothing Then
                 Dim listType = GetWellKnownType(WellKnownType.System_Collections_Generic_List_T, syntax, diagnostics).Construct(
@@ -382,7 +382,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            syntax As XmlNodeSyntax,
                                            prefix As String,
                                            namespaceName As String,
-                                           diagnostics As DiagnosticBag) As BoundXmlAttribute
+                                           diagnostics As BindingDiagnosticBag) As BoundXmlAttribute
             Dim name = BindXmlnsName(syntax, prefix, compilerGenerated:=True, diagnostics:=diagnostics)
             Dim [namespace] = BindXmlNamespace(syntax,
                                                CreateStringLiteral(syntax, namespaceName, compilerGenerated:=True, diagnostics:=diagnostics),
@@ -394,7 +394,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       syntax As XmlNodeSyntax,
                                       prefix As String,
                                       compilerGenerated As Boolean,
-                                      diagnostics As DiagnosticBag) As BoundExpression
+                                      diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim name = GetXmlnsXmlName(prefix)
             Return BindXmlName(syntax,
                                    CreateStringLiteral(syntax,
@@ -416,7 +416,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            matchesImport As Boolean,
                                            compilerGenerated As Boolean,
                                            hasErrors As Boolean,
-                                           diagnostics As DiagnosticBag) As BoundXmlAttribute
+                                           diagnostics As BindingDiagnosticBag) As BoundXmlAttribute
             Dim objectCreation As BoundExpression
             If useConstructor Then
                 objectCreation = BindObjectCreationExpression(syntax,
@@ -440,7 +440,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          syntax As XmlAttributeSyntax,
                                          rootInfo As XmlElementRootInfo,
                                          <Out()> ByRef xmlName As XmlName,
-                                         diagnostics As DiagnosticBag) As BoundXmlAttribute
+                                         diagnostics As BindingDiagnosticBag) As BoundXmlAttribute
             Dim nameSyntax = syntax.Name
             Dim name As BoundExpression
 
@@ -520,9 +520,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function MatchesXmlnsImport(name As XmlNameSyntax, value As String) As Boolean
             Dim prefix As String = Nothing
-            Dim diagnostics = DiagnosticBag.GetInstance()
-            TryGetXmlnsPrefix(name, prefix, diagnostics)
-            diagnostics.Free()
+            TryGetXmlnsPrefix(name, prefix, BindingDiagnosticBag.Discarded)
 
             If prefix Is Nothing Then
                 Return False
@@ -537,7 +535,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Bind the expression within the XmlEmbeddedExpressionSyntax,
         ''' and wrap in a BoundXmlEmbeddedExpression.
         ''' </summary>
-        Private Function BindXmlEmbeddedExpression(syntax As XmlEmbeddedExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlEmbeddedExpression(syntax As XmlEmbeddedExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim binder = New XmlEmbeddedExpressionBinder(Me)
             Dim expr = binder.BindRValue(syntax.Expression, diagnostics)
             Debug.Assert(expr IsNot Nothing)
@@ -550,7 +548,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                      attributes As ArrayBuilder(Of XmlNodeSyntax),
                                      childNodeBuilder As ArrayBuilder(Of BoundExpression),
                                      rootInfo As XmlElementRootInfo,
-                                     diagnostics As DiagnosticBag)
+                                     diagnostics As BindingDiagnosticBag)
             For Each childSyntax In attributes
                 If childSyntax.Kind = SyntaxKind.XmlAttribute Then
                     Dim attributeSyntax = DirectCast(childSyntax, XmlAttributeSyntax)
@@ -598,13 +596,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Function
         End Class
 
-        Private Sub BindXmlContent(content As SyntaxList(Of XmlNodeSyntax), childNodeBuilder As ArrayBuilder(Of BoundExpression), rootInfoOpt As XmlElementRootInfo, diagnostics As DiagnosticBag)
+        Private Sub BindXmlContent(content As SyntaxList(Of XmlNodeSyntax), childNodeBuilder As ArrayBuilder(Of BoundExpression), rootInfoOpt As XmlElementRootInfo, diagnostics As BindingDiagnosticBag)
             For Each childSyntax In content
                 childNodeBuilder.Add(BindXmlContent(childSyntax, rootInfoOpt, diagnostics))
             Next
         End Sub
 
-        Private Function BindXmlContent(syntax As XmlNodeSyntax, rootInfoOpt As XmlElementRootInfo, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlContent(syntax As XmlNodeSyntax, rootInfoOpt As XmlElementRootInfo, diagnostics As BindingDiagnosticBag) As BoundExpression
             Select Case syntax.Kind
                 Case SyntaxKind.XmlProcessingInstruction
                     Return BindXmlProcessingInstruction(DirectCast(syntax, XmlProcessingInstructionSyntax), diagnostics)
@@ -632,7 +630,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Function BindXmlAttributeAccess(syntax As XmlMemberAccessExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlAttributeAccess(syntax As XmlMemberAccessExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
 
             Dim receiver = BindXmlMemberAccessReceiver(syntax, diagnostics)
@@ -651,8 +649,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Determine the appropriate overload, allowing
                 ' XElement or IEnumerable(Of XElement) argument.
                 Dim xmlType = GetWellKnownType(WellKnownType.System_Xml_Linq_XElement, syntax, diagnostics)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                If receiverType.IsOrDerivedFrom(xmlType, useSiteDiagnostics) OrElse receiverType.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteDiagnostics) Then
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                If receiverType.IsOrDerivedFrom(xmlType, useSiteInfo) OrElse receiverType.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteInfo) Then
                     group = GetXmlMethodOrPropertyGroup(syntax,
                                                             GetInternalXmlHelperType(syntax, diagnostics),
                                                             StringConstants.XmlAttributeValueMethodName,
@@ -660,7 +658,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                             diagnostics)
                 End If
 
-                diagnostics.Add(syntax, useSiteDiagnostics)
+                diagnostics.Add(syntax, useSiteInfo)
 
                 If group IsNot Nothing Then
                     memberAccess = BindInvocationExpressionIfGroupNotNothing(syntax, group, ImmutableArray.Create(Of BoundExpression)(receiver, name), diagnostics)
@@ -677,15 +675,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlMemberAccess(syntax, memberAccess, memberAccess.Type)
         End Function
 
-        Private Function BindXmlElementAccess(syntax As XmlMemberAccessExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlElementAccess(syntax As XmlMemberAccessExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return BindXmlElementAccess(syntax, StringConstants.XmlElementsMethodName, ERRID.ERR_TypeDisallowsElements, diagnostics)
         End Function
 
-        Private Function BindXmlDescendantAccess(syntax As XmlMemberAccessExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlDescendantAccess(syntax As XmlMemberAccessExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             Return BindXmlElementAccess(syntax, StringConstants.XmlDescendantsMethodName, ERRID.ERR_TypeDisallowsDescendants, diagnostics)
         End Function
 
-        Private Function BindXmlElementAccess(syntax As XmlMemberAccessExpressionSyntax, memberName As String, typeDisallowsError As ERRID, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlElementAccess(syntax As XmlMemberAccessExpressionSyntax, memberName As String, typeDisallowsError As ERRID, diagnostics As BindingDiagnosticBag) As BoundExpression
             diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
 
             Dim receiver = BindXmlMemberAccessReceiver(syntax, diagnostics)
@@ -702,16 +700,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Determine the appropriate overload, allowing
                 ' XContainer or IEnumerable(Of XContainer) argument.
                 Dim xmlType = GetWellKnownType(WellKnownType.System_Xml_Linq_XContainer, syntax, diagnostics)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-                If receiverType.IsOrDerivedFrom(xmlType, useSiteDiagnostics) Then
+                If receiverType.IsOrDerivedFrom(xmlType, useSiteInfo) Then
                     group = GetXmlMethodOrPropertyGroup(syntax,
                                                             xmlType,
                                                             memberName,
                                                             receiver,
                                                             diagnostics)
                     arguments = ImmutableArray.Create(Of BoundExpression)(name)
-                ElseIf receiverType.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteDiagnostics) Then
+                ElseIf receiverType.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteInfo) Then
                     group = GetXmlMethodOrPropertyGroup(syntax,
                                                             GetWellKnownType(WellKnownType.System_Xml_Linq_Extensions, syntax, diagnostics),
                                                             memberName,
@@ -720,7 +718,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     arguments = ImmutableArray.Create(Of BoundExpression)(receiver, name)
                 End If
 
-                diagnostics.Add(syntax, useSiteDiagnostics)
+                diagnostics.Add(syntax, useSiteInfo)
 
                 If group IsNot Nothing Then
                     memberAccess = BindInvocationExpressionIfGroupNotNothing(syntax, group, arguments, diagnostics)
@@ -737,7 +735,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlMemberAccess(syntax, memberAccess, memberAccess.Type)
         End Function
 
-        Private Function BindXmlMemberAccessReceiver(syntax As XmlMemberAccessExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlMemberAccessReceiver(syntax As XmlMemberAccessExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             If syntax.Base Is Nothing Then
                 Dim receiver As BoundExpression
 
@@ -763,7 +761,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function BindXmlName(
                                     syntax As XmlNameSyntax,
                                     forElement As Boolean,
-                                    diagnostics As DiagnosticBag) As BoundExpression
+                                    diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim fromImports = False
             Dim prefix As String = Nothing
             Dim localName As String = Nothing
@@ -779,7 +777,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     <Out()> ByRef prefix As String,
                                     <Out()> ByRef localName As String,
                                     <Out()> ByRef [namespace] As String,
-                                    diagnostics As DiagnosticBag) As BoundExpression
+                                    diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim prefixSyntax = syntax.Prefix
             Dim namespaceExpr As BoundLiteral
 
@@ -848,7 +846,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             importedNamespaces.Add(New KeyValuePair(Of String, String)(prefix, [namespace]))
         End Sub
 
-        Private Function BindXmlName(syntax As VisualBasicSyntaxNode, localName As BoundExpression, [namespace] As BoundExpression, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlName(syntax As VisualBasicSyntaxNode, localName As BoundExpression, [namespace] As BoundExpression, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim group = GetXmlMethodOrPropertyGroup(
                 syntax,
                 GetWellKnownType(WellKnownType.System_Xml_Linq_XName, syntax, diagnostics),
@@ -859,7 +857,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlName(syntax, [namespace], localName, objectCreation, objectCreation.Type)
         End Function
 
-        Private Function BindGetXmlNamespace(syntax As GetXmlNamespaceExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindGetXmlNamespace(syntax As GetXmlNamespaceExpressionSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
 
             Dim nameSyntax = syntax.Name
@@ -884,7 +882,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return BindXmlNamespace(syntax, expr, diagnostics)
         End Function
 
-        Private Function BindXmlNamespace(syntax As VisualBasicSyntaxNode, [namespace] As BoundExpression, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlNamespace(syntax As VisualBasicSyntaxNode, [namespace] As BoundExpression, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim group = GetXmlMethodOrPropertyGroup(
                 syntax,
                 GetWellKnownType(WellKnownType.System_Xml_Linq_XNamespace, syntax, diagnostics),
@@ -895,7 +893,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlNamespace(syntax, [namespace], objectCreation, objectCreation.Type)
         End Function
 
-        Private Function ReportXmlNamespacePrefixNotDefined(syntax As VisualBasicSyntaxNode, prefixToken As SyntaxToken, prefix As String, compilerGenerated As Boolean, diagnostics As DiagnosticBag) As BoundBadExpression
+        Private Function ReportXmlNamespacePrefixNotDefined(syntax As VisualBasicSyntaxNode, prefixToken As SyntaxToken, prefix As String, compilerGenerated As Boolean, diagnostics As BindingDiagnosticBag) As BoundBadExpression
             Debug.Assert(prefix IsNot Nothing)
             Debug.Assert(prefix = GetXmlName(prefixToken))
             ' "XML namespace prefix '{0}' is not defined."
@@ -907,7 +905,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result
         End Function
 
-        Private Function BindXmlCData(syntax As XmlCDataSectionSyntax, rootInfoOpt As XmlElementRootInfo, diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindXmlCData(syntax As XmlCDataSectionSyntax, rootInfoOpt As XmlElementRootInfo, diagnostics As BindingDiagnosticBag) As BoundExpression
             If rootInfoOpt Is Nothing Then
                 diagnostics = CheckXmlFeaturesAllowed(syntax, diagnostics)
             End If
@@ -921,7 +919,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New BoundXmlCData(syntax, value, objectCreation, objectCreation.Type)
         End Function
 
-        Private Function BindXmlText(syntax As XmlTextSyntax, diagnostics As DiagnosticBag) As BoundLiteral
+        Private Function BindXmlText(syntax As XmlTextSyntax, diagnostics As BindingDiagnosticBag) As BoundLiteral
             Return CreateStringLiteral(syntax, GetXmlString(syntax.TextTokens), compilerGenerated:=False, diagnostics:=diagnostics)
         End Function
 
@@ -952,14 +950,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Function GetXmlMethodOrPropertyGroup(syntax As VisualBasicSyntaxNode, type As NamedTypeSymbol, memberName As String, receiverOpt As BoundExpression, diagnostics As DiagnosticBag) As BoundMethodOrPropertyGroup
+        Private Function GetXmlMethodOrPropertyGroup(syntax As VisualBasicSyntaxNode, type As NamedTypeSymbol, memberName As String, receiverOpt As BoundExpression, diagnostics As BindingDiagnosticBag) As BoundMethodOrPropertyGroup
             If type.IsErrorType() Then
                 Return Nothing
             End If
 
             Debug.Assert((receiverOpt Is Nothing) OrElse
                          receiverOpt.Type.IsErrorType() OrElse
-                         receiverOpt.Type.IsOrDerivedFrom(type, Nothing))
+                         receiverOpt.Type.IsOrDerivedFrom(type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
 
             Dim group As BoundMethodOrPropertyGroup = Nothing
             Dim result = LookupResult.GetInstance()
@@ -968,15 +966,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' on this type only, not base types, and ignore extension methods or properties
             ' from the current scope. (Extension methods and properties will be included,
             ' as shared members, if the members are defined on 'type' however.)
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             LookupMember(result,
                          type,
                          memberName,
                          arity:=0,
                          options:=LookupOptions.AllMethodsOfAnyArity Or LookupOptions.NoBaseClassLookup Or LookupOptions.IgnoreExtensionMethods,
-                         useSiteDiagnostics:=useSiteDiagnostics)
+                         useSiteInfo:=useSiteInfo)
 
-            diagnostics.Add(syntax, useSiteDiagnostics)
+            diagnostics.Add(syntax, useSiteInfo)
 
             If result.IsGood Then
                 Debug.Assert(result.Symbols.Count > 0)
@@ -1014,7 +1012,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' If the method or property group is not Nothing, bind as an invocation expression.
         ''' Otherwise return a BoundBadExpression containing the arguments.
         ''' </summary>
-        Private Function BindInvocationExpressionIfGroupNotNothing(syntax As SyntaxNode, groupOpt As BoundMethodOrPropertyGroup, arguments As ImmutableArray(Of BoundExpression), diagnostics As DiagnosticBag) As BoundExpression
+        Private Function BindInvocationExpressionIfGroupNotNothing(syntax As SyntaxNode, groupOpt As BoundMethodOrPropertyGroup, arguments As ImmutableArray(Of BoundExpression), diagnostics As BindingDiagnosticBag) As BoundExpression
             If groupOpt Is Nothing Then
                 Return BadExpression(syntax, arguments, ErrorTypeSymbol.UnknownResultType)
             Else
@@ -1033,7 +1031,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Check if XML features are allowed. If not, report an error and return a
         ''' separate DiagnosticBag that can be used for binding sub-expressions.
         ''' </summary>
-        Private Function CheckXmlFeaturesAllowed(syntax As VisualBasicSyntaxNode, diagnostics As DiagnosticBag) As DiagnosticBag
+        Private Function CheckXmlFeaturesAllowed(syntax As VisualBasicSyntaxNode, diagnostics As BindingDiagnosticBag) As BindingDiagnosticBag
             ' Check if XObject is available, which matches the native compiler.
             Dim type = Compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XObject)
             If type.IsErrorType() Then
@@ -1041,7 +1039,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ReportDiagnostic(diagnostics, syntax, ERRID.ERR_XmlFeaturesNotAvailable)
                 ' DiagnosticBag does not need to be created from the pool
                 ' since this is an error recovery scenario only.
-                Return New DiagnosticBag()
+                Return BindingDiagnosticBag.Discarded
             Else
                 Return diagnostics
             End If
@@ -1051,7 +1049,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             syntax As VisualBasicSyntaxNode,
                                             str As String,
                                             compilerGenerated As Boolean,
-                                            diagnostics As DiagnosticBag,
+                                            diagnostics As BindingDiagnosticBag,
                                             Optional hasErrors As Boolean = False) As BoundLiteral
             Debug.Assert(syntax IsNot Nothing)
             Dim result = New BoundLiteral(syntax, ConstantValue.Create(str), GetSpecialType(SpecialType.System_String, syntax, diagnostics), hasErrors:=hasErrors)
@@ -1076,7 +1074,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       xmlnsAttributes As ArrayBuilder(Of BoundXmlAttribute),
                                       otherAttributes As ArrayBuilder(Of XmlNodeSyntax),
                                       importedNamespaces As ArrayBuilder(Of KeyValuePair(Of String, String)),
-                                      diagnostics As DiagnosticBag) As Dictionary(Of String, String)
+                                      diagnostics As BindingDiagnosticBag) As Dictionary(Of String, String)
             Debug.Assert(xmlnsAttributes.Count = 0)
             Debug.Assert(otherAttributes.Count = 0)
 
@@ -1141,7 +1139,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       name As XmlName,
                                                       attribute As BoundXmlAttribute,
                                                       <Out()> ByRef allAttributes As Dictionary(Of XmlName, BoundXmlAttribute),
-                                                      diagnostics As DiagnosticBag) As Boolean
+                                                      diagnostics As BindingDiagnosticBag) As Boolean
             If allAttributes Is Nothing Then
                 allAttributes = New Dictionary(Of XmlName, BoundXmlAttribute)(XmlNameComparer.Instance)
             End If
@@ -1171,7 +1169,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                              <Out()> ByRef [namespace] As BoundExpression,
                                              <Out()> ByRef hasErrors As Boolean,
                                              fromImport As Boolean,
-                                             diagnostics As DiagnosticBag) As Boolean
+                                             diagnostics As BindingDiagnosticBag) As Boolean
             prefix = Nothing
             namespaceName = Nothing
             [namespace] = Nothing
@@ -1239,7 +1237,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return True
         End Function
 
-        Private Shared Function RedefinesReservedXmlNamespace(syntax As VisualBasicSyntaxNode, prefix As String, reservedPrefix As String, [namespace] As String, reservedNamespace As String, diagnostics As DiagnosticBag) As Boolean
+        Private Shared Function RedefinesReservedXmlNamespace(syntax As VisualBasicSyntaxNode, prefix As String, reservedPrefix As String, [namespace] As String, reservedNamespace As String, diagnostics As BindingDiagnosticBag) As Boolean
             If ([namespace] = reservedNamespace) AndAlso (prefix <> reservedPrefix) Then
                 ' "Prefix '{0}' cannot be bound to namespace name reserved for '{1}'."
                 ReportDiagnostic(diagnostics, syntax, ERRID.ERR_ReservedXmlNamespace, prefix, reservedPrefix)
@@ -1253,7 +1251,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' If name is "xmlns:p", set prefix to p and return True.
         ''' Otherwise return False.
         ''' </summary>
-        Private Function TryGetXmlnsPrefix(syntax As XmlNameSyntax, <Out()> ByRef prefix As String, diagnostics As DiagnosticBag) As Boolean
+        Private Function TryGetXmlnsPrefix(syntax As XmlNameSyntax, <Out()> ByRef prefix As String, diagnostics As BindingDiagnosticBag) As Boolean
             Dim localName = GetXmlName(syntax.LocalName)
             Dim prefixName As String = Nothing
 
@@ -1347,7 +1345,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                     expr As BoundExpression,
                                                                     prefixes As BoundRValuePlaceholder,
                                                                     namespaces As BoundRValuePlaceholder,
-                                                                    diagnostics As DiagnosticBag) As BoundExpression
+                                                                    diagnostics As BindingDiagnosticBag) As BoundExpression
                 Return _binder.BindRemoveNamespaceAttributesInvocation(
                     _syntax,
                     expr,

--- a/src/Compilers/VisualBasic/Portable/Binding/BindingDiagnosticBag.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BindingDiagnosticBag.vb
@@ -4,6 +4,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
+    ' PROTOTYPE(UsedAssemblyReferences) Consider if it makes sense to move this type into its own file
     Friend Module BindingDiagnosticBagExtensions
 
         <System.Runtime.CompilerServices.Extension()>
@@ -26,4 +27,67 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
     End Module
+
+    Friend NotInheritable Class BindingDiagnosticBag
+        Inherits BindingDiagnosticBag(Of AssemblySymbol)
+
+        Public Shared ReadOnly Discarded As New BindingDiagnosticBag(Nothing, Nothing)
+
+        Public Sub New()
+            MyBase.New(usePool:=False)
+        End Sub
+
+        Private Sub New(usePool As Boolean)
+            MyBase.New(usePool)
+        End Sub
+
+        Public Sub New(diagnosticBag As DiagnosticBag)
+            MyBase.New(diagnosticBag, dependenciesBag:=Nothing)
+        End Sub
+
+        Public Sub New(diagnosticBag As DiagnosticBag, dependenciesBag As ICollection(Of AssemblySymbol))
+            MyBase.New(diagnosticBag, dependenciesBag)
+        End Sub
+
+        Friend Shared Function GetInstance() As BindingDiagnosticBag
+            Return New BindingDiagnosticBag(usePool:=True)
+        End Function
+
+        Friend ReadOnly Property IsEmpty As Boolean
+            Get
+                Return (DiagnosticBag Is Nothing OrElse DiagnosticBag.IsEmptyWithoutResolution) AndAlso DependenciesBag.IsNullOrEmpty()
+            End Get
+        End Property
+
+        Protected Overrides Function ReportUseSiteDiagnostic(diagnosticInfo As DiagnosticInfo, diagnosticBag As DiagnosticBag, location As Location) As Boolean
+            Debug.Assert(diagnosticInfo.Severity = DiagnosticSeverity.Error)
+            diagnosticBag.Add(New VBDiagnostic(diagnosticInfo, location))
+            Return True
+        End Function
+
+        Friend Overloads Function Add(node As BoundNode, useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return Add(node.Syntax.Location, useSiteInfo)
+        End Function
+
+        Friend Overloads Function Add(syntax As SyntaxNodeOrToken, useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return Add(syntax.GetLocation(), useSiteInfo)
+        End Function
+
+        Friend Function ReportUseSite(symbol As Symbol, node As SyntaxNode) As Boolean
+            Return ReportUseSite(symbol, node.Location)
+        End Function
+
+        Friend Function ReportUseSite(symbol As Symbol, token As SyntaxToken) As Boolean
+            Return ReportUseSite(symbol, token.GetLocation())
+        End Function
+
+        Friend Function ReportUseSite(symbol As Symbol, location As Location) As Boolean
+            If symbol IsNot Nothing Then
+                Return Add(symbol.GetUseSiteInfo(), location)
+            End If
+
+            Return False
+        End Function
+
+    End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Binding/BlockBaseBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BlockBaseBinder.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             ' locals are always arity 0, and never types and namespaces.
             Dim locals = Me.Locals
             Dim localSymbol As T = Nothing
@@ -69,13 +69,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     For Each localSymbol In locals
                         Dim symName = localSymbol.Name
                         If symName Is name OrElse (symName.Length = name.Length And IdentifierComparison.Equals(symName, name)) Then
-                            lookupResult.SetFrom(CheckViability(localSymbol, arity, options, Nothing, useSiteDiagnostics))
+                            lookupResult.SetFrom(CheckViability(localSymbol, arity, options, Nothing, useSiteInfo))
                             Exit For
                         End If
                     Next
                 Else
                     If Me.LocalsMap.TryGetValue(name, localSymbol) Then
-                        lookupResult.SetFrom(CheckViability(localSymbol, arity, options, Nothing, useSiteDiagnostics))
+                        lookupResult.SetFrom(CheckViability(localSymbol, arity, options, Nothing, useSiteInfo))
                     End If
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentBinder.vb
@@ -138,15 +138,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Protected ReadOnly CommentedSymbol As Symbol
 
-        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Friend Overrides Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Friend Overrides Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Throw ExceptionUtilities.Unreachable
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return False
         End Function
 
-        Friend Overrides Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindInsideCrefAttributeValue(reference As CrefReferenceSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             ' If the node has trailing syntax nodes, it should report error, unless the name 
             ' is a VB intrinsic type (which ensures compatibility with Dev11)
             If HasTrailingSkippedTokensAndShouldReportError(reference) Then
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If reference.Signature Is Nothing Then
-                Return BindNameInsideCrefReferenceInLegacyMode(reference.Name, preserveAliases, useSiteDiagnostics)
+                Return BindNameInsideCrefReferenceInLegacyMode(reference.Name, preserveAliases, useSiteInfo)
             End If
 
             ' Extended 'cref' attribute syntax should not contain complex generic arguments 
@@ -86,7 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Bind the name part and collect type parameters
             Dim typeParameters As New Dictionary(Of String, CrefTypeParameterSymbol)(CaseInsensitiveComparison.Comparer)
-            CollectCrefNameSymbolsStrict(reference.Name, reference.Signature.ArgumentTypes.Count, typeParameters, symbols, preserveAliases, useSiteDiagnostics)
+            CollectCrefNameSymbolsStrict(reference.Name, reference.Signature.ArgumentTypes.Count, typeParameters, symbols, preserveAliases, useSiteInfo)
             If symbols.Count = 0 Then
                 symbols.Free()
                 Return ImmutableArray(Of Symbol).Empty
@@ -193,7 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return symbols.ToImmutableAndFree()
         End Function
 
-        Friend Overrides Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindInsideCrefAttributeValue(name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             Dim isPartOfSignatureOrReturnType As Boolean = False
             Dim crefReference As CrefReferenceSyntax = GetEnclosingCrefReference(name, isPartOfSignatureOrReturnType)
 
@@ -204,27 +204,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If crefReference.Signature Is Nothing Then
                 Debug.Assert(Not isPartOfSignatureOrReturnType)
-                Return BindNameInsideCrefReferenceInLegacyMode(name, preserveAliases, useSiteDiagnostics)
+                Return BindNameInsideCrefReferenceInLegacyMode(name, preserveAliases, useSiteInfo)
             End If
 
             If isPartOfSignatureOrReturnType Then
                 Return BindInsideCrefSignatureOrReturnType(crefReference, name, preserveAliases, diagnosticBag)
             Else
-                Return BindInsideCrefReferenceName(name, crefReference.Signature.ArgumentTypes.Count, preserveAliases, useSiteDiagnostics)
+                Return BindInsideCrefReferenceName(name, crefReference.Signature.ArgumentTypes.Count, preserveAliases, useSiteInfo)
             End If
         End Function
 
-        Private Function BindInsideCrefSignatureOrReturnType(crefReference As CrefReferenceSyntax, name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As DiagnosticBag) As ImmutableArray(Of Symbol)
+        Private Function BindInsideCrefSignatureOrReturnType(crefReference As CrefReferenceSyntax, name As TypeSyntax, preserveAliases As Boolean, diagnosticBag As BindingDiagnosticBag) As ImmutableArray(Of Symbol)
             Dim typeParameterAwareBinder As Binder = Me.GetOrCreateTypeParametersAwareBinder(crefReference)
 
-            Dim result As Symbol
-            If (diagnosticBag Is Nothing) Then
-                Dim diagnostics = DiagnosticBag.GetInstance
-                result = typeParameterAwareBinder.BindNamespaceOrTypeOrAliasSyntax(name, diagnostics)
-                diagnostics.Free()
-            Else
-                result = typeParameterAwareBinder.BindNamespaceOrTypeOrAliasSyntax(name, diagnosticBag)
-            End If
+            Dim result As Symbol = typeParameterAwareBinder.BindNamespaceOrTypeOrAliasSyntax(name, If(diagnosticBag, BindingDiagnosticBag.Discarded))
+            result = typeParameterAwareBinder.BindNamespaceOrTypeOrAliasSyntax(name, If(diagnosticBag, BindingDiagnosticBag.Discarded))
 
             If result IsNot Nothing AndAlso result.Kind = SymbolKind.Alias AndAlso Not preserveAliases Then
                 result = DirectCast(result, AliasSymbol).Target
@@ -304,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return GetOrCreateTypeParametersAwareBinder(typeParameters)
         End Function
 
-        Private Function BindInsideCrefReferenceName(name As TypeSyntax, argCount As Integer, preserveAliases As Boolean, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Private Function BindInsideCrefReferenceName(name As TypeSyntax, argCount As Integer, preserveAliases As Boolean, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             ' NOTE: in code here and below 'parent' may be Nothing in 
             '       case of speculative binding (which is NYI)
             Dim parent As VisualBasicSyntaxNode = name.Parent
@@ -376,7 +370,7 @@ lAgain:
             End Select
 
             Dim symbols = ArrayBuilder(Of Symbol).GetInstance
-            CollectCrefNameSymbolsStrict(name, argCount, New Dictionary(Of String, CrefTypeParameterSymbol)(IdentifierComparison.Comparer), symbols, preserveAliases, useSiteDiagnostics)
+            CollectCrefNameSymbolsStrict(name, argCount, New Dictionary(Of String, CrefTypeParameterSymbol)(IdentifierComparison.Comparer), symbols, preserveAliases, useSiteInfo)
 
             RemoveOverriddenMethodsAndProperties(symbols)
 
@@ -453,13 +447,13 @@ lAgain:
                                                 typeParameters As Dictionary(Of String, CrefTypeParameterSymbol),
                                                 <Out> ByRef signatureTypes As ArrayBuilder(Of SignatureElement),
                                                 <Out> ByRef returnType As TypeSymbol,
-                                                diagnosticBag As DiagnosticBag)
+                                                diagnosticBag As BindingDiagnosticBag)
 
             signatureTypes = Nothing
             returnType = Nothing
 
             Dim typeParameterAwareBinder As Binder = Me.GetOrCreateTypeParametersAwareBinder(typeParameters)
-            Dim diagnostic = If(diagnosticBag, DiagnosticBag.GetInstance())
+            Dim diagnostic = If(diagnosticBag, BindingDiagnosticBag.GetInstance())
 
             Dim signature As CrefSignatureSyntax = reference.Signature
             Debug.Assert(signature IsNot Nothing)
@@ -487,7 +481,7 @@ lAgain:
                                                  typeParameters As Dictionary(Of String, CrefTypeParameterSymbol),
                                                  symbols As ArrayBuilder(Of Symbol),
                                                  preserveAlias As Boolean,
-                                                 <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                 <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             ' This binding mode is used for extended cref-reference syntax with mandatory
             ' signature specified, we enforce more strict rules in this case
@@ -496,38 +490,38 @@ lAgain:
                 Case SyntaxKind.QualifiedCrefOperatorReference
                     ' 'A.B.Operator+' or 'C(Of T).Operator CType'
                     CollectQualifiedOperatorReferenceSymbolsStrict(
-                        DirectCast(nameFromCref, QualifiedCrefOperatorReferenceSyntax), argsCount, typeParameters, symbols, useSiteDiagnostics)
+                        DirectCast(nameFromCref, QualifiedCrefOperatorReferenceSyntax), argsCount, typeParameters, symbols, useSiteInfo)
 
                 Case SyntaxKind.CrefOperatorReference
                     ' 'Operator+' or 'Operator CType'
                     CollectTopLevelOperatorReferenceStrict(
-                        DirectCast(nameFromCref, CrefOperatorReferenceSyntax), argsCount, symbols, useSiteDiagnostics)
+                        DirectCast(nameFromCref, CrefOperatorReferenceSyntax), argsCount, symbols, useSiteInfo)
 
                 Case SyntaxKind.IdentifierName,
                      SyntaxKind.GenericName
                     ' 'New', 'A', or 'B(Of T)'
                     CollectSimpleNameSymbolsStrict(
-                        DirectCast(nameFromCref, SimpleNameSyntax), typeParameters, symbols, preserveAlias, useSiteDiagnostics, False)
+                        DirectCast(nameFromCref, SimpleNameSyntax), typeParameters, symbols, preserveAlias, useSiteInfo, False)
 
                 Case SyntaxKind.QualifiedName
                     ' 'A(Of T).B.M(Of E)'
                     CollectQualifiedNameSymbolsStrict(
-                        DirectCast(nameFromCref, QualifiedNameSyntax), typeParameters, symbols, preserveAlias, useSiteDiagnostics)
+                        DirectCast(nameFromCref, QualifiedNameSyntax), typeParameters, symbols, preserveAlias, useSiteInfo)
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(nameFromCref.Kind)
             End Select
         End Sub
 
-        Private Sub CollectTopLevelOperatorReferenceStrict(reference As CrefOperatorReferenceSyntax, argCount As Integer, symbols As ArrayBuilder(Of Symbol), <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
-            CollectOperatorsAndConversionsInType(reference, argCount, Me.ContainingType, symbols, useSiteDiagnostics)
+        Private Sub CollectTopLevelOperatorReferenceStrict(reference As CrefOperatorReferenceSyntax, argCount As Integer, symbols As ArrayBuilder(Of Symbol), <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
+            CollectOperatorsAndConversionsInType(reference, argCount, Me.ContainingType, symbols, useSiteInfo)
         End Sub
 
         Private Sub CollectSimpleNameSymbolsStrict(node As SimpleNameSyntax,
                                                    typeParameters As Dictionary(Of String, CrefTypeParameterSymbol),
                                                    symbols As ArrayBuilder(Of Symbol),
                                                    preserveAlias As Boolean,
-                                                   <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                   <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                    typeOrNamespaceOnly As Boolean)
 
             ' Name syntax of Cref should not have diagnostics
@@ -544,7 +538,7 @@ lAgain:
                                                genericName.TypeArgumentList.Arguments.Count,
                                                symbols,
                                                preserveAlias,
-                                               useSiteDiagnostics,
+                                               useSiteInfo,
                                                typeOrNamespaceOnly)
 
                 CreateTypeParameterSymbolsAndConstructSymbols(genericName, symbols, typeParameters)
@@ -561,7 +555,7 @@ lAgain:
 
                 Else
                     ' Search 0-arity only
-                    CollectSimpleNameSymbolsStrict(identifier.Identifier.ValueText, 0, symbols, preserveAlias, useSiteDiagnostics, typeOrNamespaceOnly)
+                    CollectSimpleNameSymbolsStrict(identifier.Identifier.ValueText, 0, symbols, preserveAlias, useSiteInfo, typeOrNamespaceOnly)
                 End If
             End If
         End Sub
@@ -570,7 +564,7 @@ lAgain:
                                                       typeParameters As Dictionary(Of String, CrefTypeParameterSymbol),
                                                       symbols As ArrayBuilder(Of Symbol),
                                                       preserveAlias As Boolean,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             ' Name syntax of Cref should not have diagnostics
             If node.ContainsDiagnostics Then
@@ -582,13 +576,13 @@ lAgain:
             Dim left As NameSyntax = node.Left
             Select Case left.Kind
                 Case SyntaxKind.IdentifierName
-                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteDiagnostics:=useSiteDiagnostics, typeOrNamespaceOnly:=True)
+                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteInfo:=useSiteInfo, typeOrNamespaceOnly:=True)
 
                 Case SyntaxKind.GenericName
-                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteDiagnostics:=useSiteDiagnostics, typeOrNamespaceOnly:=True)
+                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteInfo:=useSiteInfo, typeOrNamespaceOnly:=True)
 
                 Case SyntaxKind.QualifiedName
-                    CollectQualifiedNameSymbolsStrict(DirectCast(left, QualifiedNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteDiagnostics:=useSiteDiagnostics)
+                    CollectQualifiedNameSymbolsStrict(DirectCast(left, QualifiedNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteInfo:=useSiteInfo)
                     allowColorColor = False
 
                 Case SyntaxKind.GlobalName
@@ -623,7 +617,7 @@ lAgain:
                                                genericName.TypeArgumentList.Arguments.Count,
                                                symbols,
                                                preserveAlias,
-                                               useSiteDiagnostics)
+                                               useSiteInfo)
 
                 CreateTypeParameterSymbolsAndConstructSymbols(genericName, symbols, typeParameters)
 
@@ -639,7 +633,7 @@ lAgain:
 
                 Else
                     ' Search 0-arity only
-                    CollectSimpleNameSymbolsStrict(singleSymbol, allowColorColor, identifier.Identifier.ValueText, 0, symbols, preserveAlias, useSiteDiagnostics)
+                    CollectSimpleNameSymbolsStrict(singleSymbol, allowColorColor, identifier.Identifier.ValueText, 0, symbols, preserveAlias, useSiteInfo)
                 End If
             End If
         End Sub
@@ -648,7 +642,7 @@ lAgain:
                                                                    argCount As Integer,
                                                                    typeParameters As Dictionary(Of String, CrefTypeParameterSymbol),
                                                                    symbols As ArrayBuilder(Of Symbol),
-                                                                   <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                                   <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             ' Name syntax of Cref should not have diagnostics
             If node.ContainsDiagnostics Then
@@ -660,13 +654,13 @@ lAgain:
             Dim left As NameSyntax = node.Left
             Select Case left.Kind
                 Case SyntaxKind.IdentifierName
-                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteDiagnostics:=useSiteDiagnostics, typeOrNamespaceOnly:=True)
+                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteInfo:=useSiteInfo, typeOrNamespaceOnly:=True)
 
                 Case SyntaxKind.GenericName
-                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteDiagnostics:=useSiteDiagnostics, typeOrNamespaceOnly:=True)
+                    CollectSimpleNameSymbolsStrict(DirectCast(left, SimpleNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteInfo:=useSiteInfo, typeOrNamespaceOnly:=True)
 
                 Case SyntaxKind.QualifiedName
-                    CollectQualifiedNameSymbolsStrict(DirectCast(left, QualifiedNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteDiagnostics:=useSiteDiagnostics)
+                    CollectQualifiedNameSymbolsStrict(DirectCast(left, QualifiedNameSyntax), typeParameters, symbols, preserveAlias:=False, useSiteInfo:=useSiteInfo)
                     allowColorColor = False
 
                 Case Else
@@ -687,7 +681,7 @@ lAgain:
                 singleSymbol = DirectCast(singleSymbol, AliasSymbol).Target
             End If
 
-            CollectOperatorsAndConversionsInType(node.Right, argCount, TryCast(singleSymbol, TypeSymbol), symbols, useSiteDiagnostics)
+            CollectOperatorsAndConversionsInType(node.Right, argCount, TryCast(singleSymbol, TypeSymbol), symbols, useSiteInfo)
         End Sub
 
         Private Sub CollectConstructorsSymbolsStrict(symbols As ArrayBuilder(Of Symbol))
@@ -718,7 +712,7 @@ lAgain:
                                                    arity As Integer,
                                                    symbols As ArrayBuilder(Of Symbol),
                                                    preserveAlias As Boolean,
-                                                   <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                   <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                    typeOrNamespaceOnly As Boolean)
 
             Debug.Assert(Not String.IsNullOrEmpty(name))
@@ -733,7 +727,7 @@ lAgain:
 
             Dim result As LookupResult = LookupResult.GetInstance()
 
-            Me.Lookup(result, name, arity, If(typeOrNamespaceOnly, options Or LookupOptions.NamespacesOrTypesOnly, options), useSiteDiagnostics)
+            Me.Lookup(result, name, arity, If(typeOrNamespaceOnly, options Or LookupOptions.NamespacesOrTypesOnly, options), useSiteInfo)
 
             If Not result.IsGoodOrAmbiguous OrElse Not result.HasSymbol Then
                 result.Free()
@@ -750,7 +744,7 @@ lAgain:
                                                    arity As Integer,
                                                    symbols As ArrayBuilder(Of Symbol),
                                                    preserveAlias As Boolean,
-                                                   <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                   <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             Debug.Assert(Not String.IsNullOrEmpty(name))
             Debug.Assert(arity >= 0)
@@ -765,14 +759,14 @@ lAgain:
 lAgain:
             Select Case containingSymbol.Kind
                 Case SymbolKind.Namespace
-                    LookupMember(lookupResult, DirectCast(containingSymbol, NamespaceSymbol), name, arity, options, useSiteDiagnostics)
+                    LookupMember(lookupResult, DirectCast(containingSymbol, NamespaceSymbol), name, arity, options, useSiteInfo)
 
                 Case SymbolKind.Alias
                     containingSymbol = DirectCast(containingSymbol, AliasSymbol).Target
                     GoTo lAgain
 
                 Case SymbolKind.NamedType, SymbolKind.ArrayType
-                    LookupMember(lookupResult, DirectCast(containingSymbol, TypeSymbol), name, arity, options, useSiteDiagnostics)
+                    LookupMember(lookupResult, DirectCast(containingSymbol, TypeSymbol), name, arity, options, useSiteInfo)
 
                 Case SymbolKind.Property
                     If allowColorColor Then
@@ -894,7 +888,7 @@ lAgain:
         End Sub
 
         Private Shared Sub CollectOperatorsAndConversionsInType(crefOperator As CrefOperatorReferenceSyntax, argCount As Integer, type As TypeSymbol, symbols As ArrayBuilder(Of Symbol),
-                                                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             If type Is Nothing Then
                 Return
             End If
@@ -907,13 +901,13 @@ lAgain:
                 Case SyntaxKind.IsTrueKeyword
                     If argCount = 1 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(UnaryOperatorKind.IsTrue)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.TrueOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.TrueOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.IsFalseKeyword
                     If argCount = 1 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(UnaryOperatorKind.IsFalse)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.FalseOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.FalseOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.NotKeyword
@@ -921,104 +915,104 @@ lAgain:
                         Dim opInfo As New OverloadResolution.OperatorInfo(UnaryOperatorKind.Not)
                         CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator,
                                                              WellKnownMemberNames.OnesComplementOperatorName, opInfo,
-                                                             useSiteDiagnostics,
+                                                             useSiteInfo,
                                                              WellKnownMemberNames.LogicalNotOperatorName, opInfo)
                     End If
 
                 Case SyntaxKind.PlusToken
                     If argCount = 1 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(UnaryOperatorKind.Plus)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.UnaryPlusOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.UnaryPlusOperatorName, opInfo, useSiteInfo)
                     Else
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Add)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.AdditionOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.AdditionOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.MinusToken
                     If argCount = 1 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(UnaryOperatorKind.Minus)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.UnaryNegationOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.UnaryNegationOperatorName, opInfo, useSiteInfo)
                     Else
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Subtract)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.SubtractionOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.SubtractionOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.AsteriskToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Multiply)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.MultiplyOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.MultiplyOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.SlashToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Divide)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.DivisionOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.DivisionOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.BackslashToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.IntegerDivide)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.IntegerDivisionOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.IntegerDivisionOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.ModKeyword
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Modulo)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ModulusOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ModulusOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.CaretToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Power)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ExponentOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ExponentOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.EqualsToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Equals)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.EqualityOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.EqualityOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.LessThanGreaterThanToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.NotEquals)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.InequalityOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.InequalityOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.LessThanToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.LessThan)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.LessThanOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.LessThanOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.GreaterThanToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.GreaterThan)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.GreaterThanOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.GreaterThanOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.LessThanEqualsToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.LessThanOrEqual)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.LessThanOrEqualOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.LessThanOrEqualOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.GreaterThanEqualsToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.GreaterThanOrEqual)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.GreaterThanOrEqualOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.GreaterThanOrEqualOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.LikeKeyword
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Like)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.LikeOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.LikeOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.AmpersandToken
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Concatenate)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ConcatenateOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ConcatenateOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.AndKeyword
@@ -1026,7 +1020,7 @@ lAgain:
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.And)
                         CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator,
                                                              WellKnownMemberNames.BitwiseAndOperatorName, opInfo,
-                                                             useSiteDiagnostics,
+                                                             useSiteInfo,
                                                              WellKnownMemberNames.LogicalAndOperatorName, opInfo)
                     End If
 
@@ -1035,14 +1029,14 @@ lAgain:
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Or)
                         CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator,
                                                              WellKnownMemberNames.BitwiseOrOperatorName, opInfo,
-                                                             useSiteDiagnostics,
+                                                             useSiteInfo,
                                                              WellKnownMemberNames.LogicalOrOperatorName, opInfo)
                     End If
 
                 Case SyntaxKind.XorKeyword
                     If argCount = 2 Then
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.Xor)
-                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ExclusiveOrOperatorName, opInfo, useSiteDiagnostics)
+                        CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator, WellKnownMemberNames.ExclusiveOrOperatorName, opInfo, useSiteInfo)
                     End If
 
                 Case SyntaxKind.LessThanLessThanToken
@@ -1050,7 +1044,7 @@ lAgain:
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.LeftShift)
                         CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator,
                                                              WellKnownMemberNames.LeftShiftOperatorName, opInfo,
-                                                             useSiteDiagnostics,
+                                                             useSiteInfo,
                                                              WellKnownMemberNames.UnsignedLeftShiftOperatorName, opInfo)
                     End If
 
@@ -1059,7 +1053,7 @@ lAgain:
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.RightShift)
                         CollectOperatorsAndConversionsInType(type, symbols, MethodKind.UserDefinedOperator,
                                                              WellKnownMemberNames.RightShiftOperatorName, opInfo,
-                                                             useSiteDiagnostics,
+                                                             useSiteInfo,
                                                              WellKnownMemberNames.UnsignedRightShiftOperatorName, opInfo)
                     End If
 
@@ -1068,7 +1062,7 @@ lAgain:
                         Dim opInfo As New OverloadResolution.OperatorInfo(BinaryOperatorKind.RightShift)
                         CollectOperatorsAndConversionsInType(type, symbols, MethodKind.Conversion,
                                                              WellKnownMemberNames.ImplicitConversionName, New OverloadResolution.OperatorInfo(UnaryOperatorKind.Implicit),
-                                                             useSiteDiagnostics,
+                                                             useSiteInfo,
                                                              WellKnownMemberNames.ExplicitConversionName, New OverloadResolution.OperatorInfo(UnaryOperatorKind.Explicit))
                     End If
 
@@ -1082,12 +1076,12 @@ lAgain:
                                                          kind As MethodKind,
                                                          name1 As String,
                                                          info1 As OverloadResolution.OperatorInfo,
-                                                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                          Optional name2 As String = Nothing,
                                                          Optional info2 As OverloadResolution.OperatorInfo = Nothing)
 
             Dim methods = ArrayBuilder(Of MethodSymbol).GetInstance()
-            OverloadResolution.CollectUserDefinedOperators(type, Nothing, kind, name1, info1, name2, info2, methods, useSiteDiagnostics)
+            OverloadResolution.CollectUserDefinedOperators(type, Nothing, kind, name1, info1, name2, info2, methods, useSiteInfo)
             symbols.AddRange(methods)
             methods.Free()
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder_Compat.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder_Compat.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Function BindNameInsideCrefReferenceInLegacyMode(nameFromCref As TypeSyntax, preserveAliases As Boolean, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Private Function BindNameInsideCrefReferenceInLegacyMode(nameFromCref As TypeSyntax, preserveAliases As Boolean, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             ' This binding mode is used for cref-references without signatures and 
             ' emulate Dev11 behavior
 
@@ -41,11 +41,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             While name IsNot Nothing And name.Kind <> SyntaxKind.CrefReference
                 If name.Kind <> SyntaxKind.QualifiedName Then
                     ' Not a top-level name or a top-level qualified name part
-                    Dim discarded = DiagnosticBag.GetInstance
                     Dim result As Symbol = If(preserveAliases,
-                                              BindTypeOrAliasSyntax(nameFromCref, discarded),
-                                              BindTypeSyntax(nameFromCref, discarded))
-                    discarded.Free()
+                                              BindTypeOrAliasSyntax(nameFromCref, BindingDiagnosticBag.Discarded),
+                                              BindTypeSyntax(nameFromCref, BindingDiagnosticBag.Discarded))
                     Return ImmutableArray.Create(Of Symbol)(result)
                 End If
 
@@ -65,13 +63,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Select Case nameFromCref.Kind
                 Case SyntaxKind.IdentifierName,
                      SyntaxKind.GenericName
-                    BindSimpleNameForCref(DirectCast(nameFromCref, SimpleNameSyntax), symbols, preserveAliases, useSiteDiagnostics, False)
+                    BindSimpleNameForCref(DirectCast(nameFromCref, SimpleNameSyntax), symbols, preserveAliases, useSiteInfo, False)
 
                 Case SyntaxKind.PredefinedType
                     BindPredefinedTypeForCref(DirectCast(nameFromCref, PredefinedTypeSyntax), symbols)
 
                 Case SyntaxKind.QualifiedName
-                    BindQualifiedNameForCref(DirectCast(nameFromCref, QualifiedNameSyntax), symbols, preserveAliases, useSiteDiagnostics)
+                    BindQualifiedNameForCref(DirectCast(nameFromCref, QualifiedNameSyntax), symbols, preserveAliases, useSiteInfo)
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(nameFromCref.Kind)
@@ -82,17 +80,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return symbols.ToImmutableAndFree()
         End Function
 
-        Private Sub BindQualifiedNameForCref(node As QualifiedNameSyntax, symbols As ArrayBuilder(Of Symbol), preserveAliases As Boolean, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+        Private Sub BindQualifiedNameForCref(node As QualifiedNameSyntax, symbols As ArrayBuilder(Of Symbol), preserveAliases As Boolean, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Dim allowColorColor As Boolean = True
 
             Dim left As NameSyntax = node.Left
             Select Case left.Kind
                 Case SyntaxKind.IdentifierName,
                      SyntaxKind.GenericName
-                    BindSimpleNameForCref(DirectCast(left, SimpleNameSyntax), symbols, preserveAliases, useSiteDiagnostics, True)
+                    BindSimpleNameForCref(DirectCast(left, SimpleNameSyntax), symbols, preserveAliases, useSiteInfo, True)
 
                 Case SyntaxKind.QualifiedName
-                    BindQualifiedNameForCref(DirectCast(left, QualifiedNameSyntax), symbols, preserveAliases, useSiteDiagnostics)
+                    BindQualifiedNameForCref(DirectCast(left, QualifiedNameSyntax), symbols, preserveAliases, useSiteInfo)
                     allowColorColor = False
 
                 Case SyntaxKind.GlobalName
@@ -123,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       genericName.TypeArgumentList.Arguments.Count,
                                       symbols,
                                       preserveAliases,
-                                      useSiteDiagnostics,
+                                      useSiteInfo,
                                       containingSymbol:=singleSymbol,
                                       allowColorColor:=allowColorColor)
 
@@ -144,7 +142,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       0,
                                       symbols,
                                       preserveAliases,
-                                      useSiteDiagnostics,
+                                      useSiteInfo,
                                       containingSymbol:=singleSymbol,
                                       allowColorColor:=allowColorColor)
                 If symbols.Count > 0 Then
@@ -157,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                       -1,
                                       symbols,
                                       preserveAliases,
-                                      useSiteDiagnostics,
+                                      useSiteInfo,
                                       containingSymbol:=singleSymbol,
                                       allowColorColor:=allowColorColor)
             End If
@@ -170,11 +168,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        preserveAliases As Boolean,
                                                        lookupResult As LookupResult,
                                                        options As LookupOptions,
-                                                       <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                       <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 lAgain:
             Select Case containingSymbol.Kind
                 Case SymbolKind.Namespace
-                    LookupMember(lookupResult, DirectCast(containingSymbol, NamespaceSymbol), name, arity, options, useSiteDiagnostics)
+                    LookupMember(lookupResult, DirectCast(containingSymbol, NamespaceSymbol), name, arity, options, useSiteInfo)
 
                 Case SymbolKind.Alias
                     If Not preserveAliases Then
@@ -183,7 +181,7 @@ lAgain:
                     End If
 
                 Case SymbolKind.NamedType, SymbolKind.ArrayType
-                    LookupMember(lookupResult, DirectCast(containingSymbol, TypeSymbol), name, arity, options, useSiteDiagnostics)
+                    LookupMember(lookupResult, DirectCast(containingSymbol, TypeSymbol), name, arity, options, useSiteInfo)
 
                 Case SymbolKind.Property
                     If allowColorColor Then
@@ -230,7 +228,7 @@ lAgain:
                                           arity As Integer,
                                           symbols As ArrayBuilder(Of Symbol),
                                           preserveAliases As Boolean,
-                                          <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                          <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                           Optional containingSymbol As Symbol = Nothing,
                                           Optional allowColorColor As Boolean = False,
                                           Optional typeOrNamespaceOnly As Boolean = False)
@@ -260,7 +258,7 @@ lAgain:
             Dim lookupResult As LookupResult = LookupResult.GetInstance()
 
             If containingSymbol Is Nothing Then
-                Me.Lookup(lookupResult, name, arity, options, useSiteDiagnostics)
+                Me.Lookup(lookupResult, name, arity, options, useSiteInfo)
             Else
                 LookupSimpleNameInContainingSymbol(containingSymbol,
                                                allowColorColor,
@@ -269,7 +267,7 @@ lAgain:
                                                preserveAliases,
                                                lookupResult,
                                                options,
-                                               useSiteDiagnostics)
+                                               useSiteInfo)
             End If
 
             If Not lookupResult.IsGoodOrAmbiguous OrElse Not lookupResult.HasSymbol Then
@@ -283,7 +281,7 @@ lAgain:
         Private Sub BindSimpleNameForCref(node As SimpleNameSyntax,
                                           symbols As ArrayBuilder(Of Symbol),
                                           preserveAliases As Boolean,
-                                          <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                          <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                           typeOrNamespaceOnly As Boolean)
 
             ' Name syntax of Cref should not have diagnostics
@@ -300,7 +298,7 @@ lAgain:
                                       genericName.TypeArgumentList.Arguments.Count,
                                       symbols,
                                       preserveAliases,
-                                      useSiteDiagnostics,
+                                      useSiteInfo,
                                       typeOrNamespaceOnly:=typeOrNamespaceOnly)
 
                 If symbols.Count <> 1 Then
@@ -321,7 +319,7 @@ lAgain:
                                       0,
                                       symbols,
                                       preserveAliases,
-                                      useSiteDiagnostics,
+                                      useSiteInfo,
                                       typeOrNamespaceOnly:=typeOrNamespaceOnly)
 
                 If symbols.Count > 0 Then
@@ -334,7 +332,7 @@ lAgain:
                                       -1,
                                       symbols,
                                       preserveAliases,
-                                      useSiteDiagnostics,
+                                      useSiteInfo,
                                       typeOrNamespaceOnly:=typeOrNamespaceOnly)
             End If
         End Sub
@@ -387,9 +385,7 @@ lAgain:
             End Select
 
             ' We discard diagnostics in case 
-            Dim diagnostics = DiagnosticBag.GetInstance
-            symbols.Add(Me.GetSpecialType(type, node, diagnostics))
-            diagnostics.Free()
+            symbols.Add(Me.GetSpecialType(type, node, BindingDiagnosticBag.Discarded))
         End Sub
 
         Private Function ConstructGenericSymbolWithTypeArgumentsForCref(genericSymbol As Symbol, genericName As GenericNameSyntax) As Symbol
@@ -415,11 +411,9 @@ lAgain:
 
         Private Function BingTypeArgumentsForCref(args As SeparatedSyntaxList(Of TypeSyntax)) As ImmutableArray(Of TypeSymbol)
             Dim result(args.Count - 1) As TypeSymbol
-            Dim diagBag = DiagnosticBag.GetInstance
             For i = 0 To args.Count - 1
-                result(i) = Me.BindTypeSyntax(args(i), diagBag)
+                result(i) = Me.BindTypeSyntax(args(i), BindingDiagnosticBag.Discarded)
             Next
-            diagBag.Free()
             Return result.AsImmutableOrNull()
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder_TypeParameters.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder_TypeParameters.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                          arity As Integer,
                                                          options As LookupOptions,
                                                          originalBinder As Binder,
-                                                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
                 Debug.Assert(lookupResult.IsClear)
 
                 Dim typeParameter As CrefTypeParameterSymbol = Nothing
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                         arity,
                                                         options Or LookupOptions.IgnoreAccessibility,
                                                         Nothing,
-                                                        useSiteDiagnostics))
+                                                        useSiteInfo))
                 End If
             End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentParamBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentParamBinder.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             If Me.CommentedSymbol Is Nothing Then
                 Return ImmutableArray(Of Symbol).Empty
             End If
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      arity As Integer,
                                                      options As LookupOptions,
                                                      originalBinder As Binder,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             If (options And s_invalidLookupOptions) <> 0 OrElse arity > 0 Then
@@ -98,7 +98,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             For Each parameter In Me.Parameters
                 If IdentifierComparison.Equals(parameter.Name, name) Then
-                    lookupResult.SetFrom(CheckViability(parameter, arity, options, Nothing, useSiteDiagnostics))
+                    lookupResult.SetFrom(CheckViability(parameter, arity, options, Nothing, useSiteInfo))
                 End If
             Next
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentTypeParamBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentTypeParamBinder.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             MyBase.New(containingBinder, commentedSymbol)
         End Sub
 
-        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
+        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
             If Me.CommentedSymbol Is Nothing Then
                 Return ImmutableArray(Of Symbol).Empty
             End If
@@ -72,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             If (options And (LookupOptions.LabelsOnly Or LookupOptions.MustBeInstance Or LookupOptions.AttributeTypeOnly)) <> 0 Then
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Not TypeParameters.IsEmpty Then
                 For Each typeParameter In TypeParameters
                     If IdentifierComparison.Equals(typeParameter.Name, name) Then
-                        lookupResult.SetFrom(CheckViability(typeParameter, arity, options, Nothing, useSiteDiagnostics))
+                        lookupResult.SetFrom(CheckViability(typeParameter, arity, options, Nothing, useSiteInfo))
                     End If
                 Next
             End If

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentTypeParamRefBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentTypeParamRefBinder.vb
@@ -19,8 +19,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             MyBase.New(containingBinder, commentedSymbol)
         End Sub
 
-        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of Symbol)
-            Dim result As ImmutableArray(Of Symbol) = MyBase.BindXmlNameAttributeValue(identifier, useSiteDiagnostics)
+        Friend Overrides Function BindXmlNameAttributeValue(identifier As IdentifierNameSyntax, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of Symbol)
+            Dim result As ImmutableArray(Of Symbol) = MyBase.BindXmlNameAttributeValue(identifier, useSiteInfo)
             If Not result.IsEmpty Then
                 Return result
             End If
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     LookupOptions.MustNotBeLocalOrParameter
 
             Dim lookupResult As LookupResult = lookupResult.GetInstance()
-            Me.Lookup(lookupResult, identifier.Identifier.ValueText, 0, options, useSiteDiagnostics)
+            Me.Lookup(lookupResult, identifier.Identifier.ValueText, 0, options, useSiteInfo)
 
             If Not lookupResult.HasSingleSymbol Then
                 lookupResult.Free()

--- a/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
@@ -49,9 +49,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' Hide the GetAttribute overload which takes a diagnostic bag.
         ' This ensures that diagnostics from the early bound attributes are never preserved.
         Friend Shadows Function GetAttribute(node As AttributeSyntax, boundAttributeType As NamedTypeSymbol, <Out> ByRef generatedDiagnostics As Boolean) As SourceAttributeData
-            Dim diagnostics = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
             Dim earlyAttribute = MyBase.GetAttribute(node, boundAttributeType, diagnostics)
-            generatedDiagnostics = Not diagnostics.IsEmptyWithoutResolution()
+            generatedDiagnostics = Not diagnostics.DiagnosticBag.IsEmptyWithoutResolution()
             diagnostics.Free()
             Return earlyAttribute
         End Function
@@ -167,9 +167,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Dim memberAccess = TryCast(DirectCast(node, InvocationExpressionSyntax).Expression, MemberAccessExpressionSyntax)
                     If memberAccess IsNot Nothing Then
-                        Dim diagnostics = DiagnosticBag.GetInstance
-                        Dim boundExpression = memberAccessBinder.BindExpression(memberAccess, diagnostics)
-                        diagnostics.Free()
+                        Dim boundExpression = memberAccessBinder.BindExpression(memberAccess, BindingDiagnosticBag.Discarded)
 
                         If boundExpression.HasErrors Then
                             Return False

--- a/src/Compilers/VisualBasic/Portable/Binding/ExecutableCodeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ExecutableCodeBinder.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             If (options And LookupOptions.LabelsOnly) = LookupOptions.LabelsOnly AndAlso LabelsMap IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Binding/ForOrForEachBlockBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ForOrForEachBlockBinder.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         Dim result = LookupResult.GetInstance()
 
-                        ContainingBinder.Lookup(result, identifier.ValueText, 0, LookupOptions.AllMethodsOfAnyArity, useSiteDiagnostics:=Nothing)
+                        ContainingBinder.Lookup(result, identifier.ValueText, 0, LookupOptions.AllMethodsOfAnyArity, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                         ' If there was something found we do not create a new local of an inferred type.
                         ' The only exception is if all symbols (should be one only, or the result is not good) are type symbols.

--- a/src/Compilers/VisualBasic/Portable/Binding/IgnoreAccessibilityBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/IgnoreAccessibilityBinder.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return ContainingBinder.BinderSpecificLookupOptions(options) Or LookupOptions.IgnoreAccessibility
         End Function
 
-        Public Overrides Function CheckAccessibility(sym As Symbol, <[In]> <Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo), Optional accessThroughType As TypeSymbol = Nothing, Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
+        Public Overrides Function CheckAccessibility(sym As Symbol, <[In]> <Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol), Optional accessThroughType As TypeSymbol = Nothing, Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
             Return AccessCheckResult.Accessible
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Portable/Binding/ImplicitVariableBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImplicitVariableBinder.vb
@@ -68,12 +68,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             _frozen = False
         End Sub
 
-        Friend Overrides Function BindGroupAggregationExpression(group As GroupAggregationSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Friend Overrides Function BindGroupAggregationExpression(group As GroupAggregationSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' Need this for ImplicitVariableBinder created by SpeculativeBinder.
             Return Me.ContainingBinder.BindGroupAggregationExpression(group, diagnostics)
         End Function
 
-        Friend Overrides Function BindFunctionAggregationExpression([function] As FunctionAggregationSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Friend Overrides Function BindFunctionAggregationExpression([function] As FunctionAggregationSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' Need this for ImplicitVariableBinder created by SpeculativeBinder.
             Return Me.ContainingBinder.BindFunctionAggregationExpression([function], diagnostics)
         End Function
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' and report delayed shadowing diagnostics.
         ''' </summary>
         ''' <remarks></remarks>
-        Public Overrides Sub DisallowFurtherImplicitVariableDeclaration(diagnostics As DiagnosticBag)
+        Public Overrides Sub DisallowFurtherImplicitVariableDeclaration(diagnostics As BindingDiagnosticBag)
 #If DEBUG Then
             CheckVariableDeclarationOnSingleThread()
 #End If
@@ -145,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Declare an implicit local variable. The type of the local is determined
         ''' by the type character (if any) on the variable.
         ''' </summary>
-        Public Overrides Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As DiagnosticBag) As LocalSymbol
+        Public Overrides Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As BindingDiagnosticBag) As LocalSymbol
 #If DEBUG Then
             Debug.Assert(Not _frozen)
             CheckVariableDeclarationOnSingleThread()
@@ -207,7 +207,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 #If DEBUG Then
             CheckVariableDeclarationOnSingleThread()
 #End If
@@ -215,7 +215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim localSymbol As LocalSymbol = Nothing
             If _implicitLocals IsNot Nothing AndAlso (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly)) = 0 Then
                 If _implicitLocals.TryGetValue(name, localSymbol) Then
-                    lookupResult.SetFrom(CheckViability(localSymbol, arity, options, Nothing, useSiteDiagnostics))
+                    lookupResult.SetFrom(CheckViability(localSymbol, arity, options, Nothing, useSiteInfo))
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImportAliasesBinder.vb
@@ -43,14 +43,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      arity As Integer,
                                                      options As LookupOptions,
                                                      originalBinder As Binder,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             Dim [alias] As AliasAndImportsClausePosition = Nothing
             If _importedAliases.TryGetValue(name, [alias]) Then
                 ' Got an alias. Return it without checking arity.
 
-                Dim res = CheckViability([alias].Alias, arity, options, Nothing, useSiteDiagnostics)
+                Dim res = CheckViability([alias].Alias, arity, options, Nothing, useSiteInfo)
                 If res.IsGoodOrAmbiguous AndAlso Not originalBinder.IsSemanticModelBinder Then
                     Me.Compilation.MarkImportDirectiveAsUsed(Me.SyntaxTree, [alias].ImportsClausePosition)
                 End If
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                     options As LookupOptions,
                                                                     originalBinder As Binder)
             For Each [alias] In _importedAliases.Values
-                If originalBinder.CheckViability([alias].Alias.Target, -1, options, Nothing, useSiteDiagnostics:=Nothing).IsGoodOrAmbiguous Then
+                If originalBinder.CheckViability([alias].Alias.Target, -1, options, Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded).IsGoodOrAmbiguous Then
                     nameSet.AddSymbol([alias].Alias, [alias].Alias.Name, 0)
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Binding/ImportedTypesAndNamespacesMembersBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/ImportedTypesAndNamespacesMembersBinder.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      arity As Integer,
                                                      options As LookupOptions,
                                                      originalBinder As Binder,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             ' Look up the name in all imported symbols, merging and generating ambiguity errors if needed.
@@ -48,9 +48,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 currentResult = LookupResult.GetInstance()
 
                 If importedSym.NamespaceOrType.IsNamespace Then
-                    originalBinder.LookupMemberImmediate(currentResult, DirectCast(importedSym.NamespaceOrType, NamespaceSymbol), name, arity, options, useSiteDiagnostics)
+                    originalBinder.LookupMemberImmediate(currentResult, DirectCast(importedSym.NamespaceOrType, NamespaceSymbol), name, arity, options, useSiteInfo)
                 Else
-                    originalBinder.LookupMember(currentResult, importedSym.NamespaceOrType, name, arity, options, useSiteDiagnostics)
+                    originalBinder.LookupMember(currentResult, importedSym.NamespaceOrType, name, arity, options, useSiteInfo)
                 End If
 
                 If currentResult.IsGoodOrAmbiguous AndAlso Not originalBinder.IsSemanticModelBinder Then

--- a/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/InitializerSemanticModel.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New InitializerSemanticModel(root, binder, parentSemanticModelOpt:=parentSemanticModel, speculatedPosition:=position)
         End Function
 
-        Friend Overrides Function Bind(binder As Binder, node As SyntaxNode, diagnostics As DiagnosticBag) As BoundNode
+        Friend Overrides Function Bind(binder As Binder, node As SyntaxNode, diagnostics As BindingDiagnosticBag) As BoundNode
             Debug.Assert(binder.IsSemanticModelBinder)
 
             Dim boundInitializer As BoundNode = Nothing
@@ -101,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Next
         End Function
 
-        Private Function BindInitializer(binder As Binder, initializer As SyntaxNode, diagnostics As DiagnosticBag) As BoundNode
+        Private Function BindInitializer(binder As Binder, initializer As SyntaxNode, diagnostics As BindingDiagnosticBag) As BoundNode
             Dim boundInitializer As BoundNode = Nothing
 
             Select Case Me.MemberSymbol.Kind

--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -156,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
             End Select
 
-            Return New Conversion(Conversions.ClassifyConversion(boundExpression, vbDestination, GetEnclosingBinder(boundExpression.Syntax), Nothing))
+            Return New Conversion(Conversions.ClassifyConversion(boundExpression, vbDestination, GetEnclosingBinder(boundExpression.Syntax), CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
         End Function
 
         ''' <summary>
@@ -789,7 +789,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If elementType IsNot Nothing AndAlso Not elementType.IsErrorType() Then
                 If current IsNot Nothing AndAlso Not current.Type.IsErrorType() Then
-                    currentConversion = New Conversion(Conversions.ClassifyConversion(current.Type, elementType, useSiteDiagnostics:=Nothing))
+                    currentConversion = New Conversion(Conversions.ClassifyConversion(current.Type, elementType, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
                 End If
 
                 Dim boundCurrentConversion As BoundExpression = enumeratorInfo.CurrentConversion
@@ -797,7 +797,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' NOTE: What VB calls the current conversion is used to convert the current placeholder to the iteration
                     ' variable type.  In the terminology of the public API, this is a conversion from the element type to the
                     ' iteration variable type, and is referred to as the element conversion.
-                    elementConversion = New Conversion(Conversions.ClassifyConversion(elementType, boundCurrentConversion.Type, useSiteDiagnostics:=Nothing))
+                    elementConversion = New Conversion(Conversions.ClassifyConversion(elementType, boundCurrentConversion.Type, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
                 End If
             End If
 
@@ -1217,8 +1217,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _guardedQueryBindersMap As New Dictionary(Of SyntaxNode, ImmutableArray(Of Binder))()
         Private ReadOnly _guardedAnonymousTypeBinderMap As New Dictionary(Of FieldInitializerSyntax, Binder.AnonymousTypeFieldInitializerBinder)()
 
-        Private ReadOnly _guardedDiagnostics As DiagnosticBag = New DiagnosticBag()
-
         ' If implicit variable declaration is in play, then we must bind everything
         ' up front in order to get all implicit local variables declared.
         ' Because order of declaration is important, and any expression could declare
@@ -1233,7 +1231,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Me.GuardedIncrementalBind(Me.Root, Me.RootBinder)
 
                         ' after this call, RootBinder.AllImplicitVariableDeclarationsAreHandled = True
-                        Me.RootBinder.DisallowFurtherImplicitVariableDeclaration(Me._guardedDiagnostics)
+                        Me.RootBinder.DisallowFurtherImplicitVariableDeclaration(BindingDiagnosticBag.Discarded)
                     End If
                 Finally
                     _rwLock.ExitWriteLock()
@@ -1892,7 +1890,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If bound.IsDefault Then
                         ' Bind the node and cache any associated bound nodes we find.
-                        Dim boundNode = Me.Bind(binder, node, Me._guardedDiagnostics)
+                        Dim boundNode = Me.Bind(binder, node, BindingDiagnosticBag.Discarded)
                         SemanticModelMapsBuilder.GuardedCacheBoundNodes(boundNode, Me, _guardedNodeMap, node)
                     End If
 
@@ -1946,7 +1944,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(enclosingBinder.IsSemanticModelBinder)
             Dim binder = New IncrementalBinder(Me, enclosingBinder)
-            Dim boundRoot As BoundNode = Me.Bind(binder, bindingRoot, Me._guardedDiagnostics)
+            Dim boundRoot As BoundNode = Me.Bind(binder, bindingRoot, BindingDiagnosticBag.Discarded)
 
             ' if the node could not be bound, there's nothing more to do.
             If boundRoot Is Nothing Then
@@ -2066,7 +2064,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing
             End Function
 
-            Public Overrides Function BindStatement(node As StatementSyntax, diagnostics As DiagnosticBag) As BoundStatement
+            Public Overrides Function BindStatement(node As StatementSyntax, diagnostics As BindingDiagnosticBag) As BoundStatement
                 ' Check the bound node cache to see if the statement was already bound.
                 Dim boundNodes As ImmutableArray(Of BoundNode) = _binding.GuardedGetBoundNodesFromMap(node)
 

--- a/src/Compilers/VisualBasic/Portable/Binding/MethodTypeParametersBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MethodTypeParametersBinder.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             ' type parameters can only be accessed with arity 0
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             For i = 0 To _typeParameters.Length - 1
                 Dim tp = _typeParameters(i)
                 If IdentifierComparison.Equals(tp.Name, name) Then
-                    lookupResult.SetFrom(CheckViability(tp, arity, options, Nothing, useSiteDiagnostics))
+                    lookupResult.SetFrom(CheckViability(tp, arity, options, Nothing, useSiteInfo))
                 End If
             Next
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Binding/NamedTypeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/NamedTypeBinder.vb
@@ -72,18 +72,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             ' 1. look for members. This call automatically gets members of base types.
-            originalBinder.LookupMember(lookupResult, _typeSymbol, name, arity, options, useSiteDiagnostics)
+            originalBinder.LookupMember(lookupResult, _typeSymbol, name, arity, options, useSiteInfo)
             If lookupResult.StopFurtherLookup Then
                 Return ' short cut result
             End If
 
             ' 2. Lookup type parameter.
             Dim typeParameterLookupResult = LookupResult.GetInstance()
-            LookupTypeParameter(typeParameterLookupResult, name, arity, options, originalBinder, useSiteDiagnostics)
+            LookupTypeParameter(typeParameterLookupResult, name, arity, options, originalBinder, useSiteInfo)
             lookupResult.MergePrioritized(typeParameterLookupResult)
             typeParameterLookupResult.Free()
 
@@ -131,14 +131,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         arity As Integer,
                                         options As LookupOptions,
                                         originalBinder As Binder,
-                                        <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                        <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(name IsNot Nothing)
             Debug.Assert(lookupResult.IsClear)
 
             If _typeSymbol.Arity > 0 Then
                 For Each tp In _typeSymbol.TypeParameters
                     If IdentifierComparison.Equals(tp.Name, name) Then
-                        lookupResult.SetFrom(originalBinder.CheckViability(tp, arity, options, Nothing, useSiteDiagnostics))
+                        lookupResult.SetFrom(originalBinder.CheckViability(tp, arity, options, Nothing, useSiteInfo))
                     End If
                 Next
             End If
@@ -147,12 +147,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Overrides Function CheckAccessibility(sym As Symbol,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                      Optional accessThroughType As TypeSymbol = Nothing,
                                                      Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
             Return If(IgnoresAccessibility,
                 AccessCheckResult.Accessible,
-                AccessCheck.CheckSymbolAccessibility(sym, _typeSymbol, accessThroughType, useSiteDiagnostics, basesBeingResolved))
+                AccessCheck.CheckSymbolAccessibility(sym, _typeSymbol, accessThroughType, useSiteInfo, basesBeingResolved))
         End Function
 
         Public Overrides ReadOnly Property ContainingType As NamedTypeSymbol

--- a/src/Compilers/VisualBasic/Portable/Binding/NamespaceBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/NamespaceBinder.vb
@@ -70,9 +70,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             ' Look it up in the associated namespace.
-            originalBinder.LookupMember(lookupResult, _nsSymbol, name, arity, options Or LookupOptions.IgnoreExtensionMethods, useSiteDiagnostics)
+            originalBinder.LookupMember(lookupResult, _nsSymbol, name, arity, options Or LookupOptions.IgnoreExtensionMethods, useSiteInfo)
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/SourceModuleBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SourceModuleBinder.vb
@@ -28,12 +28,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Overrides Function CheckAccessibility(sym As Symbol,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                      Optional accessThroughType As TypeSymbol = Nothing,
                                                      Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
             Return If(IgnoresAccessibility,
                 AccessCheckResult.Accessible,
-                AccessCheck.CheckSymbolAccessibility(sym, _sourceModule.ContainingSourceAssembly, useSiteDiagnostics, basesBeingResolved))  ' accessThroughType doesn't matter at assembly level.
+                AccessCheck.CheckSymbolAccessibility(sym, _sourceModule.ContainingSourceAssembly, useSiteInfo, basesBeingResolved))  ' accessThroughType doesn't matter at assembly level.
         End Function
 
         Public Overrides ReadOnly Property OptionStrict As OptionStrict

--- a/src/Compilers/VisualBasic/Portable/Binding/SpeculativeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SpeculativeBinder.vb
@@ -37,12 +37,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ' TODO override SyntaxTree property to return correct tree. (after e.g. bugs 2174, 5848)
 
-        Friend Overrides Function BindGroupAggregationExpression(group As GroupAggregationSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Friend Overrides Function BindGroupAggregationExpression(group As GroupAggregationSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' Overridden method returns a BadExpression.
             Return Me.ContainingBinder.BindGroupAggregationExpression(group, diagnostics)
         End Function
 
-        Friend Overrides Function BindFunctionAggregationExpression([function] As FunctionAggregationSyntax, diagnostics As DiagnosticBag) As BoundExpression
+        Friend Overrides Function BindFunctionAggregationExpression([function] As FunctionAggregationSyntax, diagnostics As BindingDiagnosticBag) As BoundExpression
             ' Overridden method returns a BadExpression.
             Return Me.ContainingBinder.BindFunctionAggregationExpression([function], diagnostics)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Binding/SubOrFunctionBodyBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SubOrFunctionBodyBinder.vb
@@ -61,17 +61,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       arity As Integer,
                                                       options As LookupOptions,
                                                       originalBinder As Binder,
-                                                      <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                      <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             ' Parameters always have arity 0 and are not namespaces or types.
             If (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly Or LookupOptions.MustNotBeLocalOrParameter)) = 0 Then
                 Dim parameterSymbol As Symbol = Nothing
                 If _parameterMap.TryGetValue(name, parameterSymbol) Then
-                    lookupResult.SetFrom(CheckViability(parameterSymbol, arity, options, Nothing, useSiteDiagnostics))
+                    lookupResult.SetFrom(CheckViability(parameterSymbol, arity, options, Nothing, useSiteInfo))
                 End If
             Else
-                MyBase.LookupInSingleBinder(lookupResult, name, arity, options, originalBinder, useSiteDiagnostics)
+                MyBase.LookupInSingleBinder(lookupResult, name, arity, options, originalBinder, useSiteInfo)
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/AnonymousTypeSyntheticMethods.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/AnonymousTypeSyntheticMethods.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Partial Private Class AnonymousTypeConstructorSymbol
             Inherits SynthesizedConstructorBase
 
-            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
                 methodBodyBinder = Nothing
 
                 Dim syntax As SyntaxNode = Me.Syntax
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Partial Private NotInheritable Class AnonymousTypeEqualsMethodSymbol
             Inherits SynthesizedRegularMethodBase
 
-            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
                 methodBodyBinder = Nothing
 
                 Dim syntax As SyntaxNode = Me.Syntax
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Partial Private NotInheritable Class AnonymousTypeGetHashCodeMethodSymbol
             Inherits SynthesizedRegularMethodBase
 
-            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
                 methodBodyBinder = Nothing
 
                 Dim syntax As SyntaxNode = Me.Syntax
@@ -181,7 +181,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Partial Private NotInheritable Class AnonymousType_IEquatable_EqualsMethodSymbol
             Inherits SynthesizedRegularMethodBase
 
-            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
                 methodBodyBinder = Nothing
 
                 Dim syntax As SyntaxNode = Me.Syntax
@@ -315,7 +315,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Partial Private NotInheritable Class AnonymousTypeToStringMethodSymbol
             Inherits SynthesizedRegularMethodBase
 
-            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+            Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
                 methodBodyBinder = Nothing
 
                 Dim syntax As SyntaxNode = Me.Syntax

--- a/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/SynthesizedConstructorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/SynthesizedConstructorSymbol.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Partial Class SynthesizedConstructorSymbol
         Inherits SynthesizedConstructorBase
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             methodBodyBinder = Nothing
             Dim returnStmt = New BoundReturnStatement(Me.Syntax, Nothing, Nothing, Nothing)
             returnStmt.SetWasCompilerGenerated()

--- a/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/SynthesizedStringSwitchHashMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/SynthesizedStringSwitchHashMethod.vb
@@ -50,7 +50,7 @@ start:
         ''' <remarks>
         ''' This method should be kept consistent with ComputeStringHash
         ''' </remarks>
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Dim F = New SyntheticBoundNodeFactory(Me, Me, Me.Syntax, Nothing, diagnostics)
             F.CurrentMethod = Me
 

--- a/src/Compilers/VisualBasic/Portable/Binding/TypesOfImportedNamespacesMembersBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/TypesOfImportedNamespacesMembersBinder.vb
@@ -34,14 +34,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      arity As Integer,
                                                      options As LookupOptions,
                                                      originalBinder As Binder,
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             ' Lookup in modules of imported namespaces. 
             For Each importedSym In _importedSymbols
                 If importedSym.NamespaceOrType.IsNamespace Then
                     Dim currentResult = LookupResult.GetInstance()
-                    originalBinder.LookupMemberInModules(currentResult, DirectCast(importedSym.NamespaceOrType, NamespaceSymbol), name, arity, options, useSiteDiagnostics)
+                    originalBinder.LookupMemberInModules(currentResult, DirectCast(importedSym.NamespaceOrType, NamespaceSymbol), name, arity, options, useSiteInfo)
                     If currentResult.IsGood AndAlso Not originalBinder.IsSemanticModelBinder Then
                         Me.Compilation.MarkImportDirectiveAsUsed(Me.SyntaxTree, importedSym.ImportsClausePosition)
                     End If

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundBinaryConditionalExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundBinaryConditionalExpression.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
                 Else
                     If Not Type.IsSameTypeIgnoringAll(TestExpression.Type.GetNullableUnderlyingTypeOrSelf()) Then
-                        Dim conversion As ConversionKind = Conversions.ClassifyDirectCastConversion(TestExpression.Type, Type, Nothing)
+                        Dim conversion As ConversionKind = Conversions.ClassifyDirectCastConversion(TestExpression.Type, Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                         Debug.Assert(Conversions.IsWideningConversion(conversion) AndAlso Conversions.IsCLRPredefinedConversion(conversion))
                     End If
                 End If

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundExpressionExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundExpressionExtensions.vb
@@ -571,7 +571,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Next
 
             ' Merge methodGroup.AdditionalExtensionMethods into the result.
-            For Each method In methodGroup.AdditionalExtensionMethods(useSiteDiagnostics:=Nothing)
+            For Each method In methodGroup.AdditionalExtensionMethods(useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                 ' This is a quick fix for the fact that binder lookup in VB does not perform arity check for 
                 '       method symbols leaving it to overload resolution code. Here we filter wrong arity methods
                 If targetArity = 0 Then

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundMethodGroup.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundMethodGroup.vb
@@ -25,12 +25,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         ' Lazily filled once the value is requested.
-        Public Function AdditionalExtensionMethods(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of MethodSymbol)
+        Public Function AdditionalExtensionMethods(<[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of MethodSymbol)
             If _PendingExtensionMethodsOpt Is Nothing Then
                 Return ImmutableArray(Of MethodSymbol).Empty
             End If
 
-            Return _PendingExtensionMethodsOpt.LazyLookupAdditionalExtensionMethods(Me, useSiteDiagnostics)
+            Return _PendingExtensionMethodsOpt.LazyLookupAdditionalExtensionMethods(Me, useSiteInfo)
         End Function
 
     End Class
@@ -39,7 +39,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _lookupBinder As Binder
         Private ReadOnly _lookupOptions As LookupOptions
         Private _lazyMethods As ImmutableArray(Of MethodSymbol)
-        Private _lazyUseSiteDiagnostics As HashSet(Of DiagnosticInfo)
+        Private _lazyUseSiteDiagnostics As IReadOnlyCollection(Of DiagnosticInfo)
+        Private _lazyUseSiteDependencies As IReadOnlyCollection(Of AssemblySymbol)
 
         Public Sub New(lookupBinder As Binder, lookupOptions As LookupOptions)
             Debug.Assert(lookupBinder IsNot Nothing)
@@ -47,13 +48,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             _lookupOptions = lookupOptions
         End Sub
 
-        Public Function LazyLookupAdditionalExtensionMethods(group As BoundMethodGroup, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of MethodSymbol)
+        Public Function LazyLookupAdditionalExtensionMethods(group As BoundMethodGroup, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of MethodSymbol)
             Debug.Assert(group.PendingExtensionMethodsOpt Is Me)
 
             If _lazyMethods.IsDefault Then
                 Dim receiverOpt As BoundExpression = group.ReceiverOpt
                 Dim methods As ImmutableArray(Of MethodSymbol) = ImmutableArray(Of MethodSymbol).Empty
-                Dim localUseSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                Dim localUseSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
                 If receiverOpt IsNot Nothing AndAlso receiverOpt.Type IsNot Nothing Then
                     Dim lookup = LookupResult.GetInstance()
@@ -63,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     group.Methods(0).Name,
                                                     If(group.TypeArgumentsOpt Is Nothing, 0, group.TypeArgumentsOpt.Arguments.Length),
                                                     _lookupOptions,
-                                                    localUseSiteDiagnostics)
+                                                    localUseSiteInfo)
 
                     If lookup.IsGood Then
                         methods = lookup.Symbols.ToDowncastedImmutable(Of MethodSymbol)()
@@ -72,19 +73,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     lookup.Free()
                 End If
 
-                Interlocked.CompareExchange(_lazyUseSiteDiagnostics, localUseSiteDiagnostics, Nothing)
+                Interlocked.CompareExchange(_lazyUseSiteDiagnostics, localUseSiteInfo.Diagnostics, Nothing)
+                Interlocked.CompareExchange(_lazyUseSiteDependencies, localUseSiteInfo.Dependencies, Nothing)
                 ImmutableInterlocked.InterlockedCompareExchange(_lazyMethods, methods, Nothing)
             End If
 
-            If Not _lazyUseSiteDiagnostics.IsNullOrEmpty Then
-                If useSiteDiagnostics Is Nothing Then
-                    useSiteDiagnostics = New HashSet(Of DiagnosticInfo)()
-                End If
-
-                For Each info In _lazyUseSiteDiagnostics
-                    useSiteDiagnostics.Add(info)
-                Next
-            End If
+            useSiteInfo.AddDiagnostics(System.Threading.Volatile.Read(_lazyUseSiteDiagnostics))
+            useSiteInfo.AddDependencies(System.Threading.Volatile.Read(_lazyUseSiteDependencies))
 
             Return _lazyMethods
         End Function

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -35,6 +35,10 @@
     <ValueType Name="NoOpStatementFlavor"/>
     <ValueType Name="BoundTypeOrValueData"/>
     <ValueType Name="BitVector" />
+      <!-- PROTOTYPE(UsedAssemblyReferences): Remove this entry once code generator is adjusted to 
+                                              handle ImmutableBindingDiagnostic specially.
+      -->
+    <ValueType Name="ImmutableBindingDiagnostic" />
 
   <AbstractNode Name="BoundExpression" Base="BoundNode">
     <Field Name="Type" Type="TypeSymbol" Null="allow"/>
@@ -1486,7 +1490,10 @@
 
       <Field Name="LambdaSymbol" Type="LambdaSymbol" Null="disallow" />
       <Field Name="Body" Type="BoundBlock"/>
-      <Field Name="Diagnostics" Type="ImmutableArray(Of Microsoft.CodeAnalysis.Diagnostic)" Null="disallow" />
+      <!-- PROTOTYPE(UsedAssemblyReferences): Remove Null="allow" once code generator is adjusted to 
+                                              handle ImmutableBindingDiagnostic specially.
+      -->
+      <Field Name="Diagnostics" Type="ImmutableBindingDiagnostic(Of AssemblySymbol)" Null="allow" /> 
       <Field Name="LambdaBinderOpt" Type="LambdaBodyBinder" Null="allow" />
 
       <!-- 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundTreeVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundTreeVisitor.vb
@@ -152,6 +152,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 diagnostics.Add(ERRID.ERR_TooLongOrComplexExpression, GetTooLongOrComplexExpressionErrorLocation(Node))
             End Sub
 
+            Public Sub AddAnError(diagnostics As BindingDiagnosticBag)
+                diagnostics.Add(ERRID.ERR_TooLongOrComplexExpression, GetTooLongOrComplexExpressionErrorLocation(Node))
+            End Sub
+
             Public Shared Function GetTooLongOrComplexExpressionErrorLocation(node As BoundNode) As Location
                 Dim syntax As SyntaxNode = node.Syntax
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundTypeOrValueExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundTypeOrValueExpression.vb
@@ -18,8 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly _valueDiagnostics As DiagnosticBag
-        Public ReadOnly Property ValueDiagnostics As DiagnosticBag
+        Private ReadOnly _valueDiagnostics As BindingDiagnosticBag
+        Public ReadOnly Property ValueDiagnostics As BindingDiagnosticBag
             Get
                 Return Me._valueDiagnostics
             End Get
@@ -32,14 +32,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly _typeDiagnostics As DiagnosticBag
-        Public ReadOnly Property TypeDiagnostics As DiagnosticBag
+        Private ReadOnly _typeDiagnostics As BindingDiagnosticBag
+        Public ReadOnly Property TypeDiagnostics As BindingDiagnosticBag
             Get
                 Return Me._typeDiagnostics
             End Get
         End Property
 
-        Public Sub New(valueExpression As BoundExpression, valueDiagnostics As DiagnosticBag, typeExpression As BoundExpression, typeDiagnostics As DiagnosticBag)
+        Public Sub New(valueExpression As BoundExpression, valueDiagnostics As BindingDiagnosticBag, typeExpression As BoundExpression, typeDiagnostics As BindingDiagnosticBag)
             Debug.Assert(valueExpression IsNot Nothing, "Field 'valueExpression' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
             Debug.Assert(valueDiagnostics IsNot Nothing, "Field 'valueDiagnostics' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
             Debug.Assert(typeExpression IsNot Nothing, "Field 'typeExpression' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")

--- a/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
@@ -54,11 +54,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' target.ReturnType is ignored and must be Void, only parameter types are taken into consideration.
         ''' </summary>
-        Public Function InferReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))
+        Public Function InferReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             Debug.Assert(target IsNot Nothing AndAlso target.ReturnType.IsVoidType())
 
             If Me.ReturnType IsNot Nothing Then
-                Dim result = New KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))(If(Me.IsFunctionLambda AndAlso Me.ReturnType.IsVoidType(),
+                Dim result = New KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(If(Me.IsFunctionLambda AndAlso Me.ReturnType.IsVoidType(),
                                                                                LambdaSymbol.ReturnTypeVoidReplacement,
                                                                          Me.ReturnType),
                                                                       Nothing)
@@ -100,29 +100,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return _Binder.BindUnboundLambda(Me, target)
         End Function
 
-        Private Function DoInferFunctionLambdaReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))
+        Private Function DoInferFunctionLambdaReturnType(target As TargetSignature) As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             Return _Binder.InferFunctionLambdaReturnType(Me, target)
         End Function
 
-        Public ReadOnly Property InferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic))
+        Public ReadOnly Property InferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             Get
-                Dim info As Tuple(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) = _BindingCache.AnonymousDelegate
+                Dim info As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = _BindingCache.AnonymousDelegate
                 If info Is Nothing Then
-                    Dim delegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) = _Binder.InferAnonymousDelegateForLambda(Me)
+                    Dim delegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = _Binder.InferAnonymousDelegateForLambda(Me)
 
                     Interlocked.CompareExchange(_BindingCache.AnonymousDelegate,
-                                                New Tuple(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic))(delegateInfo.Key, delegateInfo.Value),
+                                                New Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(delegateInfo.Key, delegateInfo.Value),
                                                 Nothing)
 
                     info = _BindingCache.AnonymousDelegate
                 End If
 
-                Return New KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic))(info.Item1, info.Item2)
+                Return New KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))(info.Item1, info.Item2)
             End Get
         End Property
 
         Public Function IsInferredDelegateForThisLambda(delegateType As NamedTypeSymbol) As Boolean
-            Dim info As Tuple(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) = _BindingCache.AnonymousDelegate
+            Dim info As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = _BindingCache.AnonymousDelegate
             If info Is Nothing Then
                 Return False
             End If
@@ -217,8 +217,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' outside of the UnboundLambda class.
         ''' </summary>
         Public Class UnboundLambdaBindingCache
-            Public AnonymousDelegate As Tuple(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic))
-            Public ReadOnly InferredReturnType As New ConcurrentDictionary(Of TargetSignature, KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic)))()
+            Public AnonymousDelegate As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
+            Public ReadOnly InferredReturnType As New ConcurrentDictionary(Of TargetSignature, KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)))()
             Public ReadOnly BoundLambdas As New ConcurrentDictionary(Of TargetSignature, BoundLambda)()
             Public ErrorRecoverySignature As TargetSignature
         End Class

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitConversion.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitConversion.vb
@@ -208,7 +208,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                             EmitInitObj(typeTo, used:=True, syntaxNode:=conversion.Syntax)
                         Else
                             ' before we use constructor symbol we need to report use site error if any
-                            Binder.ReportUseSiteError(_diagnostics, conversion.Syntax, constructor)
+                            Dim diagnosticInfo As DiagnosticInfo = constructor.GetUseSiteInfo().DiagnosticInfo
+                            If diagnosticInfo IsNot Nothing Then
+                                _diagnostics.Add(New VBDiagnostic(diagnosticInfo, conversion.Syntax.Location))
+                            End If
 
                             EmitNewObj(constructor, ImmutableArray(Of BoundExpression).Empty, used:=True, syntaxNode:=conversion.Syntax)
                         End If
@@ -242,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                 '       optional parameters; this matches Dev10 behavior
                 If constr.ParameterCount = 0 Then
                     '  check 'constr' 
-                    If AccessCheck.IsSymbolAccessible(constr, _method.ContainingType, typeTo, useSiteDiagnostics:=Nothing) Then
+                    If AccessCheck.IsSymbolAccessible(constr, _method.ContainingType, typeTo, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                         Return constr
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' if filterTree and filterSpanWithinTree is not null, limit analysis to types residing within this span in the filterTree.
         Private ReadOnly _filterSpanWithinTree As TextSpan?
 
-        Private ReadOnly _diagnostics As ConcurrentQueue(Of Diagnostic)
+        Private ReadOnly _diagnostics As BindingDiagnosticBag
 
         Private ReadOnly _cancellationToken As CancellationToken
 
@@ -34,7 +34,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <seealso cref="MethodCompiler._compilerTasks"/>
         Private ReadOnly _compilerTasks As ConcurrentStack(Of Task)
 
-        Private Sub New(compilation As VisualBasicCompilation, filterTree As SyntaxTree, filterSpanWithinTree As TextSpan?, diagnostics As ConcurrentQueue(Of Diagnostic), cancellationToken As CancellationToken)
+        Private Sub New(compilation As VisualBasicCompilation, filterTree As SyntaxTree, filterSpanWithinTree As TextSpan?, diagnostics As BindingDiagnosticBag, cancellationToken As CancellationToken)
+            Debug.Assert(TypeOf diagnostics.DependenciesBag Is ConcurrentSet(Of AssemblySymbol))
+
             Me._compilation = compilation
             Me._filterTree = filterTree
             Me._filterSpanWithinTree = filterSpanWithinTree
@@ -64,15 +66,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="cancellationToken">To stop traversing the symbol table early.</param>
         ''' <param name="filterTree">Only report diagnostics from this syntax tree, if non-null.</param>
         ''' <param name="filterSpanWithinTree">If <paramref name="filterTree"/> and <paramref name="filterSpanWithinTree"/> is non-null, report diagnostics within this span in the <paramref name="filterTree"/>.</param>
-        Public Shared Sub CheckCompliance(compilation As VisualBasicCompilation, diagnostics As DiagnosticBag, cancellationToken As CancellationToken, Optional filterTree As SyntaxTree = Nothing, Optional filterSpanWithinTree As TextSpan? = Nothing)
-            Dim queue = New ConcurrentQueue(Of Diagnostic)()
+        Public Shared Sub CheckCompliance(compilation As VisualBasicCompilation, diagnostics As BindingDiagnosticBag, cancellationToken As CancellationToken, Optional filterTree As SyntaxTree = Nothing, Optional filterSpanWithinTree As TextSpan? = Nothing)
+            Dim queue = New BindingDiagnosticBag(diagnostics.DiagnosticBag, New ConcurrentSet(Of AssemblySymbol))
             Dim checker = New ClsComplianceChecker(compilation, filterTree, filterSpanWithinTree, queue, cancellationToken)
             checker.Visit(compilation.Assembly)
             checker.WaitForWorkers()
-
-            For Each diag In queue
-                diagnostics.Add(diag)
-            Next
+            diagnostics.AddDependencies(queue.DependenciesBag)
         End Sub
 
         Private Sub WaitForWorkers()
@@ -782,12 +781,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If attributeData.IsTargetAttribute(symbol, AttributeDescription.CLSCompliantAttribute) Then
                     Dim attributeClass = attributeData.AttributeClass
                     If attributeClass IsNot Nothing Then
-                        Dim info = attributeClass.GetUseSiteErrorInfo()
-                        If info IsNot Nothing Then
-                            Dim location = If(symbol.Locations.IsEmpty, NoLocation.Singleton, symbol.Locations(0))
-                            _diagnostics.Enqueue(New VBDiagnostic(info, location))
-                            Continue For
-                        End If
+                        _diagnostics.ReportUseSite(attributeClass, If(symbol.Locations.IsEmpty, NoLocation.Singleton, symbol.Locations(0)))
                     End If
 
                     If Not attributeData.HasErrors Then
@@ -862,7 +856,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Sub AddDiagnostic(symbol As Symbol, code As ERRID, location As Location, ParamArray args As Object())
             Dim info = New BadSymbolDiagnostic(symbol, code, args)
             Dim diag = New VBDiagnostic(info, location)
-            Me._diagnostics.Enqueue(diag)
+            Me._diagnostics.Add(diag)
         End Sub
 
         Private Shared Function IsImplicitClass(symbol As Symbol) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Common.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Common.vb
@@ -414,11 +414,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        ERRID.ERR_None)
 
                         If nameAttribute IsNot Nothing Then
-                            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                            Dim bindResult As ImmutableArray(Of Symbol) = binder.BindXmlNameAttributeValue(nameAttribute.Reference, useSiteDiagnostics)
+                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            Dim bindResult As ImmutableArray(Of Symbol) = binder.BindXmlNameAttributeValue(nameAttribute.Reference, useSiteInfo)
 
                             If node.SyntaxTree.ReportDocumentationCommentDiagnostics() Then
-                                Me._diagnostics.Add(node, useSiteDiagnostics)
+                                Me._diagnostics.Add(node, useSiteInfo)
+                            Else
+                                Me._diagnostics.AddDependencies(useSiteInfo)
                             End If
 
                             Dim needDiagnostic As Boolean = True

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Includes.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Includes.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Private ReadOnly _tree As SyntaxTree
                 Private ReadOnly _onlyDiagnosticsFromTree As SyntaxTree
                 Private ReadOnly _filterSpanWithinTree As TextSpan?
-                Private ReadOnly _diagnostics As DiagnosticBag
+                Private ReadOnly _diagnostics As BindingDiagnosticBag
                 Private ReadOnly _cancellationToken As CancellationToken
 
                 Private _binders As Dictionary(Of DocumentationCommentBinder.BinderType, Binder) = Nothing
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 includedFileCache As DocumentationCommentIncludeCache,
                                 onlyDiagnosticsFromTree As SyntaxTree,
                                 filterSpanWithinTree As TextSpan?,
-                                diagnostics As DiagnosticBag,
+                                diagnostics As BindingDiagnosticBag,
                                 cancellationToken As CancellationToken)
 
                     Me._symbol = symbol
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        onlyDiagnosticsFromTree As SyntaxTree,
                                                        filterSpanWithinTree As TextSpan?,
                                                        ByRef includedFileCache As DocumentationCommentIncludeCache,
-                                                       diagnostics As DiagnosticBag,
+                                                       diagnostics As BindingDiagnosticBag,
                                                        cancellationToken As CancellationToken) As String
 
                     ' If there are no include elements, then there's nothing to expand.
@@ -618,18 +618,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Case SyntaxKind.XmlCrefAttribute
                             Dim binder As binder = Me.GetOrCreateBinder(DocumentationCommentBinder.BinderType.Cref)
                             Dim reference As CrefReferenceSyntax = DirectCast(attr, XmlCrefAttributeSyntax).Reference
-                            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                            Dim diagnostics = DiagnosticBag.GetInstance
-                            Dim bindResult As ImmutableArray(Of Symbol) = binder.BindInsideCrefAttributeValue(reference, preserveAliases:=False, diagnosticBag:=diagnostics, useSiteDiagnostics:=useSiteDiagnostics)
+                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            Dim diagnostics = BindingDiagnosticBag.GetInstance()
+                            Dim bindResult As ImmutableArray(Of Symbol) = binder.BindInsideCrefAttributeValue(reference, preserveAliases:=False,
+                                                                                                              diagnosticBag:=diagnostics, useSiteInfo:=useSiteInfo)
+                            _diagnostics.AddDependencies(diagnostics)
+                            _diagnostics.AddDependencies(useSiteInfo)
 
-                            Dim errorLocations = diagnostics.ToReadOnlyAndFree().SelectAsArray(Function(x) x.Location).WhereAsArray(Function(x) x IsNot Nothing)
-                            If Me.ProduceXmlDiagnostics AndAlso Not useSiteDiagnostics.IsNullOrEmpty Then
-                                ProcessErrorLocations(XmlLocation.Create(attribute, currentXmlFilePath), Nothing, useSiteDiagnostics, errorLocations, Nothing)
+                            Dim errorLocations = diagnostics.DiagnosticBag.ToReadOnly().SelectAsArray(Function(x) x.Location).WhereAsArray(Function(x) x IsNot Nothing)
+                            diagnostics.Free()
+
+                            If Me.ProduceXmlDiagnostics AndAlso Not useSiteInfo.Diagnostics.IsNullOrEmpty Then
+                                ProcessErrorLocations(XmlLocation.Create(attribute, currentXmlFilePath), Nothing, useSiteInfo, errorLocations, Nothing)
                             End If
 
                             If bindResult.IsDefaultOrEmpty Then
                                 If Me.ProduceXmlDiagnostics Then
-                                    ProcessErrorLocations(XmlLocation.Create(attribute, currentXmlFilePath), reference.ToFullString().TrimEnd(Nothing), useSiteDiagnostics, errorLocations, ERRID.WRN_XMLDocCrefAttributeNotFound1)
+                                    ProcessErrorLocations(XmlLocation.Create(attribute, currentXmlFilePath), reference.ToFullString().TrimEnd(Nothing), useSiteInfo, errorLocations, ERRID.WRN_XMLDocCrefAttributeNotFound1)
                                 End If
                                 attribute.Value = "?:" + attribute.Value
 
@@ -702,10 +707,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End Select
                 End Sub
 
-                Private Sub ProcessErrorLocations(currentXmlLocation As XmlLocation, referenceName As String, useSiteDiagnostics As HashSet(Of DiagnosticInfo), errorLocations As ImmutableArray(Of Location), errid As Nullable(Of ERRID))
+                Private Sub ProcessErrorLocations(currentXmlLocation As XmlLocation, referenceName As String, useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol), errorLocations As ImmutableArray(Of Location), errid As Nullable(Of ERRID))
                     If errorLocations.Length = 0 Then
-                        If useSiteDiagnostics IsNot Nothing Then
-                            Me._diagnostics.Add(currentXmlLocation, useSiteDiagnostics)
+                        If useSiteInfo.Diagnostics IsNot Nothing Then
+                            Me._diagnostics.AddDiagnostics(currentXmlLocation, useSiteInfo)
                         ElseIf errid.HasValue Then
                             Me._diagnostics.Add(errid.Value, currentXmlLocation, referenceName)
                         End If
@@ -715,7 +720,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Next
                     Else
                         For Each location In errorLocations
-                            Me._diagnostics.Add(location, useSiteDiagnostics)
+                            Me._diagnostics.AddDiagnostics(location, useSiteInfo)
                         Next
                     End If
                 End Sub
@@ -750,13 +755,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Case SyntaxKind.XmlNameAttribute
                             Dim binder As binder = Me.GetOrCreateBinder(type)
                             Dim identifier As IdentifierNameSyntax = DirectCast(attr, XmlNameAttributeSyntax).Reference
-                            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                            Dim bindResult As ImmutableArray(Of Symbol) = binder.BindXmlNameAttributeValue(identifier, useSiteDiagnostics)
+                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            Dim bindResult As ImmutableArray(Of Symbol) = binder.BindXmlNameAttributeValue(identifier, useSiteInfo)
 
-                            If Me.ProduceDiagnostics AndAlso Not useSiteDiagnostics.IsNullOrEmpty Then
+                            Me._diagnostics.AddDependencies(useSiteInfo)
+
+                            If Me.ProduceDiagnostics AndAlso Not useSiteInfo.Diagnostics.IsNullOrEmpty Then
                                 Dim loc As Location = XmlLocation.Create(attribute, currentXmlFilePath)
                                 If ShouldProcessLocation(loc) Then
-                                    Me._diagnostics.Add(loc, useSiteDiagnostics)
+                                    Me._diagnostics.AddDiagnostics(loc, useSiteInfo)
                                 End If
                             End If
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private ReadOnly _compilation As VisualBasicCompilation
             Private ReadOnly _processIncludes As Boolean
             Private ReadOnly _isForSingleSymbol As Boolean ' minor differences in behavior between batch case and API case.
-            Private ReadOnly _diagnostics As DiagnosticBag
+            Private ReadOnly _diagnostics As BindingDiagnosticBag
             Private ReadOnly _cancellationToken As CancellationToken
             Private ReadOnly _filterSyntaxTree As SyntaxTree ' if not null, limit analysis to types residing in this tree
             Private ReadOnly _filterSpanWithinTree As TextSpan? ' if filterTree and filterSpanWithinTree is not null, limit analysis to types residing within this span in the filterTree.
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private _includedFileCache As DocumentationCommentIncludeCache
 
             Private Sub New(assemblyName As String, compilation As VisualBasicCompilation, writer As TextWriter,
-                processIncludes As Boolean, isForSingleSymbol As Boolean, diagnostics As DiagnosticBag,
+                processIncludes As Boolean, isForSingleSymbol As Boolean, diagnostics As BindingDiagnosticBag,
                 filterTree As SyntaxTree, filterSpanWithinTree As TextSpan?,
                 preferredCulture As CultureInfo, cancellationToken As CancellationToken)
 
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Friend Shared Sub WriteDocumentationCommentXml(compilation As VisualBasicCompilation,
                                                            assemblyName As String,
                                                            xmlDocStream As Stream,
-                                                           diagnostics As DiagnosticBag,
+                                                           diagnostics As BindingDiagnosticBag,
                                                            cancellationToken As CancellationToken,
                                                            Optional filterTree As SyntaxTree = Nothing,
                                                            Optional filterSpanWithinTree As TextSpan? = Nothing)
@@ -83,12 +83,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     diagnostics.Add(ERRID.ERR_DocFileGen, Location.None, ex.Message)
                 End Try
 
-                If filterTree IsNot Nothing Then
-                    MislocatedDocumentationCommentFinder.ReportUnprocessed(filterTree, filterSpanWithinTree, diagnostics, cancellationToken)
-                Else
-                    For Each tree In compilation.SyntaxTrees
-                        MislocatedDocumentationCommentFinder.ReportUnprocessed(tree, filterSpanWithinTree:=Nothing, diagnostics, cancellationToken)
-                    Next
+                If diagnostics.DiagnosticBag IsNot Nothing Then
+                    If filterTree IsNot Nothing Then
+                        MislocatedDocumentationCommentFinder.ReportUnprocessed(filterTree, filterSpanWithinTree, diagnostics.DiagnosticBag, cancellationToken)
+                    Else
+                        For Each tree In compilation.SyntaxTrees
+                            MislocatedDocumentationCommentFinder.ReportUnprocessed(tree, filterSpanWithinTree:=Nothing, diagnostics.DiagnosticBag, cancellationToken)
+                        Next
+                    End If
                 End If
             End Sub
 
@@ -121,14 +123,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim pooled As PooledStringBuilder = PooledStringBuilder.GetInstance()
                 Dim writer As New StringWriter(pooled.Builder, CultureInfo.InvariantCulture)
-                Dim discardedDiagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
 
                 Dim compiler = New DocumentationCommentCompiler(Nothing, compilation, writer, processIncludes,
-                    True, discardedDiagnostics, Nothing, Nothing, preferredCulture, cancellationToken)
+                    True, BindingDiagnosticBag.Discarded, Nothing, Nothing, preferredCulture, cancellationToken)
                 compiler.Visit(symbol)
                 Debug.Assert(compiler._writer.IndentDepth = 0)
 
-                discardedDiagnostics.Free()
                 writer.Dispose()
                 Return pooled.ToStringAndFree()
             End Function

--- a/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SemanticModel.vb
@@ -720,8 +720,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function GetSpeculativelyBoundNode(
             binder As Binder,
             expression As ExpressionSyntax,
-            bindingOption As SpeculativeBindingOption,
-            diagnostics As DiagnosticBag
+            bindingOption As SpeculativeBindingOption
         ) As BoundNode
             Debug.Assert(binder IsNot Nothing)
             Debug.Assert(binder.IsSemanticModelBinder)
@@ -731,10 +730,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim bnode As BoundNode
             If bindingOption = SpeculativeBindingOption.BindAsTypeOrNamespace Then
-                bnode = binder.BindNamespaceOrTypeExpression(DirectCast(expression, TypeSyntax), diagnostics)
+                bnode = binder.BindNamespaceOrTypeExpression(DirectCast(expression, TypeSyntax), BindingDiagnosticBag.Discarded)
             Else
                 Debug.Assert(bindingOption = SpeculativeBindingOption.BindAsExpression)
-                bnode = Me.Bind(binder, expression, diagnostics)
+                bnode = Me.Bind(binder, expression, BindingDiagnosticBag.Discarded)
                 bnode = MakeValueIfPossible(binder, bnode)
             End If
 
@@ -749,9 +748,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             binder = Me.GetSpeculativeBinderForExpression(position, expression, bindingOption)
             If binder IsNot Nothing Then
-                Dim diagnostics = DiagnosticBag.GetInstance()
-                Dim bnode = Me.GetSpeculativelyBoundNode(binder, expression, bindingOption, diagnostics)
-                diagnostics.Free()
+                Dim bnode = Me.GetSpeculativelyBoundNode(binder, expression, bindingOption)
                 Return bnode
             Else
                 Return Nothing
@@ -791,7 +788,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim boundExpression = TryCast(node, BoundExpression)
             If boundExpression IsNot Nothing Then
                 ' Try calling ReclassifyAsValue
-                Dim diagnostics = DiagnosticBag.GetInstance()
+                Dim diagnostics = New BindingDiagnosticBag(DiagnosticBag.GetInstance())
                 Dim resultNode = binder.ReclassifyAsValue(boundExpression, diagnostics)
 
                 ' Reclassify ArrayLiterals and other expressions missing types to expressions with types.
@@ -830,10 +827,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             binder = Me.GetSpeculativeAttributeBinder(position, attribute)
 
             If binder IsNot Nothing Then
-                Dim diagnostics = DiagnosticBag.GetInstance()
-                Dim bnode As BoundAttribute = binder.BindAttribute(attribute, diagnostics)
-                diagnostics.Free()
-
+                Dim bnode As BoundAttribute = binder.BindAttribute(attribute, BindingDiagnosticBag.Discarded)
                 Return bnode
             Else
                 Return Nothing
@@ -978,7 +972,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim conversionNode = DirectCast(highestExpr, BoundConversion)
 
                             If useOfLocalBeforeDeclaration AndAlso Not type.IsErrorType() Then
-                                conversion = New Conversion(Conversions.ClassifyConversion(type, convertedType, Nothing))
+                                conversion = New Conversion(Conversions.ClassifyConversion(type, convertedType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
                             Else
                                 conversion = New Conversion(KeyValuePairUtil.Create(conversionNode.ConversionKind,
                                                                                 TryCast(conversionNode.ExpressionSymbol, MethodSymbol)))
@@ -1490,7 +1484,7 @@ _Default:
                 If binder IsNot Nothing Then
                     Dim interfaceCoClass As NamedTypeSymbol = If(namedTypeSymbol.IsInterface,
                                                                  TryCast(namedTypeSymbol.CoClassType, NamedTypeSymbol), Nothing)
-                    candidateConstructors = binder.GetAccessibleConstructors(If(interfaceCoClass, namedTypeSymbol), useSiteDiagnostics:=Nothing)
+                    candidateConstructors = binder.GetAccessibleConstructors(If(interfaceCoClass, namedTypeSymbol), useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                     Dim instanceConstructors = namedTypeSymbol.InstanceConstructors
                     If Not candidateConstructors.Any() AndAlso instanceConstructors.Any() Then
@@ -1564,7 +1558,7 @@ _Default:
         End Function
 
         ' This is used by other binding API's to invoke the right binder API
-        Friend Overridable Function Bind(binder As Binder, node As SyntaxNode, diagnostics As DiagnosticBag) As BoundNode
+        Friend Overridable Function Bind(binder As Binder, node As SyntaxNode, diagnostics As BindingDiagnosticBag) As BoundNode
             Dim expr = TryCast(node, ExpressionSyntax)
             If expr IsNot Nothing Then
                 Return binder.BindNamespaceOrTypeOrExpressionSyntaxForSemanticModel(expr, diagnostics)
@@ -1968,11 +1962,11 @@ _Default:
             options = CType(options Or LookupOptions.EagerlyLookupExtensionMethods, LookupOptions)
 
             If options.IsAttributeTypeLookup Then
-                binder.LookupAttributeType(result, container, name, options, useSiteDiagnostics:=Nothing)
+                binder.LookupAttributeType(result, container, name, options, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             ElseIf container Is Nothing Then
-                binder.Lookup(result, name, realArity, options, useSiteDiagnostics:=Nothing)
+                binder.Lookup(result, name, realArity, options, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             Else
-                binder.LookupMember(result, container, name, realArity, options, useSiteDiagnostics:=Nothing)
+                binder.LookupMember(result, container, name, realArity, options, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             End If
 
             If result.IsGoodOrAmbiguous Then
@@ -2015,7 +2009,7 @@ _Default:
                 If (options And LookupOptions.IgnoreAccessibility) <> 0 Then
                     constructors = type.InstanceConstructors
                 Else
-                    constructors = binder.GetAccessibleConstructors(type, useSiteDiagnostics:=Nothing)
+                    constructors = binder.GetAccessibleConstructors(type, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                 End If
             End If
 
@@ -2082,7 +2076,7 @@ _Default:
 
             Dim binder = Me.GetEnclosingBinder(position)
             If binder IsNot Nothing Then
-                Return binder.IsAccessible(vbsymbol, Nothing)
+                Return binder.IsAccessible(vbsymbol, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             End If
 
             Return False
@@ -2340,12 +2334,10 @@ _Default:
                 ' Add speculative binder to bind speculatively.
                 binder = SpeculativeBinder.Create(binder)
 
-                Dim diagnostics = DiagnosticBag.GetInstance()
-                Dim bnode = binder.BindValue(expression, diagnostics)
-                diagnostics.Free()
+                Dim bnode = binder.BindValue(expression, BindingDiagnosticBag.Discarded)
 
                 If bnode IsNot Nothing AndAlso Not vbdestination.IsErrorType() Then
-                    Return New Conversion(Conversions.ClassifyConversion(bnode, vbdestination, binder, Nothing))
+                    Return New Conversion(Conversions.ClassifyConversion(bnode, vbdestination, binder, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
                 End If
             End If
 
@@ -2373,7 +2365,7 @@ _Default:
                 Dim lookupResult As LookupResult = LookupResult.GetInstance()
                 Try
                     ' NB: "binder", not "blockBinder", so that we don't incorrectly mark imports as used.
-                    binder.Lookup(lookupResult, identifierSyntax.Identifier.ValueText, 0, Nothing, useSiteDiagnostics:=Nothing)
+                    binder.Lookup(lookupResult, identifierSyntax.Identifier.ValueText, 0, Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
                     If lookupResult.IsGood Then
                         Dim sym As LocalSymbol = TryCast(lookupResult.Symbols(0), LocalSymbol)
                         If sym IsNot Nothing AndAlso sym.IdentifierToken = identifierSyntax.Identifier Then

--- a/src/Compilers/VisualBasic/Portable/Compilation/SpeculativeSyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SpeculativeSyntaxTreeSemanticModel.vb
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Function Bind(binder As Binder, node As SyntaxNode, diagnostics As DiagnosticBag) As BoundNode
+        Friend Overrides Function Bind(binder As Binder, node As SyntaxNode, diagnostics As BindingDiagnosticBag) As BoundNode
             Return _parentSemanticModel.Bind(binder, node, diagnostics)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -440,7 +440,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim result As IEnumerable(Of NamedTypeSymbol) =
                 interfaces.Where(Function(sym As NamedTypeSymbol) As Boolean
                                      Return Not (base IsNot Nothing AndAlso
-                                                 base.ImplementsInterface(sym, EqualsIgnoringComparer.InstanceCLRSignatureCompare, Nothing) AndAlso
+                                                 base.ImplementsInterface(sym, EqualsIgnoringComparer.InstanceCLRSignatureCompare, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) AndAlso
                                                  Not Me.ImplementsAllMembersOfInterface(sym))
                                  End Function)
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
@@ -80,9 +80,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                             ' ERRID_SourceInterfaceMustBeInterface/ERR_MissingSourceInterface
                             EmbeddedTypesManager.ReportDiagnostic(diagnostics, ERRID.ERR_SourceInterfaceMustBeInterface, syntaxNodeOpt, underlyingContainingType, UnderlyingEvent)
                         Else
-                            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                            sourceInterface.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                            diagnostics.Add(If(syntaxNodeOpt Is Nothing, NoLocation.Singleton, syntaxNodeOpt.GetLocation()), useSiteDiagnostics)
+                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            sourceInterface.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
+                            diagnostics.Add(If(syntaxNodeOpt Is Nothing, NoLocation.Singleton, syntaxNodeOpt.GetLocation()), useSiteInfo.Diagnostics)
 
                             ' ERRID_EventNoPIANoBackingMember/ERR_MissingMethodOnSourceInterface
                             EmbeddedTypesManager.ReportDiagnostic(diagnostics, ERRID.ERR_EventNoPIANoBackingMember, syntaxNodeOpt, sourceInterface, UnderlyingEvent.MetadataName, UnderlyingEvent)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -28,15 +28,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
         Public Function GetSystemStringType(syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As NamedTypeSymbol
             If _lazySystemStringType Is ErrorTypeSymbol.UnknownResultType Then
                 Dim type = ModuleBeingBuilt.Compilation.GetSpecialType(SpecialType.System_String)
-                Dim info = type.GetUseSiteErrorInfo()
+                Dim info = type.GetUseSiteInfo()
 
                 If type.IsErrorType() Then
                     type = Nothing
                 End If
 
                 If TypeSymbol.Equals(Interlocked.CompareExchange(Of NamedTypeSymbol)(_lazySystemStringType, type, ErrorTypeSymbol.UnknownResultType), ErrorTypeSymbol.UnknownResultType, TypeCompareKind.ConsiderEverything) Then
-                    If info IsNot Nothing Then
-                        ReportDiagnostic(diagnostics, syntaxNodeOpt, info)
+                    If info.DiagnosticInfo IsNot Nothing Then
+                        ReportDiagnostic(diagnostics, syntaxNodeOpt, info.DiagnosticInfo)
                     End If
                 End If
             End If
@@ -50,14 +50,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
         Private Function LazyGetWellKnownTypeMethod(ByRef lazyMethod As MethodSymbol, method As WellKnownMember, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As MethodSymbol
             If lazyMethod Is ErrorMethodSymbol.UnknownMethod Then
-                Dim info As DiagnosticInfo = Nothing
+                Dim info As UseSiteInfo(Of AssemblySymbol) = Nothing
                 Dim symbol = DirectCast(Binder.GetWellKnownTypeMember(ModuleBeingBuilt.Compilation, method, info), MethodSymbol)
 
-                Debug.Assert(info Is Nothing OrElse symbol Is Nothing)
+                Debug.Assert(info.DiagnosticInfo Is Nothing OrElse symbol Is Nothing)
 
                 If Interlocked.CompareExchange(Of MethodSymbol)(lazyMethod, symbol, ErrorMethodSymbol.UnknownMethod) = ErrorMethodSymbol.UnknownMethod Then
-                    If info IsNot Nothing Then
-                        ReportDiagnostic(diagnostics, syntaxNodeOpt, info)
+                    If info.DiagnosticInfo IsNot Nothing Then
+                        ReportDiagnostic(diagnostics, syntaxNodeOpt, info.DiagnosticInfo)
                     End If
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -573,9 +573,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
         Private Function GetUntranslatedSpecialType(specialType As SpecialType, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag) As NamedTypeSymbol
             Dim typeSymbol = SourceModule.ContainingAssembly.GetSpecialType(specialType)
 
-            Dim info = Binder.GetUseSiteErrorForSpecialType(typeSymbol)
-            If info IsNot Nothing Then
-                Binder.ReportDiagnostic(diagnostics, If(syntaxNodeOpt IsNot Nothing, syntaxNodeOpt.GetLocation(), NoLocation.Singleton), info)
+            Dim info = Binder.GetUseSiteInfoForSpecialType(typeSymbol)
+            If info.DiagnosticInfo IsNot Nothing Then
+                Binder.ReportDiagnostic(diagnostics, If(syntaxNodeOpt IsNot Nothing, syntaxNodeOpt.GetLocation(), NoLocation.Singleton), info.DiagnosticInfo)
             End If
 
             Return typeSymbol

--- a/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
@@ -128,11 +128,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             ' Unreported bad types can come through NoPia embedding, for example.
             If namedTypeSymbol.OriginalDefinition.Kind = SymbolKind.ErrorType Then
                 Dim errorType = DirectCast(namedTypeSymbol.OriginalDefinition, ErrorTypeSymbol)
-                Dim diagInfo = If(errorType.GetUseSiteErrorInfo(), errorType.ErrorInfo)
+                Dim diagInfo = If(errorType.GetUseSiteInfo().DiagnosticInfo, errorType.ErrorInfo)
 
                 If diagInfo Is Nothing AndAlso namedTypeSymbol.Kind = SymbolKind.ErrorType Then
                     errorType = DirectCast(namedTypeSymbol, ErrorTypeSymbol)
-                    diagInfo = If(errorType.GetUseSiteErrorInfo(), errorType.ErrorInfo)
+                    diagInfo = If(errorType.GetUseSiteInfo().DiagnosticInfo, errorType.ErrorInfo)
                 End If
 
                 ' Try to decrease noise by not complaining about the same type over and over again.
@@ -221,7 +221,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
             Dim location = If(syntaxNodeOpt Is Nothing, NoLocation.Singleton, syntaxNodeOpt.GetLocation())
             If declaredBase IsNot Nothing Then
-                Dim diagnosticInfo = declaredBase.GetUseSiteErrorInfo()
+                Dim diagnosticInfo = declaredBase.GetUseSiteInfo().DiagnosticInfo
                 If diagnosticInfo IsNot Nothing Then
                     diagnostics.Add(diagnosticInfo, location)
                     Return

--- a/src/Compilers/VisualBasic/Portable/Emit/SynthesizedPrivateImplementationDetailsSharedConstructor.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SynthesizedPrivateImplementationDetailsSharedConstructor.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             methodBodyBinder = Nothing
 
             Dim factory As New SyntheticBoundNodeFactory(Me, Me, VisualBasicSyntaxTree.Dummy.GetRoot(), compilationState, diagnostics)

--- a/src/Compilers/VisualBasic/Portable/Errors/DiagnosticBagExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/DiagnosticBagExtensions.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function Add(
             diagnostics As DiagnosticBag,
             node As VisualBasicSyntaxNode,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            useSiteDiagnostics As IReadOnlyCollection(Of DiagnosticInfo)
         ) As Boolean
             Return Not useSiteDiagnostics.IsNullOrEmpty AndAlso diagnostics.Add(node.GetLocation, useSiteDiagnostics)
         End Function
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function Add(
             diagnostics As DiagnosticBag,
             node As BoundNode,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            useSiteDiagnostics As IReadOnlyCollection(Of DiagnosticInfo)
         ) As Boolean
             Return Not useSiteDiagnostics.IsNullOrEmpty AndAlso diagnostics.Add(node.Syntax.GetLocation, useSiteDiagnostics)
         End Function
@@ -74,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function Add(
             diagnostics As DiagnosticBag,
             node As SyntaxNodeOrToken,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            useSiteDiagnostics As IReadOnlyCollection(Of DiagnosticInfo)
         ) As Boolean
             Return Not useSiteDiagnostics.IsNullOrEmpty AndAlso diagnostics.Add(node.GetLocation, useSiteDiagnostics)
         End Function
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function Add(
             diagnostics As DiagnosticBag,
             location As Location,
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            useSiteDiagnostics As IReadOnlyCollection(Of DiagnosticInfo)
         ) As Boolean
 
             If useSiteDiagnostics.IsNullOrEmpty Then

--- a/src/Compilers/VisualBasic/Portable/Errors/ErrorFactories.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/ErrorFactories.vb
@@ -32,8 +32,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return map.ToImmutableDictionary
         End Function
 
-        Public Shared ReadOnly EmptyErrorInfo As DiagnosticInfo = ErrorInfo(0)
-
         Public Shared ReadOnly VoidDiagnosticInfo As DiagnosticInfo = ErrorInfo(ERRID.Void)
 
         Public Shared ReadOnly GetErrorInfo_ERR_WithEventsRequiresClass As Func(Of DiagnosticInfo) =

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -461,37 +461,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Public Overrides Sub ReportInvalidAttributeArgument(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterIndex As Integer, attribute As AttributeData)
+        Protected Overrides Sub ReportInvalidAttributeArgument(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterIndex As Integer, attribute As AttributeData)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_BadAttribute1, node.ArgumentList.Arguments(parameterIndex).GetLocation(), attribute.AttributeClass)
         End Sub
 
-        Public Overrides Sub ReportInvalidNamedArgument(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, namedArgumentIndex As Integer, attributeClass As ITypeSymbol, parameterName As String)
+        Protected Overrides Sub ReportInvalidNamedArgument(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, namedArgumentIndex As Integer, attributeClass As ITypeSymbol, parameterName As String)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_BadAttribute1, node.ArgumentList.Arguments(namedArgumentIndex).GetLocation(), attributeClass)
         End Sub
 
-        Public Overrides Sub ReportParameterNotValidForType(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, namedArgumentIndex As Integer)
+        Protected Overrides Sub ReportParameterNotValidForType(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, namedArgumentIndex As Integer)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_ParameterNotValidForType, node.ArgumentList.Arguments(namedArgumentIndex).GetLocation())
         End Sub
 
-        Public Overrides Sub ReportMarshalUnmanagedTypeNotValidForFields(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterIndex As Integer, unmanagedTypeName As String, attribute As AttributeData)
+        Protected Overrides Sub ReportMarshalUnmanagedTypeNotValidForFields(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterIndex As Integer, unmanagedTypeName As String, attribute As AttributeData)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_MarshalUnmanagedTypeNotValidForFields, node.ArgumentList.Arguments(parameterIndex).GetLocation(), unmanagedTypeName)
         End Sub
 
-        Public Overrides Sub ReportMarshalUnmanagedTypeOnlyValidForFields(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterIndex As Integer, unmanagedTypeName As String, attribute As AttributeData)
+        Protected Overrides Sub ReportMarshalUnmanagedTypeOnlyValidForFields(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterIndex As Integer, unmanagedTypeName As String, attribute As AttributeData)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_MarshalUnmanagedTypeOnlyValidForFields, node.ArgumentList.Arguments(parameterIndex).GetLocation(), unmanagedTypeName)
         End Sub
 
-        Public Overrides Sub ReportAttributeParameterRequired(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterName As String)
+        Protected Overrides Sub ReportAttributeParameterRequired(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterName As String)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_AttributeParameterRequired1, node.Name.GetLocation(), parameterName)
         End Sub
 
-        Public Overrides Sub ReportAttributeParameterRequired(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterName1 As String, parameterName2 As String)
+        Protected Overrides Sub ReportAttributeParameterRequired(diagnostics As DiagnosticBag, attributeSyntax As SyntaxNode, parameterName1 As String, parameterName2 As String)
             Dim node = DirectCast(attributeSyntax, AttributeSyntax)
             diagnostics.Add(ERRID.ERR_AttributeParameterRequired2, node.Name.GetLocation(), parameterName1, parameterName2)
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -210,6 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
 
 
+
     Friend MustInherit Partial Class BoundExpression
         Inherits BoundNode
 
@@ -6822,12 +6823,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     Friend NotInheritable Partial Class BoundLambda
         Inherits BoundExpression
 
-        Public Sub New(syntax As SyntaxNode, lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ImmutableArray(Of Microsoft.CodeAnalysis.Diagnostic), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind, Optional hasErrors As Boolean = False)
+        Public Sub New(syntax As SyntaxNode, lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind, Optional hasErrors As Boolean = False)
             MyBase.New(BoundKind.Lambda, syntax, Nothing, hasErrors OrElse body.NonNullAndHasErrors())
 
             Debug.Assert(lambdaSymbol IsNot Nothing, "Field 'lambdaSymbol' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
             Debug.Assert(body IsNot Nothing, "Field 'body' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
-            Debug.Assert(Not (diagnostics.IsDefault), "Field 'diagnostics' cannot be null (use Null=""allow"" in BoundNodes.xml to remove this check)")
 
             Me._LambdaSymbol = lambdaSymbol
             Me._Body = body
@@ -6857,8 +6857,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly _Diagnostics As ImmutableArray(Of Microsoft.CodeAnalysis.Diagnostic)
-        Public ReadOnly Property Diagnostics As ImmutableArray(Of Microsoft.CodeAnalysis.Diagnostic)
+        Private ReadOnly _Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
+        Public ReadOnly Property Diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol)
             Get
                 Return _Diagnostics
             End Get
@@ -6890,7 +6890,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return visitor.VisitLambda(Me)
         End Function
 
-        Public Function Update(lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ImmutableArray(Of Microsoft.CodeAnalysis.Diagnostic), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind) As BoundLambda
+        Public Function Update(lambdaSymbol As LambdaSymbol, body As BoundBlock, diagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol), lambdaBinderOpt As LambdaBodyBinder, delegateRelaxation As ConversionKind, methodConversionKind As MethodConversionKind) As BoundLambda
             If lambdaSymbol IsNot Me.LambdaSymbol OrElse body IsNot Me.Body OrElse diagnostics <> Me.Diagnostics OrElse lambdaBinderOpt IsNot Me.LambdaBinderOpt OrElse delegateRelaxation <> Me.DelegateRelaxation OrElse methodConversionKind <> Me.MethodConversionKind Then
                 Dim result = New BoundLambda(Me.Syntax, lambdaSymbol, body, diagnostics, lambdaBinderOpt, delegateRelaxation, methodConversionKind, Me.HasErrors)
                 result.CopyAttributes(Me)

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -210,12 +210,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' STMT:   this.builder.AwaitUnsafeOnCompleted(Of TAwaiter,TSM)((ByRef) $awaiterTemp, (ByRef) Me)
                         '  or
                         ' STMT:   this.builder.AwaitOnCompleted(Of TAwaiter,TSM)((ByRef) $awaiterTemp, (ByRef) Me)
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                         Dim useUnsafeOnCompleted As Boolean =
                             Conversions.IsWideningConversion(
                                 Conversions.ClassifyDirectCastConversion(
                                     awaiterType,
                                     ICriticalNotifyCompletion,
-                                    useSiteDiagnostics:=Nothing))
+                                    useSiteInfo:=useSiteInfo))
+
+                        Me.F.Diagnostics.Add(Me.F.Syntax, useSiteInfo)
 
                         blockBuilder.Add(
                             Me.F.ExpressionStatement(

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            slotAllocatorOpt As VariableSlotAllocator,
                            nextFreeHoistedLocalSlot As Integer,
                            owner As AsyncRewriter,
-                           diagnostics As DiagnosticBag)
+                           diagnostics As BindingDiagnosticBag)
 
                 MyBase.New(F, state, hoistedVariables, nonReusableLocalProxies, synthesizedLocalOrdinals, slotAllocatorOpt, nextFreeHoistedLocalSlot, diagnostics)
 
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' to find the previous awaiter field.
                 If Not Me._awaiterFields.TryGetValue(awaiterType, result) Then
                     Dim slotIndex As Integer = -1
-                    If Me.SlotAllocatorOpt Is Nothing OrElse Not Me.SlotAllocatorOpt.TryGetPreviousAwaiterSlotIndex(F.CompilationState.ModuleBuilderOpt.Translate(awaiterType, F.Syntax, F.Diagnostics), F.Diagnostics, slotIndex) Then
+                    If Me.SlotAllocatorOpt Is Nothing OrElse Not Me.SlotAllocatorOpt.TryGetPreviousAwaiterSlotIndex(F.CompilationState.ModuleBuilderOpt.Translate(awaiterType, F.Syntax, F.Diagnostics.DiagnosticBag), F.Diagnostics.DiagnosticBag, slotIndex) Then
                         slotIndex = _nextAwaiterId
                         _nextAwaiterId = _nextAwaiterId + 1
                     End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                        slotAllocatorOpt As VariableSlotAllocator,
                        asyncKind As AsyncMethodKind,
                        compilationState As TypeCompilationState,
-                       diagnostics As DiagnosticBag)
+                       diagnostics As BindingDiagnosticBag)
 
             MyBase.New(body, method, stateMachineType, slotAllocatorOpt, compilationState, diagnostics)
 
@@ -71,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                  methodOrdinal As Integer,
                                                  slotAllocatorOpt As VariableSlotAllocator,
                                                  compilationState As TypeCompilationState,
-                                                 diagnostics As DiagnosticBag,
+                                                 diagnostics As BindingDiagnosticBag,
                                                  <Out> ByRef stateMachineType As AsyncStateMachine) As BoundBlock
 
             If body.HasErrors Then
@@ -302,7 +302,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End If
 
-            Dim bag = DiagnosticBag.GetInstance()
+            Dim bag = BindingDiagnosticBag.GetInstance()
 
             EnsureSpecialType(SpecialType.System_Object, bag)
             EnsureSpecialType(SpecialType.System_Void, bag)
@@ -540,9 +540,9 @@ lCaptureRValue:
             Dim group As BoundMethodGroup = Nothing
             Dim result = LookupResult.GetInstance()
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Me._binder.LookupMember(result, type, methodName, arity:=0, options:=_lookupOptions, useSiteDiagnostics:=useSiteDiagnostics)
-            Me.Diagnostics.Add(Me.F.Syntax, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Me._binder.LookupMember(result, type, methodName, arity:=0, options:=_lookupOptions, useSiteInfo:=useSiteInfo)
+            Me.Diagnostics.Add(Me.F.Syntax, useSiteInfo)
 
             If result.IsGood Then
                 Debug.Assert(result.Symbols.Count > 0)
@@ -599,9 +599,9 @@ lCaptureRValue:
             Dim group As BoundPropertyGroup = Nothing
             Dim result = LookupResult.GetInstance()
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Me._binder.LookupMember(result, type, propertyName, arity:=0, options:=_lookupOptions, useSiteDiagnostics:=useSiteDiagnostics)
-            Me.Diagnostics.Add(Me.F.Syntax, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Me._binder.LookupMember(result, type, propertyName, arity:=0, options:=_lookupOptions, useSiteInfo:=useSiteInfo)
+            Me.Diagnostics.Add(Me.F.Syntax, useSiteInfo)
 
             If result.IsGood Then
                 Debug.Assert(result.Symbols.Count > 0)

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private _recursionDepth As Integer
 
         Private Sub New(currentMethod As MethodSymbol, compilationState As TypeCompilationState, typeMap As TypeSubstitution, binder As Binder,
-                        node As SyntaxNode, recursionDepth As Integer, diagnostics As DiagnosticBag)
+                        node As SyntaxNode, recursionDepth As Integer, diagnostics As BindingDiagnosticBag)
             _binder = binder
             _typeMap = typeMap
             _factory = New SyntheticBoundNodeFactory(Nothing, currentMethod, node, compilationState, diagnostics)
@@ -99,7 +99,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                              delegateType As NamedTypeSymbol,
                                              compilationState As TypeCompilationState,
                                              typeMap As TypeSubstitution,
-                                             diagnostics As DiagnosticBag,
+                                             diagnostics As BindingDiagnosticBag,
                                              rewrittenNodes As HashSet(Of BoundNode),
                                              recursionDepth As Integer) As BoundExpression
 
@@ -119,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return expressionTree
         End Function
 
-        Private ReadOnly Property Diagnostics As DiagnosticBag
+        Private ReadOnly Property Diagnostics As BindingDiagnosticBag
             Get
                 Return _factory.Diagnostics
             End Get
@@ -469,9 +469,12 @@ lSelect:
 
             Dim methodInfo As BoundExpression = Me._factory.MethodInfo(If(method.CallsiteReducedFromMethod, method))
 
-            Dim useSiteError As DiagnosticInfo = Nothing
-            Dim createDelegate = Binder.GetWellKnownTypeMember(Me._factory.Compilation, WellKnownMember.System_Reflection_MethodInfo__CreateDelegate, useSiteError)
-            If createDelegate IsNot Nothing And useSiteError Is Nothing Then
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim createDelegate = Binder.GetWellKnownTypeMember(Me._factory.Compilation, WellKnownMember.System_Reflection_MethodInfo__CreateDelegate, useSiteInfo)
+            If createDelegate IsNot Nothing And useSiteInfo.DiagnosticInfo Is Nothing Then
+
+                Diagnostics.AddDependencies(useSiteInfo)
+
                 ' beginning in 4.5, we do it this way
                 result = Me._factory.Call(methodInfo,
                                           DirectCast(createDelegate, MethodSymbol),
@@ -818,14 +821,14 @@ lSelect:
             Dim group As BoundMethodGroup = Nothing
             Dim result = LookupResult.GetInstance()
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             _binder.LookupMember(result,
                                  Me._expressionType,
                                  methodName,
                                  arity:=0,
                                  options:=LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods,
-                                 useSiteDiagnostics:=useSiteDiagnostics)
-            Me.Diagnostics.Add(Me._factory.Syntax, useSiteDiagnostics)
+                                 useSiteInfo:=useSiteInfo)
+            Me.Diagnostics.Add(Me._factory.Syntax, useSiteInfo)
 
             If result.IsGood Then
                 Debug.Assert(result.Symbols.Count > 0)

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
@@ -101,9 +101,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' the type of the argument of 'conversion' in case 'parameter' is a nullable and the real 
                 ' conversion argument is not
                 Dim parameterType As TypeSymbol = parameter.Type
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim convKind As ConversionKind = Conversions.ClassifyPredefinedConversion(parameterType, conversion.Operand.Type, useSiteDiagnostics)
-                Diagnostics.Add(conversion, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim convKind As ConversionKind = Conversions.ClassifyPredefinedConversion(parameterType, conversion.Operand.Type, useSiteInfo)
+                Diagnostics.Add(conversion, useSiteInfo)
 
                 If (convKind And ConversionKind.NarrowingNullable) = ConversionKind.NarrowingNullable AndAlso Not toType.IsNullableType Then
                     ' Convert to non-nullable type first to mimic Dev11
@@ -194,9 +194,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim realParameterType As TypeSymbol = parameter.Type
             Debug.Assert(TypeSymbol.Equals(expectedParameterType.GetNullableUnderlyingTypeOrSelf, realParameterType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything))
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim innerConversion As ConversionKind = Conversions.ClassifyConversion(realParameterType, expectedParameterType, useSiteDiagnostics).Key
-            Diagnostics.Add(conversion, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim innerConversion As ConversionKind = Conversions.ClassifyConversion(realParameterType, expectedParameterType, useSiteInfo).Key
+            Diagnostics.Add(conversion, useSiteInfo)
 
             Dim innerConversionApplied As Boolean = Not Conversions.IsIdentityConversion(innerConversion)
             If innerConversionApplied Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _methodEntryInstrumentation As BoundStatement
         Private ReadOnly _payloadType As ArrayTypeSymbol
         Private ReadOnly _methodPayload As LocalSymbol
-        Private ReadOnly _diagnostics As DiagnosticBag
+        Private ReadOnly _diagnostics As BindingDiagnosticBag
         Private ReadOnly _debugDocumentProvider As DebugDocumentProvider
         Private ReadOnly _methodBodyFactory As SyntheticBoundNodeFactory
 
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             method As MethodSymbol,
             methodBody As BoundStatement,
             methodBodyFactory As SyntheticBoundNodeFactory,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             debugDocumentProvider As DebugDocumentProvider,
             previous As Instrumenter) As DynamicAnalysisInjector
 
@@ -104,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             methodBodyFactory As SyntheticBoundNodeFactory,
             createPayloadForMethodsSpanningSingleFile As MethodSymbol,
             createPayloadForMethodsSpanningMultipleFiles As MethodSymbol,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             debugDocumentProvider As DebugDocumentProvider,
             previous As Instrumenter)
 
@@ -510,7 +510,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return statement.Syntax
         End Function
 
-        Private Shared Function GetCreatePayloadOverload(compilation As VisualBasicCompilation, overload As WellKnownMember, syntax As SyntaxNode, diagnostics As DiagnosticBag) As MethodSymbol
+        Private Shared Function GetCreatePayloadOverload(compilation As VisualBasicCompilation, overload As WellKnownMember, syntax As SyntaxNode, diagnostics As BindingDiagnosticBag) As MethodSymbol
             Return DirectCast(Binder.GetWellKnownTypeMember(compilation, overload, syntax, diagnostics), MethodSymbol)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            SynthesizedLocalOrdinals As SynthesizedLocalOrdinalsDispenser,
                            slotAllocatorOpt As VariableSlotAllocator,
                            nextFreeHoistedLocalSlot As Integer,
-                           diagnostics As DiagnosticBag)
+                           diagnostics As BindingDiagnosticBag)
 
                 MyBase.New(F, state, hoistedVariables, localProxies, SynthesizedLocalOrdinals, slotAllocatorOpt, nextFreeHoistedLocalSlot, diagnostics)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                        stateMachineType As IteratorStateMachine,
                        slotAllocatorOpt As VariableSlotAllocator,
                        compilationState As TypeCompilationState,
-                       diagnostics As DiagnosticBag)
+                       diagnostics As BindingDiagnosticBag)
 
             MyBase.New(body, method, stateMachineType, slotAllocatorOpt, compilationState, diagnostics)
 
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                  methodOrdinal As Integer,
                                                  slotAllocatorOpt As VariableSlotAllocator,
                                                  compilationState As TypeCompilationState,
-                                                 diagnostics As DiagnosticBag,
+                                                 diagnostics As BindingDiagnosticBag,
                                                  <Out> ByRef stateMachineType As IteratorStateMachine) As BoundBlock
 
             If body.HasErrors Or Not method.IsIterator Then
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End If
 
-            Dim bag = DiagnosticBag.GetInstance()
+            Dim bag = BindingDiagnosticBag.GetInstance()
 
             ' NOTE: We don't ensure DebuggerStepThroughAttribute, it is just not emitted if not found
             ' EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Diagnostics_DebuggerStepThroughAttribute__ctor, hasErrors)
@@ -122,6 +122,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim hasErrors As Boolean = bag.HasAnyErrors
             If hasErrors Then
                 Me.Diagnostics.AddRange(bag)
+            Else
+                Me.Diagnostics.AddDependencies(bag)
             End If
 
             bag.Free()

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaFrame.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaFrame.vb
@@ -173,27 +173,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim type = ContainingAssembly.GetSpecialType(SpecialType.System_Object)
             ' WARN: We assume that if System_Object was not found we would never reach 
             '       this point because the error should have been/processed generated earlier
-            Debug.Assert(type.GetUseSiteErrorInfo() Is Nothing)
+            Debug.Assert(type.GetUseSiteInfo().DiagnosticInfo Is Nothing)
             Return type
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim type = ContainingAssembly.GetSpecialType(SpecialType.System_Object)
             ' WARN: We assume that if System_Object was not found we would never reach 
             '       this point because the error should have been/processed generated earlier
-            Debug.Assert(type.GetUseSiteErrorInfo() Is Nothing)
+            Debug.Assert(type.GetUseSiteInfo().DiagnosticInfo Is Nothing)
             Return type
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend NotInheritable Class Analysis
             Inherits BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
 
-            Private ReadOnly _diagnostics As DiagnosticBag
+            Private ReadOnly _diagnostics As BindingDiagnosticBag
             Private ReadOnly _method As MethodSymbol
 
             Private _currentParent As MethodSymbol
@@ -121,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ''' </summary>
             Friend ReadOnly symbolsCapturedWithoutCopyCtor As ISet(Of Symbol)
 
-            Private Sub New(method As MethodSymbol, symbolsCapturedWithoutCopyCtor As ISet(Of Symbol), diagnostics As DiagnosticBag)
+            Private Sub New(method As MethodSymbol, symbolsCapturedWithoutCopyCtor As ISet(Of Symbol), diagnostics As BindingDiagnosticBag)
                 Me._currentParent = method
                 Me._method = method
                 Me.symbolsCapturedWithoutCopyCtor = symbolsCapturedWithoutCopyCtor
@@ -132,7 +132,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ''' <summary>
             ''' Analyzes method body that belongs to the given method symbol.
             ''' </summary>
-            Public Shared Function AnalyzeMethodBody(node As BoundBlock, method As MethodSymbol, symbolsCapturedWithoutCtor As ISet(Of Symbol), diagnostics As DiagnosticBag) As Analysis
+            Public Shared Function AnalyzeMethodBody(node As BoundBlock, method As MethodSymbol, symbolsCapturedWithoutCtor As ISet(Of Symbol), diagnostics As BindingDiagnosticBag) As Analysis
                 Debug.Assert(Not node.HasErrors)
 
                 Dim analysis = New Analysis(method, symbolsCapturedWithoutCtor, diagnostics)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         delegateRelaxationIdDispenser As Integer,
                         slotAllocatorOpt As VariableSlotAllocator,
                         compilationState As TypeCompilationState,
-                        diagnostics As DiagnosticBag)
+                        diagnostics As BindingDiagnosticBag)
             MyBase.New(slotAllocatorOpt, compilationState, diagnostics, method.PreserveOriginalLocals)
 
             Me._topLevelMethod = method
@@ -154,7 +154,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        slotAllocatorOpt As VariableSlotAllocator,
                                        CompilationState As TypeCompilationState,
                                        symbolsCapturedWithoutCopyCtor As ISet(Of Symbol),
-                                       diagnostics As DiagnosticBag,
+                                       diagnostics As BindingDiagnosticBag,
                                        rewrittenNodes As HashSet(Of BoundNode)) As BoundBlock
 
             Dim analysis = LambdaRewriter.Analysis.AnalyzeMethodBody(node, method, symbolsCapturedWithoutCopyCtor, diagnostics)
@@ -293,7 +293,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return frame
         End Function
 
-        Private Function GetStaticFrame(lambda As BoundNode, diagnostics As DiagnosticBag) As LambdaFrame
+        Private Function GetStaticFrame(lambda As BoundNode, diagnostics As BindingDiagnosticBag) As LambdaFrame
             If Me._lazyStaticLambdaFrame Is Nothing Then
                 Dim isNonGeneric = Not TopLevelMethod.IsGenericMethod
                 If isNonGeneric Then
@@ -399,7 +399,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         constructedProxyField.Type)
         End Function
 
-        Private Function MakeFrameCtor(frame As LambdaFrame, diagnostics As DiagnosticBag) As BoundBlock
+        Private Function MakeFrameCtor(frame As LambdaFrame, diagnostics As BindingDiagnosticBag) As BoundBlock
             Dim constructor = frame.Constructor
             Dim syntaxNode As SyntaxNode = constructor.Syntax
 
@@ -425,15 +425,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim parameterExpr = New BoundParameter(syntaxNode, arg, frame)
 
                 Dim bool = frame.ContainingAssembly.GetSpecialType(SpecialType.System_Boolean)
-                Dim useSiteError = bool.GetUseSiteErrorInfo()
-                If useSiteError IsNot Nothing Then
-                    diagnostics.Add(useSiteError, syntaxNode.GetLocation())
-                End If
+                Dim useSiteError = bool.GetUseSiteInfo()
+                diagnostics.Add(useSiteError, syntaxNode.GetLocation())
 
                 Dim obj = frame.ContainingAssembly.GetSpecialType(SpecialType.System_Object)
                 ' WARN: We assume that if System_Object was not found we would never reach 
                 '       this point because the error should have been/processed generated earlier
-                Debug.Assert(obj.GetUseSiteErrorInfo() Is Nothing)
+                Debug.Assert(obj.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
                 Dim condition = New BoundBinaryOperator(syntaxNode, BinaryOperatorKind.Is,
                                                         New BoundDirectCast(syntaxNode, parameterExpr.MakeRValue(), ConversionKind.WideningReference, obj, Nothing),
@@ -899,7 +897,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) method name.
             Const methodOrdinal As Integer = -1
 
-            Dim slotAllocatorOpt = CompilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method.TopLevelMethod, Diagnostics)
+            Dim slotAllocatorOpt = CompilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method.TopLevelMethod, Diagnostics.DiagnosticBag)
             Return Rewriter.RewriteIteratorAndAsync(loweredBody, method, methodOrdinal, CompilationState, Diagnostics, slotAllocatorOpt, stateMachineTypeOpt)
         End Function
 
@@ -1411,14 +1409,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function OptimizeMethodCallForDelegateInvoke(node As BoundCall) As BoundCall
             Dim method = node.Method
             Dim receiver = node.ReceiverOpt
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             If method.MethodKind = MethodKind.DelegateInvoke AndAlso
                     method.ContainingType.IsAnonymousType AndAlso
                     receiver.Kind = BoundKind.DelegateCreationExpression AndAlso
                     Conversions.ClassifyMethodConversionForLambdaOrAnonymousDelegate(
-                        method, DirectCast(receiver, BoundDelegateCreationExpression).Method, useSiteDiagnostics) = MethodConversionKind.Identity Then
-                Diagnostics.Add(node, useSiteDiagnostics)
+                        method, DirectCast(receiver, BoundDelegateCreationExpression).Method, useSiteInfo) = MethodConversionKind.Identity Then
+                Diagnostics.Add(node, useSiteInfo)
 
                 Dim delegateCreation = DirectCast(receiver, BoundDelegateCreationExpression)
                 Debug.Assert(delegateCreation.RelaxationLambdaOpt Is Nothing AndAlso delegateCreation.RelaxationReceiverPlaceholderOpt Is Nothing)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                        topLevelMethodId As DebugId,
                        lambdaNode As BoundLambda,
                        lambdaId As DebugId,
-                       diagnostics As DiagnosticBag)
+                       diagnostics As BindingDiagnosticBag)
 
             MyBase.New(lambdaNode.Syntax,
                        containingType,

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _emitModule As PEModuleBuilder
         Private ReadOnly _compilationState As TypeCompilationState
         Private ReadOnly _previousSubmissionFields As SynthesizedSubmissionFields
-        Private ReadOnly _diagnostics As DiagnosticBag
+        Private ReadOnly _diagnostics As BindingDiagnosticBag
         Private ReadOnly _instrumenterOpt As Instrumenter
         Private _symbolsCapturedWithoutCopyCtor As ISet(Of Symbol)
 
@@ -117,12 +117,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             currentMethod As MethodSymbol,
             compilationState As TypeCompilationState,
             previousSubmissionFields As SynthesizedSubmissionFields,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             flags As RewritingFlags,
             instrumenterOpt As Instrumenter,
             recursionDepth As Integer
         )
             MyBase.New(recursionDepth)
+            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
 
             Me._topMethod = topMethod
             Me._currentMethodOrLambda = currentMethod
@@ -148,7 +149,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             currentMethod As MethodSymbol,
             compilationState As TypeCompilationState,
             previousSubmissionFields As SynthesizedSubmissionFields,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             <[In], Out> ByRef rewrittenNodes As HashSet(Of BoundNode),
             <Out> ByRef hasLambdas As Boolean,
             <Out> ByRef symbolsCapturedWithoutCtor As ISet(Of Symbol),
@@ -205,7 +206,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             topMethod As MethodSymbol,
             compilationState As TypeCompilationState,
             previousSubmissionFields As SynthesizedSubmissionFields,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             <Out> ByRef rewrittenNodes As HashSet(Of BoundNode),
             <Out> ByRef hasLambdas As Boolean,
             <Out> ByRef symbolsCapturedWithoutCopyCtor As ISet(Of Symbol),
@@ -234,7 +235,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                      method As MethodSymbol,
                                                      compilationState As TypeCompilationState,
                                                      previousSubmissionFields As SynthesizedSubmissionFields,
-                                                     diagnostics As DiagnosticBag,
+                                                     diagnostics As BindingDiagnosticBag,
                                                      rewrittenNodes As HashSet(Of BoundNode),
                                                      recursionDepth As Integer) As BoundExpression
 
@@ -555,17 +556,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="specialType">Special Type to get.</param><returns></returns>
         Private Function GetSpecialType(specialType As SpecialType) As NamedTypeSymbol
             Dim result As NamedTypeSymbol = Me._topMethod.ContainingAssembly.GetSpecialType(specialType)
-            Debug.Assert(Binder.GetUseSiteErrorForSpecialType(result) Is Nothing)
+            Debug.Assert(Binder.GetUseSiteInfoForSpecialType(result).DiagnosticInfo Is Nothing)
             Return result
         End Function
 
         Private Function GetSpecialTypeWithUseSiteDiagnostics(specialType As SpecialType, syntax As SyntaxNode) As NamedTypeSymbol
             Dim result As NamedTypeSymbol = Me._topMethod.ContainingAssembly.GetSpecialType(specialType)
 
-            Dim info = Binder.GetUseSiteErrorForSpecialType(result)
-            If info IsNot Nothing Then
-                Binder.ReportDiagnostic(_diagnostics, syntax, info)
-            End If
+            Dim info = Binder.GetUseSiteInfoForSpecialType(result)
+            Binder.ReportUseSite(_diagnostics, syntax, info)
 
             Return result
         End Function
@@ -590,21 +589,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Checks for special member and reports diagnostics if the member is Nothing or has UseSiteError.
         ''' Returns True in case diagnostics was actually reported
         ''' </summary>
-        Friend Shared Function ReportMissingOrBadRuntimeHelper(node As BoundNode, specialMember As SpecialMember, memberSymbol As Symbol, diagnostics As DiagnosticBag, Optional embedVBCoreRuntime As Boolean = False) As Boolean
+        Friend Shared Function ReportMissingOrBadRuntimeHelper(node As BoundNode, specialMember As SpecialMember, memberSymbol As Symbol, diagnostics As BindingDiagnosticBag, Optional embedVBCoreRuntime As Boolean = False) As Boolean
             If memberSymbol Is Nothing Then
                 ReportMissingRuntimeHelper(node, specialMember, diagnostics, embedVBCoreRuntime)
                 Return True
             Else
-                Dim useSiteError = If(memberSymbol.GetUseSiteErrorInfo(), memberSymbol.ContainingType.GetUseSiteErrorInfo())
-                If useSiteError IsNot Nothing Then
-                    ReportDiagnostic(node, useSiteError, diagnostics)
-                    Return True
-                End If
+                Return ReportUseSite(node, Binder.GetUseSiteInfoForMemberAndContainingType(memberSymbol), diagnostics)
             End If
-            Return False
         End Function
 
-        Private Shared Sub ReportMissingRuntimeHelper(node As BoundNode, specialMember As SpecialMember, diagnostics As DiagnosticBag, Optional embedVBCoreRuntime As Boolean = False)
+        Private Shared Sub ReportMissingRuntimeHelper(node As BoundNode, specialMember As SpecialMember, diagnostics As BindingDiagnosticBag, Optional embedVBCoreRuntime As Boolean = False)
             Dim descriptor = SpecialMembers.GetDescriptor(specialMember)
 
             ' TODO: If the type is generic, we might want to use VB style name rather than emitted name.
@@ -626,21 +620,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Checks for well known member and reports diagnostics if the member is Nothing or has UseSiteError.
         ''' Returns True in case diagnostics was actually reported
         ''' </summary>
-        Friend Shared Function ReportMissingOrBadRuntimeHelper(node As BoundNode, wellKnownMember As WellKnownMember, memberSymbol As Symbol, diagnostics As DiagnosticBag, embedVBCoreRuntime As Boolean) As Boolean
+        Friend Shared Function ReportMissingOrBadRuntimeHelper(node As BoundNode, wellKnownMember As WellKnownMember, memberSymbol As Symbol, diagnostics As BindingDiagnosticBag, embedVBCoreRuntime As Boolean) As Boolean
             If memberSymbol Is Nothing Then
                 ReportMissingRuntimeHelper(node, wellKnownMember, diagnostics, embedVBCoreRuntime)
                 Return True
             Else
-                Dim useSiteError = If(memberSymbol.GetUseSiteErrorInfo(), memberSymbol.ContainingType.GetUseSiteErrorInfo())
-                If useSiteError IsNot Nothing Then
-                    ReportDiagnostic(node, useSiteError, diagnostics)
-                    Return True
-                End If
+                Return ReportUseSite(node, Binder.GetUseSiteInfoForMemberAndContainingType(memberSymbol), diagnostics)
             End If
-            Return False
         End Function
 
-        Private Shared Sub ReportMissingRuntimeHelper(node As BoundNode, wellKnownMember As WellKnownMember, diagnostics As DiagnosticBag, embedVBCoreRuntime As Boolean)
+        Private Shared Sub ReportMissingRuntimeHelper(node As BoundNode, wellKnownMember As WellKnownMember, diagnostics As BindingDiagnosticBag, embedVBCoreRuntime As Boolean)
             Dim descriptor = WellKnownMembers.GetDescriptor(wellKnownMember)
 
             ' TODO: If the type is generic, we might want to use VB style name rather than emitted name.
@@ -651,7 +640,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
 
-        Private Shared Sub ReportMissingRuntimeHelper(node As BoundNode, typeName As String, memberName As String, diagnostics As DiagnosticBag, embedVBCoreRuntime As Boolean)
+        Private Shared Sub ReportMissingRuntimeHelper(node As BoundNode, typeName As String, memberName As String, diagnostics As BindingDiagnosticBag, embedVBCoreRuntime As Boolean)
             If memberName.Equals(WellKnownMemberNames.InstanceConstructorName) OrElse memberName.Equals(WellKnownMemberNames.StaticConstructorName) Then
                 memberName = "New"
             End If
@@ -661,15 +650,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ReportDiagnostic(node, diag, diagnostics)
         End Sub
 
-        Private Shared Sub ReportDiagnostic(node As BoundNode, diagnostic As DiagnosticInfo, diagnostics As DiagnosticBag)
+        Private Shared Sub ReportDiagnostic(node As BoundNode, diagnostic As DiagnosticInfo, diagnostics As BindingDiagnosticBag)
             diagnostics.Add(New VBDiagnostic(diagnostic, node.Syntax.GetLocation()))
         End Sub
 
+        Private Shared Function ReportUseSite(node As BoundNode, useSiteInfo As UseSiteInfo(Of AssemblySymbol), diagnostics As BindingDiagnosticBag) As Boolean
+            Return diagnostics.Add(useSiteInfo, node.Syntax.GetLocation())
+        End Function
+
         Private Sub ReportBadType(node As BoundNode, typeSymbol As TypeSymbol)
-            Dim useSiteError = typeSymbol.GetUseSiteErrorInfo()
-            If useSiteError IsNot Nothing Then
-                ReportDiagnostic(node, useSiteError, Me._diagnostics)
-            End If
+            ReportUseSite(node, typeSymbol.GetUseSiteInfo(), Me._diagnostics)
         End Sub
         ''
         '' The following nodes should be removed from the tree.

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AddRemoveHandler.vb
@@ -283,7 +283,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' but the com event binder needs the event to exist on the local type. We'll poke the pia reference
             ' cache directly so that the event is embedded.
             If _emitModule IsNot Nothing Then
-                _emitModule.EmbeddedTypesManagerOpt.EmbedEventIfNeedTo([event], node.Syntax, _diagnostics, isUsedForComAwareEventBinding:=True)
+                _emitModule.EmbeddedTypesManagerOpt.EmbedEventIfNeedTo([event], node.Syntax, _diagnostics.DiagnosticBag, isUsedForComAwareEventBinding:=True)
             End If
 
             If result IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AsNewLocalDeclarations.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_AsNewLocalDeclarations.vb
@@ -81,14 +81,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         placeholder.SetWasCompilerGenerated()
 
                         ' Rebind and discard diagnostics
-                        Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
                         initializerToRewrite = objectInitializer.Binder.BindObjectCreationExpression(asNew.Type,
                                                                                                      objectCreationExpressionSyntax.ArgumentList,
                                                                                                      localType,
                                                                                                      objectCreationExpressionSyntax,
-                                                                                                     diagnostics,
+                                                                                                     BindingDiagnosticBag.Discarded,
                                                                                                      placeholder)
-                        diagnostics.Free()
                     End If
 
                     If Not objectInitializer.CreateTemporaryLocalForInitialization Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Constant.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Constant.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return If(node.Kind = BoundKind.Literal, node, New BoundLiteral(node.Syntax, constantValue, node.Type, hasErrors:=constantValue.IsBad))
         End Function
 
-        Private Shared Function RewriteDecimalConstant(node As BoundExpression, nodeValue As ConstantValue, currentMethod As MethodSymbol, diagnostics As DiagnosticBag) As BoundExpression
+        Private Shared Function RewriteDecimalConstant(node As BoundExpression, nodeValue As ConstantValue, currentMethod As MethodSymbol, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim assembly As AssemblySymbol = currentMethod.ContainingAssembly
 
             Dim isNegative As Boolean
@@ -59,9 +59,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
                     End If
 
-                    If useField IsNot Nothing AndAlso useField.GetUseSiteErrorInfo() Is Nothing AndAlso useField.ContainingType.GetUseSiteErrorInfo() Is Nothing Then
-                        Dim fieldSymbol = DirectCast(useField, FieldSymbol)
-                        Return New BoundFieldAccess(node.Syntax, Nothing, fieldSymbol, isLValue:=False, type:=fieldSymbol.Type)
+                    If useField IsNot Nothing Then
+                        Dim useSiteInfo = Binder.GetUseSiteInfoForMemberAndContainingType(useField)
+                        If useSiteInfo.DiagnosticInfo Is Nothing Then
+                            Dim fieldSymbol = DirectCast(useField, FieldSymbol)
+                            diagnostics.AddDependencies(useSiteInfo)
+                            Return New BoundFieldAccess(node.Syntax, Nothing, fieldSymbol, isLValue:=False, type:=fieldSymbol.Type)
+                        End If
                     End If
                 End If
 
@@ -77,16 +81,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim decCtorInt64 As MethodSymbol
                 decCtorInt64 = DirectCast(assembly.GetSpecialTypeMember(SpecialMember.System_Decimal__CtorInt64), MethodSymbol)
 
-                If decCtorInt64 IsNot Nothing AndAlso decCtorInt64.GetUseSiteErrorInfo() Is Nothing AndAlso decCtorInt64.ContainingType.GetUseSiteErrorInfo() Is Nothing Then
+                If decCtorInt64 IsNot Nothing Then
+                    Dim useSiteInfo = Binder.GetUseSiteInfoForMemberAndContainingType(decCtorInt64)
 
-                    ' generate New Decimal(value)
-                    Return New BoundObjectCreationExpression(
-                        node.Syntax,
-                        decCtorInt64,
-                        ImmutableArrayExtensions.AsImmutableOrNull(Of BoundExpression)(
-                            {New BoundLiteral(node.Syntax, ConstantValue.Create(value), decCtorInt64.Parameters(0).Type)}),
-                        Nothing,
-                        node.Type)
+                    If useSiteInfo.DiagnosticInfo Is Nothing Then
+                        diagnostics.AddDependencies(useSiteInfo)
+
+                        ' generate New Decimal(value)
+                        Return New BoundObjectCreationExpression(
+                            node.Syntax,
+                            decCtorInt64,
+                            ImmutableArrayExtensions.AsImmutableOrNull(Of BoundExpression)(
+                                {New BoundLiteral(node.Syntax, ConstantValue.Create(value), decCtorInt64.Parameters(0).Type)}),
+                            Nothing,
+                            node.Type)
+                    End If
                 End If
             End If
 
@@ -124,7 +133,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return node ' We get here only if we failed to rewrite the constant
         End Function
 
-        Private Shared Function RewriteDateConstant(node As BoundExpression, nodeValue As ConstantValue, currentMethod As MethodSymbol, diagnostics As DiagnosticBag) As BoundExpression
+        Private Shared Function RewriteDateConstant(node As BoundExpression, nodeValue As ConstantValue, currentMethod As MethodSymbol, diagnostics As BindingDiagnosticBag) As BoundExpression
             Dim assembly As AssemblySymbol = currentMethod.ContainingAssembly
 
             Dim dt As Date = nodeValue.DateTimeValue
@@ -137,8 +146,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim dtMinValue = DirectCast(assembly.GetSpecialTypeMember(SpecialMember.System_DateTime__MinValue), FieldSymbol)
 
-                If dtMinValue IsNot Nothing AndAlso dtMinValue.GetUseSiteErrorInfo() Is Nothing AndAlso dtMinValue.ContainingType.GetUseSiteErrorInfo() Is Nothing Then
-                    Return New BoundFieldAccess(node.Syntax, Nothing, dtMinValue, isLValue:=False, type:=dtMinValue.Type)
+                If dtMinValue IsNot Nothing Then
+                    Dim useSiteInfo = Binder.GetUseSiteInfoForMemberAndContainingType(dtMinValue)
+
+                    If useSiteInfo.DiagnosticInfo Is Nothing Then
+                        diagnostics.AddDependencies(useSiteInfo)
+                        Return New BoundFieldAccess(node.Syntax, Nothing, dtMinValue, isLValue:=False, type:=dtMinValue.Type)
+                    End If
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -210,11 +210,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             For i As Integer = 0 To numElements - 1
                 Dim field = srcElementFields(i)
 
-                Dim useSiteInfo As DiagnosticInfo = field.CalculateUseSiteErrorInfo()
+                Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = field.CalculateUseSiteInfo()
 
-                If useSiteInfo IsNot Nothing AndAlso useSiteInfo.Severity = DiagnosticSeverity.Error Then
-                    ReportDiagnostic(rewrittenOperand, useSiteInfo, _diagnostics)
-                End If
+                ReportUseSite(rewrittenOperand, useSiteInfo, _diagnostics)
 
                 Dim fieldAccess = MakeTupleFieldAccess(syntax, field, savedTuple, constantValueOpt:=Nothing, isLValue:=False)
 
@@ -423,10 +421,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ElseIf operandType.IsStringType Then
                     ' CType(string, T?) ---> new T?(CType(string, T))
                     Dim innerTargetType = resultType.GetNullableUnderlyingType
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim convKind = Conversions.ClassifyConversion(rewrittenOperand.Type, innerTargetType, useSiteDiagnostics).Key
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim convKind = Conversions.ClassifyConversion(rewrittenOperand.Type, innerTargetType, useSiteInfo).Key
                     Debug.Assert(Conversions.ConversionExists(convKind))
-                    _diagnostics.Add(node, useSiteDiagnostics)
+                    _diagnostics.Add(node, useSiteInfo)
                     Return WrapInNullable(
                                     TransformRewrittenConversion(
                                         node.Update(rewrittenOperand,
@@ -450,10 +448,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If HasValue(rewrittenOperand) Then
                         ' DirectCast(operand.GetValueOrDefault, operatorType)
                         Dim unwrappedOperand = NullableValueOrDefault(rewrittenOperand)
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                        Dim convKind = Conversions.ClassifyDirectCastConversion(unwrappedOperand.Type, resultType, useSiteDiagnostics)
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim convKind = Conversions.ClassifyDirectCastConversion(unwrappedOperand.Type, resultType, useSiteInfo)
                         Debug.Assert(Conversions.ConversionExists(convKind))
-                        _diagnostics.Add(node, useSiteDiagnostics)
+                        _diagnostics.Add(node, useSiteInfo)
                         Return New BoundDirectCast(node.Syntax,
                                                    unwrappedOperand,
                                                    convKind,
@@ -529,8 +527,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' apply unlifted conversion
             If Not operand.Type.IsSameTypeIgnoringAll(unwrappedResultType) Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim convKind = Conversions.ClassifyConversion(operand.Type, unwrappedResultType, useSiteDiagnostics).Key
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim convKind = Conversions.ClassifyConversion(operand.Type, unwrappedResultType, useSiteInfo).Key
                 Debug.Assert(Conversions.ConversionExists(convKind))
                 Debug.Assert((convKind And ConversionKind.Tuple) = (node.ConversionKind And ConversionKind.Tuple))
 
@@ -546,7 +544,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     operand = RewriteConstant(New BoundLiteral(node.Syntax, constantResult, unwrappedResultType), constantResult)
 
                 Else
-                    _diagnostics.Add(node, useSiteDiagnostics)
+                    _diagnostics.Add(node, useSiteInfo)
 
                     If (convKind And ConversionKind.Tuple) <> 0 Then
                         operand = MakeTupleConversion(node.Syntax, operand, unwrappedResultType, DirectCast(node.ExtendedInfoOpt, BoundConvertedTupleElements))
@@ -598,10 +596,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If operandType.IsStringType Then
                 ' CType(string, T?) ---> new T?(CType(string, T))
                 Dim innerTargetType = resultType.GetNullableUnderlyingType
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim convKind = Conversions.ClassifyConversion(operandType, innerTargetType, useSiteDiagnostics).Key
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim convKind = Conversions.ClassifyConversion(operandType, innerTargetType, useSiteInfo).Key
                 Debug.Assert(Conversions.ConversionExists(convKind))
-                _diagnostics.Add(node, useSiteDiagnostics)
+                _diagnostics.Add(node, useSiteInfo)
                 Return WrapInNullable(
                             TransformRewrittenConversion(
                                 node.Update(rewrittenOperand,
@@ -621,10 +619,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' is not null-propagating
 
                 rewrittenOperand = NullableValue(rewrittenOperand)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenOperand.Type, resultType, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenOperand.Type, resultType, useSiteInfo)
                 Debug.Assert(Conversions.ConversionExists(convKind))
-                _diagnostics.Add(node, useSiteDiagnostics)
+                _diagnostics.Add(node, useSiteInfo)
                 Return TransformRewrittenConversion(
                             node.Update(rewrittenOperand,
                                         node.ConversionKind And (Not ConversionKind.Nullable),
@@ -648,10 +646,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If HasValue(rewrittenOperand) Then
                     ' DirectCast(operand.GetValueOrDefault, operatorType)
                     Dim unwrappedOperand = NullableValueOrDefault(rewrittenOperand)
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim convKind = Conversions.ClassifyDirectCastConversion(unwrappedOperand.Type, resultType, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim convKind = Conversions.ClassifyDirectCastConversion(unwrappedOperand.Type, resultType, useSiteInfo)
                     Debug.Assert(Conversions.ConversionExists(convKind))
-                    _diagnostics.Add(node, useSiteDiagnostics)
+                    _diagnostics.Add(node, useSiteInfo)
                     Return New BoundDirectCast(node.Syntax,
                                                unwrappedOperand,
                                                convKind,
@@ -662,10 +660,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If resultType.IsNullableType Then
                 ' RefType --> T? , this is just an unboxing conversion.
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenOperand.Type, resultType, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenOperand.Type, resultType, useSiteInfo)
                 Debug.Assert(Conversions.ConversionExists(convKind))
-                _diagnostics.Add(node, useSiteDiagnostics)
+                _diagnostics.Add(node, useSiteInfo)
                 Return New BoundDirectCast(node.Syntax,
                                            rewrittenOperand,
                                            convKind,
@@ -887,12 +885,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not operand.Type.IsObjectType() Then
                     Dim objectType As TypeSymbol = memberSymbol.Parameters(0).Type
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                     operand = New BoundDirectCast(operand.Syntax,
                                                   operand,
-                                                  Conversions.ClassifyDirectCastConversion(operand.Type, objectType, useSiteDiagnostics),
+                                                  Conversions.ClassifyDirectCastConversion(operand.Type, objectType, useSiteInfo),
                                                   objectType)
-                    _diagnostics.Add(node, useSiteDiagnostics)
+                    _diagnostics.Add(node, useSiteInfo)
                 End If
 
                 result = New BoundCall(node.Syntax, memberSymbol, Nothing, Nothing,
@@ -905,12 +903,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Shared Function RewriteAsDirectCast(node As BoundConversion) As BoundExpression
-#If DEBUG Then
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
             Debug.Assert(node.Operand.IsNothingLiteral() OrElse
                          (node.ConversionKind And (Not ConversionKind.DelegateRelaxationLevelMask)) =
-                            Conversions.ClassifyDirectCastConversion(node.Operand.Type, node.Type, useSiteDiagnostics))
-#End If
+                            Conversions.ClassifyDirectCastConversion(node.Operand.Type, node.Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
 
             ' TODO: A chain of widening reference conversions that starts from NOTHING literal can be collapsed to a single node.
             '       Semantics::Convert does this in Dev10.
@@ -965,12 +960,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(operand.Type.IsReferenceType)
                         Debug.Assert(underlyingTypeTo.IsIntrinsicValueType())
 
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                         operand = New BoundDirectCast(operand.Syntax,
                                                       operand,
-                                                      Conversions.ClassifyDirectCastConversion(operand.Type, typeFrom, useSiteDiagnostics),
+                                                      Conversions.ClassifyDirectCastConversion(operand.Type, typeFrom, useSiteInfo),
                                                       typeFrom)
-                        _diagnostics.Add(node, useSiteDiagnostics)
+                        _diagnostics.Add(node, useSiteInfo)
                     End If
 
                     Debug.Assert(memberSymbol.ReturnType.IsSameTypeIgnoringAll(underlyingTypeTo))
@@ -986,10 +981,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(targetResultType.IsEnumType())
 
                         Dim conv = ConversionKind.NarrowingNumeric Or ConversionKind.InvolvesEnumTypeConversions
-#If DEBUG Then
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                        Debug.Assert(conv = Conversions.ClassifyConversion(memberSymbol.ReturnType, targetResultType, useSiteDiagnostics).Key)
-#End If
+                        Debug.Assert(conv = Conversions.ClassifyConversion(memberSymbol.ReturnType, targetResultType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
 
                         result = New BoundConversion(node.Syntax, DirectCast(result, BoundExpression),
                                                      conv, node.Checked, node.ExplicitCastInCode, targetResultType, Nothing)
@@ -1062,10 +1054,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         conv = ConversionKind.WideningNumeric
                     End If
 
-#If DEBUG Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Debug.Assert(conv = Conversions.ClassifyConversion(operandType, memberSymbol.Parameters(0).Type, useSiteDiagnostics).Key)
-#End If
+                    Debug.Assert(conv = Conversions.ClassifyConversion(operandType, memberSymbol.Parameters(0).Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
 
                     operand = New BoundConversion(node.Syntax, operand, conv, node.Checked, node.ExplicitCastInCode,
                                                   memberSymbol.Parameters(0).Type, Nothing)
@@ -1137,10 +1126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(targetResultType.IsEnumType())
                         Dim conv = ConversionKind.NarrowingNumeric Or ConversionKind.InvolvesEnumTypeConversions
 
-#If DEBUG Then
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                        Debug.Assert(conv = Conversions.ClassifyConversion(memberSymbol.ReturnType, targetResultType, useSiteDiagnostics).Key)
-#End If
+                        Debug.Assert(conv = Conversions.ClassifyConversion(memberSymbol.ReturnType, targetResultType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
 
                         result = New BoundConversion(node.Syntax, DirectCast(result, BoundExpression),
                                                      conv, node.Checked, node.ExplicitCastInCode, targetResultType, Nothing)
@@ -1207,10 +1193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         conv = ConversionKind.WideningNumeric
                     End If
 
-#If DEBUG Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Debug.Assert(conv = Conversions.ClassifyConversion(operandType, memberSymbol.Parameters(0).Type, useSiteDiagnostics).Key)
-#End If
+                    Debug.Assert(conv = Conversions.ClassifyConversion(operandType, memberSymbol.Parameters(0).Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
 
                     operand = New BoundConversion(node.Syntax, operand, conv, node.Checked, node.ExplicitCastInCode,
                                                   memberSymbol.Parameters(0).Type, Nothing)
@@ -1280,10 +1263,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Debug.Assert(targetResultType.IsEnumType())
                     Dim conv = ConversionKind.NarrowingNumeric Or ConversionKind.InvolvesEnumTypeConversions
 
-#If DEBUG Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Debug.Assert(conv = Conversions.ClassifyConversion(memberSymbol.ReturnType, targetResultType, useSiteDiagnostics).Key)
-#End If
+                    Debug.Assert(conv = Conversions.ClassifyConversion(memberSymbol.ReturnType, targetResultType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
 
                     result = New BoundConversion(node.Syntax, DirectCast(result, BoundExpression),
                                                  conv, node.Checked, node.ExplicitCastInCode, targetResultType, Nothing)
@@ -1318,14 +1298,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' If we got here and passed badness check, it should be safe to assume that we have 
                 ' a "good" symbol for Double type
 
-#If DEBUG Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-#End If
                 If typeFrom IsNot mathRound.Parameters(0).Type Then
                     ' Converting from Single
-#If DEBUG Then
-                    Debug.Assert(ConversionKind.WideningNumeric = Conversions.ClassifyConversion(typeFrom, mathRound.Parameters(0).Type, useSiteDiagnostics).Key)
-#End If
+                    Debug.Assert(ConversionKind.WideningNumeric = Conversions.ClassifyConversion(typeFrom, mathRound.Parameters(0).Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
+
                     operand = New BoundConversion(node.Syntax, operand, ConversionKind.WideningNumeric, node.Checked, node.ExplicitCastInCode,
                                                   mathRound.Parameters(0).Type, Nothing)
                 End If
@@ -1333,9 +1309,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim callMathRound = New BoundCall(node.Syntax, mathRound, Nothing, Nothing,
                                                   ImmutableArray.Create(operand), Nothing, mathRound.ReturnType)
 
-#If DEBUG Then
-                Debug.Assert(node.ConversionKind = Conversions.ClassifyConversion(mathRound.ReturnType, node.Type, useSiteDiagnostics).Key)
-#End If
+                Debug.Assert(node.ConversionKind = Conversions.ClassifyConversion(mathRound.ReturnType, node.Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key)
 
                 result = New BoundConversion(node.Syntax, callMathRound, node.ConversionKind,
                                              node.Checked, node.ExplicitCastInCode, node.Type, Nothing)
@@ -1445,10 +1419,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         If (Not typeTo.IsTypeParameter()) AndAlso typeTo.IsReferenceType AndAlso
                            (Not typeFrom.IsTypeParameter()) AndAlso typeFrom.IsReferenceType Then
-#If DEBUG Then
-                            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                            Debug.Assert(node.ConversionKind = Conversions.ClassifyDirectCastConversion(operand.Type, node.Type, useSiteDiagnostics))
-#End If
+
+                            Debug.Assert(node.ConversionKind = Conversions.ClassifyDirectCastConversion(operand.Type, node.Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
                             returnValue = New BoundDirectCast(node.Syntax, DirectCast(Visit(operand), BoundExpression), node.ConversionKind, typeTo, Nothing)
                         End If
                     End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
@@ -95,11 +95,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim binder = node.Binder
 
             Dim lookup = LookupResult.GetInstance()
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-            binder.LookupMember(lookup, factoryType, factoryMethodName, 0, LookupOptions.MustNotBeInstance Or LookupOptions.MethodsOnly Or LookupOptions.AllMethodsOfAnyArity, useSiteDiagnostics)
+            binder.LookupMember(lookup, factoryType, factoryMethodName, 0, LookupOptions.MustNotBeInstance Or LookupOptions.MethodsOnly Or LookupOptions.AllMethodsOfAnyArity, useSiteInfo)
 
-            _diagnostics.Add(node, useSiteDiagnostics)
+            _diagnostics.Add(node, useSiteInfo)
 
             If lookup.Kind = LookupResultKind.Inaccessible Then
                 hasErrors = True

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateAddressOf.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateAddressOf.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 targetType As NamedTypeSymbol,
                 boundMember As BoundLateMemberAccess,
                 binder As Binder,
-                diagnostics As DiagnosticBag
+                diagnostics As BindingDiagnosticBag
             ) As BoundExpression
 
             Dim delegateInvoke = targetType.DelegateInvokeMethod
@@ -136,7 +136,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim boundLambda = New BoundLambda(syntaxNode,
                                           lambdaSymbol,
                                           lambdaBody,
-                                          ImmutableArray(Of Diagnostic).Empty,
+                                          ImmutableBindingDiagnostic(Of AssemblySymbol).Empty,
                                           Nothing,
                                           ConversionKind.DelegateRelaxationLevelWidening,
                                           MethodConversionKind.Identity)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateBindingHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateBindingHelpers.vb
@@ -22,9 +22,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return MakeNullLiteral(node, objectType)
             Else
                 If Not rewrittenReceiver.Type.IsObjectType Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenReceiver.Type, objectType, useSiteDiagnostics)
-                    _diagnostics.Add(node, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenReceiver.Type, objectType, useSiteInfo)
+                    _diagnostics.Add(node, useSiteInfo)
                     rewrittenReceiver = New BoundDirectCast(node, rewrittenReceiver, convKind, objectType)
                 End If
 
@@ -128,9 +128,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim argument = rewrittenArguments(i)
                 argument = argument.MakeRValue
                 If Not argument.Type.IsObjectType Then
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteDiagnostics)
-                    _diagnostics.Add(node, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteInfo)
+                    _diagnostics.Add(node, useSiteInfo)
                     argument = New BoundDirectCast(node, argument, convKind, objectType)
                 End If
 
@@ -167,11 +167,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(arrayType.IsSZArray)
             Debug.Assert(objectType.IsObjectType)
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             If Not rewrittenValue.Type.IsObjectType Then
-                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenValue.Type, objectType, useSiteDiagnostics)
-                _diagnostics.Add(node, useSiteDiagnostics)
+                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenValue.Type, objectType, useSiteInfo)
+                _diagnostics.Add(node, useSiteInfo)
                 rewrittenValue = New BoundDirectCast(node, rewrittenValue, convKind, objectType)
             End If
 
@@ -217,8 +217,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim argument = rewrittenArguments(i)
                 argument = argument.MakeRValue
                 If Not argument.Type.IsObjectType Then
-                    Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteDiagnostics)
-                    _diagnostics.Add(argument, useSiteDiagnostics)
+                    Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteInfo)
+                    _diagnostics.Add(argument, useSiteInfo)
                     argument = New BoundDirectCast(node, argument, convKind, objectType)
                 End If
 
@@ -233,8 +233,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' value goes last
             If Not rewrittenValue.Type.IsObjectType Then
-                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenValue.Type, objectType, useSiteDiagnostics)
-                _diagnostics.Add(rewrittenValue, useSiteDiagnostics)
+                Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenValue.Type, objectType, useSiteInfo)
+                _diagnostics.Add(rewrittenValue, useSiteInfo)
                 rewrittenValue = New BoundDirectCast(node, rewrittenValue, convKind, objectType)
             End If
 
@@ -282,9 +282,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each argument In rewrittenArguments
                     argument = argument.MakeRValue
                     If Not argument.Type.IsObjectType Then
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                        Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteDiagnostics)
-                        _diagnostics.Add(argument, useSiteDiagnostics)
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteInfo)
+                        _diagnostics.Add(argument, useSiteInfo)
                         argument = New BoundDirectCast(node, argument, convKind, objectType)
                     End If
 
@@ -382,10 +382,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                           type:=objectType)
 
                 End If
-
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim conversionKind = Conversions.ClassifyDirectCastConversion(objectType, targetType, useSiteDiagnostics)
-                Debug.Assert(useSiteDiagnostics.IsNullOrEmpty)
+#If DEBUG Then
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+#Else
+                Dim useSiteInfo = CompoundUseSiteInfo(Of AssemblySymbol).Discarded
+#End If
+                Dim conversionKind = Conversions.ClassifyDirectCastConversion(objectType, targetType, useSiteInfo)
+#If DEBUG Then
+                Debug.Assert(useSiteInfo.Diagnostics.IsNullOrEmpty)
+                Debug.Assert(useSiteInfo.Dependencies.IsNullOrEmpty)
+#End If
                 value = New BoundDirectCast(syntax, value, conversionKind, targetType)
             End If
 
@@ -965,17 +971,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                syntax As SyntaxNode,
                                                                Optional isOptional As Boolean = False) As Boolean
 
-            Dim diagInfo As DiagnosticInfo = Nothing
-            Dim memberSymbol = Binder.GetWellKnownTypeMember(Me.Compilation, memberId, diagInfo)
+            result = Nothing
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim memberSymbol = Binder.GetWellKnownTypeMember(Me.Compilation, memberId, useSiteInfo)
 
-            If diagInfo IsNot Nothing Then
+            If useSiteInfo.DiagnosticInfo IsNot Nothing Then
                 If Not isOptional Then
-                    Binder.ReportDiagnostic(_diagnostics, New VBDiagnostic(diagInfo, syntax.GetLocation()))
+                    Binder.ReportUseSite(_diagnostics, syntax.GetLocation(), useSiteInfo)
                 End If
 
                 Return False
             End If
 
+            _diagnostics.AddDependencies(useSiteInfo)
             result = DirectCast(memberSymbol, T)
             Return True
         End Function
@@ -987,12 +995,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        memberId As SpecialMember,
                                                        syntax As SyntaxNode) As Boolean
 
-            Dim diagInfo As DiagnosticInfo = Nothing
-            Dim memberSymbol = Binder.GetSpecialTypeMember(Me._topMethod.ContainingAssembly, memberId, diagInfo)
+            result = Nothing
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim memberSymbol = Binder.GetSpecialTypeMember(Me._topMethod.ContainingAssembly, memberId, useSiteInfo)
 
-            If diagInfo IsNot Nothing Then
-                Binder.ReportDiagnostic(_diagnostics, New VBDiagnostic(diagInfo, syntax.GetLocation()))
-                result = Nothing
+            If Binder.ReportUseSite(_diagnostics, syntax.GetLocation(), useSiteInfo) Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.vb
@@ -193,12 +193,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                New BoundMeReference(syntax, _topMethod.ContainingType)),
                                             staticLocalBackingFields.Value, isLValue:=True, type:=staticLocalBackingFields.Value.Type)
 
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
             Dim flagAsObject = New BoundDirectCast(syntax,
                                                    flag.MakeRValue(),
-                                                   Conversions.ClassifyDirectCastConversion(flag.Type, objectType, useSiteDiagnostics),
+                                                   Conversions.ClassifyDirectCastConversion(flag.Type, objectType, useSiteInfo),
                                                    objectType)
-            _diagnostics.Add(syntax, useSiteDiagnostics)
+            _diagnostics.Add(syntax, useSiteInfo)
 
             ' If flag Is Nothing
             '    Interlocked.CompareExchange(flag, New StaticLocalInitFlag, Nothing)  

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreation.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreation.vb
@@ -37,10 +37,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If node.Type.IsInterfaceType() Then
                     Debug.Assert(result.Type.Equals(DirectCast(node.Type, NamedTypeSymbol).CoClassType))
 
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                    Dim conv As ConversionKind = Conversions.ClassifyDirectCastConversion(result.Type, node.Type, useSiteDiagnostics)
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim conv As ConversionKind = Conversions.ClassifyDirectCastConversion(result.Type, node.Type, useSiteInfo)
                     Debug.Assert(Conversions.ConversionExists(conv))
-                    _diagnostics.Add(result, useSiteDiagnostics)
+                    _diagnostics.Add(result, useSiteInfo)
                     result = New BoundDirectCast(node.Syntax, result, conv, node.Type, Nothing)
                 Else
                     Debug.Assert(node.Type.IsSameTypeIgnoringAll(result.Type))
@@ -84,9 +84,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim createInstance = factory.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Activator__CreateInstance)
             Dim rewrittenObjectCreation As BoundExpression
             If createInstance IsNot Nothing AndAlso Not createInstance.ReturnType.IsErrorType() Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim conversion = Conversions.ClassifyDirectCastConversion(createInstance.ReturnType, node.Type, useSiteDiagnostics)
-                _diagnostics.Add(node, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim conversion = Conversions.ClassifyDirectCastConversion(createInstance.ReturnType, node.Type, useSiteInfo)
+                _diagnostics.Add(node, useSiteInfo)
                 rewrittenObjectCreation = New BoundDirectCast(node.Syntax, factory.Call(Nothing, createInstance, callGetTypeFromCLSID), conversion, node.Type)
             Else
                 rewrittenObjectCreation = New BoundBadExpression(node.Syntax, LookupResultKind.OverloadResolutionFailure, ImmutableArray(Of Symbol).Empty, ImmutableArray(Of BoundExpression).Empty, node.Type, hasErrors:=True)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_OmittedArgument.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_OmittedArgument.vb
@@ -18,9 +18,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim fieldAccess = New BoundFieldAccess(node.Syntax, Nothing, missingField, isLValue:=False, type:=missingField.Type)
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim conversion = Conversions.ClassifyDirectCastConversion(fieldAccess.Type, node.Type, useSiteDiagnostics)
-            _diagnostics.Add(node, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim conversion = Conversions.ClassifyDirectCastConversion(fieldAccess.Type, node.Type, useSiteInfo)
+            _diagnostics.Add(node, useSiteInfo)
 
             ' Return Directcast(Missing.Value, Object)
             Return New BoundDirectCast(node.Syntax, fieldAccess, conversion, node.Type)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Query.vb
@@ -202,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As BoundLambda = New BoundLambda(originalNode.Syntax,
                                    originalNode.LambdaSymbol,
                                    lambdaBody,
-                                   ImmutableArray(Of Diagnostic).Empty,
+                                   ImmutableBindingDiagnostic(Of AssemblySymbol).Empty,
                                    Nothing,
                                    ConversionKind.DelegateRelaxationLevelNone,
                                    MethodConversionKind.Identity)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RedimClause.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RedimClause.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim temporaries As ArrayBuilder(Of SynthesizedLocal) = Nothing
             Dim assignmentTarget = node.Operand
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             Dim copyArrayUtilityMethod As MethodSymbol = Nothing
             If node.Preserve AndAlso TryGetWellknownMember(copyArrayUtilityMethod, WellKnownMember.Microsoft_VisualBasic_CompilerServices_Utils__CopyArray, node.Syntax) Then
@@ -50,11 +50,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 '  add conversion
                 arrayValueAccess = New BoundDirectCast(node.Syntax, arrayValueAccess,
-                                                       Conversions.ClassifyDirectCastConversion(arrayValueAccess.Type, systemArray, useSiteDiagnostics),
+                                                       Conversions.ClassifyDirectCastConversion(arrayValueAccess.Type, systemArray, useSiteInfo),
                                                        systemArray, Nothing)
 
                 valueBeingAssigned = New BoundDirectCast(node.Syntax, valueBeingAssigned,
-                                                       Conversions.ClassifyDirectCastConversion(valueBeingAssigned.Type, systemArray, useSiteDiagnostics),
+                                                       Conversions.ClassifyDirectCastConversion(valueBeingAssigned.Type, systemArray, useSiteInfo),
                                                        systemArray, Nothing)
 
                 '  bind call to CopyArray
@@ -66,9 +66,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             '  add conversion if needed
             valueBeingAssigned = New BoundDirectCast(node.Syntax, valueBeingAssigned,
-                                                     Conversions.ClassifyDirectCastConversion(valueBeingAssigned.Type, assignmentTarget.Type, useSiteDiagnostics),
+                                                     Conversions.ClassifyDirectCastConversion(valueBeingAssigned.Type, assignmentTarget.Type, useSiteInfo),
                                                      assignmentTarget.Type, Nothing)
-            _diagnostics.Add(node, useSiteDiagnostics)
+            _diagnostics.Add(node, useSiteInfo)
 
             '  adjust assignment target
             If assignmentTarget.Kind = BoundKind.PropertyAccess Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SelectCase.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SelectCase.vb
@@ -181,7 +181,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' If we have already generated this helper method, possibly for another select case
             ' or on another thread, we don't need to regenerate it.
-            Dim privateImplClass = _emitModule.GetPrivateImplClass(node.Syntax, _diagnostics)
+            Dim privateImplClass = _emitModule.GetPrivateImplClass(node.Syntax, _diagnostics.DiagnosticBag)
             If privateImplClass.GetMethod(PrivateImplementationDetails.SynthesizedStringHashFunctionName) IsNot Nothing Then
                 Return
             End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SyncLock.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SyncLock.vb
@@ -20,9 +20,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim visitedLockExpression = VisitExpressionNode(node.LockExpression)
 
             Dim objectType = GetSpecialType(SpecialType.System_Object)
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim conversionKind = Conversions.ClassifyConversion(visitedLockExpression.Type, objectType, useSiteDiagnostics).Key
-            _diagnostics.Add(node, useSiteDiagnostics)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim conversionKind = Conversions.ClassifyConversion(visitedLockExpression.Type, objectType, useSiteInfo).Key
+            _diagnostics.Add(node, useSiteInfo)
 
             ' when passing this boundlocal to Monitor.Enter and Monitor.Exit we need to pass a local of type object, because the parameter
             ' are of type object. We also do not want to have this conversion being shown in the semantic model, which is why we add it 

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Protected ReadOnly CompilationState As TypeCompilationState
 
-        Protected ReadOnly Diagnostics As DiagnosticBag
+        Protected ReadOnly Diagnostics As BindingDiagnosticBag
         Protected ReadOnly SlotAllocatorOpt As VariableSlotAllocator
 
         ''' <summary>
@@ -67,8 +67,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Protected ReadOnly PreserveOriginalLocals As Boolean
 
-        Protected Sub New(slotAllocatorOpt As VariableSlotAllocator, compilationState As TypeCompilationState, diagnostics As DiagnosticBag, preserveOriginalLocals As Boolean)
+        Protected Sub New(slotAllocatorOpt As VariableSlotAllocator, compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, preserveOriginalLocals As Boolean)
             Debug.Assert(compilationState IsNot Nothing)
+            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
             Me.CompilationState = compilationState
             Me.Diagnostics = diagnostics
             Me.SlotAllocatorOpt = slotAllocatorOpt

--- a/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             instrumentForDynamicAnalysis As Boolean,
             <Out> ByRef dynamicAnalysisSpans As ImmutableArray(Of SourceSpan),
             debugDocumentProvider As DebugDocumentProvider,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             ByRef lazyVariableSlotAllocator As VariableSlotAllocator,
             lambdaDebugInfoBuilder As ArrayBuilder(Of LambdaDebugInfo),
             closureDebugInfoBuilder As ArrayBuilder(Of ClosureDebugInfo),
@@ -30,13 +30,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(Not body.HasErrors)
             Debug.Assert(compilationState.ModuleBuilderOpt IsNot Nothing)
+            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
 
             ' performs node-specific lowering.
             Dim sawLambdas As Boolean
             Dim symbolsCapturedWithoutCopyCtor As ISet(Of Symbol) = Nothing
             Dim rewrittenNodes As HashSet(Of BoundNode) = Nothing
             Dim flags = If(allowOmissionOfConditionalCalls, LocalRewriter.RewritingFlags.AllowOmissionOfConditionalCalls, LocalRewriter.RewritingFlags.Default)
-            Dim localDiagnostics = DiagnosticBag.GetInstance()
+            Dim localDiagnostics = BindingDiagnosticBag.GetInstance()
             dynamicAnalysisSpans = ImmutableArray(Of SourceSpan).Empty
 
             Try
@@ -79,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If lazyVariableSlotAllocator Is Nothing Then
                     ' synthesized lambda methods are handled in LambdaRewriter.RewriteLambdaAsMethod
                     Debug.Assert(TypeOf method IsNot SynthesizedLambdaMethod)
-                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method, diagnostics)
+                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method, diagnostics.DiagnosticBag)
                 End If
 
                 ' Lowers lambda expressions into expressions that construct delegates.    
@@ -120,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        method As MethodSymbol,
                                                        methodOrdinal As Integer,
                                                        compilationState As TypeCompilationState,
-                                                       diagnostics As DiagnosticBag,
+                                                       diagnostics As BindingDiagnosticBag,
                                                        slotAllocatorOpt As VariableSlotAllocator,
                                                        <Out> ByRef stateMachineTypeOpt As StateMachineTypeSymbol) As BoundBlock
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.StateMachineMethodToClassRewriter.vb
@@ -72,16 +72,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            synthesizedLocalOrdinals As SynthesizedLocalOrdinalsDispenser,
                            slotAllocatorOpt As VariableSlotAllocator,
                            nextFreeHoistedLocalSlot As Integer,
-                           Diagnostics As DiagnosticBag)
+                           diagnostics As BindingDiagnosticBag)
 
-                MyBase.New(slotAllocatorOpt, F.CompilationState, Diagnostics, preserveOriginalLocals:=False)
+                MyBase.New(slotAllocatorOpt, F.CompilationState, diagnostics, preserveOriginalLocals:=False)
 
                 Debug.Assert(F IsNot Nothing)
                 Debug.Assert(stateField IsNot Nothing)
                 Debug.Assert(hoistedVariables IsNot Nothing)
                 Debug.Assert(initialProxies IsNot Nothing)
                 Debug.Assert(nextFreeHoistedLocalSlot >= 0)
-                Debug.Assert(Diagnostics IsNot Nothing)
+                Debug.Assert(diagnostics IsNot Nothing)
 
                 Me.F = F
                 Me.StateField = stateField

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected ReadOnly Body As BoundStatement
         Protected ReadOnly Method As MethodSymbol
-        Protected ReadOnly Diagnostics As DiagnosticBag
+        Protected ReadOnly Diagnostics As BindingDiagnosticBag
         Protected ReadOnly F As SyntheticBoundNodeFactory
         Protected ReadOnly StateMachineType As SynthesizedContainer
         Protected ReadOnly SlotAllocatorOpt As VariableSlotAllocator
@@ -38,12 +38,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                           stateMachineType As StateMachineTypeSymbol,
                           slotAllocatorOpt As VariableSlotAllocator,
                           compilationState As TypeCompilationState,
-                          diagnostics As DiagnosticBag)
+                          diagnostics As BindingDiagnosticBag)
 
             Debug.Assert(body IsNot Nothing)
             Debug.Assert(method IsNot Nothing)
             Debug.Assert(compilationState IsNot Nothing)
             Debug.Assert(diagnostics IsNot Nothing)
+            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
             Debug.Assert(stateMachineType IsNot Nothing)
 
             Me.Body = body
@@ -101,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' add fields for the captured variables of the method
-            Dim variablesToHoist = IteratorAndAsyncCaptureWalker.Analyze(New FlowAnalysisInfo(F.CompilationState.Compilation, Me.Method, Me.Body), Me.Diagnostics)
+            Dim variablesToHoist = IteratorAndAsyncCaptureWalker.Analyze(New FlowAnalysisInfo(F.CompilationState.Compilation, Me.Method, Me.Body), Me.Diagnostics.DiagnosticBag)
 
             CreateNonReusableLocalProxies(variablesToHoist, Me.nextFreeHoistedLocalSlot)
 
@@ -297,10 +298,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Dim previousSlotIndex = -1
                 If SlotAllocatorOpt IsNot Nothing AndAlso SlotAllocatorOpt.TryGetPreviousHoistedLocalSlotIndex(declaratorSyntax,
-                                                                                                               F.CompilationState.ModuleBuilderOpt.Translate(fieldType, declaratorSyntax, Diagnostics),
+                                                                                                               F.CompilationState.ModuleBuilderOpt.Translate(fieldType, declaratorSyntax, Diagnostics.DiagnosticBag),
                                                                                                                local.SynthesizedKind,
                                                                                                                id,
-                                                                                                               Diagnostics,
+                                                                                                               Diagnostics.DiagnosticBag,
                                                                                                                previousSlotIndex) Then
                     slotIndex = previousSlotIndex
                 End If
@@ -369,26 +370,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return False
         End Function
 
-        Friend Function EnsureSpecialType(type As SpecialType, bag As DiagnosticBag) As Symbol
-            Return Binder.GetSpecialType(F.Compilation.Assembly, type, Me.Body.Syntax, bag)
+        Friend Function EnsureSpecialType(type As SpecialType, bag As BindingDiagnosticBag) As Symbol
+            Return Binder.GetSpecialType(F.Compilation, type, Me.Body.Syntax, bag)
         End Function
 
-        Friend Function EnsureWellKnownType(type As WellKnownType, bag As DiagnosticBag) As Symbol
+        Friend Function EnsureWellKnownType(type As WellKnownType, bag As BindingDiagnosticBag) As Symbol
             Return Binder.GetWellKnownType(F.Compilation, type, Me.Body.Syntax, bag)
         End Function
 
-        Friend Function EnsureSpecialMember(member As SpecialMember, bag As DiagnosticBag) As Symbol
+        Friend Function EnsureSpecialMember(member As SpecialMember, bag As BindingDiagnosticBag) As Symbol
             Return Binder.GetSpecialTypeMember(F.Compilation.Assembly, member, Me.Body.Syntax, bag)
         End Function
 
-        Friend Function EnsureWellKnownMember(member As WellKnownMember, bag As DiagnosticBag) As Symbol
+        Friend Function EnsureWellKnownMember(member As WellKnownMember, bag As BindingDiagnosticBag) As Symbol
             Return Binder.GetWellKnownTypeMember(F.Compilation, member, Me.Body.Syntax, bag)
         End Function
 
         ''' <summary>
         ''' Check that the property and its getter exist and collect any use-site errors.
         ''' </summary>
-        Friend Sub EnsureSpecialPropertyGetter(member As SpecialMember, bag As DiagnosticBag)
+        Friend Sub EnsureSpecialPropertyGetter(member As SpecialMember, bag As BindingDiagnosticBag)
             Dim symbol = DirectCast(EnsureSpecialMember(member, bag), PropertySymbol)
 
             If symbol IsNot Nothing Then
@@ -399,10 +400,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return
                 End If
 
-                Dim useSiteError = getter.GetUseSiteErrorInfo()
-                If useSiteError IsNot Nothing Then
-                    Binder.ReportDiagnostic(bag, Body.Syntax, useSiteError)
-                End If
+                Dim useSiteInfo = getter.GetUseSiteInfo()
+                Binder.ReportUseSite(bag, Body.Syntax, useSiteInfo)
             End If
         End Sub
 
@@ -431,7 +430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                   Optional associatedProperty As PropertySymbol = Nothing) As SynthesizedMethod
 
             ' Errors must be reported before and if any this point should not be reachable
-            Debug.Assert(methodToImplement IsNot Nothing AndAlso methodToImplement.GetUseSiteErrorInfo Is Nothing)
+            Debug.Assert(methodToImplement IsNot Nothing AndAlso methodToImplement.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
             Dim result As New SynthesizedStateMachineDebuggerNonUserCodeMethod(DirectCast(Me.F.CurrentType, StateMachineTypeSymbol),
                                                                                methodName,
@@ -498,7 +497,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function OpenMoveNextMethodImplementation(methodToImplement As MethodSymbol, accessibility As Accessibility) As SynthesizedMethod
 
             ' Errors must be reported before and if any this point should not be reachable
-            Debug.Assert(methodToImplement IsNot Nothing AndAlso methodToImplement.GetUseSiteErrorInfo Is Nothing)
+            Debug.Assert(methodToImplement IsNot Nothing AndAlso methodToImplement.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
             Dim result As New SynthesizedStateMachineMoveNextMethod(DirectCast(Me.F.CurrentType, StateMachineTypeSymbol),
                                                                     methodToImplement,

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedContainer.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedContainer.vb
@@ -196,19 +196,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Me._baseType
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return MakeAcyclicBaseType(diagnostics)
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return Me._interfaces
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return MakeAcyclicInterfaces(diagnostics)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private _currentClass As NamedTypeSymbol
         Private _syntax As SyntaxNode
 
-        Public ReadOnly Diagnostics As DiagnosticBag
+        Public ReadOnly Diagnostics As BindingDiagnosticBag
         Public ReadOnly TopLevelMethod As MethodSymbol
         Public ReadOnly CompilationState As TypeCompilationState
 
@@ -62,11 +62,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Public Sub New(topLevelMethod As MethodSymbol, currentMethod As MethodSymbol, node As SyntaxNode, compilationState As TypeCompilationState, diagnostics As DiagnosticBag)
+        Public Sub New(topLevelMethod As MethodSymbol, currentMethod As MethodSymbol, node As SyntaxNode, compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag)
             Me.New(topLevelMethod, currentMethod, Nothing, node, compilationState, diagnostics)
         End Sub
 
-        Public Sub New(topLevelMethod As MethodSymbol, currentMethod As MethodSymbol, currentClass As NamedTypeSymbol, node As SyntaxNode, compilationState As TypeCompilationState, diagnostics As DiagnosticBag)
+        Public Sub New(topLevelMethod As MethodSymbol, currentMethod As MethodSymbol, currentClass As NamedTypeSymbol, node As SyntaxNode, compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag)
             Me.CompilationState = compilationState
             Me.CurrentMethod = currentMethod
             Me.TopLevelMethod = topLevelMethod
@@ -222,20 +222,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function SpecialType(st As SpecialType) As NamedTypeSymbol
-            Dim typeSymbol = Me.Compilation.GetSpecialType(st)
-
-            If typeSymbol.TypeKind = TypeKind.Error AndAlso TypeOf typeSymbol Is MissingMetadataTypeSymbol.TopLevel Then
-                Dim missing = DirectCast(typeSymbol, MissingMetadataTypeSymbol.TopLevel)
-                ReportDiagnostic(ErrorFactory.ErrorInfo(ERRID.ERR_UndefinedType1,
-                                 MetadataHelpers.BuildQualifiedName(missing.NamespaceName, missing.Name)))
-            Else
-                Dim useSiteError = typeSymbol.GetUseSiteErrorInfo()
-                If useSiteError IsNot Nothing Then
-                    ReportDiagnostic(useSiteError)
-                End If
-            End If
-
-            Return typeSymbol
+            Return Binder.GetSpecialType(Me.Compilation, st, _syntax, Me.Diagnostics)
         End Function
 
         Public Function NullableOf(type As TypeSymbol) As NamedTypeSymbol
@@ -253,31 +240,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function WellKnownType(wt As WellKnownType) As NamedTypeSymbol
-            Dim typeSymbol = Me.Compilation.GetWellKnownType(wt)
-            Debug.Assert(typeSymbol IsNot Nothing)
-
-            Dim useSiteError = typeSymbol.GetUseSiteErrorInfo()
-            If useSiteError IsNot Nothing Then
-                ReportDiagnostic(useSiteError)
-            End If
-
-            Return typeSymbol
+            Return Binder.GetWellKnownType(Me.Compilation, wt, _syntax, Me.Diagnostics)
         End Function
 
-        Public Sub ReportDiagnostic(diagInfo As DiagnosticInfo)
-            Me.Diagnostics.Add(diagInfo, _syntax.GetLocation())
-        End Sub
-
         Public Function WellKnownMember(Of T As Symbol)(wm As WellKnownMember, Optional isOptional As Boolean = False) As T
-            Dim useSiteError As DiagnosticInfo = Nothing
-            Dim member = DirectCast(Binder.GetWellKnownTypeMember(Me.Compilation, wm, useSiteError), T)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim member = DirectCast(Binder.GetWellKnownTypeMember(Me.Compilation, wm, useSiteInfo), T)
 
-            If useSiteError IsNot Nothing Then
-                If isOptional Then
-                    member = Nothing
-                Else
-                    ReportDiagnostic(useSiteError)
-                End If
+            If useSiteInfo.DiagnosticInfo IsNot Nothing AndAlso isOptional Then
+                member = Nothing
+            Else
+                Me.Diagnostics.Add(useSiteInfo, _syntax)
             End If
 
             Return member
@@ -285,19 +258,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Function SpecialMember(sm As SpecialMember) As Symbol
             Dim memberSymbol As Symbol = Me.Compilation.GetSpecialTypeMember(sm)
-            Dim diagInfo As DiagnosticInfo = Nothing
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol)
 
             If memberSymbol Is Nothing Then
                 Dim memberDescriptor As MemberDescriptor = SpecialMembers.GetDescriptor(sm)
-                diagInfo = GetDiagnosticForMissingRuntimeHelper(memberDescriptor.DeclaringTypeMetadataName, memberDescriptor.Name, CompilationState.Compilation.Options.EmbedVbCoreRuntime)
+                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(GetDiagnosticForMissingRuntimeHelper(memberDescriptor.DeclaringTypeMetadataName, memberDescriptor.Name, CompilationState.Compilation.Options.EmbedVbCoreRuntime))
             Else
-                diagInfo = If(memberSymbol.GetUseSiteErrorInfo(), memberSymbol.ContainingType.GetUseSiteErrorInfo())
+                useSiteInfo = Binder.GetUseSiteInfoForMemberAndContainingType(memberSymbol)
             End If
 
-            If diagInfo IsNot Nothing Then
-                ReportDiagnostic(diagInfo)
-            End If
-
+            Me.Diagnostics.Add(useSiteInfo, _syntax)
             Return memberSymbol
         End Function
 
@@ -377,10 +347,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function [Return](Optional expression As BoundExpression = Nothing) As BoundReturnStatement
             If expression IsNot Nothing Then
                 ' If necessary, add a conversion on the return expression.
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim conversion = Conversions.ClassifyDirectCastConversion(expression.Type, Me.CurrentMethod.ReturnType, useSiteDiagnostics)
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim conversion = Conversions.ClassifyDirectCastConversion(expression.Type, Me.CurrentMethod.ReturnType, useSiteInfo)
                 Debug.Assert(Conversions.IsWideningConversion(conversion))
-                Diagnostics.Add(expression, useSiteDiagnostics)
+                Diagnostics.Add(expression, useSiteInfo)
 
                 If Not Conversions.IsIdentityConversion(conversion) Then
                     expression = New BoundDirectCast(Me.Syntax, expression, conversion, Me.CurrentMethod.ReturnType)
@@ -648,7 +618,7 @@ nextm:
             Debug.Assert(Not expression.Type.IsErrorType)
             Debug.Assert(Not type.IsErrorType)
 
-            Return New BoundTryCast(Me.Syntax, expression, Conversions.ClassifyTryCastConversion(expression.Type, type, Nothing), type)
+            Return New BoundTryCast(Me.Syntax, expression, Conversions.ClassifyTryCastConversion(expression.Type, type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded), type)
         End Function
 
         Public Function [DirectCast](expression As BoundExpression, type As TypeSymbol) As BoundDirectCast
@@ -662,7 +632,7 @@ nextm:
                                        expression,
                                        If(expression.IsNothingLiteral,
                                           ConversionKind.WideningNothingLiteral,
-                                          Conversions.ClassifyDirectCastConversion(expression.Type, type, Nothing)),
+                                          Conversions.ClassifyDirectCastConversion(expression.Type, type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)),
                                        type)
         End Function
 
@@ -1007,7 +977,7 @@ nextm:
             ElseIf type.IsErrorType() OrElse arg.Type.IsErrorType() Then
                 Return Convert(type, arg, ConversionKind.WideningReference, isChecked) ' will abort before code gen due to error, so doesn't matter if conversion kind is wrong.
             Else
-                Return Convert(type, arg, Conversions.ClassifyConversion(arg.Type, type, Nothing).Key, isChecked)
+                Return Convert(type, arg, Conversions.ClassifyConversion(arg.Type, type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded).Key, isChecked)
             End If
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -1162,7 +1162,7 @@ Namespace Microsoft.CodeAnalysis.Operations
                                                                                                     getEnumeratorArguments, getEnumeratorDefaultArguments,
                                                                                                     moveNextArguments, moveNextDefaultArguments,
                                                                                                     currentArguments, currentDefaultArguments)
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+
             Return New ForEachLoopOperationInfo(statementInfo.ElementType,
                                                      statementInfo.GetEnumeratorMethod,
                                                      statementInfo.CurrentProperty,

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -6190,14 +6190,21 @@ checkNullable:
         ''' <summary>
         ''' Returns false and reports an error if the feature is un-available
         ''' </summary>
-        Friend Shared Function CheckFeatureAvailability(diagnostics As DiagnosticBag, location As Location, languageVersion As LanguageVersion, feature As Feature) As Boolean
+        Friend Shared Function CheckFeatureAvailability(diagnosticsOpt As DiagnosticBag, location As Location, languageVersion As LanguageVersion, feature As Feature) As Boolean
             If Not CheckFeatureAvailability(languageVersion, feature) Then
-                Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
-                Dim requiredVersion = New VisualBasicRequiredLanguageVersion(feature.GetLanguageVersion())
-                diagnostics.Add(ERRID.ERR_LanguageVersion, location, languageVersion.GetErrorName(), featureName, requiredVersion)
+                If diagnosticsOpt IsNot Nothing Then
+                    Dim featureName = ErrorFactory.ErrorInfo(feature.GetResourceId())
+                    Dim requiredVersion = New VisualBasicRequiredLanguageVersion(feature.GetLanguageVersion())
+                    diagnosticsOpt.Add(ERRID.ERR_LanguageVersion, location, languageVersion.GetErrorName(), featureName, requiredVersion)
+                End If
+
                 Return False
             End If
             Return True
+        End Function
+
+        Friend Shared Function CheckFeatureAvailability(diagnostics As BindingDiagnosticBag, location As Location, languageVersion As LanguageVersion, feature As Feature) As Boolean
+            Return CheckFeatureAvailability(diagnostics.DiagnosticBag, location, languageVersion, feature)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
@@ -38,9 +38,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shared Function IsSymbolAccessible(symbol As Symbol,
                                                   within As AssemblySymbol,
-                                                  <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                  <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                   Optional basesBeingResolved As BasesBeingResolved = Nothing) As Boolean
-            Return CheckSymbolAccessibilityCore(symbol, within, Nothing, basesBeingResolved, useSiteDiagnostics) = AccessCheckResult.Accessible
+            Return CheckSymbolAccessibilityCore(symbol, within, Nothing, basesBeingResolved, useSiteInfo) = AccessCheckResult.Accessible
         End Function
 
         ''' <summary>
@@ -48,9 +48,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shared Function CheckSymbolAccessibility(symbol As Symbol,
                                                         within As AssemblySymbol,
-                                                        <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                        <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                         Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
-            Return CheckSymbolAccessibilityCore(symbol, within, Nothing, basesBeingResolved, useSiteDiagnostics)
+            Return CheckSymbolAccessibilityCore(symbol, within, Nothing, basesBeingResolved, useSiteInfo)
         End Function
 
         ''' <summary>
@@ -60,9 +60,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function IsSymbolAccessible(symbol As Symbol,
                                                   within As NamedTypeSymbol,
                                                   throughTypeOpt As TypeSymbol,
-                                                  <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                  <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                   Optional basesBeingResolved As BasesBeingResolved = Nothing) As Boolean
-            Return CheckSymbolAccessibilityCore(symbol, within, throughTypeOpt, basesBeingResolved, useSiteDiagnostics) = AccessCheckResult.Accessible
+            Return CheckSymbolAccessibilityCore(symbol, within, throughTypeOpt, basesBeingResolved, useSiteInfo) = AccessCheckResult.Accessible
         End Function
 
         ''' <summary>
@@ -73,9 +73,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function CheckSymbolAccessibility(symbol As Symbol,
                                                         within As NamedTypeSymbol,
                                                         throughTypeOpt As TypeSymbol,
-                                                        <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+                                                        <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
                                                         Optional basesBeingResolved As BasesBeingResolved = Nothing) As AccessCheckResult
-            Return CheckSymbolAccessibilityCore(symbol, within, throughTypeOpt, basesBeingResolved, useSiteDiagnostics)
+            Return CheckSymbolAccessibilityCore(symbol, within, throughTypeOpt, basesBeingResolved, useSiteInfo)
         End Function
 
         ''' <summary>
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                              within As Symbol,
                                                              throughTypeOpt As TypeSymbol,
                                                              basesBeingResolved As BasesBeingResolved,
-                                                             <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As AccessCheckResult
+                                                             <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As AccessCheckResult
             Debug.Assert(symbol IsNot Nothing)
             Debug.Assert(within IsNot Nothing)
             Debug.Assert(TypeOf within Is NamedTypeSymbol OrElse TypeOf within Is AssemblySymbol)
@@ -99,13 +99,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Select Case symbol.Kind
                 Case SymbolKind.ArrayType
-                    Return CheckSymbolAccessibilityCore((DirectCast(symbol, ArrayTypeSymbol)).ElementType, within, Nothing, basesBeingResolved, useSiteDiagnostics)
+                    Return CheckSymbolAccessibilityCore((DirectCast(symbol, ArrayTypeSymbol)).ElementType, within, Nothing, basesBeingResolved, useSiteInfo)
 
                 Case SymbolKind.NamedType
-                    Return CheckNamedTypeAccessibility(DirectCast(symbol, NamedTypeSymbol), within, basesBeingResolved, useSiteDiagnostics)
+                    Return CheckNamedTypeAccessibility(DirectCast(symbol, NamedTypeSymbol), within, basesBeingResolved, useSiteInfo)
 
                 Case SymbolKind.Alias
-                    Return CheckSymbolAccessibilityCore((DirectCast(symbol, AliasSymbol)).Target, within, Nothing, basesBeingResolved, useSiteDiagnostics)
+                    Return CheckSymbolAccessibilityCore((DirectCast(symbol, AliasSymbol)).Target, within, Nothing, basesBeingResolved, useSiteInfo)
 
                 Case SymbolKind.ErrorType
                     ' Always assume that error types are accessible.
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 throughTypeOpt = Nothing
             End If
 
-            Return CheckMemberAccessibility(symbol.ContainingType, symbol.DeclaredAccessibility, within, throughTypeOpt, basesBeingResolved, useSiteDiagnostics)
+            Return CheckMemberAccessibility(symbol.ContainingType, symbol.DeclaredAccessibility, within, throughTypeOpt, basesBeingResolved, useSiteInfo)
         End Function
 
         ' Is the named type "typeSym" accessible from within "within", which must
@@ -138,19 +138,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function CheckNamedTypeAccessibility(typeSym As NamedTypeSymbol,
                                                             within As Symbol,
                                                             basesBeingResolved As BasesBeingResolved,
-                                                            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As AccessCheckResult
+                                                            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As AccessCheckResult
             Debug.Assert(TypeOf within Is NamedTypeSymbol OrElse TypeOf within Is AssemblySymbol)
             Debug.Assert(typeSym IsNot Nothing)
 
             If Not typeSym.IsDefinition Then
                 ' All type argument must be accessible.
-                Dim typeArgs = typeSym.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                Dim typeArgs = typeSym.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteInfo)
 
                 For i As Integer = 0 To typeArgs.Length - 1
                     ' type parameters are always accessible, so don't check those (so common it's
                     ' worth optimizing this).
                     If typeArgs(i).Kind <> SymbolKind.TypeParameter Then
-                        Dim result = CheckSymbolAccessibilityCore(typeArgs(i), within, Nothing, basesBeingResolved, useSiteDiagnostics)
+                        Dim result = CheckSymbolAccessibilityCore(typeArgs(i), within, Nothing, basesBeingResolved, useSiteInfo)
                         If result <> AccessCheckResult.Accessible Then
                             Return result
                         End If
@@ -163,7 +163,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If containingType Is Nothing Then
                 Return CheckNonNestedTypeAccessibility(typeSym.ContainingAssembly, typeSym.DeclaredAccessibility, within)
             Else
-                Return CheckMemberAccessibility(typeSym.ContainingType, typeSym.DeclaredAccessibility, within, Nothing, basesBeingResolved, useSiteDiagnostics)
+                Return CheckMemberAccessibility(typeSym.ContainingType, typeSym.DeclaredAccessibility, within, Nothing, basesBeingResolved, useSiteInfo)
             End If
         End Function
 
@@ -201,7 +201,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                          within As Symbol,
                                                          throughTypeOpt As TypeSymbol,
                                                          basesBeingResolved As BasesBeingResolved,
-                                                         <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As AccessCheckResult
+                                                         <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As AccessCheckResult
             Debug.Assert(TypeOf within Is NamedTypeSymbol OrElse TypeOf within Is AssemblySymbol)
             Debug.Assert(containingType IsNot Nothing)
 
@@ -210,7 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim withinAssembly As AssemblySymbol = If(TryCast(within, AssemblySymbol), withinNamedType.ContainingAssembly)
 
             ' A member is only accessible to us if its containing type is accessible as well.
-            Dim result = CheckNamedTypeAccessibility(containingType, within, basesBeingResolved, useSiteDiagnostics)
+            Dim result = CheckNamedTypeAccessibility(containingType, within, basesBeingResolved, useSiteInfo)
             If result <> AccessCheckResult.Accessible Then
                 Return result
             End If
@@ -249,7 +249,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     ' We had friend access.  Also have to make sure we have protected access.
-                    Return CheckProtectedSymbolAccessibility(within, throughTypeOpt, originalContainingType, basesBeingResolved, useSiteDiagnostics)
+                    Return CheckProtectedSymbolAccessibility(within, throughTypeOpt, originalContainingType, basesBeingResolved, useSiteInfo)
 
                 Case Accessibility.ProtectedOrFriend
                     If HasFriendAccessTo(withinAssembly, containingType.ContainingAssembly) Then
@@ -260,10 +260,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ' We don't have friend access.  But if we have protected access then that's
                     ' sufficient.
-                    Return CheckProtectedSymbolAccessibility(within, throughTypeOpt, originalContainingType, basesBeingResolved, useSiteDiagnostics)
+                    Return CheckProtectedSymbolAccessibility(within, throughTypeOpt, originalContainingType, basesBeingResolved, useSiteInfo)
 
                 Case Accessibility.Protected
-                    Return CheckProtectedSymbolAccessibility(within, throughTypeOpt, originalContainingType, basesBeingResolved, useSiteDiagnostics)
+                    Return CheckProtectedSymbolAccessibility(within, throughTypeOpt, originalContainingType, basesBeingResolved, useSiteInfo)
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(declaredAccessibility)
@@ -276,7 +276,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                   throughTypeOpt As TypeSymbol,
                                                                   originalContainingType As NamedTypeSymbol,
                                                                   basesBeingResolved As BasesBeingResolved,
-                                                                  <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As AccessCheckResult
+                                                                  <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As AccessCheckResult
             Debug.Assert(TypeOf within Is NamedTypeSymbol OrElse TypeOf within Is AssemblySymbol)
 
             ' It is not an error to define protected member in a sealed Script class, it's just a
@@ -325,7 +325,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             While current IsNot Nothing
                 Debug.Assert(current.IsDefinition)
 
-                If InheritsFromOrImplementsIgnoringConstruction(current, originalContainingType, basesBeingResolved, useSiteDiagnostics) Then
+                If InheritsFromOrImplementsIgnoringConstruction(current, originalContainingType, basesBeingResolved, useSiteInfo) Then
                     ' Any protected instance members in or visible in the current context
                     ' through inheritance are accessible in the current context through an
                     ' instance of the current context or any type derived from the current
@@ -349,7 +349,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     '    End Sub
                     ' End Class
                     If originalThroughTypeOpt Is Nothing OrElse
-                       InheritsFromOrImplementsIgnoringConstruction(originalThroughTypeOpt, current, basesBeingResolved, useSiteDiagnostics) Then
+                       InheritsFromOrImplementsIgnoringConstruction(originalThroughTypeOpt, current, basesBeingResolved, useSiteInfo) Then
                         Return AccessCheckResult.Accessible
                     End If
 
@@ -407,7 +407,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared Function InheritsFromOrImplementsIgnoringConstruction(derivedType As TypeSymbol,
                                                                              baseType As TypeSymbol,
                                                                              basesBeingResolved As BasesBeingResolved,
-                                                                             <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+                                                                             <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Debug.Assert(derivedType.IsDefinition)
             Debug.Assert(baseType.IsDefinition)
 
@@ -442,9 +442,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Case TypeKind.Interface
                             current = Nothing
                         Case TypeKind.TypeParameter
-                            current = DirectCast(current, TypeParameterSymbol).GetClassConstraint(useSiteDiagnostics)
+                            current = DirectCast(current, TypeParameterSymbol).GetClassConstraint(useSiteInfo)
                         Case Else
-                            current = current.GetDirectBaseTypeWithDefinitionUseSiteDiagnostics(basesBeingResolved, useSiteDiagnostics)
+                            current = current.GetDirectBaseTypeWithDefinitionUseSiteDiagnostics(basesBeingResolved, useSiteInfo)
                     End Select
 
                     ' NOTE: The base type of an 'original' type may not be 'original'. i.e. 
@@ -471,7 +471,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not result Then
                     For Each candidate In interfacesLookedAt
-                        candidate.AddUseSiteDiagnostics(useSiteDiagnostics)
+                        candidate.AddUseSiteInfo(useSiteInfo)
                     Next
                 End If
             End If
@@ -585,7 +585,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             exposedThrough As Symbol,
             exposedType As TypeSymbol,
             ByRef illegalExposure As ArrayBuilder(Of AccessExposure),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             Dim typeArgumentsExposureIsLegal As Boolean = True
 
@@ -614,7 +614,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Do
                 If possiblyGeneric.Arity > 0 Then
                     For Each typeArgument In possiblyGeneric.TypeArgumentsNoUseSiteDiagnostics
-                        If Not VerifyAccessExposure(exposedThrough, typeArgument, illegalExposure, useSiteDiagnostics) Then
+                        If Not VerifyAccessExposure(exposedThrough, typeArgument, illegalExposure, useSiteInfo) Then
                             typeArgumentsExposureIsLegal = False
                         End If
                     Next
@@ -627,7 +627,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' check the original definition of the type.
             Dim containerWithAccessError As NamespaceOrTypeSymbol = Nothing
 
-            If VerifyAccessExposure(exposedThrough, exposedNamedType.OriginalDefinition, containerWithAccessError, useSiteDiagnostics) Then
+            If VerifyAccessExposure(exposedThrough, exposedNamedType.OriginalDefinition, containerWithAccessError, useSiteInfo) Then
                 Return typeArgumentsExposureIsLegal
             End If
 
@@ -647,7 +647,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             exposedThrough As Symbol,
             exposedType As NamedTypeSymbol,
             ByRef containerWithAccessError As NamespaceOrTypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
 
             containerWithAccessError = Nothing
@@ -665,11 +665,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End If
 
-            If Not VerifyAccessExposureWithinAssembly(exposedThrough, exposedType, containerWithAccessError, useSiteDiagnostics) Then
+            If Not VerifyAccessExposureWithinAssembly(exposedThrough, exposedType, containerWithAccessError, useSiteInfo) Then
                 Return False
             End If
 
-            Return VerifyAccessExposureOutsideAssembly(exposedThrough, exposedType, useSiteDiagnostics)
+            Return VerifyAccessExposureOutsideAssembly(exposedThrough, exposedType, useSiteInfo)
         End Function
 
         ''' <summary>
@@ -704,7 +704,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             exposedThrough As Symbol,
             exposedType As NamedTypeSymbol,
             ByRef containerWithAccessError As NamespaceOrTypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             Return VerifyAccessExposureHelper(
                         exposedThrough,
@@ -712,13 +712,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         containerWithAccessError,
                         Nothing,
                         isOutsideAssembly:=False,
-                        useSiteDiagnostics:=useSiteDiagnostics)
+                        useSiteInfo:=useSiteInfo)
         End Function
 
         Private Shared Function VerifyAccessExposureOutsideAssembly(
             exposedThrough As Symbol,
             exposedType As NamedTypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             Dim memberAccessOutsideAssembly As Accessibility = GetEffectiveAccessOutsideAssembly(exposedThrough)
 
@@ -754,7 +754,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Nothing,
                 typeSeenThroughInheritance,
                 isOutsideAssembly:=True,
-                useSiteDiagnostics:=useSiteDiagnostics)
+                useSiteInfo:=useSiteInfo)
 
             Return typeSeenThroughInheritance
         End Function
@@ -854,7 +854,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ByRef containerWithAccessError As NamespaceOrTypeSymbol,
             ByRef seenThroughInheritance As Boolean,
             isOutsideAssembly As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             seenThroughInheritance = False
             Dim exposingType As NamedTypeSymbol = Nothing
@@ -880,7 +880,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim parentOfExposingType As NamespaceOrTypeSymbol
 
             If membersAccessibilityInAssemblyContext <= Accessibility.Protected Then
-                If CanBeAccessedThroughInheritance(exposedType, exposingMember.ContainingType, isOutsideAssembly, useSiteDiagnostics) Then
+                If CanBeAccessedThroughInheritance(exposedType, exposingMember.ContainingType, isOutsideAssembly, useSiteInfo) Then
                     seenThroughInheritance = True
                     Return True
                 End If
@@ -892,7 +892,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                          If(parentOfExposingType.IsNamespace,
                                             DirectCast(parentOfExposingType.ContainingAssembly, Symbol),
                                             parentOfExposingType), Nothing,
-                                        useSiteDiagnostics) <> AccessCheckResult.Accessible Then
+                                        useSiteInfo) <> AccessCheckResult.Accessible Then
                 containerWithAccessError = parentOfExposingType
                 Return False
             End If
@@ -911,7 +911,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     containerWithAccessError,
                     seenThroughInheritance,
                     isOutsideAssembly,
-                    useSiteDiagnostics)
+                    useSiteInfo)
             End If
         End Function
 
@@ -922,7 +922,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             type As NamedTypeSymbol,
             container As NamedTypeSymbol,
             isOutsideAssembly As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             If GetAccessInAssemblyContext(type, isOutsideAssembly) = Accessibility.Private Then
                 Return False
@@ -950,20 +950,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If containerOfType.IsInterfaceType() Then
-                For Each iface In container.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each iface In container.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     If iface.OriginalDefinition.Equals(containerOfTypeDefinition) Then
                         Return True
                     End If
                 Next
             Else
-                Dim baseDefinition = container.BaseTypeOriginalDefinition(useSiteDiagnostics)
+                Dim baseDefinition = container.BaseTypeOriginalDefinition(useSiteInfo)
 
                 While baseDefinition IsNot Nothing
                     If baseDefinition.Equals(containerOfTypeDefinition) Then
                         Return True
                     End If
 
-                    baseDefinition = baseDefinition.BaseTypeOriginalDefinition(useSiteDiagnostics)
+                    baseDefinition = baseDefinition.BaseTypeOriginalDefinition(useSiteInfo)
                 End While
             End If
 
@@ -972,7 +972,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                         containerOfType,
                                                         container,
                                                         isOutsideAssembly,
-                                                        useSiteDiagnostics)
+                                                        useSiteInfo)
             End If
 
             Return False
@@ -1032,16 +1032,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             classOrInterface As NamedTypeSymbol,
             baseClassSyntax As TypeSyntax,
             base As TypeSymbol,
-            diagBag As DiagnosticBag
+            diagBag As BindingDiagnosticBag
         ) As Boolean
             Debug.Assert(base.IsClassType() OrElse base.IsInterfaceType(), "Expected class or interface!!!")
 
             Dim illegalExposure As ArrayBuilder(Of AccessExposure) = Nothing
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-            VerifyAccessExposure(classOrInterface, base, illegalExposure, useSiteDiagnostics)
+            VerifyAccessExposure(classOrInterface, base, illegalExposure, useSiteInfo)
 
-            diagBag.Add(baseClassSyntax, useSiteDiagnostics)
+            diagBag.Add(baseClassSyntax, useSiteInfo)
 
             If illegalExposure IsNot Nothing Then
 
@@ -1109,14 +1109,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             paramName As String,
             errorLocation As VisualBasicSyntaxNode,
             TypeBehindParam As TypeSymbol,
-            diagBag As DiagnosticBag
+            diagBag As BindingDiagnosticBag
         )
             Dim illegalExposure As ArrayBuilder(Of AccessExposure) = Nothing
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-            VerifyAccessExposure(member, TypeBehindParam, illegalExposure, useSiteDiagnostics)
+            VerifyAccessExposure(member, TypeBehindParam, illegalExposure, useSiteInfo)
 
-            diagBag.Add(errorLocation, useSiteDiagnostics)
+            diagBag.Add(errorLocation, useSiteInfo)
 
             If illegalExposure IsNot Nothing Then
                 Debug.Assert(illegalExposure.Count > 0)
@@ -1155,15 +1155,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             member As Symbol,
             errorLocation As SyntaxNodeOrToken,
             typeBehindMember As TypeSymbol,
-            diagBag As DiagnosticBag,
+            diagBag As BindingDiagnosticBag,
             Optional isDelegateFromImplements As Boolean = False
         )
             Dim illegalExposure As ArrayBuilder(Of AccessExposure) = Nothing
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
-            VerifyAccessExposure(member, typeBehindMember, illegalExposure, useSiteDiagnostics)
+            VerifyAccessExposure(member, typeBehindMember, illegalExposure, useSiteInfo)
 
-            diagBag.Add(errorLocation, useSiteDiagnostics)
+            diagBag.Add(errorLocation, useSiteInfo)
 
             If illegalExposure IsNot Nothing Then
                 Debug.Assert(illegalExposure.Count > 0)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -901,28 +901,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' This function classifies all intrinsic language conversions and user-defined conversions.
         ''' </summary>
-        Public Shared Function ClassifyConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As KeyValuePair(Of ConversionKind, MethodSymbol)
+        Public Shared Function ClassifyConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As KeyValuePair(Of ConversionKind, MethodSymbol)
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(source.Kind <> SymbolKind.ErrorType)
             Debug.Assert(Not TypeOf source Is ArrayLiteralTypeSymbol)
             Debug.Assert(destination.Kind <> SymbolKind.ErrorType)
 
-            Dim predefinedConversion As ConversionKind = ClassifyPredefinedConversion(source, destination, useSiteDiagnostics)
+            Dim predefinedConversion As ConversionKind = ClassifyPredefinedConversion(source, destination, useSiteInfo)
 
             If ConversionExists(predefinedConversion) Then
                 Return New KeyValuePair(Of ConversionKind, MethodSymbol)(predefinedConversion, Nothing)
             End If
 
-            Return ClassifyUserDefinedConversion(source, destination, useSiteDiagnostics)
+            Return ClassifyUserDefinedConversion(source, destination, useSiteInfo)
         End Function
 
         ''' <summary>
         ''' This function classifies all intrinsic language conversions, such as inheritance,
         ''' implementation, array covariance, and conversions between intrinsic types.
         ''' </summary>
-        Public Shared Function ClassifyPredefinedConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
-            Return ClassifyPredefinedConversion(source, destination, binder, userDefinedConversionsMightStillBeApplicable:=Nothing, useSiteDiagnostics:=useSiteDiagnostics)
+        Public Shared Function ClassifyPredefinedConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
+            Return ClassifyPredefinedConversion(source, destination, binder, userDefinedConversionsMightStillBeApplicable:=Nothing, useSiteInfo:=useSiteInfo)
         End Function
 
         Private Shared Function ClassifyPredefinedConversion(
@@ -930,7 +930,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             destination As TypeSymbol,
             binder As Binder,
             <Out()> ByRef userDefinedConversionsMightStillBeApplicable As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
@@ -992,7 +992,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If sourceType.Kind <> SymbolKind.ErrorType Then
-                Dim predefinedConversion As ConversionKind = ClassifyPredefinedConversion(sourceType, destination, useSiteDiagnostics)
+                Dim predefinedConversion As ConversionKind = ClassifyPredefinedConversion(sourceType, destination, useSiteInfo)
 
                 If ConversionExists(predefinedConversion) Then
                     Return predefinedConversion
@@ -1007,7 +1007,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' This function classifies all intrinsic language conversions and user-defined conversions.
         ''' </summary>
-        Public Shared Function ClassifyConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As KeyValuePair(Of ConversionKind, MethodSymbol)
+        Public Shared Function ClassifyConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As KeyValuePair(Of ConversionKind, MethodSymbol)
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(destination.Kind <> SymbolKind.ErrorType)
@@ -1015,14 +1015,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim conv As ConversionKind
 
             ' Reclassify lambdas, array literals, etc. 
-            conv = ClassifyExpressionReclassification(source, destination, binder, useSiteDiagnostics)
+            conv = ClassifyExpressionReclassification(source, destination, binder, useSiteInfo)
             If ConversionExists(conv) OrElse FailedDueToQueryLambdaBodyMismatch(conv) OrElse
                (conv And (ConversionKind.Lambda Or ConversionKind.FailedDueToArrayLiteralElementConversion)) <> 0 Then
                 Return New KeyValuePair(Of ConversionKind, MethodSymbol)(conv, Nothing)
             End If
 
             Dim userDefinedConversionsMightStillBeApplicable As Boolean = False
-            conv = ClassifyPredefinedConversion(source, destination, binder, userDefinedConversionsMightStillBeApplicable, useSiteDiagnostics)
+            conv = ClassifyPredefinedConversion(source, destination, binder, userDefinedConversionsMightStillBeApplicable, useSiteInfo)
 
             If ConversionExists(conv) OrElse Not userDefinedConversionsMightStillBeApplicable Then
                 Return New KeyValuePair(Of ConversionKind, MethodSymbol)(conv, Nothing)
@@ -1031,26 +1031,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' There could be some interesting conversions between the source expression 
             ' and the input type of the conversion operator. We might need to keep track 
             ' of them.
-            Return ClassifyUserDefinedConversion(source, destination, binder, useSiteDiagnostics)
+            Return ClassifyUserDefinedConversion(source, destination, binder, useSiteInfo)
         End Function
 
         ''' <summary>
         ''' Reclassify lambdas, array literals, etc. 
         ''' </summary>
-        Private Shared Function ClassifyExpressionReclassification(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyExpressionReclassification(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
 
             Select Case source.Kind
                 Case BoundKind.Parenthesized
                     If source.Type Is Nothing Then
                         ' Try to reclassify enclosed expression.
-                        Return ClassifyExpressionReclassification(DirectCast(source, BoundParenthesized).Expression, destination, binder, useSiteDiagnostics)
+                        Return ClassifyExpressionReclassification(DirectCast(source, BoundParenthesized).Expression, destination, binder, useSiteInfo)
                     End If
 
                 Case BoundKind.UnboundLambda
                     Return ClassifyUnboundLambdaConversion(DirectCast(source, UnboundLambda), destination)
 
                 Case BoundKind.QueryLambda
-                    Return ClassifyQueryLambdaConversion(DirectCast(source, BoundQueryLambda), destination, binder, useSiteDiagnostics)
+                    Return ClassifyQueryLambdaConversion(DirectCast(source, BoundQueryLambda), destination, binder, useSiteInfo)
 
                 Case BoundKind.GroupTypeInferenceLambda
                     Return ClassifyGroupTypeInferenceLambdaConversion(DirectCast(source, GroupTypeInferenceLambda), destination)
@@ -1059,13 +1059,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return ClassifyAddressOfConversion(DirectCast(source, BoundAddressOfOperator), destination)
 
                 Case BoundKind.ArrayLiteral
-                    Return ClassifyArrayLiteralConversion(DirectCast(source, BoundArrayLiteral), destination, binder, useSiteDiagnostics)
+                    Return ClassifyArrayLiteralConversion(DirectCast(source, BoundArrayLiteral), destination, binder, useSiteInfo)
 
                 Case BoundKind.InterpolatedStringExpression
                     Return ClassifyInterpolatedStringConversion(DirectCast(source, BoundInterpolatedStringExpression), destination, binder)
 
                 Case BoundKind.TupleLiteral
-                    Return ClassifyTupleConversion(DirectCast(source, BoundTupleLiteral), destination, binder, useSiteDiagnostics)
+                    Return ClassifyTupleConversion(DirectCast(source, BoundTupleLiteral), destination, binder, useSiteInfo)
             End Select
 
             Return Nothing 'ConversionKind.NoConversion
@@ -1083,10 +1083,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 leastRelaxationLevel = ConversionKind.DelegateRelaxationLevelWideningToNonLambda
 
                 ' Infer Anonymous Delegate as the target for the lambda.
-                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) = source.InferredAnonymousDelegate
+                Dim anonymousDelegateInfo As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = source.InferredAnonymousDelegate
 
                 ' If we have errors for the inference, we know that there is no conversion.
-                If Not anonymousDelegateInfo.Value.IsDefault AndAlso anonymousDelegateInfo.Value.HasAnyErrors() Then
+                If Not anonymousDelegateInfo.Value.Diagnostics.IsDefault AndAlso anonymousDelegateInfo.Value.Diagnostics.HasAnyErrors() Then
                     Return ConversionKind.Lambda ' No conversion
                 End If
 
@@ -1101,15 +1101,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     conversionKindExpressionTree = ConversionKind.ConvertedToExpressionTree
                 End If
 
-                If delegateInvoke Is Nothing OrElse delegateInvoke.GetUseSiteErrorInfo() IsNot Nothing Then
+                If delegateInvoke Is Nothing OrElse delegateInvoke.GetUseSiteInfo().DiagnosticInfo IsNot Nothing Then
                     Return ConversionKind.Lambda Or conversionKindExpressionTree ' No conversion
                 End If
 
                 If source.IsInferredDelegateForThisLambda(delegateInvoke.ContainingType) Then
-                    Dim inferenceDiagnostics As ImmutableArray(Of Diagnostic) = source.InferredAnonymousDelegate.Value
+                    Dim inferenceDiagnostics As ImmutableBindingDiagnostic(Of AssemblySymbol) = source.InferredAnonymousDelegate.Value
 
                     ' If we have errors for the inference, we know that there is no conversion.
-                    If Not inferenceDiagnostics.IsDefault AndAlso inferenceDiagnostics.HasAnyErrors() Then
+                    If Not inferenceDiagnostics.Diagnostics.IsDefault AndAlso inferenceDiagnostics.Diagnostics.HasAnyErrors() Then
                         Return ConversionKind.Lambda Or conversionKindExpressionTree ' No conversion
                     End If
                 End If
@@ -1119,7 +1119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim bound As BoundLambda = source.Bind(New UnboundLambda.TargetSignature(delegateInvoke))
 
-            Debug.Assert(Not bound.Diagnostics.HasAnyErrors OrElse
+            Debug.Assert(Not bound.Diagnostics.Diagnostics.HasAnyErrors OrElse
                          bound.DelegateRelaxation = ConversionKind.DelegateRelaxationLevelInvalid)
 
             If bound.DelegateRelaxation = ConversionKind.DelegateRelaxationLevelInvalid Then
@@ -1131,7 +1131,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                    CType(Math.Max(bound.DelegateRelaxation, leastRelaxationLevel), ConversionKind)
         End Function
 
-        Public Shared Function ClassifyArrayLiteralConversion(source As BoundArrayLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyArrayLiteralConversion(source As BoundArrayLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
 
             ' § 11.1.1
             ' 9. An array literal can be reclassified as a value. The type of the value is determined as follows:
@@ -1182,14 +1182,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                  originalTargetType.SpecialType = SpecialType.System_Collections_Generic_IReadOnlyList_T OrElse
                  originalTargetType.SpecialType = SpecialType.System_Collections_Generic_IReadOnlyCollection_T) Then
 
-                targetElementType = targetType.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)(0)
+                targetElementType = targetType.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteInfo)(0)
 
             Else
                 Dim conv As ConversionKind = ClassifyStringConversion(sourceType, destination)
 
                 If Conversions.NoConversion(conv) Then
                     ' No char() to string conversion
-                    conv = ClassifyDirectCastConversion(sourceType, destination, useSiteDiagnostics)
+                    conv = ClassifyDirectCastConversion(sourceType, destination, useSiteInfo)
                 End If
 
                 If Conversions.NoConversion(conv) Then
@@ -1197,7 +1197,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return Nothing
                 End If
 
-                Dim arrayLiteralElementConv = ClassifyArrayInitialization(source.Initializer, sourceType.ElementType, binder, useSiteDiagnostics)
+                Dim arrayLiteralElementConv = ClassifyArrayInitialization(source.Initializer, sourceType.ElementType, binder, useSiteInfo)
 
                 If Conversions.NoConversion(arrayLiteralElementConv) Then
                     ' No conversion for array elements. Preserve ConversionKind.FailedDueToArrayLiteralElementConversion
@@ -1214,7 +1214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return ConversionKind.Narrowing
             End If
 
-            Return ClassifyArrayInitialization(source.Initializer, targetElementType, binder, useSiteDiagnostics)
+            Return ClassifyArrayInitialization(source.Initializer, targetElementType, binder, useSiteInfo)
         End Function
 
         Public Shared Function ClassifyInterpolatedStringConversion(source As BoundInterpolatedStringExpression, destination As TypeSymbol, binder As Binder) As ConversionKind
@@ -1230,7 +1230,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         End Function
 
-        Public Shared Function ClassifyTupleConversion(source As BoundTupleLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyTupleConversion(source As BoundTupleLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             If TypeSymbol.Equals(source.Type, destination, TypeCompareKind.ConsiderEverything) Then
                 Return ConversionKind.Identity
             End If
@@ -1280,7 +1280,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
-                Dim elementConversion = ClassifyConversion(argument, targetElementType, binder, useSiteDiagnostics).Key
+                Dim elementConversion = ClassifyConversion(argument, targetElementType, binder, useSiteInfo).Key
 
                 If NoConversion(elementConversion) Then
                     Return Nothing 'ConversionKind.NoConversion
@@ -1303,7 +1303,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return result Or (involvesNarrowingFromNumericConstant And allNarrowingIsFromNumericConstant) Or maxDelegateRelaxationLevel
         End Function
 
-        Private Shared Function ClassifyArrayInitialization(source As BoundArrayInitialization, targetElementType As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyArrayInitialization(source As BoundArrayInitialization, targetElementType As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             ' Now we have to check that every element converts to TargetElementType.
             ' It's tempting to say "if the dominant type converts to TargetElementType, then it must be true that
             ' every element converts." But this isn't true for several reasons. First, the dominant type might
@@ -1322,9 +1322,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim elementConv As ConversionKind
 
                 If sourceElement.Kind = BoundKind.ArrayInitialization Then
-                    elementConv = ClassifyArrayInitialization(DirectCast(sourceElement, BoundArrayInitialization), targetElementType, binder, useSiteDiagnostics)
+                    elementConv = ClassifyArrayInitialization(DirectCast(sourceElement, BoundArrayInitialization), targetElementType, binder, useSiteInfo)
                 Else
-                    elementConv = ClassifyConversion(sourceElement, targetElementType, binder, useSiteDiagnostics).Key
+                    elementConv = ClassifyConversion(sourceElement, targetElementType, binder, useSiteInfo).Key
                 End If
 
                 If IsNarrowingConversion(elementConv) Then
@@ -1360,7 +1360,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Binder.ClassifyAddressOfConversion(source, destination)
         End Function
 
-        Private Shared Function ClassifyQueryLambdaConversion(source As BoundQueryLambda, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyQueryLambdaConversion(source As BoundQueryLambda, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             ' The delegate type we're converting to (could be type argument of Expression(Of T)).
             Dim wasExpressionTree As Boolean
             Dim delegateDestination As NamedTypeSymbol = destination.DelegateOrExpressionDelegate(binder, wasExpressionTree)
@@ -1372,7 +1372,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim conversionKindExpressionTree As ConversionKind = If(wasExpressionTree, ConversionKind.ConvertedToExpressionTree, Nothing)
             Dim invoke As MethodSymbol = delegateDestination.DelegateInvokeMethod
 
-            If invoke Is Nothing OrElse invoke.GetUseSiteErrorInfo() IsNot Nothing OrElse invoke.IsSub Then
+            If invoke Is Nothing OrElse invoke.GetUseSiteInfo().DiagnosticInfo IsNot Nothing OrElse invoke.IsSub Then
                 Return Nothing ' No conversion
             End If
 
@@ -1401,9 +1401,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol)
 
                     If source.ExprIsOperandOfConditionalBranch AndAlso invoke.ReturnType.IsBooleanType() Then
-                        conv = ClassifyConversionOfOperandOfConditionalBranch(source.Expression, invoke.ReturnType, binder, Nothing, Nothing, useSiteDiagnostics)
+                        conv = ClassifyConversionOfOperandOfConditionalBranch(source.Expression, invoke.ReturnType, binder, Nothing, Nothing, useSiteInfo)
                     Else
-                        conv = ClassifyConversion(source.Expression, invoke.ReturnType, binder, useSiteDiagnostics)
+                        conv = ClassifyConversion(source.Expression, invoke.ReturnType, binder, useSiteInfo)
                     End If
 
                     If IsIdentityConversion(conv.Key) Then
@@ -1428,7 +1428,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             binder As Binder,
             <Out> ByRef applyNullableIsTrueOperator As Boolean,
             <Out> ByRef isTrueOperator As OverloadResolution.OverloadResolutionResult,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As KeyValuePair(Of ConversionKind, MethodSymbol)
             Debug.Assert(operand IsNot Nothing)
             Debug.Assert(booleanType IsNot Nothing)
@@ -1451,7 +1451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' otherwise it is false (but never calls the IsFalse operator).
             applyNullableIsTrueOperator = False
             isTrueOperator = Nothing
-            Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = Conversions.ClassifyConversion(operand, booleanType, binder, useSiteDiagnostics)
+            Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = Conversions.ClassifyConversion(operand, booleanType, binder, useSiteInfo)
 
             ' See if we need to use IsTrue operator.
             If Conversions.IsWideningConversion(conv.Key) Then
@@ -1475,10 +1475,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim nullableOfT As NamedTypeSymbol = booleanType.ContainingAssembly.GetSpecialType(SpecialType.System_Nullable_T)
 
                     If Not nullableOfT.IsErrorType() AndAlso
-                       (sourceType.IsNullableType() OrElse sourceType.CanContainUserDefinedOperators(useSiteDiagnostics)) Then
+                       (sourceType.IsNullableType() OrElse sourceType.CanContainUserDefinedOperators(useSiteInfo)) Then
                         nullableOfBoolean = nullableOfT.Construct(ImmutableArray.Create(Of TypeSymbol)(booleanType))
 
-                        convToNullableOfBoolean = Conversions.ClassifyConversion(operand, nullableOfBoolean, binder, useSiteDiagnostics)
+                        convToNullableOfBoolean = Conversions.ClassifyConversion(operand, nullableOfBoolean, binder, useSiteInfo)
                     End If
                 End If
 
@@ -1491,8 +1491,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' Is there IsTrue operator that we can use.
                     Dim results As OverloadResolution.OverloadResolutionResult = Nothing
 
-                    If sourceType.CanContainUserDefinedOperators(useSiteDiagnostics) Then
-                        results = OverloadResolution.ResolveIsTrueOperator(operand, binder, useSiteDiagnostics)
+                    If sourceType.CanContainUserDefinedOperators(useSiteInfo) Then
+                        results = OverloadResolution.ResolveIsTrueOperator(operand, binder, useSiteInfo)
                     End If
 
                     If results.BestResult.HasValue Then
@@ -1537,7 +1537,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Return type of the delegate must be an Anonymous Type corresponding to the following initializer:
             '   New With {key .$VB$ItAnonymous = <delegates's second parameter> }
 
-            If invoke Is Nothing OrElse invoke.GetUseSiteErrorInfo() IsNot Nothing OrElse invoke.IsSub Then
+            If invoke Is Nothing OrElse invoke.GetUseSiteInfo().DiagnosticInfo IsNot Nothing OrElse invoke.IsSub Then
                 Return Nothing ' No conversion
             End If
 
@@ -1713,7 +1713,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function ClassifyDirectCastConversion(
             source As TypeSymbol,
             destination As TypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
@@ -1756,30 +1756,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             'Reference conversions
-            result = ClassifyReferenceConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            result = ClassifyReferenceConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Array conversions
-            result = ClassifyArrayConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            result = ClassifyArrayConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Value Type conversions
-            result = ClassifyValueTypeConversion(source, destination, useSiteDiagnostics)
+            result = ClassifyValueTypeConversion(source, destination, useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Type Parameter conversions
-            result = ClassifyTypeParameterConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            result = ClassifyTypeParameterConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
 
             Return result
         End Function
 
-        Public Shared Function ClassifyDirectCastConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyDirectCastConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(destination.Kind <> SymbolKind.ErrorType)
@@ -1795,7 +1795,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Reclassify lambdas, array literals, etc. 
-            conv = ClassifyExpressionReclassification(source, destination, binder, useSiteDiagnostics)
+            conv = ClassifyExpressionReclassification(source, destination, binder, useSiteInfo)
             If ConversionExists(conv) OrElse (conv And (ConversionKind.Lambda Or ConversionKind.FailedDueToArrayLiteralElementConversion)) <> 0 Then
                 Return conv
             End If
@@ -1812,13 +1812,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If sourceType.Kind <> SymbolKind.ErrorType Then
-                Return ClassifyDirectCastConversion(sourceType, destination, useSiteDiagnostics)
+                Return ClassifyDirectCastConversion(sourceType, destination, useSiteInfo)
             End If
 
             Return Nothing
         End Function
 
-        Public Shared Function ClassifyTryCastConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyTryCastConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(source.Kind <> SymbolKind.ErrorType)
@@ -1827,15 +1827,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim result As ConversionKind
 
-            result = ClassifyDirectCastConversion(source, destination, useSiteDiagnostics)
+            result = ClassifyDirectCastConversion(source, destination, useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
-            Return ClassifyTryCastConversionForTypeParameters(source, destination, useSiteDiagnostics)
+            Return ClassifyTryCastConversionForTypeParameters(source, destination, useSiteInfo)
         End Function
 
-        Public Shared Function ClassifyTryCastConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyTryCastConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(destination.Kind <> SymbolKind.ErrorType)
@@ -1851,7 +1851,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Reclassify lambdas, array literals, etc. 
-            conv = ClassifyExpressionReclassification(source, destination, binder, useSiteDiagnostics)
+            conv = ClassifyExpressionReclassification(source, destination, binder, useSiteInfo)
             If ConversionExists(conv) OrElse (conv And (ConversionKind.Lambda Or ConversionKind.FailedDueToArrayLiteralElementConversion)) <> 0 Then
                 Return conv
             End If
@@ -1868,13 +1868,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If sourceType.Kind <> SymbolKind.ErrorType Then
-                Return ClassifyTryCastConversion(sourceType, destination, useSiteDiagnostics)
+                Return ClassifyTryCastConversion(sourceType, destination, useSiteInfo)
             End If
 
             Return Nothing
         End Function
 
-        Private Shared Function ClassifyTryCastConversionForTypeParameters(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyTryCastConversionForTypeParameters(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
 
             Dim sourceKind = source.Kind
             Dim destinationKind = destination.Kind
@@ -1900,7 +1900,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Note that Dev10 compiler does not require arrays rank to match, which is probably
                 ' an oversight. Will match the same behavior for now.
 
-                Return ClassifyTryCastConversionForTypeParameters(sourceElement, destinationElement, useSiteDiagnostics)
+                Return ClassifyTryCastConversionForTypeParameters(sourceElement, destinationElement, useSiteInfo)
             End If
 
             If sourceKind <> SymbolKind.TypeParameter AndAlso destinationKind <> SymbolKind.TypeParameter Then
@@ -1958,8 +1958,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' System.ValueType and System.Enum and so value types can still be related to type params with such constraints.
             '
 
-            Dim src = GetNonInterfaceTypeConstraintOrSelf(source, useSiteDiagnostics)
-            Dim dst = GetNonInterfaceTypeConstraintOrSelf(destination, useSiteDiagnostics)
+            Dim src = GetNonInterfaceTypeConstraintOrSelf(source, useSiteInfo)
+            Dim dst = GetNonInterfaceTypeConstraintOrSelf(destination, useSiteInfo)
 
             ' If the class constraint is Nothing, then conversion is possible because the non-class constrained
             ' type parameter can be any type related to the other type or type parameter.
@@ -1975,7 +1975,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' partially handles cases: A.4, B.3, B.4, B.5 and B.6
             '
-            Dim conv As ConversionKind = ClassifyDirectCastConversion(src, dst, useSiteDiagnostics)
+            Dim conv As ConversionKind = ClassifyDirectCastConversion(src, dst, useSiteInfo)
 
             If IsWideningConversion(conv) Then
                 Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
@@ -1989,7 +1989,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 '
                 If destinationKind = SymbolKind.TypeParameter AndAlso
                    (src.TypeKind <> TypeKind.Class OrElse DirectCast(src, NamedTypeSymbol).IsNotInheritable) AndAlso
-                   Not ClassOrBasesSatisfyConstraints(src, DirectCast(destination, TypeParameterSymbol), useSiteDiagnostics) Then
+                   Not ClassOrBasesSatisfyConstraints(src, DirectCast(destination, TypeParameterSymbol), useSiteInfo) Then
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
@@ -1997,7 +1997,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' partially handles cases: A.4, B.3 and B.4
-            conv = ClassifyDirectCastConversion(dst, src, useSiteDiagnostics)
+            conv = ClassifyDirectCastConversion(dst, src, useSiteInfo)
 
             If IsWideningConversion(conv) Then
                 Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
@@ -2011,7 +2011,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 '
                 If sourceKind = SymbolKind.TypeParameter AndAlso
                    (dst.TypeKind <> TypeKind.Class OrElse DirectCast(dst, NamedTypeSymbol).IsNotInheritable) AndAlso
-                   Not ClassOrBasesSatisfyConstraints(dst, DirectCast(source, TypeParameterSymbol), useSiteDiagnostics) Then
+                   Not ClassOrBasesSatisfyConstraints(dst, DirectCast(source, TypeParameterSymbol), useSiteInfo) Then
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
@@ -2022,7 +2022,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing 'ConversionKind.NoConversion
         End Function
 
-        Private Shared Function ClassOrBasesSatisfyConstraints([class] As TypeSymbol, typeParam As TypeParameterSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Private Shared Function ClassOrBasesSatisfyConstraints([class] As TypeSymbol, typeParam As TypeParameterSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Dim candidate As TypeSymbol = [class]
 
             While candidate IsNot Nothing
@@ -2031,17 +2031,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                       typeParameter:=typeParam,
                                                       typeArgument:=candidate,
                                                       diagnosticsBuilder:=Nothing,
-                                                      useSiteDiagnostics:=useSiteDiagnostics) Then
+                                                      useSiteInfo:=useSiteInfo) Then
                     Return True
                 End If
 
-                candidate = candidate.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                candidate = candidate.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
             End While
 
             Return False
         End Function
 
-        Private Shared Function GetNonInterfaceTypeConstraintOrSelf(type As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As TypeSymbol
+        Private Shared Function GetNonInterfaceTypeConstraintOrSelf(type As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As TypeSymbol
             If type.Kind = SymbolKind.TypeParameter Then
                 Dim typeParameter = DirectCast(type, TypeParameterSymbol)
 
@@ -2062,7 +2062,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return If(valueType.Kind = SymbolKind.ErrorType, Nothing, valueType)
                 End If
 
-                Return typeParameter.GetNonInterfaceConstraint(useSiteDiagnostics)
+                Return typeParameter.GetNonInterfaceConstraint(useSiteInfo)
             End If
 
             Return type
@@ -2075,7 +2075,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="destination"></param>
         ''' <returns></returns>
         ''' <remarks></remarks>
-        Private Shared Function ClassifyUserDefinedConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As KeyValuePair(Of ConversionKind, MethodSymbol)
+        Private Shared Function ClassifyUserDefinedConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As KeyValuePair(Of ConversionKind, MethodSymbol)
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(source.Kind <> SymbolKind.ErrorType)
@@ -2084,12 +2084,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If IsInterfaceType(source) OrElse
                IsInterfaceType(destination) OrElse
-               Not (source.CanContainUserDefinedOperators(useSiteDiagnostics) OrElse destination.CanContainUserDefinedOperators(useSiteDiagnostics)) Then
+               Not (source.CanContainUserDefinedOperators(useSiteInfo) OrElse destination.CanContainUserDefinedOperators(useSiteInfo)) Then
 
                 Return Nothing 'ConversionKind.NoConversion
             End If
 
-            Return OverloadResolution.ResolveUserDefinedConversion(source, destination, useSiteDiagnostics)
+            Return OverloadResolution.ResolveUserDefinedConversion(source, destination, useSiteInfo)
         End Function
 
         ''' <summary>
@@ -2099,7 +2099,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="destination"></param>
         ''' <returns></returns>
         ''' <remarks></remarks>
-        Private Shared Function ClassifyUserDefinedConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As KeyValuePair(Of ConversionKind, MethodSymbol)
+        Private Shared Function ClassifyUserDefinedConversion(source As BoundExpression, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As KeyValuePair(Of ConversionKind, MethodSymbol)
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(destination.Kind <> SymbolKind.ErrorType)
@@ -2123,7 +2123,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(sourceType IsNot Nothing)
             Debug.Assert(sourceType.Kind <> SymbolKind.ErrorType)
 
-            Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = ClassifyUserDefinedConversion(sourceType, destination, useSiteDiagnostics)
+            Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = ClassifyUserDefinedConversion(sourceType, destination, useSiteInfo)
 
             If NoConversion(conv.Key) Then
                 Return conv
@@ -2136,9 +2136,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim inConversion As ConversionKind
 
                 If (source.Kind <> BoundKind.ArrayLiteral) Then
-                    inConversion = ClassifyPredefinedConversion(source, userDefinedInputType, binder, useSiteDiagnostics)
+                    inConversion = ClassifyPredefinedConversion(source, userDefinedInputType, binder, useSiteInfo)
                 Else
-                    inConversion = ClassifyArrayLiteralConversion(DirectCast(source, BoundArrayLiteral), userDefinedInputType, binder, useSiteDiagnostics)
+                    inConversion = ClassifyArrayLiteralConversion(DirectCast(source, BoundArrayLiteral), userDefinedInputType, binder, useSiteInfo)
                 End If
 
                 If NoConversion(inConversion) Then
@@ -2164,7 +2164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Need to keep track of the fact that narrowing is from numeric constant.
                 If (inConversion And ConversionKind.InvolvesNarrowingFromNumericConstant) <> 0 AndAlso
                    OverloadResolution.IsWidening(conv.Value) AndAlso
-                   IsWideningConversion(ClassifyPredefinedConversion(conv.Value.ReturnType, destination, useSiteDiagnostics)) Then
+                   IsWideningConversion(ClassifyPredefinedConversion(conv.Value.ReturnType, destination, useSiteInfo)) Then
 
                     Dim newConv As ConversionKind = conv.Key Or ConversionKind.InvolvesNarrowingFromNumericConstant
 
@@ -2184,7 +2184,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' This function classifies all intrinsic language conversions, such as inheritance,
         ''' implementation, array covariance, and conversions between intrinsic types.
         ''' </summary>
-        Public Shared Function ClassifyPredefinedConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyPredefinedConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             Debug.Assert(source IsNot Nothing)
             Debug.Assert(destination IsNot Nothing)
             Debug.Assert(source.Kind <> SymbolKind.ErrorType)
@@ -2197,10 +2197,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return fastConversion.Value
             End If
 
-            Return ClassifyPredefinedConversionSlow(source, destination, useSiteDiagnostics)
+            Return ClassifyPredefinedConversionSlow(source, destination, useSiteInfo)
         End Function
 
-        Private Shared Function ClassifyPredefinedConversionSlow(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyPredefinedConversionSlow(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
 
             Dim result As ConversionKind
 
@@ -2211,37 +2211,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             'Reference conversions
-            result = ClassifyReferenceConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            result = ClassifyReferenceConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
             If ConversionExists(result) Then
                 Return AddDelegateRelaxationInformationForADelegate(source, destination, result)
             End If
 
             'Anonymous Delegate conversions
-            result = ClassifyAnonymousDelegateConversion(source, destination, useSiteDiagnostics)
+            result = ClassifyAnonymousDelegateConversion(source, destination, useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Array conversions
-            result = ClassifyArrayConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            result = ClassifyArrayConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Tuple conversions
-            result = ClassifyTupleConversion(source, destination, useSiteDiagnostics)
+            result = ClassifyTupleConversion(source, destination, useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Value Type conversions
-            result = ClassifyValueTypeConversion(source, destination, useSiteDiagnostics)
+            result = ClassifyValueTypeConversion(source, destination, useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
 
             'Nullable Value Type conversions
-            result = ClassifyNullableConversion(source, destination, useSiteDiagnostics)
+            result = ClassifyNullableConversion(source, destination, useSiteInfo)
             If ConversionExists(result) Then
                 Return result
             End If
@@ -2253,7 +2253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             'Type Parameter conversions
-            result = ClassifyTypeParameterConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            result = ClassifyTypeParameterConversion(source, destination, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
 
             Return AddDelegateRelaxationInformationForADelegate(source, destination, result)
         End Function
@@ -2304,7 +2304,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As TypeSymbol,
             destination As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             '§8.8 Widening Conversions
             '•	From a reference type to a base type.
@@ -2352,7 +2352,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return ConversionKind.NarrowingReference
                 ElseIf dstIsArrayType Then
                     ' !!! VB spec doesn't mention this explicitly, but
-                    Dim conv As ConversionKind = ClassifyReferenceConversionFromArrayToAnInterface(destination, source, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                    Dim conv As ConversionKind = ClassifyReferenceConversionFromArrayToAnInterface(destination, source, varianceCompatibilityClassificationDepth, useSiteInfo)
                     If NoConversion(conv) Then
                         Return Nothing 'ConversionKind.NoConversion
                     End If
@@ -2372,7 +2372,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim conv As ConversionKind = ToInterfaceConversionClassifier.ClassifyConversionToVariantCompatibleInterface(DirectCast(source, NamedTypeSymbol),
                                                                                                                                    DirectCast(destination, NamedTypeSymbol),
                                                                                                                                    varianceCompatibilityClassificationDepth,
-                                                                                                                                   useSiteDiagnostics)
+                                                                                                                                   useSiteInfo)
 
                     If ConversionExists(conv) Then
                         'From an interface type to a variant compatible interface type.
@@ -2391,7 +2391,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ElseIf srcIsArrayType Then
                     ' !!! Spec doesn't mention this conversion explicitly.
-                    Return ClassifyReferenceConversionFromArrayToAnInterface(source, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                    Return ClassifyReferenceConversionFromArrayToAnInterface(source, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
                 End If
 
             Else
@@ -2399,11 +2399,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If (srcIsClassType OrElse srcIsArrayType) Then
 
-                    If dstIsClassType AndAlso IsDerivedFrom(source, destination, useSiteDiagnostics) Then
+                    If dstIsClassType AndAlso IsDerivedFrom(source, destination, useSiteInfo) Then
                         'From a reference type to a base type.
                         Return ConversionKind.WideningReference
 
-                    ElseIf srcIsClassType AndAlso IsDerivedFrom(destination, source, useSiteDiagnostics) Then
+                    ElseIf srcIsClassType AndAlso IsDerivedFrom(destination, source, useSiteInfo) Then
                         'From a reference type to a more derived type.
                         Return ConversionKind.NarrowingReference
 
@@ -2412,7 +2412,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Dim conv As ConversionKind = ClassifyConversionToVariantCompatibleDelegateType(DirectCast(source, NamedTypeSymbol),
                                                                                                        DirectCast(destination, NamedTypeSymbol),
                                                                                                        varianceCompatibilityClassificationDepth,
-                                                                                                       useSiteDiagnostics)
+                                                                                                       useSiteInfo)
 
                         If ConversionExists(conv) Then
                             Debug.Assert((conv And Not (ConversionKind.Widening Or ConversionKind.Narrowing Or
@@ -2434,17 +2434,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As TypeSymbol,
             destination As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             Debug.Assert(source IsNot Nothing AndAlso Conversions.IsArrayType(source))
             Debug.Assert(destination IsNot Nothing AndAlso Conversions.IsInterfaceType(destination))
 
             'Check interfaces implemented by System.Array first.
-            Dim base = source.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+            Dim base = source.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
 
             If base IsNot Nothing Then
                 If Not base.IsErrorType() AndAlso base.TypeKind = TypeKind.Class AndAlso
-                   IsWideningConversion(ClassifyDirectCastConversion(base, destination, useSiteDiagnostics)) Then
+                   IsWideningConversion(ClassifyDirectCastConversion(base, destination, useSiteInfo)) Then
                     'From a reference type to an interface type, provided that the type implements the interface or a variant compatible interface.
                     Return ConversionKind.WideningReference
                 End If
@@ -2475,7 +2475,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing 'ConversionKind.NoConversion
             End If
 
-            Dim dstUnderlyingElement = DirectCast(destination, NamedTypeSymbol).TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)(0)
+            Dim dstUnderlyingElement = DirectCast(destination, NamedTypeSymbol).TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteInfo)(0)
 
             If dstUnderlyingElement.Kind = SymbolKind.ErrorType Then
                 Return Nothing 'ConversionKind.NoConversion
@@ -2491,7 +2491,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return ConversionKind.WideningReference
             End If
 
-            Dim conv As ConversionKind = ClassifyArrayConversionBasedOnElementTypes(arrayElement, dstUnderlyingElement, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+            Dim conv As ConversionKind = ClassifyArrayConversionBasedOnElementTypes(arrayElement, dstUnderlyingElement, varianceCompatibilityClassificationDepth, useSiteInfo)
             If IsWideningConversion(conv) Then
                 Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
                 Return ConversionKind.WideningReference Or (conv And ConversionKind.InvolvesEnumTypeConversions)
@@ -2506,12 +2506,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return ConversionKind.NarrowingReference
         End Function
 
-        Public Shared Function HasWideningDirectCastConversionButNotEnumTypeConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Shared Function HasWideningDirectCastConversionButNotEnumTypeConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             If source.IsErrorType() OrElse destination.IsErrorType Then
                 Return source.IsSameTypeIgnoringAll(destination)
             End If
 
-            Dim conv As ConversionKind = ClassifyDirectCastConversion(source, destination, useSiteDiagnostics)
+            Dim conv As ConversionKind = ClassifyDirectCastConversion(source, destination, useSiteInfo)
 
             If Conversions.IsWideningConversion(conv) AndAlso
                 (conv And ConversionKind.InvolvesEnumTypeConversions) = 0 Then
@@ -2525,7 +2525,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As NamedTypeSymbol,
             destination As NamedTypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             Debug.Assert(source IsNot Nothing AndAlso Conversions.IsDelegateType(source))
             Debug.Assert(destination IsNot Nothing AndAlso Conversions.IsDelegateType(destination))
@@ -2536,14 +2536,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                  ConversionKind.MightSucceedAtRuntime Or
                                                  ConversionKind.NarrowingDueToContraVarianceInDelegate)
 
-            Dim forwardConv As ConversionKind = ClassifyImmediateVarianceCompatibility(source, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+            Dim forwardConv As ConversionKind = ClassifyImmediateVarianceCompatibility(source, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
             Debug.Assert((forwardConv And Not validBits) = 0)
 
             If ConversionExists(forwardConv) Then
                 Return forwardConv
             End If
 
-            Dim backwardConv As ConversionKind = ClassifyImmediateVarianceCompatibility(destination, source, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+            Dim backwardConv As ConversionKind = ClassifyImmediateVarianceCompatibility(destination, source, varianceCompatibilityClassificationDepth, useSiteInfo)
             Debug.Assert((backwardConv And Not validBits) = 0)
 
             If ConversionExists(backwardConv) Then
@@ -2589,10 +2589,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 source As NamedTypeSymbol,
                 destination As NamedTypeSymbol,
                 varianceCompatibilityClassificationDepth As Integer,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As ConversionKind
                 Dim helper As ToInterfaceConversionClassifier = Nothing
-                helper.AccumulateConversionClassificationToVariantCompatibleInterface(source, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                helper.AccumulateConversionClassificationToVariantCompatibleInterface(source, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
                 Return helper.Result
             End Function
 
@@ -2605,7 +2605,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 source As NamedTypeSymbol,
                 destination As NamedTypeSymbol,
                 varianceCompatibilityClassificationDepth As Integer,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As Boolean
                 Debug.Assert(source IsNot Nothing AndAlso
                              (Conversions.IsInterfaceType(source) OrElse Conversions.IsClassType(source) OrElse Conversions.IsValueType(source)))
@@ -2617,16 +2617,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If Conversions.IsInterfaceType(source) Then
-                    ClassifyInterfaceImmediateVarianceCompatibility(source, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                    ClassifyInterfaceImmediateVarianceCompatibility(source, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
                     Debug.Assert(Not IsIdentityConversion(_conv))
                 End If
 
-                For Each [interface] In source.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each [interface] In source.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     If [interface].IsErrorType() Then
                         Continue For
                     End If
 
-                    If ClassifyInterfaceImmediateVarianceCompatibility([interface], destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics) Then
+                    If ClassifyInterfaceImmediateVarianceCompatibility([interface], destination, varianceCompatibilityClassificationDepth, useSiteInfo) Then
                         Return True
                     End If
                 Next
@@ -2641,12 +2641,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 source As NamedTypeSymbol,
                 destination As NamedTypeSymbol,
                 varianceCompatibilityClassificationDepth As Integer,
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             ) As Boolean
                 Debug.Assert(Conversions.IsInterfaceType(source) AndAlso Conversions.IsInterfaceType(destination))
                 Debug.Assert(Not IsIdentityConversion(_conv))
 
-                Dim addConv As ConversionKind = ClassifyImmediateVarianceCompatibility(source, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                Dim addConv As ConversionKind = ClassifyImmediateVarianceCompatibility(source, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                 Debug.Assert((addConv And ConversionKind.NarrowingDueToContraVarianceInDelegate) = 0)
 
@@ -2695,7 +2695,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As NamedTypeSymbol,
             destination As NamedTypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             Debug.Assert(Conversions.IsInterfaceType(source) OrElse Conversions.IsDelegateType(source))
             Debug.Assert(Conversions.IsInterfaceType(destination) OrElse Conversions.IsDelegateType(destination))
@@ -2758,8 +2758,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Do
                 Dim typeParameters As ImmutableArray(Of TypeParameterSymbol) = source.TypeParameters
-                Dim sourceArguments As ImmutableArray(Of TypeSymbol) = source.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                Dim destinationArguments As ImmutableArray(Of TypeSymbol) = destination.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                Dim sourceArguments As ImmutableArray(Of TypeSymbol) = source.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteInfo)
+                Dim destinationArguments As ImmutableArray(Of TypeSymbol) = destination.TypeArgumentsWithDefinitionUseSiteDiagnostics(useSiteInfo)
 
                 For i As Integer = 0 To typeParameters.Length - 1
 
@@ -2783,7 +2783,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Select Case typeParameters(i).Variance
                         Case VarianceKind.Out
-                            conv = Classify_Reference_Array_TypeParameterConversion(sourceArg, destinationArg, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                            conv = Classify_Reference_Array_TypeParameterConversion(sourceArg, destinationArg, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                             If Not classifyingInterfaceConversions AndAlso IsNarrowingConversion(conv) AndAlso
                                (conv And ConversionKind.NarrowingDueToContraVarianceInDelegate) <> 0 Then
@@ -2794,7 +2794,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             End If
 
                         Case VarianceKind.In
-                            conv = Classify_Reference_Array_TypeParameterConversion(destinationArg, sourceArg, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                            conv = Classify_Reference_Array_TypeParameterConversion(destinationArg, sourceArg, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                             If Not classifyingInterfaceConversions AndAlso Not IsWideningConversion(conv) AndAlso
                                destinationArg.IsReferenceType AndAlso sourceArg.IsReferenceType Then
@@ -2928,15 +2928,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <returns></returns>
         ''' <remarks>
         ''' </remarks>
-        Public Shared Function IsDerivedFrom(derivedType As TypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Shared Function IsDerivedFrom(derivedType As TypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Debug.Assert(derivedType IsNot Nothing AndAlso
                          (Conversions.IsClassType(derivedType) OrElse Conversions.IsArrayType(derivedType) OrElse Conversions.IsValueType(derivedType)))
             Debug.Assert(baseType IsNot Nothing AndAlso Conversions.IsClassType(baseType))
 
-            Return baseType.IsBaseTypeOf(derivedType, useSiteDiagnostics)
+            Return baseType.IsBaseTypeOf(derivedType, useSiteInfo)
         End Function
 
-        Private Shared Function ClassifyAnonymousDelegateConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyAnonymousDelegateConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             '§8.8 Widening Conversions
             '•	From an anonymous delegate type generated for a lambda method reclassification to any wider delegate type.
             '§8.9 Narrowing Conversions
@@ -2947,13 +2947,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If source.IsAnonymousType AndAlso source.IsDelegateType() AndAlso destination.IsDelegateType() Then
                 Dim delegateInvoke As MethodSymbol = DirectCast(destination, NamedTypeSymbol).DelegateInvokeMethod
 
-                If delegateInvoke Is Nothing OrElse delegateInvoke.GetUseSiteErrorInfo() IsNot Nothing Then
+                If delegateInvoke Is Nothing OrElse delegateInvoke.GetUseSiteInfo().DiagnosticInfo IsNot Nothing Then
                     Return Nothing ' No conversion
                 End If
 
                 Dim methodConversion As MethodConversionKind = ClassifyMethodConversionForLambdaOrAnonymousDelegate(delegateInvoke,
                                                                                                                     DirectCast(source, NamedTypeSymbol).DelegateInvokeMethod,
-                                                                                                                    useSiteDiagnostics)
+                                                                                                                    useSiteInfo)
 
                 If Not IsDelegateRelaxationSupportedFor(methodConversion) Then
                     Return Nothing 'ConversionKind.NoConversion
@@ -2986,7 +2986,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As TypeSymbol,
             destination As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
 
             '§8.8 Widening Conversions
@@ -3027,10 +3027,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing 'ConversionKind.NoConversion
             End If
 
-            Return ClassifyArrayConversionBasedOnElementTypes(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+            Return ClassifyArrayConversionBasedOnElementTypes(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
         End Function
 
-        Public Shared Function ClassifyArrayElementConversion(srcElem As TypeSymbol, dstElem As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Public Shared Function ClassifyArrayElementConversion(srcElem As TypeSymbol, dstElem As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
 
             Dim result As ConversionKind
 
@@ -3040,28 +3040,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return result
             End If
 
-            Return ClassifyArrayConversionBasedOnElementTypes(srcElem, dstElem, varianceCompatibilityClassificationDepth:=0, useSiteDiagnostics:=useSiteDiagnostics)
+            Return ClassifyArrayConversionBasedOnElementTypes(srcElem, dstElem, varianceCompatibilityClassificationDepth:=0, useSiteInfo:=useSiteInfo)
         End Function
 
         Friend Shared Function Classify_Reference_Array_TypeParameterConversion(
             srcElem As TypeSymbol,
             dstElem As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
-            Dim conv = ClassifyReferenceConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+            Dim conv = ClassifyReferenceConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
 
             If NoConversion(conv) AndAlso (conv And ConversionKind.MightSucceedAtRuntime) = 0 Then
-                conv = ClassifyArrayConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                conv = ClassifyArrayConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                 If NoConversion(conv) AndAlso (conv And ConversionKind.MightSucceedAtRuntime) = 0 Then
-                    conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                    conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
                 Else
-                    Debug.Assert(NoConversion(ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, Nothing)))
+                    Debug.Assert(NoConversion(ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)))
                 End If
             Else
-                Debug.Assert(NoConversion(ClassifyArrayConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, Nothing)))
-                Debug.Assert(NoConversion(ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, Nothing)))
+                Debug.Assert(NoConversion(ClassifyArrayConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)))
+                Debug.Assert(NoConversion(ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)))
             End If
 
             Return conv
@@ -3072,7 +3072,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             srcElem As TypeSymbol,
             dstElem As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             '§8.8 Widening Conversions
             '•	From an array type S with an element type SE to an array type T with an element type TE, provided all of the following are true:
@@ -3102,7 +3102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If Not srcElemIsValueType AndAlso Not dstElemIsValueType Then
 
-                Dim conv = Classify_Reference_Array_TypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                Dim conv = Classify_Reference_Array_TypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                 If IsWideningConversion(conv) Then
                     Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
@@ -3185,7 +3185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If srcElem.Kind = SymbolKind.TypeParameter OrElse
                            dstElem.Kind = SymbolKind.TypeParameter Then
                             ' Must be the same type if there is a conversion. 
-                            Dim conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                            Dim conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
                             Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
 
                             If IsWideningConversion(conv) Then
@@ -3207,7 +3207,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Dim dstValueType As TypeSymbol = dstElem
 
                         If srcElem.Kind = SymbolKind.TypeParameter Then
-                            Dim valueType = GetValueTypeConstraint(srcElem, useSiteDiagnostics)
+                            Dim valueType = GetValueTypeConstraint(srcElem, useSiteInfo)
 
                             If valueType IsNot Nothing Then
                                 srcValueType = valueType
@@ -3215,7 +3215,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
 
                         If dstElem.Kind = SymbolKind.TypeParameter Then
-                            Dim valueType = GetValueTypeConstraint(dstElem, useSiteDiagnostics)
+                            Dim valueType = GetValueTypeConstraint(dstElem, useSiteInfo)
 
                             If valueType IsNot Nothing Then
                                 dstValueType = valueType
@@ -3279,7 +3279,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                            Not dstElem.IsReferenceType Then
 
                         If srcElem.Kind = SymbolKind.TypeParameter Then
-                            Dim conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                            Dim conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                             If IsWideningConversion(conv) Then
                                 ' !!! Spec doesn't mention this explicitly, but Dev10 compiler treats this
@@ -3306,7 +3306,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If dstElem.Kind = SymbolKind.TypeParameter Then
 
-                        Dim conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                        Dim conv = ClassifyTypeParameterConversion(srcElem, dstElem, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                         If IsNarrowingConversion(conv) Then
                             ' !!! Spec doesn't mention this explicitly, but Dev10 compiler treats this
@@ -3347,9 +3347,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Select
         End Function
 
-        Private Shared Function GetValueTypeConstraint(typeParam As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As TypeSymbol
+        Private Shared Function GetValueTypeConstraint(typeParam As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As TypeSymbol
 
-            Dim constraint = DirectCast(typeParam, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteDiagnostics)
+            Dim constraint = DirectCast(typeParam, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteInfo)
 
             If constraint IsNot Nothing AndAlso constraint.IsValueType Then
                 Return constraint
@@ -3370,7 +3370,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Private Shared Function ClassifyValueTypeConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyValueTypeConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             '§8.8 Widening Conversions
             '•	From a value type to a base type.
             '•	From a value type to an interface type that the type implements.
@@ -3395,7 +3395,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
 
                     If IsClassType(destination) Then
-                        If IsDerivedFrom(source, destination, useSiteDiagnostics) Then
+                        If IsDerivedFrom(source, destination, useSiteInfo) Then
                             'From a value type to a base type.
                             Return ConversionKind.WideningValue
                         End If
@@ -3406,7 +3406,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                             DirectCast(source, NamedTypeSymbol),
                                                             DirectCast(destination, NamedTypeSymbol),
                                                             varianceCompatibilityClassificationDepth:=0,
-                                                            useSiteDiagnostics:=useSiteDiagnostics)
+                                                            useSiteInfo:=useSiteInfo)
 
                         If ConversionExists(conv) Then
                             'From a value type to an interface type that the type implements.
@@ -3428,14 +3428,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If IsClassType(source) Then
-                    If IsDerivedFrom(destination, source, useSiteDiagnostics) Then
+                    If IsDerivedFrom(destination, source, useSiteInfo) Then
                         'From a reference type to a more derived value type.
                         Return ConversionKind.NarrowingValue
                     End If
 
                 ElseIf IsInterfaceType(source) Then
 
-                    For Each [interface] In destination.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    For Each [interface] In destination.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                         If [interface].IsErrorType() Then
                             Continue For
                         ElseIf [interface].IsSameTypeIgnoringAll(source) Then
@@ -3451,7 +3451,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing 'ConversionKind.NoConversion
         End Function
 
-        Private Shared Function ClassifyNullableConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyNullableConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
             '§8.8 Widening Conversions
             '•	From a type T to the type T?.
             '•	From a type T? to a type S?, where there is a widening conversion from the type T to the type S.
@@ -3497,7 +3497,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If dstIsNullable Then
                     'From a type T? to a type S?
-                    conv = ClassifyPredefinedConversion(srcUnderlying, dstUnderlying, useSiteDiagnostics)
+                    conv = ClassifyPredefinedConversion(srcUnderlying, dstUnderlying, useSiteInfo)
                     Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
                     Debug.Assert((conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
 
@@ -3512,7 +3512,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ElseIf IsInterfaceType(destination) Then
                     ' !!! Note that the spec doesn't mention anything about variance, but 
                     ' !!! it appears to be taken into account by Dev10 compiler.
-                    conv = ClassifyDirectCastConversion(srcUnderlying, destination, useSiteDiagnostics)
+                    conv = ClassifyDirectCastConversion(srcUnderlying, destination, useSiteInfo)
                     Debug.Assert((conv And ConversionKind.Tuple) = 0)
 
                     If IsWideningConversion(conv) Then
@@ -3527,7 +3527,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     'From a type T? to a type T.
                     Return ConversionKind.NarrowingNullable
                 Else
-                    conv = ClassifyPredefinedConversion(srcUnderlying, destination, useSiteDiagnostics)
+                    conv = ClassifyPredefinedConversion(srcUnderlying, destination, useSiteInfo)
                     Debug.Assert((conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
 
                     If ConversionExists(conv) Then
@@ -3545,7 +3545,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return ConversionKind.WideningNullable
                 End If
 
-                Dim conv = ClassifyPredefinedConversion(source, dstUnderlying, useSiteDiagnostics)
+                Dim conv = ClassifyPredefinedConversion(source, dstUnderlying, useSiteInfo)
                 Debug.Assert((conv And ConversionKind.VarianceConversionAmbiguity) = 0)
                 Debug.Assert((conv And ConversionKind.DelegateRelaxationLevelMask) = 0 OrElse (conv And ConversionKind.Tuple) <> 0)
 
@@ -3562,7 +3562,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing 'ConversionKind.NoConversion
         End Function
 
-        Private Shared Function ClassifyTupleConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+        Private Shared Function ClassifyTupleConversion(source As TypeSymbol, destination As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ConversionKind
 
             If Not source.IsTupleType Then
                 Return Nothing  'ConversionKind.NoConversion
@@ -3590,7 +3590,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
-                Dim elementConversion = ClassifyConversion(argumentType, targetType, useSiteDiagnostics).Key
+                Dim elementConversion = ClassifyConversion(argumentType, targetType, useSiteInfo).Key
 
                 If NoConversion(elementConversion) Then
                     Return Nothing 'ConversionKind.NoConversion
@@ -3645,7 +3645,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As TypeSymbol,
             destination As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             '§8.8 Widening Conversions
             '•	From a type parameter to Object.
@@ -3673,7 +3673,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim conv As ConversionKind
 
             If source.Kind = SymbolKind.TypeParameter Then
-                conv = ClassifyConversionFromTypeParameter(DirectCast(source, TypeParameterSymbol), destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                conv = ClassifyConversionFromTypeParameter(DirectCast(source, TypeParameterSymbol), destination, varianceCompatibilityClassificationDepth, useSiteInfo)
 
                 If ConversionExists(conv) Then
                     Return conv
@@ -3681,7 +3681,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If destination.Kind = SymbolKind.TypeParameter Then
-                conv = ClassifyConversionToTypeParameter(source, DirectCast(destination, TypeParameterSymbol), varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                conv = ClassifyConversionToTypeParameter(source, DirectCast(destination, TypeParameterSymbol), varianceCompatibilityClassificationDepth, useSiteInfo)
 
                 If ConversionExists(conv) Then
                     Debug.Assert(IsNarrowingConversion(conv)) ' We are relying on this while classifying conversions from type parameter to avoid need for recursion.
@@ -3700,7 +3700,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             typeParameter As TypeParameterSymbol,
             destination As TypeSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
 
             If destination.SpecialType = SpecialType.System_Object Then
@@ -3709,7 +3709,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim queue As ArrayBuilder(Of TypeParameterSymbol) = Nothing
-            Dim result As ConversionKind = ClassifyConversionFromTypeParameter(typeParameter, destination, queue, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+            Dim result As ConversionKind = ClassifyConversionFromTypeParameter(typeParameter, destination, queue, varianceCompatibilityClassificationDepth, useSiteInfo)
 
             If queue IsNot Nothing Then
                 queue.Free()
@@ -3724,7 +3724,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             destination As TypeSymbol,
             <[In], Out> ByRef queue As ArrayBuilder(Of TypeParameterSymbol),
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
 
             Dim queueIndex As Integer = 0
@@ -3758,7 +3758,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             ' !!! Not mentioned explicitly in the spec.
                             If convToInterface.AccumulateConversionClassificationToVariantCompatibleInterface(valueType, destinationInterface,
                                                                                                               varianceCompatibilityClassificationDepth,
-                                                                                                              useSiteDiagnostics) Then
+                                                                                                              useSiteInfo) Then
                                 convToInterface.AssertFoundIdentity()
                                 Return ConversionKind.WideningTypeParameter
                             End If
@@ -3769,7 +3769,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 ' Iterate over the constraints
-                For Each constraint As TypeSymbol In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each constraint As TypeSymbol In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     If constraint.Kind = SymbolKind.ErrorType Then
                         Continue For
                     End If
@@ -3803,7 +3803,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             If convToInterface.AccumulateConversionClassificationToVariantCompatibleInterface(DirectCast(constraint, NamedTypeSymbol),
                                                                                                               destinationInterface,
                                                                                                               varianceCompatibilityClassificationDepth,
-                                                                                                              useSiteDiagnostics) Then
+                                                                                                              useSiteInfo) Then
                                 convToInterface.AssertFoundIdentity()
                                 'From a type parameter to any interface variant compatible with an interface type constraint.
                                 'From a type parameter to an interface implemented by a class constraint.
@@ -3815,7 +3815,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         ElseIf constraintIsArrayType Then
 
-                            Dim conv As ConversionKind = ClassifyReferenceConversionFromArrayToAnInterface(constraint, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                            Dim conv As ConversionKind = ClassifyReferenceConversionFromArrayToAnInterface(constraint, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
                             If IsWideningConversion(conv) Then
                                 'From a type parameter to an interface implemented by a class constraint.
                                 'From a type parameter to an interface variant compatible with an interface implemented by a class constraint.
@@ -3826,14 +3826,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     ElseIf dstIsClassType Then
                         If (constraintIsClassType OrElse constraintIsValueType OrElse constraintIsArrayType) AndAlso
-                           IsDerivedFrom(constraint, destination, useSiteDiagnostics) Then
+                           IsDerivedFrom(constraint, destination, useSiteInfo) Then
                             'From a type parameter to a base type of the class constraint.
                             Return ConversionKind.WideningTypeParameter
                         End If
 
                     ElseIf dstIsArrayType Then
                         If constraintIsArrayType Then
-                            Dim conv As ConversionKind = ClassifyArrayConversion(constraint, destination, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                            Dim conv As ConversionKind = ClassifyArrayConversion(constraint, destination, varianceCompatibilityClassificationDepth, useSiteInfo)
                             If IsWideningConversion(conv) Then
                                 ' !!! Spec doesn't explicitly mention array covariance, but Dev10 compiler takes them
                                 ' !!! into consideration.
@@ -3898,7 +3898,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             source As TypeSymbol,
             typeParameter As TypeParameterSymbol,
             varianceCompatibilityClassificationDepth As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
             If source.SpecialType = SpecialType.System_Object Then
                 'From Object to a type parameter.
@@ -3914,7 +3914,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If IsClassType(source) Then
                     Dim valueType = typeParameter.ContainingAssembly.GetSpecialType(SpecialType.System_ValueType)
 
-                    If valueType.Kind <> SymbolKind.ErrorType AndAlso IsDerivedFrom(valueType, source, useSiteDiagnostics) Then
+                    If valueType.Kind <> SymbolKind.ErrorType AndAlso IsDerivedFrom(valueType, source, useSiteInfo) Then
                         ' !!! Not mentioned explicitly in the spec.
                         Return ConversionKind.NarrowingTypeParameter
                     End If
@@ -3934,7 +3934,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Else
 
                 ' Iterate over constraints
-                For Each constraint As TypeSymbol In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                For Each constraint As TypeSymbol In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     If constraint.Kind = SymbolKind.ErrorType Then
                         Continue For
                     End If
@@ -3962,14 +3962,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If (constraintIsClassType OrElse constraintIsValueType OrElse constraintIsArrayType) Then
                         If srcIsClassType Then
-                            If IsDerivedFrom(constraint, source, useSiteDiagnostics) Then
+                            If IsDerivedFrom(constraint, source, useSiteInfo) Then
                                 'From a base type of the class constraint to a type parameter.
                                 Return ConversionKind.NarrowingTypeParameter
                             End If
 
                         ElseIf srcIsArrayType Then
                             If constraintIsArrayType Then
-                                Dim conv = ClassifyArrayConversion(constraint, source, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                                Dim conv = ClassifyArrayConversion(constraint, source, varianceCompatibilityClassificationDepth, useSiteInfo)
                                 If IsWideningConversion(conv) Then
                                     ' !!! Spec doesn't explicitly mention array covariance, but Dev10 compiler takes them
                                     ' !!! into consideration.
@@ -3986,7 +3986,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
 
                     ElseIf constraint.Kind = SymbolKind.TypeParameter Then
-                        Dim conv As ConversionKind = ClassifyTypeParameterConversion(source, constraint, varianceCompatibilityClassificationDepth, useSiteDiagnostics)
+                        Dim conv As ConversionKind = ClassifyTypeParameterConversion(source, constraint, varianceCompatibilityClassificationDepth, useSiteInfo)
                         If IsNarrowingConversion(conv) Then
                             'From anything that has narrowing conversion to a type parameter constraint TX.
 
@@ -4028,20 +4028,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             convertFromMethodIsByRef As Boolean,
             returnTypeOfConvertToMethod As TypeSymbol,
             convertToMethodIsByRef As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
             If convertToMethodIsByRef <> convertFromMethodIsByRef Then
                 Return MethodConversionKind.Error_ByRefByValMismatch
             End If
 
-            Return ClassifyMethodConversionBasedOnReturnType(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, convertFromMethodIsByRef, useSiteDiagnostics)
+            Return ClassifyMethodConversionBasedOnReturnType(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, convertFromMethodIsByRef, useSiteInfo)
         End Function
 
         Public Shared Function ClassifyMethodConversionBasedOnReturnType(
             returnTypeOfConvertFromMethod As TypeSymbol,
             returnTypeOfConvertToMethod As TypeSymbol,
             isRefReturning As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
             Debug.Assert(returnTypeOfConvertFromMethod IsNot Nothing)
             Debug.Assert(returnTypeOfConvertToMethod IsNot Nothing)
@@ -4069,7 +4069,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return MethodConversionKind.Error_Unspecified
             End If
 
-            Dim typeConversion As ConversionKind = ClassifyConversion(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, useSiteDiagnostics).Key
+            Dim typeConversion As ConversionKind = ClassifyConversion(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, useSiteInfo).Key
 
             If isRefReturning AndAlso Not IsIdentityConversion(typeConversion) Then
                 Return MethodConversionKind.Error_ReturnTypeMismatch
@@ -4090,7 +4090,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                        (typeConversion And ConversionKind.UserDefined) <> 0 Then
                         result = MethodConversionKind.ReturnIsIsVbOrBoxNarrowing
                     Else
-                        Dim clrTypeConversion = ClassifyDirectCastConversion(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, useSiteDiagnostics)
+                        Dim clrTypeConversion = ClassifyDirectCastConversion(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, useSiteInfo)
 
                         If IsWideningConversion(clrTypeConversion) Then
                             result = MethodConversionKind.ReturnIsClrNarrowing
@@ -4144,23 +4144,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function ClassifyMethodConversionForLambdaOrAnonymousDelegate(
             toMethod As MethodSymbol,
             lambdaOrDelegateInvokeSymbol As MethodSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
-            Return ClassifyMethodConversionForLambdaOrAnonymousDelegate(New UnboundLambda.TargetSignature(toMethod), lambdaOrDelegateInvokeSymbol, useSiteDiagnostics)
+            Return ClassifyMethodConversionForLambdaOrAnonymousDelegate(New UnboundLambda.TargetSignature(toMethod), lambdaOrDelegateInvokeSymbol, useSiteInfo)
         End Function
 
         Public Shared Function ClassifyMethodConversionForLambdaOrAnonymousDelegate(
             toMethodSignature As UnboundLambda.TargetSignature,
             lambdaOrDelegateInvokeSymbol As MethodSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
 
             ' determine conversions based on return type
             Dim methodConversions = Conversions.ClassifyMethodConversionBasedOnReturn(lambdaOrDelegateInvokeSymbol.ReturnType, lambdaOrDelegateInvokeSymbol.ReturnsByRef,
-                                                                                      toMethodSignature.ReturnType, toMethodSignature.ReturnsByRef, useSiteDiagnostics)
+                                                                                      toMethodSignature.ReturnType, toMethodSignature.ReturnsByRef, useSiteInfo)
 
             ' determine conversions based on arguments
-            methodConversions = methodConversions Or ClassifyMethodConversionForLambdaOrAnonymousDelegateBasedOnParameters(toMethodSignature, lambdaOrDelegateInvokeSymbol.Parameters, useSiteDiagnostics)
+            methodConversions = methodConversions Or ClassifyMethodConversionForLambdaOrAnonymousDelegateBasedOnParameters(toMethodSignature, lambdaOrDelegateInvokeSymbol.Parameters, useSiteInfo)
 
             Debug.Assert(Not lambdaOrDelegateInvokeSymbol.ReturnsByRef) ' No interaction of ByRef return with other relaxations
             Return methodConversions
@@ -4169,18 +4169,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function ClassifyMethodConversionForEventRaise(
             toDelegateInvokeMethod As MethodSymbol,
             parameters As ImmutableArray(Of ParameterSymbol),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
 
             Debug.Assert(toDelegateInvokeMethod.MethodKind = MethodKind.DelegateInvoke)
 
-            Return ClassifyMethodConversionForLambdaOrAnonymousDelegateBasedOnParameters(New UnboundLambda.TargetSignature(toDelegateInvokeMethod), parameters, useSiteDiagnostics)
+            Return ClassifyMethodConversionForLambdaOrAnonymousDelegateBasedOnParameters(New UnboundLambda.TargetSignature(toDelegateInvokeMethod), parameters, useSiteInfo)
         End Function
 
         Private Shared Function ClassifyMethodConversionForLambdaOrAnonymousDelegateBasedOnParameters(
             toMethodSignature As UnboundLambda.TargetSignature,
             parameters As ImmutableArray(Of ParameterSymbol),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As MethodConversionKind
 
             ' TODO: Take custom modifiers into account, if needed.
@@ -4206,14 +4206,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If Not toParameterType.IsErrorType() AndAlso Not lambdaParameterType.IsErrorType() Then
                         methodConversions = methodConversions Or
                                             Conversions.ClassifyMethodConversionBasedOnArgumentConversion(
-                                                                     Conversions.ClassifyConversion(toParameterType, lambdaParameterType, useSiteDiagnostics).Key,
+                                                                     Conversions.ClassifyConversion(toParameterType, lambdaParameterType, useSiteInfo).Key,
                                                                      toParameterType)
 
                         ' Check copy back conversion.
                         If toMethodSignature.ParameterIsByRef(parameterIndex) Then
                             methodConversions = methodConversions Or
                                                 Conversions.ClassifyMethodConversionBasedOnArgumentConversion(
-                                                                         Conversions.ClassifyConversion(lambdaParameterType, toParameterType, useSiteDiagnostics).Key,
+                                                                         Conversions.ClassifyConversion(lambdaParameterType, toParameterType, useSiteInfo).Key,
                                                                          lambdaParameterType)
                         End If
                     End If
@@ -4228,7 +4228,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Public Shared Function DetermineDelegateRelaxationLevelForLambdaReturn(
             expressionOpt As BoundExpression,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ConversionKind
 
             If expressionOpt Is Nothing OrElse expressionOpt.Kind <> BoundKind.Conversion OrElse expressionOpt.HasErrors Then
@@ -4252,7 +4252,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(conversion.Operand.IsNothingLiteral() OrElse conversion.Operand.Kind = BoundKind.Lambda)
                 methodConversion = MethodConversionKind.Identity
             Else
-                methodConversion = ClassifyMethodConversionBasedOnReturnType(operandType, conversion.Type, isRefReturning:=False, useSiteDiagnostics:=useSiteDiagnostics)
+                methodConversion = ClassifyMethodConversionBasedOnReturnType(operandType, conversion.Type, isRefReturning:=False, useSiteInfo:=useSiteInfo)
             End If
 
             Return DetermineDelegateRelaxationLevel(methodConversion)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Operators.vb
@@ -291,7 +291,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Shared Function ValidateOverloadedOperator(
             method As MethodSymbol,
             opInfo As OperatorInfo,
-            Optional diagnosticsOpt As DiagnosticBag = Nothing
+            Optional diagnosticsOpt As BindingDiagnosticBag = Nothing
         ) As Boolean
             Debug.Assert(method.IsMethodKindBasedOnSyntax OrElse diagnosticsOpt Is Nothing)
             Debug.Assert(opInfo.ParamCount <> 0)
@@ -305,6 +305,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim targetsContainingType As Boolean = False
             Dim targetMismatchError As ERRID
             Dim isConversion As Boolean = False
+            Dim useSiteInfo = If(diagnosticsOpt Is Nothing OrElse (diagnosticsOpt.DiagnosticBag Is Nothing AndAlso diagnosticsOpt.DependenciesBag Is Nothing),
+                                 CompoundUseSiteInfo(Of AssemblySymbol).Discarded,
+                                 Nothing)
 
             If opInfo.IsUnary Then
                 Select Case opInfo.UnaryOperatorKind
@@ -425,7 +428,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
                 ElseIf (sourceType.Kind = SymbolKind.NamedType OrElse sourceType.Kind = SymbolKind.TypeParameter) AndAlso
                        (targetType.Kind = SymbolKind.NamedType OrElse targetType.Kind = SymbolKind.TypeParameter) Then
-                    If Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(targetType, sourceType, Nothing) Then
+                    If Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(targetType, sourceType, useSiteInfo) Then
                         If diagnosticsOpt IsNot Nothing Then
                             diagnosticsOpt.Add(ErrorFactory.ErrorInfo(If(targetType Is method.ContainingSymbol,
                                                                       ERRID.ERR_ConversionFromBaseType,
@@ -434,7 +437,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Else
                             Return False
                         End If
-                    ElseIf Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(sourceType, targetType, Nothing) Then
+                    ElseIf Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(sourceType, targetType, useSiteInfo) Then
                         If diagnosticsOpt IsNot Nothing Then
                             diagnosticsOpt.Add(ErrorFactory.ErrorInfo(If(targetType Is method.ContainingSymbol,
                                                                       ERRID.ERR_ConversionFromDerivedType,
@@ -445,6 +448,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
                     End If
                 End If
+            End If
+
+            If result AndAlso diagnosticsOpt IsNot Nothing Then
+                diagnosticsOpt.Add(method.Locations(0), useSiteInfo)
             End If
 
             Return result
@@ -484,7 +491,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             binder As Binder,
             <Out()> ByRef intrinsicOperatorType As SpecialType,
             <Out()> ByRef userDefinedOperator As OverloadResolutionResult,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As UnaryOperatorKind
             Debug.Assert((opCode And UnaryOperatorKind.IntrinsicOpMask) = opCode AndAlso opCode <> UnaryOperatorKind.Error)
 
@@ -513,11 +520,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If sourceType.SpecialType <> SpecialType.System_Object AndAlso
                Not sourceType.IsIntrinsicType() Then
 
-                If operandType.CanContainUserDefinedOperators(useSiteDiagnostics) Then
-                    userDefinedOperator = ResolveUserDefinedUnaryOperator(operand, opCode, binder, includeEliminatedCandidates:=False, useSiteDiagnostics:=useSiteDiagnostics)
+                If operandType.CanContainUserDefinedOperators(useSiteInfo) Then
+                    userDefinedOperator = ResolveUserDefinedUnaryOperator(operand, opCode, binder, includeEliminatedCandidates:=False, useSiteInfo:=useSiteInfo)
 
                     If Not userDefinedOperator.BestResult.HasValue AndAlso userDefinedOperator.Candidates.Length = 0 Then
-                        userDefinedOperator = ResolveUserDefinedUnaryOperator(operand, opCode, binder, includeEliminatedCandidates:=True, useSiteDiagnostics:=useSiteDiagnostics)
+                        userDefinedOperator = ResolveUserDefinedUnaryOperator(operand, opCode, binder, includeEliminatedCandidates:=True, useSiteInfo:=useSiteInfo)
 
                         If userDefinedOperator.Candidates.Length = 0 Then
                             Return UnaryOperatorKind.Error
@@ -841,7 +848,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             considerUserDefinedOrLateBound As Boolean,
             <Out()> ByRef intrinsicOperatorType As SpecialType,
             <Out()> ByRef userDefinedOperator As OverloadResolutionResult,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As BinaryOperatorKind
 
             Debug.Assert((opCode And BinaryOperatorKind.OpMask) = opCode AndAlso opCode <> BinaryOperatorKind.Error)
@@ -876,18 +883,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If UseUserDefinedBinaryOperators(opCode, leftType, rightType) Then
 
                 If considerUserDefinedOrLateBound Then
-                    If leftType.CanContainUserDefinedOperators(useSiteDiagnostics) OrElse rightType.CanContainUserDefinedOperators(useSiteDiagnostics) OrElse
+                    If leftType.CanContainUserDefinedOperators(useSiteInfo) OrElse rightType.CanContainUserDefinedOperators(useSiteInfo) OrElse
                        (opCode = BinaryOperatorKind.Subtract AndAlso
                         leftType.GetNullableUnderlyingTypeOrSelf().IsDateTimeType() AndAlso
                         rightType.GetNullableUnderlyingTypeOrSelf().IsDateTimeType()) Then ' Let (Date - Date) use operator overloading.
 
-                        userDefinedOperator = ResolveUserDefinedBinaryOperator(left, right, opCode, binder, includeEliminatedCandidates:=False, useSiteDiagnostics:=useSiteDiagnostics)
+                        userDefinedOperator = ResolveUserDefinedBinaryOperator(left, right, opCode, binder, includeEliminatedCandidates:=False, useSiteInfo:=useSiteInfo)
 
                         If userDefinedOperator.ResolutionIsLateBound Then
                             intrinsicOperatorType = SpecialType.System_Object
                             Return opCode
                         ElseIf Not userDefinedOperator.BestResult.HasValue AndAlso userDefinedOperator.Candidates.Length = 0 Then
-                            userDefinedOperator = ResolveUserDefinedBinaryOperator(left, right, opCode, binder, includeEliminatedCandidates:=True, useSiteDiagnostics:=Nothing)
+                            userDefinedOperator = ResolveUserDefinedBinaryOperator(left, right, opCode, binder, includeEliminatedCandidates:=True, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
                             If userDefinedOperator.Candidates.Length = 0 Then
                                 Return BinaryOperatorKind.Error
@@ -900,11 +907,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' is latebound if the Type Parameter has no class constraint.
                         Dim latebound As Boolean = False
                         If leftType.IsObjectType() Then
-                            If rightType.IsTypeParameter() AndAlso DirectCast(rightType, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteDiagnostics) Is Nothing Then
+                            If rightType.IsTypeParameter() AndAlso DirectCast(rightType, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteInfo) Is Nothing Then
                                 latebound = True
                             End If
                         ElseIf rightType.IsObjectType() Then
-                            If leftType.IsTypeParameter() AndAlso DirectCast(leftType, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteDiagnostics) Is Nothing Then
+                            If leftType.IsTypeParameter() AndAlso DirectCast(leftType, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteInfo) Is Nothing Then
                                 latebound = True
                             End If
                         End If
@@ -1910,7 +1917,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function ResolveUserDefinedConversion(
             source As TypeSymbol,
             destination As TypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As KeyValuePair(Of ConversionKind, MethodSymbol)
             Debug.Assert(Not source.IsErrorType())
             Debug.Assert(Not destination.IsErrorType())
@@ -1935,7 +1942,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' !!!    operator that converts from the most specific source type to the most specific target type, then
             ' !!!    nullable lifting isn't considered.
 
-            CollectUserDefinedConversionOperators(source, destination, opSet, useSiteDiagnostics)
+            CollectUserDefinedConversionOperators(source, destination, opSet, useSiteInfo)
 
             If opSet.Count = 0 Then
                 opSet.Free()
@@ -1948,7 +1955,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim applicable = BitVector.Create(opSet.Count)
             Dim bestMatch As MethodSymbol = Nothing
 
-            If DetermineMostSpecificWideningConversion(source, destination, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=False, useSiteDiagnostics:=useSiteDiagnostics) Then
+            If DetermineMostSpecificWideningConversion(source, destination, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=False, useSiteInfo:=useSiteInfo) Then
                 If bestMatch IsNot Nothing Then
                     result = New KeyValuePair(Of ConversionKind, MethodSymbol)(ConversionKind.Widening Or ConversionKind.UserDefined, bestMatch)
                 End If
@@ -1958,7 +1965,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 GoTo Done
             End If
 
-            If DetermineMostSpecificNarrowingConversion(source, destination, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=False, useSiteDiagnostics:=useSiteDiagnostics) Then
+            If DetermineMostSpecificNarrowingConversion(source, destination, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=False, useSiteInfo:=useSiteInfo) Then
                 If bestMatch IsNot Nothing Then
                     result = New KeyValuePair(Of ConversionKind, MethodSymbol)(ConversionKind.Narrowing Or ConversionKind.UserDefined, bestMatch)
                 End If
@@ -1981,7 +1988,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' All candidates applicable to the underlying types should be applicable to the original types, no reason to 
                     ' do viability checks for the second time.
 
-                    If DetermineMostSpecificWideningConversion(sourceUnderlying, destinationUnderlying, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=True, useSiteDiagnostics:=useSiteDiagnostics) Then
+                    If DetermineMostSpecificWideningConversion(sourceUnderlying, destinationUnderlying, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=True, useSiteInfo:=useSiteInfo) Then
                         If bestMatch IsNot Nothing Then
                             Debug.Assert(Not bestMatch.Parameters(0).Type.IsNullableType())
                             Debug.Assert(Not bestMatch.ReturnType.IsNullableType())
@@ -1989,7 +1996,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                                        ConversionKind.UserDefined Or
                                                                                        ConversionKind.Nullable, bestMatch)
                         End If
-                    ElseIf DetermineMostSpecificNarrowingConversion(sourceUnderlying, destinationUnderlying, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=True, useSiteDiagnostics:=useSiteDiagnostics) Then
+                    ElseIf DetermineMostSpecificNarrowingConversion(sourceUnderlying, destinationUnderlying, opSet, conversionKinds, applicable, bestMatch, suppressViabilityChecks:=True, useSiteInfo:=useSiteInfo) Then
                         If bestMatch IsNot Nothing Then
                             Debug.Assert(Not bestMatch.Parameters(0).Type.IsNullableType())
                             Debug.Assert(Not bestMatch.ReturnType.IsNullableType())
@@ -2020,7 +2027,7 @@ Done:
             <[In]()> ByRef applicable As BitVector,
             <Out()> ByRef bestMatch As MethodSymbol,
             suppressViabilityChecks As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
 #If DEBUG Then
             Debug.Assert(bestMatch Is Nothing)
@@ -2099,7 +2106,7 @@ Done:
                 Dim conversionIn As ConversionKind
                 Dim conversionOut As ConversionKind
 
-                If ClassifyConversionOperatorInOutConversions(source, destination, method, conversionIn, conversionOut, suppressViabilityChecks, useSiteDiagnostics) Then
+                If ClassifyConversionOperatorInOutConversions(source, destination, method, conversionIn, conversionOut, suppressViabilityChecks, useSiteInfo) Then
                     conversionKinds(currentIndex) = New KeyValuePair(Of ConversionKind, ConversionKind)(conversionIn, conversionOut)
                 Else
                     'opSet(currentIndex) = Nothing
@@ -2185,7 +2192,7 @@ Done:
 
                         Debug.Assert(typeSet.Count = applicableCount)
 
-                        mostSpecificSourceType = MostEncompassed(typeSet, useSiteDiagnostics)
+                        mostSpecificSourceType = MostEncompassed(typeSet, useSiteInfo)
                     End If
 
                     If mostSpecificTargetType Is Nothing AndAlso mostSpecificSourceType IsNot Nothing Then
@@ -2205,7 +2212,7 @@ Done:
 
                         Debug.Assert(typeSet.Count = applicableCount)
 
-                        mostSpecificTargetType = MostEncompassing(typeSet, useSiteDiagnostics)
+                        mostSpecificTargetType = MostEncompassing(typeSet, useSiteInfo)
                     End If
 
                     If typeSet IsNot Nothing Then
@@ -2286,43 +2293,44 @@ Done:
             <Out()> ByRef conversionIn As ConversionKind,
             <Out()> ByRef conversionOut As ConversionKind,
             suppressViabilityChecks As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             Dim inputType As TypeSymbol = method.Parameters(0).Type
             Dim outputType As TypeSymbol = method.ReturnType
 
 
             If Not suppressViabilityChecks Then
-                If Not IsConversionOperatorViableBasedOnTypesInvolved(method, inputType, outputType) Then
+                If Not IsConversionOperatorViableBasedOnTypesInvolved(method, inputType, outputType, useSiteInfo) Then
                     conversionIn = Nothing
                     conversionOut = Nothing
                     Return False
                 End If
             Else
-                Debug.Assert(IsConversionOperatorViableBasedOnTypesInvolved(method, inputType, outputType))
+                Debug.Assert(IsConversionOperatorViableBasedOnTypesInvolved(method, inputType, outputType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
             End If
 
             ' If source is an array literal then use ClassifyArrayLiteralConversion
             Dim arrayLiteralType = TryCast(source, ArrayLiteralTypeSymbol)
             If arrayLiteralType IsNot Nothing Then
                 Dim arrayLiteral = arrayLiteralType.ArrayLiteral
-                conversionIn = Conversions.ClassifyArrayLiteralConversion(arrayLiteral, inputType, arrayLiteral.Binder, useSiteDiagnostics)
+                conversionIn = Conversions.ClassifyArrayLiteralConversion(arrayLiteral, inputType, arrayLiteral.Binder, useSiteInfo)
                 If Conversions.IsWideningConversion(conversionIn) AndAlso
                     IsSameTypeIgnoringAll(arrayLiteralType, inputType) Then
                     conversionIn = ConversionKind.Identity
                 End If
             Else
-                conversionIn = Conversions.ClassifyPredefinedConversion(source, inputType, useSiteDiagnostics)
+                conversionIn = Conversions.ClassifyPredefinedConversion(source, inputType, useSiteInfo)
             End If
 
-            conversionOut = Conversions.ClassifyPredefinedConversion(outputType, destination, useSiteDiagnostics)
+            conversionOut = Conversions.ClassifyPredefinedConversion(outputType, destination, useSiteInfo)
             Return True
         End Function
 
         Private Shared Function IsConversionOperatorViableBasedOnTypesInvolved(
             method As MethodSymbol,
             inputType As TypeSymbol,
-            outputType As TypeSymbol
+            outputType As TypeSymbol,
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             If inputType.IsErrorType() OrElse outputType.IsErrorType() Then
                 Return False
@@ -2331,11 +2339,14 @@ Done:
             ' Ignore user defined conversions between types that already have intrinsic conversions.
             ' This could happen for generics after generic param substitution.
             If Not method.ContainingType.IsDefinition Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                If Conversions.ConversionExists(Conversions.ClassifyPredefinedConversion(inputType, outputType, useSiteDiagnostics)) OrElse
-                   Not useSiteDiagnostics.IsNullOrEmpty Then
+                Dim localUseSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                If Conversions.ConversionExists(Conversions.ClassifyPredefinedConversion(inputType, outputType, localUseSiteInfo)) OrElse
+                   Not localUseSiteInfo.Diagnostics.IsNullOrEmpty Then
+                    useSiteInfo.MergeAndClear(localUseSiteInfo)
                     Return False
                 End If
+
+                useSiteInfo.MergeAndClear(localUseSiteInfo)
             End If
 
             Return True
@@ -2354,7 +2365,7 @@ Done:
             <[In]()> ByRef applicable As BitVector,
             <Out()> ByRef bestMatch As MethodSymbol,
             suppressViabilityChecks As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
 #If DEBUG Then
             Debug.Assert(bestMatch Is Nothing)
@@ -2452,7 +2463,7 @@ Done:
                     ' reached this place.
                     Debug.Assert(Not (Conversions.IsWideningConversion(conversionIn) AndAlso Conversions.IsWideningConversion(conversionOut)))
 
-                ElseIf ClassifyConversionOperatorInOutConversions(source, destination, method, conversionIn, conversionOut, suppressViabilityChecks, useSiteDiagnostics) Then
+                ElseIf ClassifyConversionOperatorInOutConversions(source, destination, method, conversionIn, conversionOut, suppressViabilityChecks, useSiteInfo) Then
                     conversionKinds(currentIndex) = New KeyValuePair(Of ConversionKind, ConversionKind)(conversionIn, conversionOut)
                 Else
                     'opSet(currentIndex) = Nothing
@@ -2584,9 +2595,9 @@ Done:
                         Debug.Assert(typeSet.Count = applicableCount OrElse (haveWideningInConversions <> 0 AndAlso typeSet.Count = haveWideningInConversions))
 
                         If haveWideningInConversions <> 0 Then
-                            mostSpecificSourceType = MostEncompassed(typeSet, useSiteDiagnostics)
+                            mostSpecificSourceType = MostEncompassed(typeSet, useSiteInfo)
                         Else
-                            mostSpecificSourceType = MostEncompassing(typeSet, useSiteDiagnostics)
+                            mostSpecificSourceType = MostEncompassing(typeSet, useSiteInfo)
                         End If
                     End If
 
@@ -2616,9 +2627,9 @@ Done:
                         Debug.Assert(typeSet.Count = applicableCount OrElse (haveWideningOutConversions <> 0 AndAlso typeSet.Count = haveWideningOutConversions))
 
                         If haveWideningOutConversions <> 0 Then
-                            mostSpecificTargetType = MostEncompassing(typeSet, useSiteDiagnostics)
+                            mostSpecificTargetType = MostEncompassing(typeSet, useSiteInfo)
                         Else
-                            mostSpecificTargetType = MostEncompassed(typeSet, useSiteDiagnostics)
+                            mostSpecificTargetType = MostEncompassed(typeSet, useSiteInfo)
                         End If
                     End If
 
@@ -2656,7 +2667,7 @@ Done:
         ''' type is the "smallest" type in the set—the one type that can be converted from each
         ''' of the other types through a narrowing conversion.
         ''' </summary>
-        Private Shared Function MostEncompassed(typeSet As ArrayBuilder(Of TypeSymbol), <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As TypeSymbol
+        Private Shared Function MostEncompassed(typeSet As ArrayBuilder(Of TypeSymbol), <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As TypeSymbol
             Dim best As TypeSymbol = Nothing
 
             For i As Integer = 0 To typeSet.Count - 1
@@ -2673,7 +2684,7 @@ Done:
                         Continue For
                     End If
 
-                    Dim conv As ConversionKind = Conversions.ClassifyPredefinedConversion(type, typeSet(j), useSiteDiagnostics)
+                    Dim conv As ConversionKind = Conversions.ClassifyPredefinedConversion(type, typeSet(j), useSiteInfo)
 
                     If Not Conversions.IsWideningConversion(conv) Then
                         ' type is not encompassed by the other type
@@ -2701,7 +2712,7 @@ Next_i:
         ''' type is the "largest" type in the set—the one type to which each of the other
         ''' types can be converted through a widening conversion.
         ''' </summary>
-        Private Shared Function MostEncompassing(typeSet As ArrayBuilder(Of TypeSymbol), <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As TypeSymbol
+        Private Shared Function MostEncompassing(typeSet As ArrayBuilder(Of TypeSymbol), <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As TypeSymbol
             Dim best As TypeSymbol = Nothing
 
             For i As Integer = 0 To typeSet.Count - 1
@@ -2718,7 +2729,7 @@ Next_i:
                         Continue For
                     End If
 
-                    Dim conv As ConversionKind = Conversions.ClassifyPredefinedConversion(typeSet(j), type, useSiteDiagnostics)
+                    Dim conv As ConversionKind = Conversions.ClassifyPredefinedConversion(typeSet(j), type, useSiteInfo)
 
                     If Not Conversions.IsWideningConversion(conv) Then
                         ' type is not encompassing the other type
@@ -2812,12 +2823,12 @@ Next_i:
             source As TypeSymbol,
             destination As TypeSymbol,
             opSet As ArrayBuilder(Of MethodSymbol),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             CollectUserDefinedOperators(source, destination, MethodKind.Conversion,
                                         WellKnownMemberNames.ImplicitConversionName, New OperatorInfo(UnaryOperatorKind.Implicit),
                                         WellKnownMemberNames.ExplicitConversionName, New OperatorInfo(UnaryOperatorKind.Explicit),
-                                        opSet, useSiteDiagnostics)
+                                        opSet, useSiteInfo)
         End Sub
 
         ''' <summary>
@@ -2834,12 +2845,12 @@ Next_i:
             name2Opt As String,
             name2InfoOpt As OperatorInfo,
             opSet As ArrayBuilder(Of MethodSymbol),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
-            type1 = GetTypeToLookForOperatorsIn(type1, useSiteDiagnostics)
+            type1 = GetTypeToLookForOperatorsIn(type1, useSiteInfo)
 
             If type2 IsNot Nothing Then
-                type2 = GetTypeToLookForOperatorsIn(type2, useSiteDiagnostics)
+                type2 = GetTypeToLookForOperatorsIn(type2, useSiteInfo)
             End If
 
             Dim commonAncestor As NamedTypeSymbol = Nothing
@@ -2849,7 +2860,7 @@ Next_i:
 
                 Do
                     If type2 IsNot Nothing AndAlso commonAncestor Is Nothing AndAlso
-                       type2.IsOrDerivedFrom(current, useSiteDiagnostics) Then
+                       type2.IsOrDerivedFrom(current, useSiteInfo) Then
                         commonAncestor = current
                     End If
 
@@ -2859,7 +2870,7 @@ Next_i:
                         Exit Do
                     End If
 
-                    current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
                 Loop While current IsNot Nothing
             End If
 
@@ -2877,7 +2888,7 @@ Next_i:
                         Exit Do
                     End If
 
-                    current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
                 Loop While current IsNot Nothing
             End If
 
@@ -2920,40 +2931,40 @@ Next_i:
         ''' Given the type of operator's argument, return corresponding type to
         ''' look for operator in. Can return Nothing.
         ''' </summary>
-        Private Shared Function GetTypeToLookForOperatorsIn(type As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As TypeSymbol
+        Private Shared Function GetTypeToLookForOperatorsIn(type As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As TypeSymbol
             type = type.GetNullableUnderlyingTypeOrSelf()
 
             If type.Kind = SymbolKind.TypeParameter Then
-                type = DirectCast(type, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteDiagnostics)
+                type = DirectCast(type, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteInfo)
             End If
 
             Return type
         End Function
 
-        Public Shared Function ResolveIsTrueOperator(argument As BoundExpression, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As OverloadResolutionResult
+        Public Shared Function ResolveIsTrueOperator(argument As BoundExpression, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As OverloadResolutionResult
             Dim opSet = ArrayBuilder(Of MethodSymbol).GetInstance()
 
             CollectUserDefinedOperators(argument.Type, Nothing, MethodKind.UserDefinedOperator,
                                         WellKnownMemberNames.TrueOperatorName, New OperatorInfo(UnaryOperatorKind.IsTrue),
                                         Nothing, Nothing,
-                                        opSet, useSiteDiagnostics)
+                                        opSet, useSiteInfo)
 
             Dim result = OperatorInvocationOverloadResolution(opSet, argument, Nothing, binder, lateBindingIsAllowed:=False, includeEliminatedCandidates:=False,
-                                                              useSiteDiagnostics:=useSiteDiagnostics)
+                                                              useSiteInfo:=useSiteInfo)
             opSet.Free()
             Return result
         End Function
 
-        Public Shared Function ResolveIsFalseOperator(argument As BoundExpression, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As OverloadResolutionResult
+        Public Shared Function ResolveIsFalseOperator(argument As BoundExpression, binder As Binder, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As OverloadResolutionResult
             Dim opSet = ArrayBuilder(Of MethodSymbol).GetInstance()
 
             CollectUserDefinedOperators(argument.Type, Nothing, MethodKind.UserDefinedOperator,
                                         WellKnownMemberNames.FalseOperatorName, New OperatorInfo(UnaryOperatorKind.IsFalse),
                                         Nothing, Nothing,
-                                        opSet, useSiteDiagnostics)
+                                        opSet, useSiteInfo)
 
             Dim result = OperatorInvocationOverloadResolution(opSet, argument, Nothing, binder, lateBindingIsAllowed:=False, includeEliminatedCandidates:=False,
-                                                              useSiteDiagnostics:=useSiteDiagnostics)
+                                                              useSiteInfo:=useSiteInfo)
             opSet.Free()
             Return result
         End Function
@@ -2962,7 +2973,7 @@ Next_i:
             argument As BoundExpression,
             opKind As UnaryOperatorKind,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional includeEliminatedCandidates As Boolean = False
         ) As OverloadResolutionResult
             Dim opSet = ArrayBuilder(Of MethodSymbol).GetInstance()
@@ -2973,23 +2984,23 @@ Next_i:
                     CollectUserDefinedOperators(argument.Type, Nothing, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.OnesComplementOperatorName, opInfo,
                                                 WellKnownMemberNames.LogicalNotOperatorName, opInfo,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case UnaryOperatorKind.Minus
                     CollectUserDefinedOperators(argument.Type, Nothing, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.UnaryNegationOperatorName, New OperatorInfo(UnaryOperatorKind.Minus),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case UnaryOperatorKind.Plus
                     CollectUserDefinedOperators(argument.Type, Nothing, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.UnaryPlusOperatorName, New OperatorInfo(UnaryOperatorKind.Minus),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(opKind)
             End Select
 
             Dim result = OperatorInvocationOverloadResolution(opSet, argument, Nothing, binder, lateBindingIsAllowed:=False, includeEliminatedCandidates:=includeEliminatedCandidates,
-                                                              useSiteDiagnostics:=useSiteDiagnostics)
+                                                              useSiteInfo:=useSiteInfo)
             opSet.Free()
             Return result
         End Function
@@ -2999,7 +3010,7 @@ Next_i:
             right As BoundExpression,
             opKind As BinaryOperatorKind,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional includeEliminatedCandidates As Boolean = False
         ) As OverloadResolutionResult
             Dim opSet = ArrayBuilder(Of MethodSymbol).GetInstance()
@@ -3009,113 +3020,113 @@ Next_i:
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.AdditionOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Subtract
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.SubtractionOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Multiply
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.MultiplyOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Divide
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.DivisionOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.IntegerDivide
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.IntegerDivisionOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Modulo
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.ModulusOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Power
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.ExponentOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Equals
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.EqualityOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.NotEquals
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.InequalityOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.LessThan
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.LessThanOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.GreaterThan
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.GreaterThanOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.LessThanOrEqual
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.LessThanOrEqualOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.GreaterThanOrEqual
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.GreaterThanOrEqualOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Like
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.LikeOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Concatenate
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.ConcatenateOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.And, BinaryOperatorKind.AndAlso
                     Dim opInfo As New OperatorInfo(opKind)
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.BitwiseAndOperatorName, opInfo,
                                                 WellKnownMemberNames.LogicalAndOperatorName, opInfo,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
 
                 Case BinaryOperatorKind.Or, BinaryOperatorKind.OrElse
                     Dim opInfo As New OperatorInfo(opKind)
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.BitwiseOrOperatorName, opInfo,
                                                 WellKnownMemberNames.LogicalOrOperatorName, opInfo,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.Xor
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.ExclusiveOrOperatorName, New OperatorInfo(opKind),
                                                 Nothing, Nothing,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.LeftShift
                     Dim opInfo As New OperatorInfo(opKind)
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.LeftShiftOperatorName, opInfo,
                                                 WellKnownMemberNames.UnsignedLeftShiftOperatorName, opInfo,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case BinaryOperatorKind.RightShift
                     Dim opInfo As New OperatorInfo(opKind)
                     CollectUserDefinedOperators(left.Type, right.Type, MethodKind.UserDefinedOperator,
                                                 WellKnownMemberNames.RightShiftOperatorName, opInfo,
                                                 WellKnownMemberNames.UnsignedRightShiftOperatorName, opInfo,
-                                                opSet, useSiteDiagnostics)
+                                                opSet, useSiteInfo)
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(opKind)
             End Select
 
             Dim result = OperatorInvocationOverloadResolution(opSet, left, right, binder, lateBindingIsAllowed:=True, includeEliminatedCandidates:=includeEliminatedCandidates,
-                                                              useSiteDiagnostics:=useSiteDiagnostics)
+                                                              useSiteInfo:=useSiteInfo)
             opSet.Free()
             Return result
         End Function
@@ -3127,7 +3138,7 @@ Next_i:
             binder As Binder,
             lateBindingIsAllowed As Boolean,
             includeEliminatedCandidates As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As OverloadResolutionResult
 
             If opSet.Count = 0 Then
@@ -3142,7 +3153,7 @@ Next_i:
             End If
 
             Dim nullableOfT As NamedTypeSymbol = opSet(0).ContainingAssembly.GetSpecialType(SpecialType.System_Nullable_T)
-            Dim liftOperators As Boolean = nullableOfT.GetUseSiteErrorInfo() Is Nothing
+            Dim liftOperators As Boolean = nullableOfT.GetUseSiteInfo().DiagnosticInfo Is Nothing
 
             Dim candidates = ArrayBuilder(Of CandidateAnalysisResult).GetInstance()
 
@@ -3159,15 +3170,10 @@ Next_i:
                     Continue For
                 End If
 
-                Dim useSiteErrorInfo As DiagnosticInfo = method.GetUseSiteErrorInfo()
+                Dim methodUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = method.GetUseSiteInfo()
+                useSiteInfo.Add(methodUseSiteInfo)
 
-                If useSiteErrorInfo IsNot Nothing Then
-                    If useSiteDiagnostics Is Nothing Then
-                        useSiteDiagnostics = New HashSet(Of DiagnosticInfo)()
-                    End If
-
-                    useSiteDiagnostics.Add(useSiteErrorInfo)
-
+                If methodUseSiteInfo.DiagnosticInfo IsNot Nothing Then
                     If includeEliminatedCandidates Then
                         candidates.Add(New CandidateAnalysisResult(New OperatorCandidate(method), CandidateAnalysisResultState.HasUseSiteError))
                     End If
@@ -3175,7 +3181,7 @@ Next_i:
                     Continue For
                 End If
 
-                CombineCandidates(candidates, New CandidateAnalysisResult(New OperatorCandidate(method)), method.ParameterCount, Nothing, useSiteDiagnostics)
+                CombineCandidates(candidates, New CandidateAnalysisResult(New OperatorCandidate(method)), method.ParameterCount, Nothing, useSiteInfo)
 
                 If liftOperators Then
                     Dim param1 As ParameterSymbol = method.Parameters(0)
@@ -3216,7 +3222,7 @@ Next_i:
                                                                                                   ImmutableArray.Create(param1),
                                                                                                   ImmutableArray.Create(Of ParameterSymbol)(param1, param2)),
                                                                                               returnType)),
-                                          method.ParameterCount, Nothing, useSiteDiagnostics)
+                                          method.ParameterCount, Nothing, useSiteInfo)
                     End If
                 End If
             Next
@@ -3231,7 +3237,7 @@ Next_i:
                                                                         Nothing, Nothing, lateBindingIsAllowed, binder:=binder,
                                                                         asyncLambdaSubToFunctionMismatch:=Nothing,
                                                                         callerInfoOpt:=Nothing, forceExpandedForm:=False,
-                                                                        useSiteDiagnostics:=useSiteDiagnostics)
+                                                                        useSiteInfo:=useSiteInfo)
             candidates.Free()
 
             Return result
@@ -3276,8 +3282,8 @@ Next_i:
                 End Get
             End Property
 
-            Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-                Return _parameterToLift.GetUseSiteErrorInfo()
+            Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+                Return _parameterToLift.GetUseSiteInfo()
             End Function
 
             Public Overrides ReadOnly Property ContainingSymbol As Symbol

--- a/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
@@ -510,10 +510,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Structure OptionalArgument
             Public ReadOnly DefaultValue As BoundExpression
             Public ReadOnly Conversion As KeyValuePair(Of ConversionKind, MethodSymbol)
+            Public ReadOnly Dependencies As ImmutableArray(Of AssemblySymbol)
 
-            Public Sub New(value As BoundExpression, conversion As KeyValuePair(Of ConversionKind, MethodSymbol))
+            Public Sub New(value As BoundExpression, conversion As KeyValuePair(Of ConversionKind, MethodSymbol), dependencies As ImmutableArray(Of AssemblySymbol))
                 Me.DefaultValue = value
                 Me.Conversion = conversion
+                Me.Dependencies = dependencies.NullToEmpty()
             End Sub
         End Structure
 
@@ -702,7 +704,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public NotInferredTypeArguments As BitVector
 
-            Public TypeArgumentInferenceDiagnosticsOpt As DiagnosticBag
+            Public TypeArgumentInferenceDiagnosticsOpt As BindingDiagnosticBag
 
             Public Sub New(candidate As Candidate, state As CandidateAnalysisResultState)
                 Me.Candidate = candidate
@@ -800,7 +802,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             argumentNames As ImmutableArray(Of String),
             binder As Binder,
             callerInfoOpt As SyntaxNode,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional includeEliminatedCandidates As Boolean = False,
             Optional forceExpandedForm As Boolean = False
         ) As OverloadResolutionResult
@@ -813,7 +815,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     argumentNames,
                     binder,
                     callerInfoOpt,
-                    useSiteDiagnostics,
+                    useSiteInfo,
                     includeEliminatedCandidates,
                     forceExpandedForm:=forceExpandedForm)
             Else
@@ -824,7 +826,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     argumentNames,
                     binder,
                     callerInfoOpt,
-                    useSiteDiagnostics,
+                    useSiteInfo,
                     includeEliminatedCandidates)
             End If
 
@@ -837,7 +839,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             methodGroup As BoundMethodGroup,
             arguments As ImmutableArray(Of BoundExpression),
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional includeEliminatedCandidates As Boolean = False
         ) As OverloadResolutionResult
             Return MethodInvocationOverloadResolution(
@@ -846,7 +848,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Nothing,
                         binder,
                         callerInfoOpt:=Nothing,
-                        useSiteDiagnostics:=useSiteDiagnostics,
+                        useSiteInfo:=useSiteInfo,
                         includeEliminatedCandidates:=includeEliminatedCandidates,
                         lateBindingIsAllowed:=False,
                         isQueryOperatorInvocation:=True)
@@ -863,7 +865,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             argumentNames As ImmutableArray(Of String),
             binder As Binder,
             callerInfoOpt As SyntaxNode,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional includeEliminatedCandidates As Boolean = False,
             Optional delegateReturnType As TypeSymbol = Nothing,
             Optional delegateReturnTypeReferenceBoundNode As BoundNode = Nothing,
@@ -915,13 +917,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     binder, candidates, instanceCandidates, typeArguments,
                     arguments, argumentNames, delegateReturnType, delegateReturnTypeReferenceBoundNode,
                     includeEliminatedCandidates, isQueryOperatorInvocation, forceExpandedForm, asyncLambdaSubToFunctionMismatch,
-                    useSiteDiagnostics)
+                    useSiteInfo)
 
                 applicableInstanceCandidateCount = EliminateNotApplicableToArguments(methodGroup, candidates, arguments, argumentNames, binder,
                                                                                      applicableNarrowingCandidateCount, asyncLambdaSubToFunctionMismatch,
                                                                                      callerInfoOpt,
                                                                                      forceExpandedForm,
-                                                                                     useSiteDiagnostics)
+                                                                                     useSiteInfo)
             End If
 
             instanceCandidates.Free()
@@ -933,7 +935,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If ShouldConsiderExtensionMethods(candidates) Then
                 ' Request additional extension methods, if any available.
                 If methodGroup.ResultKind = LookupResultKind.Good Then
-                    methods = methodGroup.AdditionalExtensionMethods(useSiteDiagnostics)
+                    methods = methodGroup.AdditionalExtensionMethods(useSiteInfo)
 
                     For Each method As MethodSymbol In methods
                         curriedCandidates.Add(New ExtensionMethodCandidate(method))
@@ -947,7 +949,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         binder, candidates, curriedCandidates, typeArguments,
                         arguments, argumentNames, delegateReturnType, delegateReturnTypeReferenceBoundNode,
                         includeEliminatedCandidates, isQueryOperatorInvocation, forceExpandedForm, asyncLambdaSubToFunctionMismatch,
-                        useSiteDiagnostics)
+                        useSiteInfo)
                 End If
             End If
 
@@ -958,7 +960,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 result = ReportOverloadResolutionFailedOrLateBound(candidates, applicableInstanceCandidateCount, lateBindingIsAllowed AndAlso binder.OptionStrict <> OptionStrict.On, asyncLambdaSubToFunctionMismatch)
             Else
                 result = ResolveOverloading(methodGroup, candidates, arguments, argumentNames, delegateReturnType, lateBindingIsAllowed, binder, asyncLambdaSubToFunctionMismatch, callerInfoOpt, forceExpandedForm,
-                                            useSiteDiagnostics)
+                                            useSiteInfo)
             End If
 
             candidates.Free()
@@ -994,7 +996,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             argumentNames As ImmutableArray(Of String),
             binder As Binder,
             callerInfoOpt As SyntaxNode,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional includeEliminatedCandidates As Boolean = False
         ) As OverloadResolutionResult
             Debug.Assert(propertyGroup.ResultKind = LookupResultKind.Good OrElse propertyGroup.ResultKind = LookupResultKind.Inaccessible)
@@ -1017,13 +1019,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             CollectOverloadedCandidates(binder, results, candidates, ImmutableArray(Of TypeSymbol).Empty,
                                         arguments, argumentNames, Nothing, Nothing, includeEliminatedCandidates,
                                         isQueryOperatorInvocation:=False, forceExpandedForm:=False, asyncLambdaSubToFunctionMismatch:=asyncLambdaSubToFunctionMismatch,
-                                        useSiteDiagnostics:=useSiteDiagnostics)
+                                        useSiteInfo:=useSiteInfo)
             Debug.Assert(asyncLambdaSubToFunctionMismatch Is Nothing)
             candidates.Free()
 
             Dim result = ResolveOverloading(propertyGroup, results, arguments, argumentNames, delegateReturnType:=Nothing, lateBindingIsAllowed:=True, binder:=binder,
                                             asyncLambdaSubToFunctionMismatch:=asyncLambdaSubToFunctionMismatch, callerInfoOpt:=callerInfoOpt, forceExpandedForm:=False,
-                                            useSiteDiagnostics:=useSiteDiagnostics)
+                                            useSiteInfo:=useSiteInfo)
             results.Free()
 
             Return result
@@ -1062,7 +1064,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
             callerInfoOpt As SyntaxNode,
             forceExpandedForm As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As OverloadResolutionResult
 
             Debug.Assert(argumentNames.IsDefault OrElse argumentNames.Length = arguments.Length)
@@ -1087,7 +1089,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                      applicableNarrowingCandidates, asyncLambdaSubToFunctionMismatch,
                                                                      callerInfoOpt,
                                                                      forceExpandedForm,
-                                                                     useSiteDiagnostics)
+                                                                     useSiteInfo)
             If applicableCandidates < 2 Then
                 narrowingCandidatesRemainInTheSet = (applicableNarrowingCandidates > 0)
                 GoTo ResolutionComplete
@@ -1119,7 +1121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' level, however it needs other tie breaking rules applied to equally applicable candidates prior
             ' to figuring out the minimal inference level to use as the filter.
             ShadowBasedOnInferenceLevel(candidates, arguments, Not argumentNames.IsDefault, delegateReturnType, binder,
-                                        applicableCandidates, applicableNarrowingCandidates, useSiteDiagnostics)
+                                        applicableCandidates, applicableNarrowingCandidates, useSiteInfo)
             If applicableCandidates < 2 Then
                 narrowingCandidatesRemainInTheSet = (applicableNarrowingCandidates > 0)
                 GoTo ResolutionComplete
@@ -1141,7 +1143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 applicableCandidates = AnalyzeNarrowingCandidates(candidates, arguments, delegateReturnType,
                                                                   lateBindingIsAllowed AndAlso binder.OptionStrict <> OptionStrict.On, binder,
                                                                   resolutionIsLateBound,
-                                                                  useSiteDiagnostics)
+                                                                  useSiteInfo)
             Else
                 If applicableNarrowingCandidates > 0 Then
                     Debug.Assert(applicableNarrowingCandidates < applicableCandidates)
@@ -1169,7 +1171,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 '7.	Otherwise, given any two members of the set, M and N, apply the following tie-breaking rules, in order.
                 applicableCandidates = EliminateLessApplicableToTheArguments(candidates, arguments, delegateReturnType,
                                                                              False, ' appliedTieBreakingRules
-                                                                             binder, useSiteDiagnostics)
+                                                                             binder, useSiteInfo)
             End If
 
 ResolutionComplete:
@@ -1223,14 +1225,14 @@ ResolutionComplete:
             delegateReturnType As TypeSymbol,
             appliedTieBreakingRules As Boolean,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional mostApplicableMustNarrowOnlyFromNumericConstants As Boolean = False
         ) As Integer
             Dim applicableCandidates As Integer
 
             Dim indexesOfEqualMostApplicableCandidates As ArrayBuilder(Of Integer) = ArrayBuilder(Of Integer).GetInstance()
 
-            If FastFindMostApplicableCandidates(candidates, arguments, indexesOfEqualMostApplicableCandidates, binder, useSiteDiagnostics) AndAlso
+            If FastFindMostApplicableCandidates(candidates, arguments, indexesOfEqualMostApplicableCandidates, binder, useSiteInfo) AndAlso
                (mostApplicableMustNarrowOnlyFromNumericConstants = False OrElse
                 candidates(indexesOfEqualMostApplicableCandidates(0)).RequiresNarrowingNotFromNumericConstant = False OrElse
                 indexesOfEqualMostApplicableCandidates.Count = CountApplicableCandidates(candidates)) Then
@@ -1271,7 +1273,7 @@ ResolutionComplete:
 
                 ' Apply tie-breaking rules 
                 If Not appliedTieBreakingRules Then
-                    applicableCandidates = ApplyTieBreakingRules(candidates, indexesOfEqualMostApplicableCandidates, arguments, delegateReturnType, binder, useSiteDiagnostics)
+                    applicableCandidates = ApplyTieBreakingRules(candidates, indexesOfEqualMostApplicableCandidates, arguments, delegateReturnType, binder, useSiteInfo)
                 Else
                     applicableCandidates = indexesOfEqualMostApplicableCandidates.Count
                 End If
@@ -1282,7 +1284,7 @@ ResolutionComplete:
                 ' this will provide better error reporting experience. As we are doing this, we will redo
                 ' applicability comparisons that we've done earlier in FastFindMostApplicableCandidates, but we are willing to 
                 ' pay the price for erroneous code.
-                applicableCandidates = ApplyTieBreakingRulesToEquallyApplicableCandidates(candidates, arguments, delegateReturnType, binder, useSiteDiagnostics)
+                applicableCandidates = ApplyTieBreakingRulesToEquallyApplicableCandidates(candidates, arguments, delegateReturnType, binder, useSiteInfo)
 
             Else
                 applicableCandidates = CountApplicableCandidates(candidates)
@@ -1314,7 +1316,7 @@ ResolutionComplete:
             arguments As ImmutableArray(Of BoundExpression),
             delegateReturnType As TypeSymbol,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Integer
 
             ' First, let's break all remaining candidates into buckets of equally applicable candidates
@@ -1326,7 +1328,7 @@ ResolutionComplete:
 
             ' Apply tie-breaking rules
             For i As Integer = 0 To buckets.Count - 1 Step 1
-                applicableCandidates += ApplyTieBreakingRules(candidates, buckets(i), arguments, delegateReturnType, binder, useSiteDiagnostics)
+                applicableCandidates += ApplyTieBreakingRules(candidates, buckets(i), arguments, delegateReturnType, binder, useSiteInfo)
             Next
 
             ' Release memory we no longer need.
@@ -1350,7 +1352,7 @@ ResolutionComplete:
             arguments As ImmutableArray(Of BoundExpression),
             indexesOfMostApplicableCandidates As ArrayBuilder(Of Integer),
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             Dim mightBeTheMostApplicableIndex As Integer = -1
             Dim mightBeTheMostApplicable As CandidateAnalysisResult = Nothing
@@ -1373,7 +1375,7 @@ ResolutionComplete:
                     mightBeTheMostApplicable = contender
                     indexesOfMostApplicableCandidates.Add(i)
                 Else
-                    Dim cmp As ApplicabilityComparisonResult = CompareApplicabilityToTheArguments(mightBeTheMostApplicable, contender, arguments, binder, useSiteDiagnostics)
+                    Dim cmp As ApplicabilityComparisonResult = CompareApplicabilityToTheArguments(mightBeTheMostApplicable, contender, arguments, binder, useSiteInfo)
 
                     If cmp = ApplicabilityComparisonResult.RightIsMoreApplicable Then
                         mightBeTheMostApplicableIndex = i
@@ -1400,7 +1402,7 @@ ResolutionComplete:
                     Continue For
                 End If
 
-                Dim cmp As ApplicabilityComparisonResult = CompareApplicabilityToTheArguments(mightBeTheMostApplicable, contender, arguments, binder, useSiteDiagnostics)
+                Dim cmp As ApplicabilityComparisonResult = CompareApplicabilityToTheArguments(mightBeTheMostApplicable, contender, arguments, binder, useSiteInfo)
 
                 If cmp = ApplicabilityComparisonResult.RightIsMoreApplicable OrElse
                    cmp = ApplicabilityComparisonResult.Undefined OrElse
@@ -1427,7 +1429,7 @@ ResolutionComplete:
             arguments As ImmutableArray(Of BoundExpression),
             delegateReturnType As TypeSymbol,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Integer
             Dim leftWins As Boolean
             Dim rightWins As Boolean
@@ -1447,7 +1449,7 @@ ResolutionComplete:
                         Continue For
                     End If
 
-                    If ShadowBasedOnTieBreakingRules(left, right, arguments, delegateReturnType, leftWins, rightWins, binder, useSiteDiagnostics) Then
+                    If ShadowBasedOnTieBreakingRules(left, right, arguments, delegateReturnType, leftWins, rightWins, binder, useSiteInfo) Then
                         Debug.Assert(Not (leftWins AndAlso rightWins))
 
                         If leftWins Then
@@ -1481,7 +1483,7 @@ ResolutionComplete:
             ByRef leftWins As Boolean,
             ByRef rightWins As Boolean,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
 
             ' Let's apply various shadowing and tie-breaking rules 
@@ -1499,7 +1501,7 @@ ResolutionComplete:
             '       This rule also applies to the types that extension methods are defined on. 
             '7.2.	If M and N are extension methods and the target type of M is a class or 
             '       structure and the target type of N is an interface, eliminate N from the set.
-            If ShadowBasedOnReceiverType(left, right, leftWins, rightWins, useSiteDiagnostics) Then
+            If ShadowBasedOnReceiverType(left, right, leftWins, rightWins, useSiteInfo) Then
                 Return True  ' I believe we can get here only in presence of named arguments and optional parameters. Otherwise, CombineCandidates takes care of this shadowing.
             End If
 
@@ -1707,7 +1709,7 @@ ResolutionComplete:
             binder As Binder,
             ByRef applicableCandidates As Integer,
             ByRef applicableNarrowingCandidates As Integer,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Debug.Assert(Not haveNamedArguments OrElse Not candidates(0).Candidate.IsOperator)
 
@@ -1825,7 +1827,7 @@ ResolutionComplete:
                         Dim rightWins As Boolean = False
 
                         If (Not signatureMatch AndAlso ShadowBasedOnParamArrayUsage(left, right, leftWins, rightWins)) OrElse
-                           ShadowBasedOnReceiverType(left, right, leftWins, rightWins, useSiteDiagnostics) OrElse
+                           ShadowBasedOnReceiverType(left, right, leftWins, rightWins, useSiteInfo) OrElse
                            ShadowBasedOnExtensionMethodTargetTypeGenericity(left, right, leftWins, rightWins) Then
                             Debug.Assert(leftWins Xor rightWins)
                             If leftWins Then
@@ -1913,7 +1915,7 @@ ResolutionComplete:
             ByRef right As CandidateAnalysisResult,
             arguments As ImmutableArray(Of BoundExpression),
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ApplicabilityComparisonResult
 
             ' §11.8.1.1 Applicability
@@ -1955,7 +1957,7 @@ ResolutionComplete:
                     Continue For
                 End If
 
-                Dim cmp = CompareParameterTypeApplicability(leftParamType, rightParamType, arguments(i), binder, useSiteDiagnostics)
+                Dim cmp = CompareParameterTypeApplicability(leftParamType, rightParamType, arguments(i), binder, useSiteInfo)
 
                 If cmp = ApplicabilityComparisonResult.LeftIsMoreApplicable Then
                     leftHasMoreApplicableParameterType = True
@@ -2011,7 +2013,7 @@ ResolutionComplete:
             right As TypeSymbol,
             argument As BoundExpression,
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As ApplicabilityComparisonResult
             Debug.Assert(argument Is Nothing OrElse argument.Kind <> BoundKind.OmittedArgument)
 
@@ -2019,7 +2021,7 @@ ResolutionComplete:
             'Given a pair of parameters Mj and Nj that matches an argument Aj, 
             'the type of Mj is considered more applicable than the type of Nj if one of the following conditions is true:
 
-            Dim leftToRightConversion = Conversions.ClassifyConversion(left, right, useSiteDiagnostics)
+            Dim leftToRightConversion = Conversions.ClassifyConversion(left, right, useSiteInfo)
 
             '1.	Mj and Nj have identical types, or
             ' !!! Does this rule make sense? Not implementing it for now.  
@@ -2033,7 +2035,7 @@ ResolutionComplete:
                 ' !!! For user defined conversions that widen in both directions there is a tie-breaking rule
                 ' !!! not mentioned in the spec. The type that matches argument's type is more applicable.
                 ' !!! Otherwise neither is more applicable.
-                If Conversions.IsWideningConversion(Conversions.ClassifyConversion(right, left, useSiteDiagnostics).Key) Then
+                If Conversions.IsWideningConversion(Conversions.ClassifyConversion(right, left, useSiteInfo).Key) Then
                     GoTo BreakTheTie
                 End If
 
@@ -2051,7 +2053,7 @@ ResolutionComplete:
                 Return ApplicabilityComparisonResult.LeftIsMoreApplicable
             End If
 
-            If Conversions.IsWideningConversion(Conversions.ClassifyConversion(right, left, useSiteDiagnostics).Key) Then
+            If Conversions.IsWideningConversion(Conversions.ClassifyConversion(right, left, useSiteInfo).Key) Then
 
                 ' !!! Spec makes it look like rule #3 is a separate rule applied after the second, but this isn't the case
                 ' !!! because enumerated type widens to its underlying type, however, if argument is a zero literal,
@@ -2133,7 +2135,7 @@ ResolutionComplete:
                             newArgument = DirectCast(argument, BoundQueryLambda).Expression
                         End If
 
-                        Return CompareParameterTypeApplicability(leftInvoke.ReturnType, rightInvoke.ReturnType, newArgument, binder, useSiteDiagnostics)
+                        Return CompareParameterTypeApplicability(leftInvoke.ReturnType, rightInvoke.ReturnType, newArgument, binder, useSiteInfo)
                     End If
                 End If
             End If
@@ -2328,7 +2330,7 @@ BreakTheTie:
             lateBindingIsAllowed As Boolean,
             binder As Binder,
             ByRef resolutionIsLateBound As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Integer
             Dim applicableCandidates As Integer = 0
             Dim appliedTieBreakingRules As Boolean = False
@@ -2369,7 +2371,7 @@ BreakTheTie:
 
                     If Not appliedTieBreakingRules Then
                         ' Apply shadowing rules, Dev10 compiler does that for narrowing candidates too.
-                        applicableCandidates = ApplyTieBreakingRulesToEquallyApplicableCandidates(candidates, arguments, delegateReturnType, binder, useSiteDiagnostics)
+                        applicableCandidates = ApplyTieBreakingRulesToEquallyApplicableCandidates(candidates, arguments, delegateReturnType, binder, useSiteInfo)
                         appliedTieBreakingRules = True
                         Debug.Assert(applicableCandidates > 1) ' source and lifted operators are not equally applicable.
                     End If
@@ -2405,9 +2407,9 @@ BreakTheTie:
                                         Else
                                             ' Lifted user-defined conversions don't unwrap nullables, they are marked with Nullable bit.
                                             If (conv.Key And ConversionKind.Nullable) = 0 Then
-                                                If IsUnwrappingNullable(arguments(j).Type, conv.Value.Parameters(0).Type, useSiteDiagnostics) Then
+                                                If IsUnwrappingNullable(arguments(j).Type, conv.Value.Parameters(0).Type, useSiteInfo) Then
                                                     lost = True
-                                                ElseIf IsUnwrappingNullable(conv.Value.ReturnType, current.Candidate.Parameters(j).Type, useSiteDiagnostics) Then
+                                                ElseIf IsUnwrappingNullable(conv.Value.ReturnType, current.Candidate.Parameters(j).Type, useSiteInfo) Then
                                                     lost = True
                                                 End If
                                             End If
@@ -2442,7 +2444,7 @@ Next_i:
 
                 If haveAllNarrowingFromObject AndAlso Not appliedTieBreakingRules Then
                     ' Apply shadowing rules, Dev10 compiler does that for narrowing candidates too.
-                    applicableCandidates = ApplyTieBreakingRulesToEquallyApplicableCandidates(candidates, arguments, delegateReturnType, binder, useSiteDiagnostics)
+                    applicableCandidates = ApplyTieBreakingRulesToEquallyApplicableCandidates(candidates, arguments, delegateReturnType, binder, useSiteInfo)
                     appliedTieBreakingRules = True
 
                     If applicableCandidates < 2 Then
@@ -2483,7 +2485,7 @@ Next_i:
             ' Although all candidates narrow, there may be a best choice when factoring in narrowing of numeric constants.  
             ' Note that EliminateLessApplicableToTheArguments applies shadowing rules, Dev10 compiler does that for narrowing candidates too.
             applicableCandidates = EliminateLessApplicableToTheArguments(candidates, arguments, delegateReturnType, appliedTieBreakingRules, binder,
-                                                                         mostApplicableMustNarrowOnlyFromNumericConstants:=True, useSiteDiagnostics:=useSiteDiagnostics)
+                                                                         mostApplicableMustNarrowOnlyFromNumericConstants:=True, useSiteInfo:=useSiteInfo)
 
             ' If we ended up with 2 applicable candidates, make sure it is not the same method in
             ' ParamArray expanded and non-expanded form. The non-expanded form should win in this case.
@@ -2543,10 +2545,10 @@ Done:
         Private Shared Function IsUnwrappingNullable(
             sourceType As TypeSymbol,
             targetType As TypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             Return sourceType IsNot Nothing AndAlso
-                   IsUnwrappingNullable(Conversions.ClassifyPredefinedConversion(sourceType, targetType, useSiteDiagnostics), sourceType, targetType)
+                   IsUnwrappingNullable(Conversions.ClassifyPredefinedConversion(sourceType, targetType, useSiteInfo), sourceType, targetType)
         End Function
 
         Private Shared Function HaveNarrowingOnlyFromObjectCandidates(
@@ -2589,7 +2591,7 @@ Done:
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
             callerInfoOpt As SyntaxNode,
             forceExpandedForm As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Integer
             Dim applicableCandidates As Integer = 0
             Dim illegalInAttribute As Integer = 0
@@ -2605,7 +2607,7 @@ Done:
                 End If
 
                 If Not current.ArgumentMatchingDone Then
-                    MatchArguments(methodOrPropertyGroup, current, arguments, argumentNames, binder, asyncLambdaSubToFunctionMismatch, callerInfoOpt, forceExpandedForm, useSiteDiagnostics)
+                    MatchArguments(methodOrPropertyGroup, current, arguments, argumentNames, binder, asyncLambdaSubToFunctionMismatch, callerInfoOpt, forceExpandedForm, useSiteInfo)
                     current.SetArgumentMatchingDone()
                     candidates(i) = current
                 End If
@@ -2856,7 +2858,7 @@ Bailout:
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
             callerInfoOpt As SyntaxNode,
             forceExpandedForm As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Debug.Assert(Not arguments.IsDefault)
             Debug.Assert(argumentNames.IsDefault OrElse (argumentNames.Length > 0 AndAlso argumentNames.Length = arguments.Length))
@@ -2868,7 +2870,7 @@ Bailout:
             Dim conversionKinds As KeyValuePair(Of ConversionKind, MethodSymbol)() = Nothing
             Dim conversionBackKinds As KeyValuePair(Of ConversionKind, MethodSymbol)() = Nothing
             Dim optionalArguments As OptionalArgument() = Nothing
-            Dim diagnostics As DiagnosticBag = Nothing
+            Dim defaultValueDiagnostics As BindingDiagnosticBag = Nothing
 
             BuildParameterToArgumentMap(candidate, arguments, argumentNames, parameterToArgumentMap, paramArrayItems)
 
@@ -2896,12 +2898,8 @@ Bailout:
                     diagnosticsBuilder.Free()
 
                     If useSiteDiagnosticsBuilder IsNot Nothing AndAlso useSiteDiagnosticsBuilder.Count > 0 Then
-                        If useSiteDiagnostics Is Nothing Then
-                            useSiteDiagnostics = New HashSet(Of DiagnosticInfo)()
-                        End If
-
                         For Each diag In useSiteDiagnosticsBuilder
-                            useSiteDiagnostics.Add(diag.DiagnosticInfo)
+                            useSiteInfo.Add(diag.UseSiteInfo)
                         Next
                     End If
 
@@ -2954,7 +2952,7 @@ Bailout:
                         Dim arrayConversion As KeyValuePair(Of ConversionKind, MethodSymbol) = Nothing
 
                         If Not (paramArrayArgument IsNot Nothing AndAlso
-                                Not paramArrayArgument.HasErrors AndAlso CanPassToParamArray(paramArrayArgument, targetType, arrayConversion, binder, useSiteDiagnostics)) Then
+                                Not paramArrayArgument.HasErrors AndAlso CanPassToParamArray(paramArrayArgument, targetType, arrayConversion, binder, useSiteInfo)) Then
                             ' It doesn't look like native compiler reports any errors in this case.
                             ' Probably due to assumption that either errors were already reported for bad argument expression or
                             ' we will report errors for expanded version of the same candidate.
@@ -3038,7 +3036,7 @@ Bailout:
                                 'Continue For
                             End If
 
-                            If Not MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, arguments(paramArrayItems(j)), targetType, binder, conv, asyncLambdaSubToFunctionMismatch, useSiteDiagnostics) Then
+                            If Not MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, arguments(paramArrayItems(j)), targetType, binder, conv, asyncLambdaSubToFunctionMismatch, useSiteInfo) Then
                                 ' Note, IgnoreExtensionMethods is not cleared here, MatchArgumentToByValParameter makes required changes.
                                 Continue For
                             End If
@@ -3067,15 +3065,16 @@ Bailout:
                 If argument Is Nothing OrElse argument.Kind = BoundKind.OmittedArgument Then
 
                     ' Deal with Optional arguments.
-                    If diagnostics Is Nothing Then
-                        diagnostics = DiagnosticBag.GetInstance()
+                    If defaultValueDiagnostics Is Nothing Then
+                        defaultValueDiagnostics = BindingDiagnosticBag.GetInstance()
+                    Else
+                        defaultValueDiagnostics.Clear()
                     End If
 
-                    defaultArgument = binder.GetArgumentForParameterDefaultValue(param, If(argument, methodOrPropertyGroup).Syntax, diagnostics, callerInfoOpt)
+                    defaultArgument = binder.GetArgumentForParameterDefaultValue(param, If(argument, methodOrPropertyGroup).Syntax, defaultValueDiagnostics, callerInfoOpt)
 
-                    If defaultArgument IsNot Nothing AndAlso Not diagnostics.HasAnyErrors Then
-                        Debug.Assert(Not diagnostics.AsEnumerable().Any())
-
+                    If defaultArgument IsNot Nothing AndAlso Not defaultValueDiagnostics.HasAnyErrors Then
+                        Debug.Assert(Not defaultValueDiagnostics.DiagnosticBag.AsEnumerable().Any())
                         ' Mark these as compiler generated so they are ignored by later phases. For example,
                         ' these bound nodes will mess up the incremental binder cache, because they use the 
                         ' the same syntax node as the method identifier from the invocation / AddressOf if they
@@ -3115,10 +3114,10 @@ Bailout:
                 ' are passed through a temp without copy-back.
                 If isByRef AndAlso Not candidateIsAProperty AndAlso defaultArgument Is Nothing AndAlso
                    (param.IsExplicitByRef OrElse (argument.Type IsNot Nothing AndAlso argument.Type.IsStringType())) Then
-                    MatchArgumentToByRefParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, conversion, conversionBack, asyncLambdaSubToFunctionMismatch, useSiteDiagnostics)
+                    MatchArgumentToByRefParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, conversion, conversionBack, asyncLambdaSubToFunctionMismatch, useSiteInfo)
                 Else
                     conversionBack = Conversions.Identity
-                    MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, conversion, asyncLambdaSubToFunctionMismatch, useSiteDiagnostics, defaultArgument IsNot Nothing)
+                    MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, conversion, asyncLambdaSubToFunctionMismatch, useSiteInfo, defaultArgument IsNot Nothing)
                 End If
 
                 ' typically all conversions in otherwise acceptable candidate are identity conversions
@@ -3144,7 +3143,7 @@ Bailout:
                     If optionalArguments Is Nothing Then
                         optionalArguments = New OptionalArgument(candidate.Candidate.ParameterCount - 1) {}
                     End If
-                    optionalArguments(paramIndex) = New OptionalArgument(defaultArgument, conversion)
+                    optionalArguments(paramIndex) = New OptionalArgument(defaultArgument, conversion, defaultValueDiagnostics.DependenciesBag.ToImmutableArray())
                 End If
 
                 If Not Conversions.IsIdentityConversion(conversionBack.Key) Then
@@ -3162,8 +3161,8 @@ Bailout:
             Next
 
 Bailout:
-            If diagnostics IsNot Nothing Then
-                diagnostics.Free()
+            If defaultValueDiagnostics IsNot Nothing Then
+                defaultValueDiagnostics.Free()
             End If
 
             If paramArrayItems IsNot Nothing Then
@@ -3201,7 +3200,7 @@ Bailout:
             <Out()> ByRef outConversionKind As KeyValuePair(Of ConversionKind, MethodSymbol),
             <Out()> ByRef outConversionBackKind As KeyValuePair(Of ConversionKind, MethodSymbol),
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
 
             If argument.IsSupportingAssignment() Then
@@ -3213,11 +3212,11 @@ Bailout:
                 Else
                     outConversionBackKind = Conversions.Identity
 
-                    If MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, outConversionKind, asyncLambdaSubToFunctionMismatch, useSiteDiagnostics) Then
+                    If MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, outConversionKind, asyncLambdaSubToFunctionMismatch, useSiteInfo) Then
 
                         ' Check copy back conversion
                         Dim copyBackType = argument.GetTypeOfAssignmentTarget()
-                        Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = Conversions.ClassifyConversion(targetType, copyBackType, useSiteDiagnostics)
+                        Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = Conversions.ClassifyConversion(targetType, copyBackType, useSiteInfo)
                         outConversionBackKind = conv
 
                         If Conversions.NoConversion(conv.Key) Then
@@ -3263,7 +3262,7 @@ Bailout:
                 End If
 
                 outConversionBackKind = Conversions.Identity
-                MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, outConversionKind, asyncLambdaSubToFunctionMismatch, useSiteDiagnostics)
+                MatchArgumentToByValParameter(methodOrPropertyGroup, candidate, argument, targetType, binder, outConversionKind, asyncLambdaSubToFunctionMismatch, useSiteInfo)
             End If
 
         End Sub
@@ -3280,7 +3279,7 @@ Bailout:
             binder As Binder,
             <Out()> ByRef outConversionKind As KeyValuePair(Of ConversionKind, MethodSymbol),
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             Optional isDefaultValueArgument As Boolean = False
         ) As Boolean
 
@@ -3294,7 +3293,7 @@ Bailout:
                 Return False
             End If
 
-            Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = Conversions.ClassifyConversion(argument, targetType, binder, useSiteDiagnostics)
+            Dim conv As KeyValuePair(Of ConversionKind, MethodSymbol) = Conversions.ClassifyConversion(argument, targetType, binder, useSiteInfo)
 
             outConversionKind = conv
 
@@ -3323,7 +3322,7 @@ Bailout:
                             Debug.Assert(bound IsNot Nothing)
 
                             If bound IsNot Nothing AndAlso (bound.MethodConversionKind And MethodConversionKind.AllErrorReasons) = MethodConversionKind.Error_SubToFunction AndAlso
-                               (Not bound.Diagnostics.HasAnyErrors) Then
+                               (Not bound.Diagnostics.Diagnostics.HasAnyErrors) Then
                                 If asyncLambdaSubToFunctionMismatch Is Nothing Then
                                     asyncLambdaSubToFunctionMismatch = New HashSet(Of BoundExpression)(ReferenceEqualityComparer.Instance)
                                 End If
@@ -3390,22 +3389,19 @@ Bailout:
                methodOrPropertyGroup.Kind = BoundKind.MethodGroup AndAlso
                IsWithinAppliedAttributeName(methodOrPropertyGroup.Syntax) AndAlso
                DirectCast(candidate.Candidate.UnderlyingSymbol, MethodSymbol).MethodKind = MethodKind.Constructor AndAlso
-               binder.Compilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(candidate.Candidate.UnderlyingSymbol.ContainingType, useSiteDiagnostics) Then
+               binder.Compilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(candidate.Candidate.UnderlyingSymbol.ContainingType, useSiteInfo) Then
 
                 Debug.Assert(Not argument.HasErrors)
-                Dim diagnostics = DiagnosticBag.GetInstance()
-                Dim passedExpression As BoundExpression = binder.PassArgumentByVal(argument, conv, targetType, diagnostics)
+                Dim passedExpression As BoundExpression = binder.PassArgumentByVal(argument, conv, targetType, BindingDiagnosticBag.Discarded)
 
                 If Not passedExpression.IsConstant Then ' Trying to match native compiler behavior in Semantics::IsValidAttributeConstant
                     Dim visitor As New Binder.AttributeExpressionVisitor(binder, passedExpression.HasErrors)
-                    visitor.VisitExpression(passedExpression, diagnostics)
+                    visitor.VisitExpression(passedExpression, BindingDiagnosticBag.Discarded)
 
                     If visitor.HasErrors Then
                         candidate.SetIllegalInAttribute()
                     End If
                 End If
-
-                diagnostics.Free()
             End If
 
             Return True
@@ -3432,12 +3428,12 @@ Bailout:
             targetType As TypeSymbol,
             <Out()> ByRef outConvKind As KeyValuePair(Of ConversionKind, MethodSymbol),
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             '§11.8.2 Applicable Methods
             'If the conversion from the type of the argument expression to the paramarray type is narrowing, 
             'then the method is only applicable in its expanded form.
-            outConvKind = Conversions.ClassifyConversion(expression, targetType, binder, useSiteDiagnostics)
+            outConvKind = Conversions.ClassifyConversion(expression, targetType, binder, useSiteInfo)
 
             ' Note, user-defined conversions are acceptable here.
             If Conversions.IsWideningConversion(outConvKind.Key) Then
@@ -3496,7 +3492,7 @@ Bailout:
             isQueryOperatorInvocation As Boolean,
             forceExpandedForm As Boolean,
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Debug.Assert(results IsNot Nothing)
             Debug.Assert(argumentNames.IsDefault OrElse (argumentNames.Length > 0 AndAlso argumentNames.Length = arguments.Length))
@@ -3510,7 +3506,7 @@ Bailout:
                     Continue For
                 End If
 
-                Dim info As QuickApplicabilityInfo = DoQuickApplicabilityCheck(group(i), typeArguments, arguments, isQueryOperatorInvocation, forceExpandedForm, useSiteDiagnostics)
+                Dim info As QuickApplicabilityInfo = DoQuickApplicabilityCheck(group(i), typeArguments, arguments, isQueryOperatorInvocation, forceExpandedForm, useSiteInfo)
 
                 If info.Candidate Is Nothing Then
                     Continue For
@@ -3521,7 +3517,7 @@ Bailout:
                     CollectOverloadedCandidate(results, info, typeArguments, arguments, argumentNames,
                                                delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                                includeEliminatedCandidates, binder, asyncLambdaSubToFunctionMismatch,
-                                               useSiteDiagnostics)
+                                               useSiteInfo)
                     Continue For
                 End If
 
@@ -3545,7 +3541,7 @@ Bailout:
                     End If
 
                     If container = group(j).UnderlyingSymbol.ContainingSymbol Then
-                        info = DoQuickApplicabilityCheck(group(j), typeArguments, arguments, isQueryOperatorInvocation, forceExpandedForm, useSiteDiagnostics)
+                        info = DoQuickApplicabilityCheck(group(j), typeArguments, arguments, isQueryOperatorInvocation, forceExpandedForm, useSiteInfo)
                         group(j) = Nothing
 
                         If info.Candidate Is Nothing Then
@@ -3637,12 +3633,12 @@ Bailout:
                         CollectOverloadedCandidate(results, info, typeArguments, arguments, argumentNames,
                                                    delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                                    includeEliminatedCandidates, binder, asyncLambdaSubToFunctionMismatch,
-                                                   useSiteDiagnostics)
+                                                   useSiteInfo)
                     ElseIf includeEliminatedCandidates Then
                         CollectOverloadedCandidate(results, info, typeArguments, arguments, argumentNames,
                                                    delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                                    includeEliminatedCandidates, binder, asyncLambdaSubToFunctionMismatch,
-                                                   useSiteDiagnostics)
+                                                   useSiteInfo)
 
                         For l As Integer = k + 1 To quickInfo.Count - 1
                             Dim info2 As QuickApplicabilityInfo = quickInfo(l)
@@ -3652,7 +3648,7 @@ Bailout:
                                 CollectOverloadedCandidate(results, info2, typeArguments, arguments, argumentNames,
                                                            delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                                            includeEliminatedCandidates, binder, asyncLambdaSubToFunctionMismatch,
-                                                           useSiteDiagnostics)
+                                                           useSiteInfo)
                             End If
                         Next
                     End If
@@ -3693,7 +3689,7 @@ Bailout:
             arguments As ImmutableArray(Of BoundExpression),
             isQueryOperatorInvocation As Boolean,
             forceExpandedForm As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As QuickApplicabilityInfo
             If isQueryOperatorInvocation AndAlso DirectCast(candidate.UnderlyingSymbol, MethodSymbol).IsSub Then
                 ' Subs are never considered as candidates for Query Operators, but method group might have subs in it. 
@@ -3742,14 +3738,10 @@ Bailout:
                 Return New QuickApplicabilityInfo(candidate, CandidateAnalysisResultState.ArgumentCountMismatch, Not hasParamArray, hasParamArray)
             End If
 
-            Dim useSiteErrorInfo As DiagnosticInfo = candidate.UnderlyingSymbol.GetUseSiteErrorInfo()
+            Dim candidateUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = candidate.UnderlyingSymbol.GetUseSiteInfo()
 
-            If useSiteErrorInfo IsNot Nothing Then
-                If useSiteDiagnostics Is Nothing Then
-                    useSiteDiagnostics = New HashSet(Of DiagnosticInfo)()
-                End If
-
-                useSiteDiagnostics.Add(useSiteErrorInfo)
+            useSiteInfo.Add(candidateUseSiteInfo)
+            If candidateUseSiteInfo.DiagnosticInfo IsNot Nothing Then
                 Return New QuickApplicabilityInfo(candidate, CandidateAnalysisResultState.HasUseSiteError)
             End If
 
@@ -3789,7 +3781,7 @@ Bailout:
             includeEliminatedCandidates As Boolean,
             binder As Binder,
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Select Case candidate.State
                 Case CandidateAnalysisResultState.HasUnsupportedMetadata
@@ -3842,7 +3834,7 @@ Bailout:
                                                                                    arguments, argumentNames,
                                                                                    delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                                                                    binder, asyncLambdaSubToFunctionMismatch,
-                                                                                   useSiteDiagnostics)
+                                                                                   useSiteInfo)
                     End If
 
                     ' How about it's expanded form? It always applies if there's a paramarray.
@@ -3858,7 +3850,7 @@ Bailout:
                                                                                    arguments, argumentNames,
                                                                                    delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                                                                    binder, asyncLambdaSubToFunctionMismatch,
-                                                                                   useSiteDiagnostics)
+                                                                                   useSiteInfo)
                     End If
 
 #If DEBUG Then
@@ -3886,7 +3878,7 @@ Bailout:
             delegateReturnTypeReferenceBoundNode As BoundNode,
             binder As Binder,
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
 
             If typeArguments.Length = 0 AndAlso newCandidate.Candidate.Arity > 0 Then
@@ -3898,14 +3890,14 @@ Bailout:
                 'in the place of the type parameters in the signature.
 
                 If Not InferTypeArguments(newCandidate, arguments, argumentNames, delegateReturnType, delegateReturnTypeReferenceBoundNode,
-                                          asyncLambdaSubToFunctionMismatch, binder, useSiteDiagnostics) Then
+                                          asyncLambdaSubToFunctionMismatch, binder, useSiteInfo) Then
                     Debug.Assert(newCandidate.State <> CandidateAnalysisResultState.Applicable)
                     results.Add(newCandidate)
                     Return
                 End If
             End If
 
-            CombineCandidates(results, newCandidate, arguments.Length, argumentNames, useSiteDiagnostics)
+            CombineCandidates(results, newCandidate, arguments.Length, argumentNames, useSiteInfo)
         End Sub
 
         ''' <summary>
@@ -3918,7 +3910,7 @@ Bailout:
             newCandidate As CandidateAnalysisResult,
             argumentCount As Integer,
             argumentNames As ImmutableArray(Of String),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Debug.Assert(newCandidate.State = CandidateAnalysisResultState.Applicable)
 
@@ -4085,7 +4077,7 @@ Bailout:
                     '       This rule also applies to the types that extension methods are defined on. 
                     '7.2.	If M and N are extension methods and the target type of M is a class or 
                     '       structure and the target type of N is an interface, eliminate N from the set.
-                    If ShadowBasedOnReceiverType(existingCandidate, newCandidate, existingWins, newWins, useSiteDiagnostics) Then
+                    If ShadowBasedOnReceiverType(existingCandidate, newCandidate, existingWins, newWins, useSiteInfo) Then
                         GoTo DeterminedTheWinner
                     End If
 
@@ -4740,17 +4732,17 @@ ContinueCandidatesLoop:
         Private Shared Function ShadowBasedOnReceiverType(
             left As CandidateAnalysisResult, right As CandidateAnalysisResult,
             ByRef leftWins As Boolean, ByRef rightWins As Boolean,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
 
             Dim leftType = left.Candidate.ReceiverType
             Dim rightType = right.Candidate.ReceiverType
 
             If Not leftType.IsSameTypeIgnoringAll(rightType) Then
-                If DoesReceiverMatchInstance(leftType, rightType, useSiteDiagnostics) Then
+                If DoesReceiverMatchInstance(leftType, rightType, useSiteInfo) Then
                     leftWins = True
                     Return True
-                ElseIf DoesReceiverMatchInstance(rightType, leftType, useSiteDiagnostics) Then
+                ElseIf DoesReceiverMatchInstance(rightType, leftType, useSiteInfo) Then
                     rightWins = True
                     Return True
                 End If
@@ -4766,8 +4758,8 @@ ContinueCandidatesLoop:
         ''' Actually, we don't include the reference-convertibilities that seem nonsensical, e.g. enum() to underlyingtype()
         ''' We do include inheritance, implements and variance conversions amongst others.
         ''' </summary>
-        Public Shared Function DoesReceiverMatchInstance(instanceType As TypeSymbol, receiverType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
-            Return Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(instanceType, receiverType, useSiteDiagnostics)
+        Public Shared Function DoesReceiverMatchInstance(instanceType As TypeSymbol, receiverType As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(instanceType, receiverType, useSiteInfo)
         End Function
 
         ''' <summary>
@@ -4863,7 +4855,7 @@ ContinueCandidatesLoop:
             delegateReturnTypeReferenceBoundNode As BoundNode,
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
             binder As Binder,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
 
             Dim parameterToArgumentMap As ArrayBuilder(Of Integer) = Nothing
@@ -4893,7 +4885,7 @@ ContinueCandidatesLoop:
                                                inferredTypeByAssumption:=inferredTypeByAssumption,
                                                typeArgumentsLocation:=typeArgumentsLocation,
                                                asyncLambdaSubToFunctionMismatch:=asyncLambdaSubToFunctionMismatch,
-                                               useSiteDiagnostics:=useSiteDiagnostics,
+                                               useSiteInfo:=useSiteInfo,
                                                diagnostic:=candidate.TypeArgumentInferenceDiagnosticsOpt) Then
                     candidate.SetInferenceLevel(inferenceLevel)
                     candidate.Candidate = candidate.Candidate.Construct(typeArguments)
@@ -4907,7 +4899,7 @@ ContinueCandidatesLoop:
                                 Dim diagnostics = candidate.TypeArgumentInferenceDiagnosticsOpt
 
                                 If diagnostics Is Nothing Then
-                                    diagnostics = New DiagnosticBag()
+                                    diagnostics = New BindingDiagnosticBag()
                                     candidate.TypeArgumentInferenceDiagnosticsOpt = diagnostics
                                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/SemanticFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/SemanticFacts.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(within))
             End If
 
-            Return AccessCheck.IsSymbolAccessible(symbol, within, throughTypeOpt, useSiteDiagnostics:=Nothing)
+            Return AccessCheck.IsSymbolAccessible(symbol, within, throughTypeOpt, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
         End Function
 
         ''' <summary>
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(within))
             End If
 
-            Return AccessCheck.IsSymbolAccessible(symbol, within, useSiteDiagnostics:=Nothing)
+            Return AccessCheck.IsSymbolAccessible(symbol, within, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -27,8 +27,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             <Out> ByRef inferredTypeByAssumption As BitVector,
             <Out> ByRef typeArgumentsLocation As ImmutableArray(Of SyntaxNodeOrToken),
             <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
-            ByRef diagnostic As DiagnosticBag,
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
+            ByRef diagnostic As BindingDiagnosticBag,
             Optional inferTheseTypeParameters As BitVector = Nothing
         ) As Boolean
             Debug.Assert(candidate Is candidate.ConstructedFrom)
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return InferenceGraph.Infer(candidate, arguments, parameterToArgumentMap, paramArrayItems, delegateReturnType, delegateReturnTypeReferenceBoundNode,
                                         typeArguments, inferenceLevel, allFailedInferenceIsDueToObject, someInferenceFailed, inferenceErrorReasons,
                                         inferredTypeByAssumption, typeArgumentsLocation, asyncLambdaSubToFunctionMismatch,
-                                        useSiteDiagnostics, diagnostic, inferTheseTypeParameters)
+                                        useSiteInfo, diagnostic, inferTheseTypeParameters)
         End Function
 
         ' No-one should create instances of this class.
@@ -306,7 +306,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim dominantTypeDataList = ArrayBuilder(Of DominantTypeDataTypeInference).GetInstance()
                     Dim errorReasons As InferenceErrorReasons = InferenceErrorReasons.Other
 
-                    InferenceTypeCollection.FindDominantType(dominantTypeDataList, errorReasons, Graph.UseSiteDiagnostics)
+                    InferenceTypeCollection.FindDominantType(dominantTypeDataList, errorReasons, Graph.UseSiteInfo)
 
                     If dominantTypeDataList.Count = 1 Then
                         ' //consider: scottwis
@@ -446,7 +446,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Dim delegateType = DirectCast(ParameterType, NamedTypeSymbol)
                             Dim invokeMethod As MethodSymbol = delegateType.DelegateInvokeMethod
 
-                            If invokeMethod IsNot Nothing AndAlso invokeMethod.GetUseSiteErrorInfo() Is Nothing Then
+                            If invokeMethod IsNot Nothing AndAlso invokeMethod.GetUseSiteInfo().DiagnosticInfo Is Nothing Then
 
                                 Dim unboundLambda = DirectCast(Expression, UnboundLambda)
                                 Dim lambdaParameters As ImmutableArray(Of ParameterSymbol) = unboundLambda.Parameters
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        delegateParam.Type.Equals(currentTypedNode.DeclaredTypeParam) Then
 
                                         If Graph.Diagnostic Is Nothing Then
-                                            Graph.Diagnostic = New DiagnosticBag()
+                                            Graph.Diagnostic = New BindingDiagnosticBag()
                                         End If
 
                                         ' If this was an argument to the unbound Lambda, infer Object.
@@ -609,7 +609,7 @@ HandleAsAGeneralExpression:
         Private Class InferenceGraph
             Inherits Graph(Of InferenceNode)
 
-            Public Diagnostic As DiagnosticBag
+            Public Diagnostic As BindingDiagnosticBag
             Public ObjectType As NamedTypeSymbol
             Public ReadOnly Candidate As MethodSymbol
             Public ReadOnly Arguments As ImmutableArray(Of BoundExpression)
@@ -617,7 +617,7 @@ HandleAsAGeneralExpression:
             Public ReadOnly ParamArrayItems As ArrayBuilder(Of Integer)
             Public ReadOnly DelegateReturnType As TypeSymbol
             Public ReadOnly DelegateReturnTypeReferenceBoundNode As BoundNode
-            Public UseSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            Public UseSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
 
             Private _someInferenceFailed As Boolean
             Private _inferenceErrorReasons As InferenceErrorReasons
@@ -629,7 +629,7 @@ HandleAsAGeneralExpression:
             Private _verifyingAssertions As Boolean
 
             Private Sub New(
-                diagnostic As DiagnosticBag,
+                diagnostic As BindingDiagnosticBag,
                 candidate As MethodSymbol,
                 arguments As ImmutableArray(Of BoundExpression),
                 parameterToArgumentMap As ArrayBuilder(Of Integer),
@@ -637,7 +637,7 @@ HandleAsAGeneralExpression:
                 delegateReturnType As TypeSymbol,
                 delegateReturnTypeReferenceBoundNode As BoundNode,
                 asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-                useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+                useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
             )
                 Debug.Assert(delegateReturnType Is Nothing OrElse delegateReturnTypeReferenceBoundNode IsNot Nothing)
 
@@ -649,7 +649,7 @@ HandleAsAGeneralExpression:
                 Me.DelegateReturnType = delegateReturnType
                 Me.DelegateReturnTypeReferenceBoundNode = delegateReturnTypeReferenceBoundNode
                 Me._asyncLambdaSubToFunctionMismatch = asyncLambdaSubToFunctionMismatch
-                Me.UseSiteDiagnostics = useSiteDiagnostics
+                Me.UseSiteInfo = useSiteInfo
 
                 ' Allocate the array of TypeParameter nodes.
                 Dim arity As Integer = candidate.Arity
@@ -717,13 +717,13 @@ HandleAsAGeneralExpression:
                 <Out> ByRef inferredTypeByAssumption As BitVector,
                 <Out> ByRef typeArgumentsLocation As ImmutableArray(Of SyntaxNodeOrToken),
                 <[In](), Out()> ByRef asyncLambdaSubToFunctionMismatch As HashSet(Of BoundExpression),
-                <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo),
-                ByRef diagnostic As DiagnosticBag,
+                <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
+                ByRef diagnostic As BindingDiagnosticBag,
                 inferTheseTypeParameters As BitVector
             ) As Boolean
                 Dim graph As New InferenceGraph(diagnostic, candidate, arguments, parameterToArgumentMap, paramArrayItems,
                                                 delegateReturnType, delegateReturnTypeReferenceBoundNode, asyncLambdaSubToFunctionMismatch,
-                                                useSiteDiagnostics)
+                                                useSiteInfo)
 
                 ' Build a graph describing the flow of type inference data.
                 ' This creates edges from "regular" arguments to type parameters and from type parameters to lambda arguments. 
@@ -914,7 +914,7 @@ HandleAsAGeneralExpression:
                 diagnostic = graph.Diagnostic
 
                 asyncLambdaSubToFunctionMismatch = graph._asyncLambdaSubToFunctionMismatch
-                useSiteDiagnostics = graph.UseSiteDiagnostics
+                useSiteInfo = graph.UseSiteInfo
 
                 Return succeeded
             End Function
@@ -1112,7 +1112,7 @@ HandleAsAGeneralExpression:
                         Else
 
                             Do
-                                For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                                For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
                                     AddTypeToGraph(typeArgument, argNode, isOutgoingEdge, haveSeenTypeParameters)
                                 Next
 
@@ -1166,7 +1166,7 @@ HandleAsAGeneralExpression:
                     Dim delegateType As NamedTypeSymbol = DirectCast(parameterType, NamedTypeSymbol)
                     Dim invoke As MethodSymbol = delegateType.DelegateInvokeMethod
 
-                    If invoke IsNot Nothing AndAlso invoke.GetUseSiteErrorInfo() Is Nothing AndAlso delegateType.IsGenericType Then
+                    If invoke IsNot Nothing AndAlso invoke.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso delegateType.IsGenericType Then
 
                         Dim haveSeenTypeParameters = BitVector.Create(_typeParameterNodes.Length)
                         AddTypeToGraph(invoke.ReturnType, argNode, isOutgoingEdge:=True, haveSeenTypeParameters:=haveSeenTypeParameters) ' outgoing (name->type) edge
@@ -1179,7 +1179,7 @@ HandleAsAGeneralExpression:
                     End If
                 ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     ' If we've got an Expression(Of T), skip through to T
-                    AddAddressOfToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), argNode, binder)
+                    AddAddressOfToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteInfo), argNode, binder)
                 End If
             End Sub
 
@@ -1200,7 +1200,7 @@ HandleAsAGeneralExpression:
                     Dim delegateType As NamedTypeSymbol = DirectCast(parameterType, NamedTypeSymbol)
                     Dim invoke As MethodSymbol = delegateType.DelegateInvokeMethod
 
-                    If invoke IsNot Nothing AndAlso invoke.GetUseSiteErrorInfo() Is Nothing AndAlso delegateType.IsGenericType Then
+                    If invoke IsNot Nothing AndAlso invoke.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso delegateType.IsGenericType Then
 
                         Dim delegateParameters As ImmutableArray(Of ParameterSymbol) = invoke.Parameters
                         Dim lambdaParameters As ImmutableArray(Of ParameterSymbol)
@@ -1243,7 +1243,7 @@ HandleAsAGeneralExpression:
 
                 ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, binder.Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     ' If we've got an Expression(Of T), skip through to T
-                    AddLambdaToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), argNode, binder)
+                    AddLambdaToGraph(DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteInfo), argNode, binder)
                 End If
             End Sub
 
@@ -1338,7 +1338,7 @@ HandleAsAGeneralExpression:
                             Next
                         Else
                             Do
-                                For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                                For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
                                     If RefersToGenericParameterToInferArgumentFor(typeArgument) Then
                                         Return True
                                     End If
@@ -1525,9 +1525,9 @@ HandleAsAGeneralExpression:
 
                                         If Not InferTypeArgumentsFromArgument(
                                                                         argumentLocation,
-                                                                        argumentTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteDiagnostics),
+                                                                        argumentTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteInfo),
                                                                         argumentTypeByAssumption,
-                                                                        parameterTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteDiagnostics),
+                                                                        parameterTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteInfo),
                                                                         param,
                                                                         _DigThroughToBasesAndImplements,
                                                                         paramInferenceRestrictions
@@ -1679,7 +1679,7 @@ HandleAsAGeneralExpression:
 
                     ' Note, null check for parameterInvokeDeclaration should also filter out MultiCastDelegate type.
                     If argumentDelegateType.IsAnonymousType AndAlso Not parameterDelegateType.IsAnonymousType AndAlso
-                       parameterInvokeProc IsNot Nothing AndAlso parameterInvokeProc.GetUseSiteErrorInfo() Is Nothing Then
+                       parameterInvokeProc IsNot Nothing AndAlso parameterInvokeProc.GetUseSiteInfo().DiagnosticInfo Is Nothing Then
                         ' Some trickery relating to the fact that anonymous delegates can be converted to any delegate type.
                         ' We are trying to match the anonymous delegate "BaseSearchType" onto the delegate "FixedType". e.g.
                         ' Dim f = function(i as integer) i   // ArgumentType = VB$AnonymousDelegate`2(Of Integer,Integer)
@@ -1856,7 +1856,7 @@ HandleAsAGeneralExpression:
 
                 Select Case derivedType.Kind
                     Case SymbolKind.TypeParameter
-                        For Each constraint In DirectCast(derivedType, TypeParameterSymbol).ConstraintTypesWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                        For Each constraint In DirectCast(derivedType, TypeParameterSymbol).ConstraintTypesWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
                             If constraint.OriginalDefinition.IsSameTypeIgnoringAll(baseInterface.OriginalDefinition) Then
                                 If Not SetMatchIfNothingOrEqual(constraint, match) Then
                                     Return False
@@ -1869,7 +1869,7 @@ HandleAsAGeneralExpression:
                         Next
 
                     Case Else
-                        For Each [interface] In derivedType.AllInterfacesWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                        For Each [interface] In derivedType.AllInterfacesWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
                             If [interface].OriginalDefinition.IsSameTypeIgnoringAll(baseInterface.OriginalDefinition) Then
                                 If Not SetMatchIfNothingOrEqual([interface], match) Then
                                     Return False
@@ -1888,7 +1888,7 @@ HandleAsAGeneralExpression:
             Private Function FindMatchingBaseClass(derivedType As TypeSymbol, baseClass As TypeSymbol, ByRef match As TypeSymbol) As Boolean
                 Select Case derivedType.Kind
                     Case SymbolKind.TypeParameter
-                        For Each constraint In DirectCast(derivedType, TypeParameterSymbol).ConstraintTypesWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                        For Each constraint In DirectCast(derivedType, TypeParameterSymbol).ConstraintTypesWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
                             If constraint.OriginalDefinition.IsSameTypeIgnoringAll(baseClass.OriginalDefinition) Then
                                 If Not SetMatchIfNothingOrEqual(constraint, match) Then
                                     Return False
@@ -1904,7 +1904,7 @@ HandleAsAGeneralExpression:
 
                     Case Else
 
-                        Dim baseType As NamedTypeSymbol = derivedType.BaseTypeWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                        Dim baseType As NamedTypeSymbol = derivedType.BaseTypeWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
 
                         While baseType IsNot Nothing
                             If baseType.OriginalDefinition.IsSameTypeIgnoringAll(baseClass.OriginalDefinition) Then
@@ -1914,7 +1914,7 @@ HandleAsAGeneralExpression:
                                 Exit While
                             End If
 
-                            baseType = baseType.BaseTypeWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                            baseType = baseType.BaseTypeWithDefinitionUseSiteDiagnostics(Me.UseSiteInfo)
                         End While
 
                 End Select
@@ -1934,7 +1934,7 @@ HandleAsAGeneralExpression:
                     ' Now find the invoke method of the delegate
                     Dim invokeMethod As MethodSymbol = delegateType.DelegateInvokeMethod
 
-                    If invokeMethod Is Nothing OrElse invokeMethod.GetUseSiteErrorInfo() IsNot Nothing Then
+                    If invokeMethod Is Nothing OrElse invokeMethod.GetUseSiteInfo().DiagnosticInfo IsNot Nothing Then
                         ' If we don't have an Invoke method, just bail.
                         Return False
                     End If
@@ -1949,15 +1949,12 @@ HandleAsAGeneralExpression:
                     Dim addrOf = DirectCast(argument, BoundAddressOfOperator)
                     Dim fromMethod As MethodSymbol = Nothing
                     Dim methodConversions As MethodConversionKind = MethodConversionKind.Identity
-                    Dim diagnostics = DiagnosticBag.GetInstance()
 
                     Dim matchingMethod As KeyValuePair(Of MethodSymbol, MethodConversionKind) = Binder.ResolveMethodForDelegateInvokeFullAndRelaxed(
                         addrOf,
                         invokeMethod,
                         ignoreMethodReturnType:=True,
-                        diagnostics:=diagnostics)
-
-                    diagnostics.Free()
+                        diagnostics:=BindingDiagnosticBag.Discarded)
 
                     fromMethod = matchingMethod.Key
                     methodConversions = matchingMethod.Value
@@ -2018,9 +2015,9 @@ HandleAsAGeneralExpression:
 
                         Case BoundKind.UnboundLambda
                             ' Infer Anonymous Delegate type from unbound lambda.
-                            Dim inferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) = DirectCast(argument, UnboundLambda).InferredAnonymousDelegate
+                            Dim inferredAnonymousDelegate As KeyValuePair(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = DirectCast(argument, UnboundLambda).InferredAnonymousDelegate
 
-                            If (inferredAnonymousDelegate.Value.IsDefault OrElse Not inferredAnonymousDelegate.Value.HasAnyErrors()) Then
+                            If (inferredAnonymousDelegate.Value.Diagnostics.IsDefault OrElse Not inferredAnonymousDelegate.Value.Diagnostics.HasAnyErrors()) Then
 
                                 Dim delegateInvokeMethod As MethodSymbol = Nothing
 
@@ -2066,7 +2063,7 @@ HandleAsAGeneralExpression:
 
                     Dim invokeMethod As MethodSymbol = delegateType.DelegateInvokeMethod
 
-                    If invokeMethod Is Nothing OrElse invokeMethod.GetUseSiteErrorInfo() IsNot Nothing Then
+                    If invokeMethod Is Nothing OrElse invokeMethod.GetUseSiteInfo().DiagnosticInfo IsNot Nothing Then
                         ' If we don't have an Invoke method, just bail.
                         Return True
                     End If
@@ -2141,7 +2138,7 @@ HandleAsAGeneralExpression:
 
                                 If lambdaReturnType Is Nothing Then
                                     If Me.Diagnostic Is Nothing Then
-                                        Me.Diagnostic = New DiagnosticBag()
+                                        Me.Diagnostic = New BindingDiagnosticBag()
                                     End If
 
                                     Debug.Assert(Me.Diagnostic IsNot Nothing)
@@ -2157,14 +2154,14 @@ HandleAsAGeneralExpression:
 
                             If unboundLambda.IsFunctionLambda Then
                                 Dim inferenceSignature As New UnboundLambda.TargetSignature(delegateParams, unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void), returnsByRef:=False)
-                                Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic)) = unboundLambda.InferReturnType(inferenceSignature)
+                                Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)) = unboundLambda.InferReturnType(inferenceSignature)
 
-                                If Not returnTypeInfo.Value.IsDefault AndAlso returnTypeInfo.Value.HasAnyErrors() Then
+                                If Not returnTypeInfo.Value.Diagnostics.IsDefault AndAlso returnTypeInfo.Value.Diagnostics.HasAnyErrors() Then
                                     lambdaReturnType = Nothing
 
                                     ' Let's keep return type inference errors
                                     If Me.Diagnostic Is Nothing Then
-                                        Me.Diagnostic = New DiagnosticBag()
+                                        Me.Diagnostic = New BindingDiagnosticBag()
                                     End If
 
                                     Me.Diagnostic.AddRange(returnTypeInfo.Value)
@@ -2179,24 +2176,23 @@ HandleAsAGeneralExpression:
                                                                                                                           returnsByRef:=False))
 
                                     Debug.Assert(boundLambda.LambdaSymbol.ReturnType Is returnTypeInfo.Key)
-                                    If Not boundLambda.HasErrors AndAlso Not boundLambda.Diagnostics.HasAnyErrors Then
+                                    If Not boundLambda.HasErrors AndAlso Not boundLambda.Diagnostics.Diagnostics.HasAnyErrors Then
                                         lambdaReturnType = returnTypeInfo.Key
 
                                         ' Let's keep return type inference warnings, if any.
-                                        If Not returnTypeInfo.Value.IsDefaultOrEmpty Then
-                                            If Me.Diagnostic Is Nothing Then
-                                                Me.Diagnostic = New DiagnosticBag()
-                                            End If
-
-                                            Me.Diagnostic.AddRange(returnTypeInfo.Value)
+                                        If Me.Diagnostic Is Nothing Then
+                                            Me.Diagnostic = New BindingDiagnosticBag()
                                         End If
+
+                                        Me.Diagnostic.AddRange(returnTypeInfo.Value)
+                                        Me.Diagnostic.AddDependencies(boundLambda.Diagnostics.Dependencies)
                                     Else
                                         lambdaReturnType = Nothing
 
                                         ' Let's preserve diagnostics that caused the failure
-                                        If Not boundLambda.Diagnostics.IsDefaultOrEmpty Then
+                                        If Not boundLambda.Diagnostics.Diagnostics.IsDefaultOrEmpty Then
                                             If Me.Diagnostic Is Nothing Then
-                                                Me.Diagnostic = New DiagnosticBag()
+                                                Me.Diagnostic = New BindingDiagnosticBag()
                                             End If
 
                                             Me.Diagnostic.AddRange(boundLambda.Diagnostics)
@@ -2228,8 +2224,8 @@ HandleAsAGeneralExpression:
                                                      TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T), TypeCompareKind.ConsiderEverything) OrElse
                                                      TypeSymbol.Equals(lambdaReturnNamedType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerator_T), TypeCompareKind.ConsiderEverything))
 
-                                        lambdaReturnType = lambdaReturnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics)
-                                        returnType = returnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics)
+                                        lambdaReturnType = lambdaReturnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteInfo)
+                                        returnType = returnNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteInfo)
                                     End If
 
                                 End If
@@ -2242,7 +2238,7 @@ HandleAsAGeneralExpression:
                                                                             unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void),
                                                                             returnsByRef:=False))
 
-                                    If Not boundLambda.HasErrors AndAlso Not boundLambda.Diagnostics.HasAnyErrors() Then
+                                    If Not boundLambda.HasErrors AndAlso Not boundLambda.Diagnostics.Diagnostics.HasAnyErrors() Then
                                         If _asyncLambdaSubToFunctionMismatch Is Nothing Then
                                             _asyncLambdaSubToFunctionMismatch = New HashSet(Of BoundExpression)(ReferenceEqualityComparer.Instance)
                                         End If
@@ -2276,7 +2272,7 @@ HandleAsAGeneralExpression:
 
                 ElseIf TypeSymbol.Equals(parameterType.OriginalDefinition, argument.GetBinderFromLambda().Compilation.GetWellKnownType(WellKnownType.System_Linq_Expressions_Expression_T), TypeCompareKind.ConsiderEverything) Then
                     ' If we've got an Expression(Of T), skip through to T
-                    Return InferTypeArgumentsFromLambdaArgument(argument, DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteDiagnostics), param)
+                    Return InferTypeArgumentsFromLambdaArgument(argument, DirectCast(parameterType, NamedTypeSymbol).TypeArgumentWithDefinitionUseSiteDiagnostics(0, Me.UseSiteInfo), param)
                 End If
 
                 Return True

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
@@ -62,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Sub FindDominantType(
             resultList As ArrayBuilder(Of TDominantTypeData),
             ByRef inferenceErrorReasons As InferenceErrorReasons,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
 
             ' THE RULES FOR DOMINANT TYPE ARE THESE:
@@ -143,7 +143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                     candidateTypeData,
                                                                     hintTypeData,
                                                                     hintTypeData.InferenceRestrictions,
-                                                                    useSiteDiagnostics)
+                                                                    useSiteInfo)
 
                     numberSatisfied(hintSatisfaction) += 1
                 Next
@@ -260,11 +260,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim arrayLiteralType = TryCast(inner.ResultType, ArrayLiteralTypeSymbol)
 
                     If arrayLiteralType Is Nothing Then
-                        conversion = Conversions.ClassifyConversion(inner.ResultType, outer.ResultType, useSiteDiagnostics).Key
+                        conversion = Conversions.ClassifyConversion(inner.ResultType, outer.ResultType, useSiteInfo).Key
                     Else
                         ' If source is an array literal then use ClassifyArrayLiteralConversion
                         Dim arrayLiteral = arrayLiteralType.ArrayLiteral
-                        conversion = Conversions.ClassifyConversion(arrayLiteral, outer.ResultType, arrayLiteral.Binder, useSiteDiagnostics).Key
+                        conversion = Conversions.ClassifyConversion(arrayLiteral, outer.ResultType, arrayLiteral.Binder, useSiteInfo).Key
                         If Conversions.IsWideningConversion(conversion) AndAlso
                             IsSameTypeIgnoringAll(arrayLiteralType, outer.ResultType) Then
                             conversion = ConversionKind.Identity
@@ -331,10 +331,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 AppendArrayElements(DirectCast(candidate.ResultType, ArrayLiteralTypeSymbol).ArrayLiteral.Initializer, elements)
                             Next
 
+                            Dim dominantTypeDiagnostics = New BindingDiagnosticBag(diagnosticBag:=Nothing, PooledHashSet(Of AssemblySymbol).GetInstance())
                             Dim inferredElementType = DirectCast(resultList(0).ResultType, ArrayLiteralTypeSymbol).ArrayLiteral.
-                                    Binder.InferDominantTypeOfExpressions(VisualBasicSyntaxTree.Dummy.GetRoot(Nothing), elements, New DiagnosticBag(), Nothing)
+                                    Binder.InferDominantTypeOfExpressions(VisualBasicSyntaxTree.Dummy.GetRoot(Nothing), elements, dominantTypeDiagnostics, Nothing)
 
                             If inferredElementType IsNot Nothing Then
+                                useSiteInfo.AddDependencies(dominantTypeDiagnostics.DependenciesBag)
+
                                 ' That should match an element type inferred for one of the array literals 
                                 Dim match As TDominantTypeData = Nothing
                                 Dim matchLiteral As BoundArrayLiteral = Nothing
@@ -361,6 +364,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                     resultList.Add(match)
                                 End If
                             End If
+
+                            dominantTypeDiagnostics.Free()
                         End If
                     End If
                 End If
@@ -410,7 +415,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             candidateData As DominantTypeData,
             hintData As DominantTypeData,
             hintRestrictions As RequiredConversion,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As HintSatisfaction
             ' This algorithm is used in type inference (where we examine whether a candidate works against a set of hints)
             ' It is also used in inferring a dominant type out of a collection e.g. for array literals:
@@ -430,7 +435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ElseIf hintRestrictions = RequiredConversion.None Then
                 conversion = ConversionKind.Identity
             ElseIf hintRestrictions = RequiredConversion.Identity Then
-                conversion = Conversions.ClassifyDirectCastConversion(hint, candidate, useSiteDiagnostics)
+                conversion = Conversions.ClassifyDirectCastConversion(hint, candidate, useSiteInfo)
 
                 If Not Conversions.IsIdentityConversion(conversion) Then
                     conversion = Nothing
@@ -442,11 +447,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim arrayLiteralType = TryCast(hint, ArrayLiteralTypeSymbol)
 
                 If arrayLiteralType Is Nothing Then
-                    conversion = Conversions.ClassifyConversion(hint, candidate, useSiteDiagnostics).Key
+                    conversion = Conversions.ClassifyConversion(hint, candidate, useSiteInfo).Key
                 Else
                     ' If source is an array literal then use ClassifyArrayLiteralConversion
                     Dim arrayLiteral = arrayLiteralType.ArrayLiteral
-                    conversion = Conversions.ClassifyConversion(arrayLiteral, candidate, arrayLiteral.Binder, useSiteDiagnostics).Key
+                    conversion = Conversions.ClassifyConversion(arrayLiteral, candidate, arrayLiteral.Binder, useSiteInfo).Key
                     If Conversions.IsWideningConversion(conversion) Then
                         If IsSameTypeIgnoringAll(arrayLiteralType, candidate) Then
                             ' ClassifyConversion returns widening for identity.  For hint satisfaction it should be promoted to Identity
@@ -467,14 +472,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ElseIf hintRestrictions = RequiredConversion.AnyReverse Then
                 ' copyback TO the hint (i.e. argument) FROM the candidate for parameter type T
-                conversion = Conversions.ClassifyConversion(candidate, hint, useSiteDiagnostics).Key
+                conversion = Conversions.ClassifyConversion(candidate, hint, useSiteInfo).Key
 
             ElseIf hintRestrictions = RequiredConversion.AnyAndReverse Then
                 ' forwards copy of argument into parameter
-                Dim inConversion As ConversionKind = Conversions.ClassifyConversion(hint, candidate, useSiteDiagnostics).Key
+                Dim inConversion As ConversionKind = Conversions.ClassifyConversion(hint, candidate, useSiteInfo).Key
 
                 ' back copy from the parameter back into the argument
-                Dim outConversion As ConversionKind = Conversions.ClassifyConversion(candidate, hint, useSiteDiagnostics).Key
+                Dim outConversion As ConversionKind = Conversions.ClassifyConversion(candidate, hint, useSiteInfo).Key
 
                 ' Pick the lowest for our classification of identity/widening/narrowing/error.
                 If Conversions.NoConversion(inConversion) OrElse Conversions.NoConversion(outConversion) Then
@@ -490,12 +495,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
             ElseIf hintRestrictions = RequiredConversion.ArrayElement Then
-                conversion = Conversions.ClassifyArrayElementConversion(hint, candidate, useSiteDiagnostics)
+                conversion = Conversions.ClassifyArrayElementConversion(hint, candidate, useSiteInfo)
 
             ElseIf hintRestrictions = RequiredConversion.Reference Then
 
                 If hint.IsReferenceType AndAlso candidate.IsReferenceType Then
-                    conversion = Conversions.ClassifyDirectCastConversion(hint, candidate, useSiteDiagnostics)
+                    conversion = Conversions.ClassifyDirectCastConversion(hint, candidate, useSiteInfo)
 
 
 
@@ -517,7 +522,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If hint.IsReferenceType AndAlso candidate.IsReferenceType Then
                     '  in reverse
-                    conversion = Conversions.ClassifyDirectCastConversion(candidate, hint, useSiteDiagnostics)
+                    conversion = Conversions.ClassifyDirectCastConversion(candidate, hint, useSiteInfo)
 
                     ' Dev10#595234: as above, if there's narrowing inside a generic type parameter context is unforgivable.
                     If Conversions.IsNarrowingConversion(conversion) Then

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.vb
@@ -203,7 +203,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return semanticModelOpt IsNot Nothing AndAlso
                 DirectCast(derivedType, NamedTypeSymbol).IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute,
                                                                                        DirectCast(semanticModelOpt.Compilation, VisualBasicCompilation),
-                                                                                       useSiteDiagnostics:=Nothing)
+                                                                                       useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousTypeManager_Templates.vb
@@ -168,7 +168,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Resets numbering in anonymous type names and compiles the
         ''' anonymous type methods. Also seals the collection of templates.
         ''' </summary>
-        Public Sub AssignTemplatesNamesAndCompile(compiler As MethodCompiler, moduleBeingBuilt As Emit.PEModuleBuilder, diagnostics As DiagnosticBag)
+        Public Sub AssignTemplatesNamesAndCompile(compiler As MethodCompiler, moduleBeingBuilt As Emit.PEModuleBuilder, diagnostics As BindingDiagnosticBag)
 
             ' Ensure all previous anonymous type templates are included so the
             ' types are available for subsequent edit and continue generations.

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousType_SymbolCollection.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/AnonymousType_SymbolCollection.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
     Partial Friend NotInheritable Class AnonymousTypeManager
 
-        Public Function ReportMissingOrErroneousSymbols(diagnostics As DiagnosticBag, hasClass As Boolean, hasDelegate As Boolean, hasKeys As Boolean) As Boolean
+        Public Function ReportMissingOrErroneousSymbols(diagnostics As BindingDiagnosticBag, hasClass As Boolean, hasDelegate As Boolean, hasKeys As Boolean) As Boolean
             Debug.Assert(hasClass OrElse hasDelegate)
             Debug.Assert(Not hasKeys OrElse hasClass)
 
@@ -59,17 +59,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return hasErrors
         End Function
 
-        Private Shared Sub ReportErrorOnSymbol(symbol As Symbol, diagnostics As DiagnosticBag, ByRef hasError As Boolean)
+        Private Shared Sub ReportErrorOnSymbol(symbol As Symbol, diagnostics As BindingDiagnosticBag, ByRef hasError As Boolean)
             If symbol IsNot Nothing Then
-                Dim errorInfo As DiagnosticInfo = symbol.GetUseSiteErrorInfo()
-                If errorInfo IsNot Nothing Then
-                    diagnostics.Add(errorInfo, NoLocation.Singleton)
+                Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = symbol.GetUseSiteInfo()
+                If diagnostics.Add(useSiteInfo, NoLocation.Singleton) Then
                     hasError = True
                 End If
             End If
         End Sub
 
-        Private Shared Sub ReportErrorOnWellKnownMember(symbol As Symbol, member As WellKnownMember, diagnostics As DiagnosticBag, ByRef hasError As Boolean, embedVBCore As Boolean)
+        Private Shared Sub ReportErrorOnWellKnownMember(symbol As Symbol, member As WellKnownMember, diagnostics As BindingDiagnosticBag, ByRef hasError As Boolean, embedVBCore As Boolean)
             If symbol Is Nothing Then
                 Dim memberDescriptor As MemberDescriptor = WellKnownMembers.GetDescriptor(member)
                 Dim diagInfo = GetDiagnosticForMissingRuntimeHelper(memberDescriptor.DeclaringTypeMetadataName, memberDescriptor.Name, embedVBCore)
@@ -82,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Sub
 
-        Private Shared Sub ReportErrorOnSpecialMember(symbol As Symbol, member As SpecialMember, diagnostics As DiagnosticBag, ByRef hasError As Boolean, embedVBCore As Boolean)
+        Private Shared Sub ReportErrorOnSpecialMember(symbol As Symbol, member As SpecialMember, diagnostics As BindingDiagnosticBag, ByRef hasError As Boolean, embedVBCore As Boolean)
             If symbol Is Nothing Then
                 Dim memberDescriptor As MemberDescriptor = SpecialMembers.GetDescriptor(member)
                 Dim diagInfo = GetDiagnosticForMissingRuntimeHelper(memberDescriptor.DeclaringTypeMetadataName, memberDescriptor.Name, embedVBCore)
@@ -97,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Checks if all special and well-known symbols required for emitting anonymous types 
         ''' provided exist, if not reports errors and returns True.
         ''' </summary>
-        Private Function CheckAndReportMissingSymbols(anonymousTypes As ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol), diagnostics As DiagnosticBag) As Boolean
+        Private Function CheckAndReportMissingSymbols(anonymousTypes As ArrayBuilder(Of AnonymousTypeOrDelegateTemplateSymbol), diagnostics As BindingDiagnosticBag) As Boolean
             Dim hasClass As Boolean = False
             Dim hasDelegate As Boolean = False
             Dim hasKeys As Boolean = False

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousDelegate_TypePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousDelegate_TypePublicSymbol.vb
@@ -149,11 +149,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Me.Manager.ConstructAnonymousDelegateImplementationSymbol(Me)
             End Function
 
-            Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                 Return Manager.System_MulticastDelegate
             End Function
 
-            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                 Return ImmutableArray(Of NamedTypeSymbol).Empty
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
@@ -113,11 +113,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                 Return MakeAcyclicBaseType(diagnostics)
             End Function
 
-            Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                 Return MakeAcyclicInterfaces(diagnostics)
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType_TypePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType_TypePublicSymbol.vb
@@ -173,11 +173,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return _members
             End Function
 
-            Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                 Return Me.Manager.System_Object
             End Function
 
-            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                 Return _interfaces
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousDelegate_TemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousDelegate_TemplateSymbol.vb
@@ -144,11 +144,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                 Return Manager.System_MulticastDelegate
             End Function
 
-            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                 Return ImmutableArray(Of NamedTypeSymbol).Empty
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
@@ -210,11 +210,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                 Return MakeAcyclicBaseType(diagnostics)
             End Function
 
-            Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                 Return MakeAcyclicInterfaces(diagnostics)
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType_TemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType_TemplateSymbol.vb
@@ -120,11 +120,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Next
             End Function
 
-            Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+            Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                 Return Me.Manager.System_Object
             End Function
 
-            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+            Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                 Return _interfaces
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -367,18 +367,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 #Region "Use-Site Diagnostics"
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             ' Check type.
-            Dim elementErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(Me.ElementType)
+            Dim elementUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromType(Me.ElementType)
 
-            If elementErrorInfo IsNot Nothing AndAlso elementErrorInfo.Code = ERRID.ERR_UnsupportedType1 Then
-                Return elementErrorInfo
+            If elementUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedType1 Then
+                Return elementUseSiteInfo
             End If
 
             ' Check custom modifiers.
-            Dim modifiersErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromCustomModifiers(Me.CustomModifiers)
+            Dim modifiersUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromCustomModifiers(Me.CustomModifiers)
 
-            Return MergeUseSiteErrorInfo(elementErrorInfo, modifiersErrorInfo)
+            Return MergeUseSiteInfo(elementUseSiteInfo, modifiersUseSiteInfo)
         End Function
 
         Friend Overrides Function GetUnificationUseSiteDiagnosticRecursive(owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
@@ -180,7 +180,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' SPEC:    it is a security custom attribute and requires special treatment.
 
             If _lazyIsSecurityAttribute = ThreeState.Unknown Then
-                _lazyIsSecurityAttribute = Me.AttributeClass.IsOrDerivedFromWellKnownClass(WellKnownType.System_Security_Permissions_SecurityAttribute, comp, useSiteDiagnostics:=Nothing).ToThreeState()
+                _lazyIsSecurityAttribute = Me.AttributeClass.IsOrDerivedFromWellKnownClass(WellKnownType.System_Security_Permissions_SecurityAttribute, comp, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded).ToThreeState()
             End If
 
             Return _lazyIsSecurityAttribute.Value
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend Sub DecodeSecurityAttribute(Of T As {WellKnownAttributeData, ISecurityAttributeTarget, New})(targetSymbol As Symbol, compilation As VisualBasicCompilation, ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
             Dim hasErrors As Boolean = False
-            Dim action As DeclarativeSecurityAction = Me.DecodeSecurityAttributeAction(targetSymbol, compilation, arguments.AttributeSyntaxOpt, hasErrors, arguments.Diagnostics)
+            Dim action As DeclarativeSecurityAction = Me.DecodeSecurityAttributeAction(targetSymbol, compilation, arguments.AttributeSyntaxOpt, hasErrors, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
             If Not hasErrors Then
                 Dim data As T = arguments.GetOrCreateData(Of T)()
                 Dim securityData As SecurityWellKnownAttributeData = data.GetOrCreateData()
@@ -208,7 +208,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             compilation As VisualBasicCompilation,
             nodeOpt As AttributeSyntax,
             ByRef hasErrors As Boolean,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As DeclarativeSecurityAction
             Debug.Assert(Not hasErrors)
             Debug.Assert(Me.IsSecurityAttribute(compilation))
@@ -233,12 +233,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Else
                 Dim firstArg As TypedConstant = Me.CommonConstructorArguments.FirstOrDefault()
                 Dim firstArgType = DirectCast(firstArg.TypeInternal, TypeSymbol)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                If firstArgType IsNot Nothing AndAlso firstArgType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Security_Permissions_SecurityAction, compilation, useSiteDiagnostics) Then
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                If firstArgType IsNot Nothing AndAlso firstArgType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Security_Permissions_SecurityAction, compilation, useSiteInfo) Then
                     Return ValidateSecurityAction(firstArg, targetSymbol, nodeOpt, diagnostics, hasErrors)
                 End If
 
-                diagnostics.Add(If(nodeOpt IsNot Nothing, nodeOpt.Name.GetLocation, NoLocation.Singleton), useSiteDiagnostics)
+                diagnostics.Add(If(nodeOpt IsNot Nothing, nodeOpt.Name.GetLocation, NoLocation.Singleton), useSiteInfo)
             End If
 
             ' BC31205: First argument to a security attribute must be a valid SecurityAction
@@ -255,7 +255,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             typedValue As TypedConstant,
             targetSymbol As Symbol,
             nodeOpt As AttributeSyntax,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             <Out> ByRef hasErrors As Boolean
         ) As DeclarativeSecurityAction
             Debug.Assert(targetSymbol.Kind = SymbolKind.Assembly OrElse targetSymbol.Kind = SymbolKind.NamedType OrElse targetSymbol.Kind = SymbolKind.Method)
@@ -413,7 +413,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return False
         End Function
 
-        Friend Sub DecodeClassInterfaceAttribute(nodeOpt As AttributeSyntax, diagnostics As DiagnosticBag)
+        Friend Sub DecodeClassInterfaceAttribute(nodeOpt As AttributeSyntax, diagnostics As BindingDiagnosticBag)
             Debug.Assert(Not Me.HasErrors)
 
             Dim ctorArgument As TypedConstant = Me.CommonConstructorArguments(0)
@@ -431,7 +431,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Select
         End Sub
 
-        Friend Sub DecodeInterfaceTypeAttribute(node As AttributeSyntax, diagnostics As DiagnosticBag)
+        Friend Sub DecodeInterfaceTypeAttribute(node As AttributeSyntax, diagnostics As BindingDiagnosticBag)
             Dim discarded As ComInterfaceType = Nothing
             If Not DecodeInterfaceTypeAttribute(discarded) Then
                 diagnostics.Add(ERRID.ERR_BadAttribute1, node.ArgumentList.Arguments(0).GetLocation(), Me.AttributeClass)
@@ -467,7 +467,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                       CType(ctorArgument.DecodeValue(Of Short)(SpecialType.System_Int16), Cci.TypeLibTypeFlags))
         End Function
 
-        Friend Sub DecodeGuidAttribute(nodeOpt As AttributeSyntax, diagnostics As DiagnosticBag)
+        Friend Sub DecodeGuidAttribute(nodeOpt As AttributeSyntax, diagnostics As BindingDiagnosticBag)
             Debug.Assert(Not Me.HasErrors)
 
             Dim guidString As String = Me.GetConstructorArgument(Of String)(0, SpecialType.System_String)

--- a/src/Compilers/VisualBasic/Portable/Symbols/ConstantValueUtils.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ConstantValueUtils.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     End Class
 
     Friend Module ConstantValueUtils
-        Public Function EvaluateFieldConstant(field As SourceFieldSymbol, equalsValueOrAsNewNodeRef As SyntaxReference, inProgress As SymbolsInProgress(Of FieldSymbol), diagnostics As DiagnosticBag) As EvaluatedConstant
+        Public Function EvaluateFieldConstant(field As SourceFieldSymbol, equalsValueOrAsNewNodeRef As SyntaxReference, inProgress As SymbolsInProgress(Of FieldSymbol), diagnostics As BindingDiagnosticBag) As EvaluatedConstant
             Debug.Assert(inProgress IsNot Nothing)
             Dim value As ConstantValue = Nothing
             Dim boundValueType As TypeSymbol = Nothing
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function BindFieldOrEnumInitializer(binder As Binder,
                                                     fieldOrEnumSymbol As FieldSymbol,
                                                     equalsValueOrAsNewSyntax As VisualBasicSyntaxNode,
-                                                    diagnostics As DiagnosticBag,
+                                                    diagnostics As BindingDiagnosticBag,
                                                     <Out> ByRef constValue As ConstantValue) As BoundExpression
 
             Debug.Assert(TypeOf fieldOrEnumSymbol Is SourceEnumConstantSymbol OrElse TypeOf fieldOrEnumSymbol Is SourceFieldSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/ConstraintsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ConstraintsHelper.vb
@@ -18,9 +18,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     ''' callers that may want to create Location instances lazily or not at all.
     ''' </summary>
     Friend Structure TypeParameterDiagnosticInfo
-        Public Sub New(typeParameter As TypeParameterSymbol, diagnostic As DiagnosticInfo)
+
+        Public Sub New(typeParameter As TypeParameterSymbol, useSiteInfo As UseSiteInfo(Of AssemblySymbol))
             Me.TypeParameter = typeParameter
-            Me.DiagnosticInfo = diagnostic
+            Me.UseSiteInfo = useSiteInfo
+        End Sub
+
+        Public Sub New(typeParameter As TypeParameterSymbol, diagnostic As DiagnosticInfo)
+            Me.New(typeParameter, New UseSiteInfo(Of AssemblySymbol)(diagnostic))
         End Sub
 
         Public Sub New(typeParameter As TypeParameterSymbol, constraint As TypeParameterConstraint, diagnostic As DiagnosticInfo)
@@ -30,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public ReadOnly TypeParameter As TypeParameterSymbol
         Public ReadOnly Constraint As TypeParameterConstraint
-        Public ReadOnly DiagnosticInfo As DiagnosticInfo
+        Public ReadOnly UseSiteInfo As UseSiteInfo(Of AssemblySymbol)
     End Structure
 
     <Flags()>
@@ -301,11 +306,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     Dim bad = False
 
-                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
                     If (pair1.TypeParameter Is typeParameter) AndAlso (pair2.TypeParameter Is typeParameter) Then
                         ' Check direct constraints to handle inherited constraints on overridden methods.
-                        If HasConflict(pair1.Constraint, pair2.Constraint, useSiteDiagnostics) Then
+                        If HasConflict(pair1.Constraint, pair2.Constraint, useSiteInfo) Then
                             ' "Constraint '{0}' conflicts with the constraint '{1}' already specified for type parameter '{2}'."
                             diagnosticsBuilder.Add(New TypeParameterDiagnosticInfo(typeParameter,
                                                                                    pair2.Constraint,
@@ -322,7 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ' parameter but not the current type parameter since those cases
                         ' will be reported directly on the other type parameter.
 
-                    ElseIf HasConflict(pair1.Constraint, pair2.Constraint, useSiteDiagnostics) Then
+                    ElseIf HasConflict(pair1.Constraint, pair2.Constraint, useSiteInfo) Then
                         If pair1.TypeParameter Is typeParameter Then
                             ' "Constraint '{0}' conflicts with the indirect constraint '{1}' obtained from the type parameter constraint '{2}'."
                             diagnosticsBuilder.Add(New TypeParameterDiagnosticInfo(typeParameter,
@@ -360,7 +365,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         End If
                     End If
 
-                    If AppendUseSiteDiagnostics(useSiteDiagnostics, typeParameter, useSiteDiagnosticsBuilder) Then
+                    If AppendUseSiteInfo(useSiteInfo, typeParameter, useSiteDiagnosticsBuilder) Then
                         bad = True
                     End If
 
@@ -377,7 +382,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Sub CheckAllConstraints(
                                         type As TypeSymbol,
                                         loc As Location,
-                                        diagnostics As DiagnosticBag)
+                                        diagnostics As BindingDiagnosticBag)
             Dim diagnosticsBuilder = ArrayBuilder(Of TypeParameterDiagnosticInfo).GetInstance()
             Dim useSiteDiagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo) = Nothing
             type.CheckAllConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder)
@@ -387,7 +392,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             For Each diagnostic In diagnosticsBuilder
-                diagnostics.Add(diagnostic.DiagnosticInfo, loc)
+                diagnostics.Add(diagnostic.UseSiteInfo, loc)
             Next
 
             diagnosticsBuilder.Free()
@@ -431,7 +436,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     tuple As TupleTypeSymbol,
                                     syntaxNode As SyntaxNode,
                                     elementLocations As ImmutableArray(Of Location),
-                                    diagnostics As DiagnosticBag)
+                                    diagnostics As BindingDiagnosticBag)
             Dim type As NamedTypeSymbol = tuple.TupleUnderlyingType
             If Not RequiresChecking(type) Then
                 Return
@@ -460,7 +465,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     ' If this is the TRest type parameter, we report it on 
                     ' the entire type syntax as it does not map to any tuple element.
                     Dim location = If(ordinal = TupleTypeSymbol.RestIndex, syntaxNode.Location, elementLocations(ordinal + offset))
-                    diagnostics.Add(diagnostic.DiagnosticInfo, location)
+                    diagnostics.Add(diagnostic.UseSiteInfo, location)
                 Next
 
                 diagnosticsBuilder.Clear()
@@ -476,7 +481,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Function CheckConstraintsForNonTuple(
                                         type As NamedTypeSymbol,
                                         typeArgumentsSyntax As SeparatedSyntaxList(Of TypeSyntax),
-                                        diagnostics As DiagnosticBag) As Boolean
+                                        diagnostics As BindingDiagnosticBag) As Boolean
             Debug.Assert(Not type.IsTupleType)
             Debug.Assert(typeArgumentsSyntax.Count = type.Arity)
             If Not RequiresChecking(type) Then
@@ -494,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             For Each diagnostic In diagnosticsBuilder
                 Dim ordinal = diagnostic.TypeParameter.Ordinal
                 Dim location = typeArgumentsSyntax(ordinal).GetLocation()
-                diagnostics.Add(diagnostic.DiagnosticInfo, location)
+                diagnostics.Add(diagnostic.UseSiteInfo, location)
             Next
 
             diagnosticsBuilder.Free()
@@ -522,7 +527,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Function CheckConstraints(
                                         method As MethodSymbol,
                                         diagnosticLocation As Location,
-                                        diagnostics As DiagnosticBag) As Boolean
+                                        diagnostics As BindingDiagnosticBag) As Boolean
             If Not RequiresChecking(method) Then
                 Return True
             End If
@@ -536,7 +541,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             For Each diagnostic In diagnosticsBuilder
-                diagnostics.Add(diagnostic.DiagnosticInfo, diagnosticLocation)
+                diagnostics.Add(diagnostic.UseSiteInfo, diagnosticLocation)
             Next
 
             diagnosticsBuilder.Free()
@@ -594,12 +599,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             For i = 0 To n - 1
                 Dim typeArgument = typeArguments(i)
                 Dim typeParameter = typeParameters(i)
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                If Not CheckConstraints(constructedSymbol, substitution, typeParameter, typeArgument, diagnosticsBuilder, useSiteDiagnostics) Then
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                If Not CheckConstraints(constructedSymbol, substitution, typeParameter, typeArgument, diagnosticsBuilder, useSiteInfo) Then
                     succeeded = False
                 End If
 
-                If AppendUseSiteDiagnostics(useSiteDiagnostics, typeParameter, useSiteDiagnosticsBuilder) Then
+                If AppendUseSiteInfo(useSiteInfo, typeParameter, useSiteDiagnosticsBuilder) Then
                     succeeded = False
                 End If
             Next
@@ -613,7 +618,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                  typeParameter As TypeParameterSymbol,
                                  typeArgument As TypeSymbol,
                                  diagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo),
-                                 <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+                                 <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             ' The type parameters must be original definitions of type parameters from the containing symbol.
             Debug.Assert(((constructedSymbol Is Nothing) AndAlso (substitution Is Nothing)) OrElse
                          (typeParameter.ContainingSymbol Is constructedSymbol.OriginalDefinition))
@@ -640,7 +645,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 succeeded = False
             End If
 
-            If typeParameter.HasValueTypeConstraint AndAlso Not SatisfiesValueTypeConstraint(constructedSymbol, typeParameter, typeArgument, diagnosticsBuilder, useSiteDiagnostics) Then
+            If typeParameter.HasValueTypeConstraint AndAlso Not SatisfiesValueTypeConstraint(constructedSymbol, typeParameter, typeArgument, diagnosticsBuilder, useSiteInfo) Then
                 succeeded = False
             End If
 
@@ -649,10 +654,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' the type parameter for T in "C(Of Object, Integer)" has constraint "U", not "Integer". We need to
             ' substitute the type parameter constraints from the original definition of the type parameters
             ' using the TypeSubstitution from the constructed type/method.
-            For Each t In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+            For Each t In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                 Dim constraintType = t.InternalSubstituteTypeParameters(substitution).Type
 
-                If Not SatisfiesTypeConstraint(typeArgument, constraintType, useSiteDiagnostics) Then
+                If Not SatisfiesTypeConstraint(typeArgument, constraintType, useSiteInfo) Then
                     If diagnosticsBuilder IsNot Nothing Then
                         ' "Type argument '{0}' does not inherit from or implement the constraint type '{1}'."
                         diagnosticsBuilder.Add(New TypeParameterDiagnosticInfo(typeParameter, ErrorFactory.ErrorInfo(ERRID.ERR_GenericConstraintNotSatisfied2, typeArgument, constraintType)))
@@ -664,12 +669,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return succeeded
         End Function
 
-        Private Function AppendUseSiteDiagnostics(
-            useSiteDiagnostics As HashSet(Of DiagnosticInfo),
+        Private Function AppendUseSiteInfo(
+            useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol),
             typeParameter As TypeParameterSymbol,
             <[In], Out> ByRef useSiteDiagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo)
         ) As Boolean
-            If useSiteDiagnostics.IsNullOrEmpty Then
+
+            If useSiteInfo.Diagnostics.IsNullOrEmpty AndAlso useSiteInfo.Dependencies.IsNullOrEmpty Then
                 Return False
             End If
 
@@ -677,7 +683,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 useSiteDiagnosticsBuilder = New ArrayBuilder(Of TypeParameterDiagnosticInfo)()
             End If
 
-            For Each info In useSiteDiagnostics
+            If useSiteInfo.Diagnostics.IsNullOrEmpty Then
+                If Not useSiteInfo.Dependencies.IsNullOrEmpty() Then
+                    useSiteDiagnosticsBuilder.Add(New TypeParameterDiagnosticInfo(typeParameter,
+                                                                              If(useSiteInfo.Dependencies.Count = 1,
+                                                                                  New UseSiteInfo(Of AssemblySymbol)(useSiteInfo.Dependencies.Single()),
+                                                                                  New UseSiteInfo(Of AssemblySymbol)(useSiteInfo.Dependencies.ToImmutableHashSet()))))
+                End If
+
+                Return False
+            End If
+
+            For Each info In useSiteInfo.Diagnostics
                 Debug.Assert(info.Severity = DiagnosticSeverity.Error)
                 useSiteDiagnosticsBuilder.Add(New TypeParameterDiagnosticInfo(typeParameter, info))
             Next
@@ -693,10 +710,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' more or less derived. This method assumes there are no constraint cycles.
         ''' </summary>
         <Extension()>
-        Public Function GetNonInterfaceConstraint(typeParameter As TypeParameterSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As TypeSymbol
+        Public Function GetNonInterfaceConstraint(typeParameter As TypeParameterSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As TypeSymbol
             Dim result As TypeSymbol = Nothing
 
-            For Each constraint In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+            For Each constraint In typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
 
                 Dim candidate As TypeSymbol = Nothing
 
@@ -705,7 +722,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         Continue For
 
                     Case SymbolKind.TypeParameter
-                        candidate = DirectCast(constraint, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteDiagnostics)
+                        candidate = DirectCast(constraint, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteInfo)
 
                     Case Else
                         If Not constraint.IsInterfaceType() Then
@@ -717,7 +734,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     result = candidate
                 ElseIf candidate IsNot Nothing Then
                     ' Pick the most derived type
-                    If result.IsClassType AndAlso Conversions.IsDerivedFrom(candidate, result, useSiteDiagnostics) Then
+                    If result.IsClassType AndAlso Conversions.IsDerivedFrom(candidate, result, useSiteInfo) Then
                         result = candidate
                     End If
                 End If
@@ -736,8 +753,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' System.ValueType for value types, System.Array for arrays, and System.Enum for enums.
         ''' </summary>
         <Extension()>
-        Public Function GetClassConstraint(typeParameter As TypeParameterSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As NamedTypeSymbol
-            Dim baseType = typeParameter.GetNonInterfaceConstraint(useSiteDiagnostics)
+        Public Function GetClassConstraint(typeParameter As TypeParameterSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As NamedTypeSymbol
+            Dim baseType = typeParameter.GetNonInterfaceConstraint(useSiteInfo)
 
             If baseType Is Nothing Then
                 Return Nothing
@@ -747,7 +764,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Case TypeKind.Array,
                     TypeKind.Enum,
                     TypeKind.Structure
-                    Return baseType.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                    Return baseType.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
 
                 Case Else
                     Debug.Assert(Not baseType.IsInterfaceType())
@@ -828,14 +845,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function SatisfiesTypeConstraint(
             typeArgument As TypeSymbol,
             constraintType As TypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         ) As Boolean
             If constraintType.IsErrorType() Then
-                constraintType.AddUseSiteDiagnostics(useSiteDiagnostics)
+                constraintType.AddUseSiteInfo(useSiteInfo)
                 Return False
             End If
 
-            Return Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(typeArgument, constraintType, useSiteDiagnostics)
+            Return Conversions.HasWideningDirectCastConversionButNotEnumTypeConversion(typeArgument, constraintType, useSiteInfo)
         End Function
 
         ' See Bindable::ValidateNewConstraintForType.
@@ -913,7 +930,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                      typeParameter As TypeParameterSymbol,
                                                      typeArgument As TypeSymbol,
                                                      diagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo),
-                                                     <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+                                                     <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Debug.Assert((typeParameter Is Nothing) OrElse typeParameter.HasValueTypeConstraint)
 
             If Not typeArgument.IsValueType Then
@@ -931,7 +948,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 Return False
 
-            ElseIf IsNullableTypeOrTypeParameter(typeArgument, useSiteDiagnostics) Then
+            ElseIf IsNullableTypeOrTypeParameter(typeArgument, useSiteInfo) Then
                 If diagnosticsBuilder IsNot Nothing Then
                     ' "'System.Nullable' does not satisfy the 'Structure' constraint for type parameter '{0}'. Only non-nullable 'Structure' types are allowed."
                     diagnosticsBuilder.Add(New TypeParameterDiagnosticInfo(typeParameter, ErrorFactory.ErrorInfo(ERRID.ERR_NullableDisallowedForStructConstr1, typeParameter)))
@@ -944,7 +961,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ' See Bindable::ConstraintsConflict.
-        Private Function HasConflict(constraint1 As TypeParameterConstraint, constraint2 As TypeParameterConstraint, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Private Function HasConflict(constraint1 As TypeParameterConstraint, constraint2 As TypeParameterConstraint, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
 
             Dim constraintType1 = constraint1.TypeConstraint
             Dim constraintType2 = constraint2.TypeConstraint
@@ -958,11 +975,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             If constraint1.IsValueTypeConstraint Then
-                If HasValueTypeConstraintConflict(constraint2, useSiteDiagnostics) Then
+                If HasValueTypeConstraintConflict(constraint2, useSiteInfo) Then
                     Return True
                 End If
             ElseIf constraint2.IsValueTypeConstraint Then
-                If HasValueTypeConstraintConflict(constraint1, useSiteDiagnostics) Then
+                If HasValueTypeConstraintConflict(constraint1, useSiteInfo) Then
                     Return True
                 End If
             End If
@@ -979,15 +996,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             If (constraintType1 IsNot Nothing) AndAlso
                 (constraintType2 IsNot Nothing) AndAlso
-                Not SatisfiesTypeConstraint(constraintType1, constraintType2, useSiteDiagnostics) AndAlso
-                Not SatisfiesTypeConstraint(constraintType2, constraintType1, useSiteDiagnostics) Then
+                Not SatisfiesTypeConstraint(constraintType1, constraintType2, useSiteInfo) AndAlso
+                Not SatisfiesTypeConstraint(constraintType2, constraintType1, useSiteInfo) Then
                 Return True
             End If
 
             Return False
         End Function
 
-        Private Function HasValueTypeConstraintConflict(constraint As TypeParameterConstraint, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Private Function HasValueTypeConstraintConflict(constraint As TypeParameterConstraint, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Dim constraintType = constraint.TypeConstraint
             If constraintType Is Nothing Then
                 Return False
@@ -995,7 +1012,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             If SatisfiesValueTypeConstraint(constructedSymbol:=Nothing, typeParameter:=Nothing, typeArgument:=constraintType,
                                             diagnosticsBuilder:=Nothing,
-                                            useSiteDiagnostics:=useSiteDiagnostics) Then
+                                            useSiteInfo:=useSiteInfo) Then
                 Return False
             End If
 
@@ -1020,13 +1037,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return True
         End Function
 
-        Private Function IsNullableTypeOrTypeParameter(type As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Private Function IsNullableTypeOrTypeParameter(type As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             If type.TypeKind = TypeKind.TypeParameter Then
                 Dim typeParameter = DirectCast(type, TypeParameterSymbol)
 
-                Dim constraintTypes = typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                Dim constraintTypes = typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                 For Each constraintType In constraintTypes
-                    If IsNullableTypeOrTypeParameter(constraintType, useSiteDiagnostics) Then
+                    If IsNullableTypeOrTypeParameter(constraintType, useSiteInfo) Then
                         Return True
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
@@ -26,32 +26,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If Me.IsDefinition Then
-                Return Me.ErrorInfo
+                Return New UseSiteInfo(Of AssemblySymbol)(Me.ErrorInfo)
             End If
 
             ' Base class handles constructed types.
-            Return MyBase.GetUseSiteErrorInfo()
+            Return MyBase.GetUseSiteInfo()
         End Function
 
         Friend Overrides Function GetUnificationUseSiteDiagnosticRecursive(owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo
             Return Nothing
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Nothing
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Nothing
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -182,18 +182,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 #Region "Use-site Diagnostics"
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If Me.IsDefinition Then
-                Return MyBase.GetUseSiteErrorInfo()
+                Return New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency)
             End If
 
-            Return Me.OriginalDefinition.GetUseSiteErrorInfo()
+            Return Me.OriginalDefinition.GetUseSiteInfo()
         End Function
 
-        Friend Function CalculateUseSiteErrorInfo() As DiagnosticInfo
+        Friend Function CalculateUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             Debug.Assert(Me.IsDefinition)
             ' Check event type.
-            Dim errorInfo = DeriveUseSiteErrorInfoFromType(Me.Type)
+            Dim useSiteInfo = MergeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency), DeriveUseSiteInfoFromType(Me.Type))
+            Dim errorInfo As DiagnosticInfo = useSiteInfo.DiagnosticInfo
 
             If errorInfo IsNot Nothing Then
                 Select Case errorInfo.Code
@@ -203,7 +204,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ' TODO: Perhaps the error wording could be changed a bit to say "type of event..." ?
                         '
                         ' Reference required to assembly '{0}' containing the definition for event '{1}'. Add one to your project.
-                        errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedAssemblyEvent3, errorInfo.Arguments(0), Me)
+                        useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedAssemblyEvent3, errorInfo.Arguments(0), Me))
 
                     Case ERRID.ERR_UnreferencedModule3
                         ' NOTE: interestingly the error in Dev10 and thus here refers to the definition of the event
@@ -211,11 +212,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ' TODO: Perhaps the error wording could be changed a bit to say "type of event..." ?
                         '
                         ' Reference required to module '{0}' containing the definition for event '{1}'. Add one to your project.
-                        errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedModuleEvent3, errorInfo.Arguments(0), Me)
+                        useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnreferencedModuleEvent3, errorInfo.Arguments(0), Me))
 
                     Case ERRID.ERR_UnsupportedType1
                         If errorInfo.Arguments(0).Equals(String.Empty) Then
-                            errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                            useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, CustomSymbolDisplayFormatter.ShortErrorName(Me)))
                         End If
 
                     Case Else
@@ -225,9 +226,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' If the member is in an assembly with unified references, 
                 ' we check if its definition depends on a type from a unified reference.
                 errorInfo = Me.Type.GetUnificationUseSiteDiagnosticRecursive(Me, checkedTypes:=Nothing)
+                If errorInfo IsNot Nothing Then
+                    Debug.Assert(errorInfo.Severity = DiagnosticSeverity.Error)
+                    useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(errorInfo)
+                End If
             End If
 
-            Return errorInfo
+            Return useSiteInfo
         End Function
 
         Protected Overrides ReadOnly Property HighestPriorityUseSiteError As Integer
@@ -238,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public NotOverridable Overrides ReadOnly Property HasUnsupportedMetadata As Boolean
             Get
-                Dim info As DiagnosticInfo = GetUseSiteErrorInfo()
+                Dim info As DiagnosticInfo = GetUseSiteInfo().DiagnosticInfo
                 Return info IsNot Nothing AndAlso (info.Code = ERRID.ERR_UnsupportedType1 OrElse info.Code = ERRID.ERR_UnsupportedEvent1)
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/Symbols/ExtendedErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ExtendedErrorTypeSymbol.vb
@@ -124,9 +124,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If _reportErrorWhenReferenced Then
-                Return Me.ErrorInfo
+                Return New UseSiteInfo(Of AssemblySymbol)(Me.ErrorInfo)
             End If
 
             Return Nothing

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -265,44 +265,49 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If Me.IsDefinition Then
-                Return MyBase.GetUseSiteErrorInfo()
+                Return New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency)
             End If
 
-            Return Me.OriginalDefinition.GetUseSiteErrorInfo()
+            Return Me.OriginalDefinition.GetUseSiteInfo()
         End Function
 
-        Friend Function CalculateUseSiteErrorInfo() As DiagnosticInfo
+        Friend Function CalculateUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
 
             Debug.Assert(IsDefinition)
 
             ' Check type.
-            Dim typeErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(Me.Type)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MergeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency), DeriveUseSiteInfoFromType(Me.Type))
 
-            If typeErrorInfo IsNot Nothing AndAlso typeErrorInfo.Code = ERRID.ERR_UnsupportedField1 Then
-                Return typeErrorInfo
+            If useSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedField1 Then
+                Return useSiteInfo
             End If
 
             ' Check custom modifiers.
-            Dim modifiersErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromCustomModifiers(Me.CustomModifiers)
+            Dim modifiersUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromCustomModifiers(Me.CustomModifiers)
 
-            If modifiersErrorInfo IsNot Nothing AndAlso modifiersErrorInfo.Code = ERRID.ERR_UnsupportedField1 Then
-                Return modifiersErrorInfo
+            If modifiersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedField1 Then
+                Return modifiersUseSiteInfo
             End If
 
-            Dim result = If(typeErrorInfo, modifiersErrorInfo)
+            useSiteInfo = MergeUseSiteInfo(useSiteInfo, modifiersUseSiteInfo)
 
             ' If the member is in an assembly with unified references, 
             ' we check if its definition depends on a type from a unified reference.
-            If result Is Nothing AndAlso Me.ContainingModule.HasUnifiedReferences Then
+            If useSiteInfo.DiagnosticInfo Is Nothing AndAlso Me.ContainingModule.HasUnifiedReferences Then
                 Dim unificationCheckedTypes As HashSet(Of TypeSymbol) = Nothing
 
-                result = If(Me.Type.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes),
-                            GetUnificationUseSiteDiagnosticRecursive(Me.CustomModifiers, Me, unificationCheckedTypes))
+                Dim errorInfo As DiagnosticInfo = If(Me.Type.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes),
+                                                     GetUnificationUseSiteDiagnosticRecursive(Me.CustomModifiers, Me, unificationCheckedTypes))
+
+                If errorInfo IsNot Nothing Then
+                    Debug.Assert(errorInfo.Severity = DiagnosticSeverity.Error)
+                    useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(errorInfo)
+                End If
             End If
 
-            Return result
+            Return useSiteInfo
         End Function
 
         ''' <summary>
@@ -316,7 +321,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public NotOverridable Overrides ReadOnly Property HasUnsupportedMetadata As Boolean
             Get
-                Dim info As DiagnosticInfo = GetUseSiteErrorInfo()
+                Dim info As DiagnosticInfo = GetUseSiteInfo().DiagnosticInfo
                 Return info IsNot Nothing AndAlso info.Code = ERRID.ERR_UnsupportedField1
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/Symbols/InstanceTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/InstanceTypeSymbol.vb
@@ -128,21 +128,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 #Region "Use-Site Diagnostics"
 
-        Protected Function CalculateUseSiteErrorInfo() As DiagnosticInfo
+        Protected Function CalculateUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             ' Check base type.
-            Dim baseErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromBase()
+            Dim useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency).AdjustDiagnosticInfo(DeriveUseSiteErrorInfoFromBase())
 
-            If baseErrorInfo IsNot Nothing Then
-                Return baseErrorInfo
+            If useSiteInfo.DiagnosticInfo IsNot Nothing Then
+                Return useSiteInfo
             End If
 
             ' If we reach a type (Me) that is in an assembly with unified references, 
             ' we check if that type definition depends on a type from a unified reference.
             If Me.ContainingModule.HasUnifiedReferences Then
-                Return GetUnificationUseSiteDiagnosticRecursive(Me, checkedTypes:=Nothing)
+                Dim errorInfo As DiagnosticInfo = GetUnificationUseSiteDiagnosticRecursive(Me, checkedTypes:=Nothing)
+                If errorInfo IsNot Nothing Then
+                    Debug.Assert(errorInfo.Severity = DiagnosticSeverity.Error)
+                    useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(errorInfo)
+                End If
             End If
 
-            Return Nothing
+            Return useSiteInfo
         End Function
 
         Private Function DeriveUseSiteErrorInfoFromBase() As DiagnosticInfo
@@ -152,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             While base IsNot Nothing
 
                 If base.IsErrorType() AndAlso TypeOf base Is NoPiaIllegalGenericInstantiationSymbol Then
-                    Return base.GetUseSiteErrorInfo()
+                    Return base.GetUseSiteInfo().DiagnosticInfo
                 End If
 
                 base = base.BaseTypeNoUseSiteDiagnostics

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -446,7 +446,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             Debug.Assert(Not targetTypeSymbol.IsTupleType)
 
-            If scope IsNot Nothing AndAlso Not TypeSymbol.Equals(targetTypeSymbol, scope, TypeCompareKind.ConsiderEverything) AndAlso Not targetTypeSymbol.IsBaseTypeOrInterfaceOf(scope, Nothing) Then
+            If scope IsNot Nothing AndAlso Not TypeSymbol.Equals(targetTypeSymbol, scope, TypeCompareKind.ConsiderEverything) AndAlso Not targetTypeSymbol.IsBaseTypeOrInterfaceOf(scope, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                 Return Nothing
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEEventSymbol.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
         Private _lazyDocComment As Tuple(Of CultureInfo, String)
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
         Private _lazyObsoleteAttributeData As ObsoleteAttributeData = ObsoleteAttributeData.Uninitialized
 
         ' Distinct accessibility value to represent unset.
@@ -64,7 +64,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     Me._name = String.Empty
                 End If
 
-                _lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedEvent1, Me)
+                _lazyCachedUseSiteInfo.Initialize(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedEvent1, Me))
 
                 If eventType.IsNil Then
                     Me._eventType = New UnsupportedMetadataTypeSymbol(mrEx)
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Public Overrides ReadOnly Property DeclaredAccessibility As Accessibility
             Get
                 If Me._lazyDeclaredAccessibility = s_unsetAccessibility Then
-                    Dim accessibility As accessibility = PEPropertyOrEventHelpers.GetDeclaredAccessibilityFromAccessors(Me.AddMethod, Me.RemoveMethod)
+                    Dim accessibility As Accessibility = PEPropertyOrEventHelpers.GetDeclaredAccessibilityFromAccessors(Me.AddMethod, Me.RemoveMethod)
                     Interlocked.CompareExchange(Me._lazyDeclaredAccessibility, DirectCast(accessibility, Integer), s_unsetAccessibility)
                 End If
 
@@ -280,12 +280,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return PEDocumentationCommentUtils.GetDocumentationComment(Me, _containingType.ContainingPEModule, preferredCulture, cancellationToken, _lazyDocComment)
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         ''' <remarks>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEFieldSymbol.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Private _lazyConstantValue As ConstantValue = Microsoft.CodeAnalysis.ConstantValue.Unset
         Private _lazyDocComment As Tuple(Of CultureInfo, String)
         Private _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
         Private _lazyObsoleteAttributeData As ObsoleteAttributeData = ObsoleteAttributeData.Uninitialized
 
         Friend Sub New(
@@ -52,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     _name = String.Empty
                 End If
 
-                _lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedField1, Me)
+                _lazyCachedUseSiteInfo.Initialize(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedField1, Me))
             End Try
         End Sub
 
@@ -368,28 +368,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Me, _containingType.ContainingPEModule, preferredCulture, cancellationToken, _lazyDocComment)
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                Dim fieldUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                Dim fieldUseSiteInfo = CalculateUseSiteInfo()
 
                 ' if there was no previous use site error for this symbol, check the constant value
-                If fieldUseSiteErrorInfo Is Nothing Then
+                If fieldUseSiteInfo.DiagnosticInfo Is Nothing Then
 
                     ' report use site errors for invalid constant values 
                     Dim constantValue = GetConstantValue(SymbolsInProgress(Of FieldSymbol).Empty)
                     If constantValue IsNot Nothing AndAlso
                         constantValue.IsBad Then
-                        fieldUseSiteErrorInfo = New DiagnosticInfo(MessageProvider.Instance,
-                                                                   ERRID.ERR_UnsupportedConstant2,
-                                                                   Me.ContainingType,
-                                                                   Me.Name)
+                        fieldUseSiteInfo = New UseSiteInfo(Of AssemblySymbol)(New DiagnosticInfo(MessageProvider.Instance,
+                                                                                                 ERRID.ERR_UnsupportedConstant2,
+                                                                                                 Me.ContainingType,
+                                                                                                 Me.Name))
                     End If
                 End If
 
-                _lazyUseSiteErrorInfo = fieldUseSiteErrorInfo
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, fieldUseSiteInfo)
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         Friend ReadOnly Property Handle As FieldDefinitionHandle

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEMethodSymbol.vb
@@ -165,7 +165,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Public _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
             Public _lazyConditionalAttributeSymbols As ImmutableArray(Of String)
             Public _lazyObsoleteAttributeData As ObsoleteAttributeData
-            Public _lazyUseSiteErrorInfo As DiagnosticInfo
+            Public _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol)
         End Class
 
         Private Function CreateUncommonFields() As UncommonFields
@@ -176,12 +176,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End If
 
             '
-            ' Do not set _lazyUseSiteErrorInfo !!!!
+            ' Do not set _lazyCachedUseSiteInfo !!!!
             '
             ' "null" Indicates "no errors" or "unknown state",
             ' and we know which one of the states we have from IsUseSiteDiagnosticPopulated
             '
-            ' Setting _lazyUseSiteErrorInfo to a sentinel value here would introduce
+            ' Setting _lazyCachedUseSiteInfo to a sentinel value here would introduce
             ' a number of extra states for various permutations of IsUseSiteDiagnosticPopulated, UncommonFields and _lazyUseSiteDiagnostic
             ' Some of them, in tight races, may lead to returning the sentinel as the diagnostics.
             '
@@ -241,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     _name = String.Empty
                 End If
 
-                InitializeUseSiteErrorInfo(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me)))
+                InitializeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me))))
             End Try
         End Sub
 
@@ -967,7 +967,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Dim returnParam = PEParameterSymbol.Create(moduleSymbol, Me, 0, paramInfo(0), isBad)
 
             If mrEx IsNot Nothing OrElse hasBadParameter OrElse isBad Then
-                InitializeUseSiteErrorInfo(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me)))
+                InitializeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me))))
             End If
 
             Dim signature As New SignatureData(signatureHeader, params, returnParam)
@@ -981,7 +981,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 EnsureTypeParametersAreLoaded(errorInfo)
                 Dim typeParams = EnsureTypeParametersAreLoaded(errorInfo)
                 If errorInfo IsNot Nothing Then
-                    InitializeUseSiteErrorInfo(errorInfo)
+                    InitializeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(errorInfo))
                 End If
                 Return typeParams
             End Get
@@ -1093,28 +1093,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If Not _packedFlags.IsUseSiteDiagnosticPopulated Then
-                Dim errorInfo As DiagnosticInfo = CalculateUseSiteErrorInfo()
+                Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = CalculateUseSiteInfo()
+                Dim errorInfo As DiagnosticInfo = useSiteInfo.DiagnosticInfo
                 EnsureTypeParametersAreLoaded(errorInfo)
-                Return InitializeUseSiteErrorInfo(errorInfo)
+                Return InitializeUseSiteInfo(useSiteInfo.AdjustDiagnosticInfo(errorInfo))
             End If
 
-            Return _uncommonFields?._lazyUseSiteErrorInfo
+            Return GetCachedUseSiteInfo()
         End Function
 
-        Private Function InitializeUseSiteErrorInfo(errorInfo As DiagnosticInfo) As DiagnosticInfo
+        Private Function GetCachedUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Return If(_uncommonFields?._lazyCachedUseSiteInfo, New CachedUseSiteInfo(Of AssemblySymbol)()).ToUseSiteInfo(PrimaryDependency)
+        End Function
+
+        Private Function InitializeUseSiteInfo(useSiteInfo As UseSiteInfo(Of AssemblySymbol)) As UseSiteInfo(Of AssemblySymbol)
             If _packedFlags.IsUseSiteDiagnosticPopulated Then
-                Return _uncommonFields?._lazyUseSiteErrorInfo
+                Return GetCachedUseSiteInfo()
             End If
 
-            If errorInfo IsNot Nothing Then
-                Debug.Assert(errorInfo IsNot ErrorFactory.EmptyErrorInfo)
-                errorInfo = InterlockedOperations.Initialize(AccessUncommonFields()._lazyUseSiteErrorInfo, errorInfo)
+            If useSiteInfo.DiagnosticInfo IsNot Nothing OrElse Not useSiteInfo.SecondaryDependencies.IsNullOrEmpty() Then
+                useSiteInfo = AccessUncommonFields()._lazyCachedUseSiteInfo.InterlockedInitialize(PrimaryDependency, useSiteInfo)
             End If
 
             _packedFlags.SetIsUseSiteDiagnosticPopulated()
-            Return errorInfo
+            Return useSiteInfo
         End Function
 
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private _lazyDefaultPropertyName As String
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Private _lazyMightContainExtensionMethods As Byte = ThreeState.Unknown
 
@@ -161,7 +161,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End If
 
             If makeBad OrElse metadataArity < containerMetadataArity Then
-                _lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me)
+                _lazyCachedUseSiteInfo.Initialize(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me))
             End If
 
             Debug.Assert(Not _mangleName OrElse _name.Length < name.Length)
@@ -242,7 +242,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return InterfacesNoUseSiteDiagnostics
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             If (Me._flags And TypeAttributes.Interface) = 0 Then
                 Dim moduleSymbol As PEModuleSymbol = Me.ContainingPEModule
 
@@ -260,7 +260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return Nothing
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Try
                 Dim moduleSymbol As PEModuleSymbol = Me.ContainingPEModule
                 Dim interfaceImpls = moduleSymbol.Module.GetInterfaceImplementationsOrThrow(Me._handle)
@@ -295,7 +295,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return New ExtendedErrorTypeSymbol(diag, True)
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim diag = BaseTypeAnalysis.GetDependencyDiagnosticsForImportedClass(Me)
             If diag IsNot Nothing Then
                 Return CyclicInheritanceError(diag)
@@ -304,7 +304,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return GetDeclaredBase(Nothing)
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Dim declaredInterfaces As ImmutableArray(Of NamedTypeSymbol) = GetDeclaredInterfacesNoUseSiteDiagnostics(Nothing)
             If (Not Me.IsInterface) Then
                 ' only interfaces needs to check for inheritance cycles via interfaces.
@@ -1254,24 +1254,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return method
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
 
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfoImpl()
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfoImpl())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
-        Private Function CalculateUseSiteErrorInfoImpl() As DiagnosticInfo
-            Dim diagnostic = CalculateUseSiteErrorInfo()
+        Private Function CalculateUseSiteInfoImpl() As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo = CalculateUseSiteInfo()
 
-            If diagnostic Is Nothing Then
+            If useSiteInfo.DiagnosticInfo Is Nothing Then
 
                 ' Check if this type Is marked by RequiredAttribute attribute.
                 ' If so mark the type as bad, because it relies upon semantics that are not understood by the VB compiler.
                 If Me.ContainingPEModule.Module.HasRequiredAttributeAttribute(Me.Handle) Then
-                    Return ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me)
+                    Return New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me))
                 End If
 
                 Dim typeKind = Me.TypeKind
@@ -1292,7 +1293,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                                      SpecialType.System_MulticastDelegate,
                                      SpecialType.System_ValueType
                                     ' This might be a structure, an enum, or a delegate
-                                    Return missingType.GetUseSiteErrorInfo()
+                                    Return missingType.GetUseSiteInfo()
                             End Select
                         End If
                     End If
@@ -1301,11 +1302,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 ' Verify type parameters for containing types
                 ' match those on the containing types.
                 If Not MatchesContainingTypeParameters() Then
-                    Return ErrorFactory.ErrorInfo(ERRID.ERR_NestingViolatesCLS1, Me)
+                    Return New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_NestingViolatesCLS1, Me))
                 End If
             End If
 
-            Return diagnostic
+            Return useSiteInfo
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEPropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEPropertySymbol.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Private _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
 
         Private _lazyDocComment As Tuple(Of CultureInfo, String)
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         ' mutable because we only know this part after the property is constructed.
         ' Integer because we want to use CMPXCHG on it
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             End If
 
             If propEx IsNot Nothing Then
-                result._lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedProperty1, CustomSymbolDisplayFormatter.QualifiedName(result))
+                result._lazyCachedUseSiteInfo.Initialize(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedProperty1, CustomSymbolDisplayFormatter.QualifiedName(result)))
             End If
 
             Return result
@@ -113,7 +113,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             If Not signaturesMatch OrElse Not parametersMatch OrElse
                getEx IsNot Nothing OrElse setEx IsNot Nothing OrElse mrEx IsNot Nothing Then
-                _lazyUseSiteErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedProperty1, CustomSymbolDisplayFormatter.QualifiedName(Me))
+                _lazyCachedUseSiteInfo.Initialize(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedProperty1, CustomSymbolDisplayFormatter.QualifiedName(Me)))
             End If
 
             If _getMethod IsNot Nothing Then
@@ -531,12 +531,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return PEDocumentationCommentUtils.GetDocumentationComment(Me, _containingType.ContainingPEModule, preferredCulture, cancellationToken, _lazyDocComment)
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         Friend ReadOnly Property Handle As PropertyDefinitionHandle

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         ''' <summary>
         ''' First error calculating bounds.
         ''' </summary>
-        Private _lazyBoundsErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedBoundsUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Friend Sub New(
             moduleSymbol As PEModuleSymbol,
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     _name = String.Empty
                 End If
 
-                _lazyBoundsErrorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me)
+                _lazyCachedBoundsUseSiteInfo.Initialize(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me))
             End Try
 
             ' Clear the '.ctor' flag if both '.ctor' and 'valuetype' are
@@ -173,7 +173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 constraints = metadataReader.GetGenericParameter(_handle).GetConstraints()
             Catch mrEx As BadImageFormatException
                 constraints = Nothing
-                Interlocked.CompareExchange(_lazyBoundsErrorInfo, ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me), ErrorFactory.EmptyErrorInfo)
+                _lazyCachedBoundsUseSiteInfo.InterlockedCompareExchange(primaryDependency:=Nothing, New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedType1, Me)))
             End Try
 
             If constraints.Count > 0 Then
@@ -270,20 +270,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 ' necessary to report redundant constraints since redundant constraints are still
                 ' valid. Redundant constraints are dropped silently.
                 Dim constraints = Me.RemoveDirectConstraintConflicts(GetDeclaredConstraints(), inProgress.Prepend(Me), DirectConstraintConflictKind.None, diagnosticsBuilder)
-                Dim errorInfo = If(diagnosticsBuilder.Count > 0, diagnosticsBuilder(0).DiagnosticInfo, Nothing)
+                Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+                Dim useSiteInfo As New UseSiteInfo(Of AssemblySymbol)(primaryDependency)
+
+                For Each pair In diagnosticsBuilder
+                    useSiteInfo = MergeUseSiteInfo(useSiteInfo, pair.UseSiteInfo)
+                    If useSiteInfo.DiagnosticInfo IsNot Nothing Then
+                        Exit For
+                    End If
+                Next
+
                 diagnosticsBuilder.Free()
 
-                Interlocked.CompareExchange(_lazyBoundsErrorInfo, errorInfo, ErrorFactory.EmptyErrorInfo)
+                _lazyCachedBoundsUseSiteInfo.InterlockedCompareExchange(primaryDependency, useSiteInfo)
                 ImmutableInterlocked.InterlockedInitialize(_lazyConstraintTypes, GetConstraintTypesOnly(constraints))
             End If
 
-            Debug.Assert(_lazyBoundsErrorInfo IsNot ErrorFactory.EmptyErrorInfo)
+            Debug.Assert(_lazyCachedBoundsUseSiteInfo.IsInitialized)
         End Sub
 
-        Friend Overrides Function GetConstraintsUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetConstraintsUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             EnsureAllConstraintsAreResolved()
-            Debug.Assert(_lazyBoundsErrorInfo IsNot ErrorFactory.EmptyErrorInfo)
-            Return _lazyBoundsErrorInfo
+            Debug.Assert(_lazyCachedBoundsUseSiteInfo.IsInitialized)
+            Return _lazyCachedBoundsUseSiteInfo.ToUseSiteInfo(PrimaryDependency)
         End Function
 
         ''' <remarks>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
@@ -110,7 +110,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 ' the type. Bad metadata.
             End Try
 
-            If metadataType.GetUseSiteErrorInfo() IsNot Nothing Then
+            If metadataType.GetUseSiteInfo().DiagnosticInfo IsNot Nothing Then
                 Return metadataType
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -605,57 +605,77 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return False
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If Me.IsDefinition Then
-                Return MyBase.GetUseSiteErrorInfo()
+                Return New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency)
             End If
 
             ' There is no reason to specially check type arguments because
             ' constructed members are never imported.
-            Return Me.OriginalDefinition.GetUseSiteErrorInfo()
+            Return Me.OriginalDefinition.GetUseSiteInfo()
         End Function
 
-        Friend Function CalculateUseSiteErrorInfo() As DiagnosticInfo
+        Friend Function CalculateUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
 
             Debug.Assert(IsDefinition)
 
             ' Check return type.
-            Dim errorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(Me.ReturnType)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MergeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(Me.PrimaryDependency), DeriveUseSiteInfoFromType(Me.ReturnType))
 
-            If errorInfo IsNot Nothing AndAlso errorInfo.Code = ERRID.ERR_UnsupportedMethod1 Then
-                Return errorInfo
+            If useSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedMethod1 Then
+                Return useSiteInfo
             End If
 
             ' Check return type custom modifiers.
-            Dim refModifiersErrorInfo = DeriveUseSiteErrorInfoFromCustomModifiers(Me.RefCustomModifiers)
+            Dim refModifiersUseSiteInfo = DeriveUseSiteInfoFromCustomModifiers(Me.RefCustomModifiers)
 
-            If refModifiersErrorInfo IsNot Nothing AndAlso refModifiersErrorInfo.Code = ERRID.ERR_UnsupportedMethod1 Then
-                Return refModifiersErrorInfo
+            If refModifiersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedMethod1 Then
+                Return refModifiersUseSiteInfo
             End If
 
-            Dim typeModifiersErrorInfo = DeriveUseSiteErrorInfoFromCustomModifiers(Me.ReturnTypeCustomModifiers)
+            Dim typeModifiersUseSiteInfo = DeriveUseSiteInfoFromCustomModifiers(Me.ReturnTypeCustomModifiers)
 
-            If typeModifiersErrorInfo IsNot Nothing AndAlso typeModifiersErrorInfo.Code = ERRID.ERR_UnsupportedMethod1 Then
-                Return typeModifiersErrorInfo
+            If typeModifiersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedMethod1 Then
+                Return typeModifiersUseSiteInfo
             End If
-
-            errorInfo = If(errorInfo, If(refModifiersErrorInfo, typeModifiersErrorInfo))
 
             ' Check parameters.
-            Dim result = MergeUseSiteErrorInfo(errorInfo, DeriveUseSiteErrorInfoFromParameters(Me.Parameters))
+            Dim parametersUseSiteInfo = DeriveUseSiteInfoFromParameters(Me.Parameters)
+
+            If parametersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedMethod1 Then
+                Return parametersUseSiteInfo
+            End If
+
+            Dim errorInfo As DiagnosticInfo = If(useSiteInfo.DiagnosticInfo,
+                                              If(refModifiersUseSiteInfo.DiagnosticInfo,
+                                              If(typeModifiersUseSiteInfo.DiagnosticInfo,
+                                                 parametersUseSiteInfo.DiagnosticInfo)))
 
             ' If the member is in an assembly with unified references, 
             ' we check if its definition depends on a type from a unified reference.
-            If result Is Nothing AndAlso Me.ContainingModule.HasUnifiedReferences Then
+            If errorInfo Is Nothing AndAlso Me.ContainingModule.HasUnifiedReferences Then
                 Dim unificationCheckedTypes As HashSet(Of TypeSymbol) = Nothing
-                result = If(Me.ReturnType.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes),
-                         If(GetUnificationUseSiteDiagnosticRecursive(Me.RefCustomModifiers, Me, unificationCheckedTypes),
-                         If(GetUnificationUseSiteDiagnosticRecursive(Me.ReturnTypeCustomModifiers, Me, unificationCheckedTypes),
-                         If(GetUnificationUseSiteDiagnosticRecursive(Me.Parameters, Me, unificationCheckedTypes),
-                            GetUnificationUseSiteDiagnosticRecursive(Me.TypeParameters, Me, unificationCheckedTypes)))))
+                errorInfo = If(Me.ReturnType.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes),
+                            If(GetUnificationUseSiteDiagnosticRecursive(Me.RefCustomModifiers, Me, unificationCheckedTypes),
+                            If(GetUnificationUseSiteDiagnosticRecursive(Me.ReturnTypeCustomModifiers, Me, unificationCheckedTypes),
+                            If(GetUnificationUseSiteDiagnosticRecursive(Me.Parameters, Me, unificationCheckedTypes),
+                               GetUnificationUseSiteDiagnosticRecursive(Me.TypeParameters, Me, unificationCheckedTypes)))))
+
+                Debug.Assert(errorInfo Is Nothing OrElse errorInfo.Severity = DiagnosticSeverity.Error)
             End If
 
-            Return result
+            If errorInfo IsNot Nothing Then
+                Return New UseSiteInfo(Of AssemblySymbol)(errorInfo)
+            End If
+
+            Dim primaryDependency = useSiteInfo.PrimaryDependency
+            Dim secondaryDependency = useSiteInfo.SecondaryDependencies
+
+            refModifiersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+            typeModifiersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+            parametersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+
+            Return New UseSiteInfo(Of AssemblySymbol)(diagnosticInfo:=Nothing, primaryDependency, secondaryDependency)
         End Function
 
         ''' <summary>
@@ -669,7 +689,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public NotOverridable Overrides ReadOnly Property HasUnsupportedMetadata As Boolean
             Get
-                Dim info As DiagnosticInfo = GetUseSiteErrorInfo()
+                Dim info As DiagnosticInfo = GetUseSiteInfo().DiagnosticInfo
                 Return info IsNot Nothing AndAlso info.Code = ERRID.ERR_UnsupportedMethod1
             End Get
         End Property
@@ -740,16 +760,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Name lookup should use this method in order to capture proximity, which affects 
         ''' overload resolution. 
         ''' </summary>
-        Friend Function ReduceExtensionMethod(instanceType As TypeSymbol, proximity As Integer) As MethodSymbol
-            Return ReducedExtensionMethodSymbol.Create(instanceType, Me, proximity)
+        Friend Function ReduceExtensionMethod(instanceType As TypeSymbol, proximity As Integer, ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As MethodSymbol
+            Return ReducedExtensionMethodSymbol.Create(instanceType, Me, proximity, useSiteInfo)
         End Function
 
         ''' <summary>
         ''' If this is an extension method that can be applied to a instance of the given type,
         ''' returns the reduced method symbol thus formed. Otherwise, returns Nothing.
         ''' </summary>
-        Public Function ReduceExtensionMethod(instanceType As TypeSymbol) As MethodSymbol
-            Return ReduceExtensionMethod(instanceType, proximity:=0)
+        Public Function ReduceExtensionMethod(instanceType As TypeSymbol, ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As MethodSymbol
+            Return ReduceExtensionMethod(instanceType, proximity:=0, useSiteInfo)
         End Function
 
         ''' <summary>
@@ -779,7 +799,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <remarks>
         ''' The method MAY return a binder used for binding so it can be reused later in method compiler
         ''' </remarks>
-        Friend Overridable Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, <Out()> Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overridable Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, <Out()> Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Throw ExceptionUtilities.Unreachable
         End Function
 
@@ -913,7 +933,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Throw New ArgumentNullException(NameOf(receiverType))
             End If
 
-            Return Me.ReduceExtensionMethod(receiverType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(receiverType)))
+            Return Me.ReduceExtensionMethod(receiverType.EnsureVbSymbolOrNothing(Of TypeSymbol)(NameOf(receiverType)), CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
         End Function
 
         Private ReadOnly Property IMethodSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IMethodSymbol.Parameters

--- a/src/Compilers/VisualBasic/Portable/Symbols/ParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ParameterSymbol.vb
@@ -272,7 +272,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public NotOverridable Overrides ReadOnly Property HasUnsupportedMetadata As Boolean
             Get
-                Dim info As DiagnosticInfo = DeriveUseSiteErrorInfoFromParameter(Me, HighestPriorityUseSiteError)
+                Dim info As DiagnosticInfo = DeriveUseSiteInfoFromParameter(Me, HighestPriorityUseSiteError).DiagnosticInfo
                 Return info IsNot Nothing AndAlso info.Code = ERRID.ERR_UnsupportedType1
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -335,54 +335,74 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If Me.IsDefinition Then
-                Return MyBase.GetUseSiteErrorInfo()
+                Return New UseSiteInfo(Of AssemblySymbol)(PrimaryDependency)
             End If
 
-            Return Me.OriginalDefinition.GetUseSiteErrorInfo()
+            Return Me.OriginalDefinition.GetUseSiteInfo()
         End Function
 
-        Friend Function CalculateUseSiteErrorInfo() As DiagnosticInfo
+        Friend Function CalculateUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
 
             Debug.Assert(IsDefinition)
 
             ' Check return type.
-            Dim errorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(Me.Type)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MergeUseSiteInfo(New UseSiteInfo(Of AssemblySymbol)(Me.PrimaryDependency), DeriveUseSiteInfoFromType(Me.Type))
 
-            If errorInfo IsNot Nothing AndAlso errorInfo.Code = ERRID.ERR_UnsupportedProperty1 Then
-                Return errorInfo
+            If useSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedProperty1 Then
+                Return useSiteInfo
             End If
 
             ' Check return type custom modifiers.
-            Dim refModifiersErrorInfo = DeriveUseSiteErrorInfoFromCustomModifiers(Me.RefCustomModifiers)
+            Dim refModifiersUseSiteInfo = DeriveUseSiteInfoFromCustomModifiers(Me.RefCustomModifiers)
 
-            If refModifiersErrorInfo IsNot Nothing AndAlso refModifiersErrorInfo.Code = ERRID.ERR_UnsupportedProperty1 Then
-                Return refModifiersErrorInfo
+            If refModifiersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedProperty1 Then
+                Return refModifiersUseSiteInfo
             End If
 
-            Dim typeModifiersErrorInfo = DeriveUseSiteErrorInfoFromCustomModifiers(Me.TypeCustomModifiers)
+            Dim typeModifiersUseSiteInfo = DeriveUseSiteInfoFromCustomModifiers(Me.TypeCustomModifiers)
 
-            If typeModifiersErrorInfo IsNot Nothing AndAlso typeModifiersErrorInfo.Code = ERRID.ERR_UnsupportedProperty1 Then
-                Return typeModifiersErrorInfo
+            If typeModifiersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedProperty1 Then
+                Return typeModifiersUseSiteInfo
             End If
-
-            errorInfo = If(errorInfo, If(refModifiersErrorInfo, typeModifiersErrorInfo))
 
             ' Check parameters.
-            Dim result = MergeUseSiteErrorInfo(errorInfo, DeriveUseSiteErrorInfoFromParameters(Me.Parameters))
+            Dim parametersUseSiteInfo = DeriveUseSiteInfoFromParameters(Me.Parameters)
+
+            If parametersUseSiteInfo.DiagnosticInfo?.Code = ERRID.ERR_UnsupportedProperty1 Then
+                Return parametersUseSiteInfo
+            End If
+
+            Dim errorInfo As DiagnosticInfo = If(useSiteInfo.DiagnosticInfo,
+                                              If(refModifiersUseSiteInfo.DiagnosticInfo,
+                                              If(typeModifiersUseSiteInfo.DiagnosticInfo,
+                                                 parametersUseSiteInfo.DiagnosticInfo)))
 
             ' If the member is in an assembly with unified references, 
             ' we check if its definition depends on a type from a unified reference.
-            If result Is Nothing AndAlso Me.ContainingModule.HasUnifiedReferences Then
+            If errorInfo Is Nothing AndAlso Me.ContainingModule.HasUnifiedReferences Then
                 Dim unificationCheckedTypes As HashSet(Of TypeSymbol) = Nothing
-                result = If(Me.Type.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes),
-                         If(GetUnificationUseSiteDiagnosticRecursive(Me.RefCustomModifiers, Me, unificationCheckedTypes),
-                         If(GetUnificationUseSiteDiagnosticRecursive(Me.TypeCustomModifiers, Me, unificationCheckedTypes),
-                            GetUnificationUseSiteDiagnosticRecursive(Me.Parameters, Me, unificationCheckedTypes))))
+                errorInfo = If(Me.Type.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes),
+                            If(GetUnificationUseSiteDiagnosticRecursive(Me.RefCustomModifiers, Me, unificationCheckedTypes),
+                            If(GetUnificationUseSiteDiagnosticRecursive(Me.TypeCustomModifiers, Me, unificationCheckedTypes),
+                               GetUnificationUseSiteDiagnosticRecursive(Me.Parameters, Me, unificationCheckedTypes))))
+
+                Debug.Assert(errorInfo Is Nothing OrElse errorInfo.Severity = DiagnosticSeverity.Error)
             End If
 
-            Return result
+            If errorInfo IsNot Nothing Then
+                Return New UseSiteInfo(Of AssemblySymbol)(errorInfo)
+            End If
+
+            Dim primaryDependency = useSiteInfo.PrimaryDependency
+            Dim secondaryDependency = useSiteInfo.SecondaryDependencies
+
+            refModifiersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+            typeModifiersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+            parametersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+
+            Return New UseSiteInfo(Of AssemblySymbol)(diagnosticInfo:=Nothing, primaryDependency, secondaryDependency)
         End Function
 
         ''' <summary>
@@ -396,7 +416,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public NotOverridable Overrides ReadOnly Property HasUnsupportedMetadata As Boolean
             Get
-                Dim info As DiagnosticInfo = GetUseSiteErrorInfo()
+                Dim info As DiagnosticInfo = GetUseSiteInfo().DiagnosticInfo
                 Return info IsNot Nothing AndAlso info.Code = ERRID.ERR_UnsupportedProperty1
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingEventSymbol.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
         Private _lazyExplicitInterfaceImplementations As ImmutableArray(Of EventSymbol)
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Public Sub New(retargetingModule As RetargetingModuleSymbol, underlyingEvent As EventSymbol)
             Debug.Assert(retargetingModule IsNot Nothing)
@@ -210,12 +210,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         Friend Overrides ReadOnly Property ObsoleteAttributeData As ObsoleteAttributeData

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingFieldSymbol.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         ''' <remarks></remarks>
         Private _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Public Sub New(retargetingModule As RetargetingModuleSymbol, underlyingField As FieldSymbol)
 
@@ -227,12 +227,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         ''' <remarks>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingMethodSymbol.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
         Private _lazyExplicitInterfaceImplementations As ImmutableArray(Of MethodSymbol)
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Public Sub New(retargetingModule As RetargetingModuleSymbol, underlyingMethod As MethodSymbol)
             Debug.Assert(retargetingModule IsNot Nothing)
@@ -476,12 +476,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         ''' <remarks>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         ''' </summary>
         Private _lazyCustomAttributes As ImmutableArray(Of VisualBasicAttributeData)
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Public Sub New(retargetingModule As RetargetingModuleSymbol, underlyingType As NamedTypeSymbol)
 
@@ -353,7 +353,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             End Get
         End Property
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim underlyingBase = _underlyingType.GetDeclaredBase(basesBeingResolved)
 
             Return If(underlyingBase IsNot Nothing,
@@ -365,7 +365,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return RetargetingTranslator.Retarget(_underlyingType.GetInterfacesToEmit())
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Dim underlyingBaseInterfaces = _underlyingType.GetDeclaredInterfacesNoUseSiteDiagnostics(basesBeingResolved)
 
             Return RetargetingTranslator.Retarget(underlyingBaseInterfaces)
@@ -375,7 +375,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return New ExtendedErrorTypeSymbol(diag, True)
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim diag = BaseTypeAnalysis.GetDependencyDiagnosticsForImportedClass(Me)
             If diag IsNot Nothing Then
                 Return CyclicInheritanceError(diag)
@@ -394,7 +394,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return acyclicBase
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Dim declaredInterfaces As ImmutableArray(Of NamedTypeSymbol) = GetDeclaredInterfacesNoUseSiteDiagnostics(Nothing)
             If (Not Me.IsInterface) Then
                 ' only interfaces needs to check for inheritance cycles via interfaces.
@@ -491,13 +491,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return RetargetingTranslator.Retarget(_underlyingType.LookupMetadataType(emittedTypeName), RetargetOptions.RetargetPrimitiveTypesByName)
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
 
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         Friend Overrides ReadOnly Property DefaultPropertyName As String

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingPropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingPropertySymbol.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
         Private _lazyExplicitInterfaceImplementations As ImmutableArray(Of PropertySymbol)
 
-        Private _lazyUseSiteErrorInfo As DiagnosticInfo = ErrorFactory.EmptyErrorInfo ' Indicates unknown state. 
+        Private _lazyCachedUseSiteInfo As CachedUseSiteInfo(Of AssemblySymbol) = CachedUseSiteInfo(Of AssemblySymbol).Uninitialized ' Indicates unknown state. 
 
         Public Sub New(retargetingModule As RetargetingModuleSymbol, underlyingProperty As PropertySymbol)
             Debug.Assert(retargetingModule IsNot Nothing)
@@ -292,12 +292,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Return builder.ToImmutableAndFree()
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            If _lazyUseSiteErrorInfo Is ErrorFactory.EmptyErrorInfo Then
-                _lazyUseSiteErrorInfo = CalculateUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim primaryDependency As AssemblySymbol = Me.PrimaryDependency
+
+            If Not _lazyCachedUseSiteInfo.IsInitialized Then
+                _lazyCachedUseSiteInfo.Initialize(primaryDependency, CalculateUseSiteInfo())
             End If
 
-            Return _lazyUseSiteErrorInfo
+            Return _lazyCachedUseSiteInfo.ToUseSiteInfo(primaryDependency)
         End Function
 
         Friend Overrides ReadOnly Property IsMyGroupCollectionProperty As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -817,8 +817,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
                 ' A retargeted error symbol must trigger an error on use so that a dependent compilation won't
                 ' improperly succeed. We therefore ensure we have a use-site diagnostic.
-                Dim useSiteDiagnostic = type.GetUseSiteErrorInfo
-                If useSiteDiagnostic IsNot Nothing Then
+                Dim useSiteDiagnostic = type.GetUseSiteInfo
+                If useSiteDiagnostic.DiagnosticInfo IsNot Nothing Then
                     Return type
                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Protected Overrides Function GetParameters(sourceModule As SourceModuleSymbol, diagBag As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+        Protected Overrides Function GetParameters(sourceModule As SourceModuleSymbol, diagBag As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
             Dim type = DirectCast(Me.ContainingType, SourceMemberContainerTypeSymbol)
             Dim binder As Binder = BinderBuilder.CreateBinderForType(sourceModule, Me.SyntaxTree, type)
             binder = New LocationSpecificBinder(BindingLocation.EventAccessorSignature, Me, binder)
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function BindParameters(location As Location,
                                         binder As Binder,
                                         parameterListOpt As ParameterListSyntax,
-                                        diagnostics As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+                                        diagnostics As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
 
             Dim parameterListSyntax = If(parameterListOpt Is Nothing, Nothing, parameterListOpt.Parameters)
             Dim nParameters = parameterListSyntax.Count
@@ -185,13 +185,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     ' If delegate is a function method we should already have diagnostics about that
                     If delInvoke IsNot Nothing AndAlso delInvoke.IsSub Then
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
                         Dim conversion = Conversions.ClassifyMethodConversionForEventRaise(
                                                             delInvoke,
                                                             parameters,
-                                                            useSiteDiagnostics)
+                                                            useSiteInfo)
 
-                        If Not diagnostics.Add(location, useSiteDiagnostics) AndAlso
+                        If Not diagnostics.Add(location, useSiteInfo) AndAlso
                             (Not Conversions.IsDelegateRelaxationSupportedFor(conversion) OrElse
                              (binder.OptionStrict = OptionStrict.On AndAlso Conversions.IsNarrowingMethodConversion(conversion, False))) Then
 
@@ -249,7 +249,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Shared ReadOnly s_checkRaiseParameterModifierCallback As Binder.CheckParameterModifierDelegate = AddressOf CheckEventMethodParameterModifier
 
         ' applicable to all event methods
-        Private Shared Function CheckEventMethodParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As DiagnosticBag) As SourceParameterFlags
+        Private Shared Function CheckEventMethodParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As BindingDiagnosticBag) As SourceParameterFlags
             If (flag And SourceParameterFlags.Optional) <> 0 Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_EventMethodOptionalParamIllegal1, location, token.ToString())
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ' additional rules for Add and Remove
-        Private Shared Function CheckAddRemoveParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As DiagnosticBag) As SourceParameterFlags
+        Private Shared Function CheckAddRemoveParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As BindingDiagnosticBag) As SourceParameterFlags
             If (flag And SourceParameterFlags.ByRef) <> 0 Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_EventAddRemoveByrefParamIllegal, location, token.ToString())

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
@@ -37,28 +37,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return AttributeUsageInfo.Null
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Me.GetDeclaredBase(Nothing)
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim baseType = DeclaringCompilation.GetSpecialType(SpecialType.System_Object)
 
             ' check that System.Object is available. 
             ' Although submission semantically doesn't have a base class we need to emit one.
-            Dim info = baseType.GetUseSiteErrorInfo()
-            If info IsNot Nothing Then
-                diagnostics.Add(info, Locations(0))
-            End If
+            Dim info = baseType.GetUseSiteInfo()
+            diagnostics.Add(info, Locations(0))
 
             Return If(Me.TypeKind = TypeKind.Submission, Nothing, baseType)
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
@@ -166,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return NoLocation.Singleton
         End Function
 
-        Protected Overrides Sub AddDeclaredNonTypeMembers(membersBuilder As MembersAndInitializersBuilder, diagnostics As DiagnosticBag)
+        Protected Overrides Sub AddDeclaredNonTypeMembers(membersBuilder As MembersAndInitializersBuilder, diagnostics As BindingDiagnosticBag)
             For Each syntaxRef In SyntaxReferences
                 Dim node = syntaxRef.GetVisualBasicSyntax()
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/LocalSymbol.vb
@@ -354,7 +354,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overridable Function GetConstantValueDiagnostics(binder As Binder) As DiagnosticBag
+        Friend Overridable Function GetConstantValueDiagnostics(binder As Binder) As BindingDiagnosticBag
             Throw ExceptionUtilities.Unreachable
         End Function
 
@@ -670,7 +670,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' Compute the type of this variable.
             Friend Overrides Function ComputeTypeInternal(localBinder As Binder) As TypeSymbol
 
-                Dim diagBag = DiagnosticBag.GetInstance()
                 Dim type As TypeSymbol = Nothing
 
                 type = localBinder.InferForEachVariableType(Me,
@@ -686,8 +685,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                        collectionPlaceholder:=Nothing,
                                                        needToDispose:=Nothing,
                                                        isOrInheritsFromOrImplementsIDisposable:=Nothing,
-                                                       diagBag)
-                diagBag.Free()
+                                                       BindingDiagnosticBag.Discarded)
                 Return type
             End Function
 
@@ -740,8 +738,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' Compute the type of this variable.
             Friend Overrides Function ComputeType(Optional containingBinder As Binder = Nothing) As TypeSymbol
 
-                Dim diagBag = DiagnosticBag.GetInstance()
-
                 Dim fromValueExpression As BoundExpression = Nothing
                 Dim toValueExpression As BoundExpression = Nothing
                 Dim stepValueExpression As BoundExpression = Nothing
@@ -756,8 +752,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                    fromValueExpression,
                                                    toValueExpression,
                                                    stepValueExpression,
-                                                   diagBag)
-                diagBag.Free()
+                                                   BindingDiagnosticBag.Discarded)
                 Return type
             End Function
 
@@ -791,7 +786,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Private NotInheritable Class EvaluatedConstantInfo
                 Inherits EvaluatedConstant
 
-                Public Sub New(value As ConstantValue, type As TypeSymbol, expression As BoundExpression, diagnostics As DiagnosticBag)
+                Public Sub New(value As ConstantValue, type As TypeSymbol, expression As BoundExpression, diagnostics As BindingDiagnosticBag)
                     MyBase.New(value, type)
 
                     Debug.Assert(expression IsNot Nothing)
@@ -801,7 +796,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Sub
 
                 Public ReadOnly Expression As BoundExpression
-                Public ReadOnly Diagnostics As DiagnosticBag
+                Public ReadOnly Diagnostics As BindingDiagnosticBag
             End Class
 
             ''' <summary>
@@ -826,8 +821,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' Compute the type of this variable.
             Friend Overrides Function ComputeTypeInternal(localBinder As Binder) As TypeSymbol
 
-                Dim diagBag = DiagnosticBag.GetInstance()
-
                 Dim declType As TypeSymbol = Nothing
                 Dim type As TypeSymbol = Nothing
                 Dim valueExpression As BoundExpression = Nothing
@@ -838,9 +831,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                        _initializerOpt,
                                                        valueExpression,
                                                        declType,
-                                                       diagBag)
+                                                       BindingDiagnosticBag.Discarded)
 
-                diagBag.Free()
                 Return type
             End Function
 
@@ -849,7 +841,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If IsConst Then
                     If _evaluatedConstant Is Nothing Then
-                        Dim diagBag = New DiagnosticBag()
+                        Dim diagBag = New BindingDiagnosticBag()
 
                         ' BindLocalConstantInitializer may be called before or after the constant's type has been set.
                         ' It is called before when we are inferring the constant's type. In that case the constant has no explicit type 
@@ -892,12 +884,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return If(_evaluatedConstant IsNot Nothing, _evaluatedConstant.Value, Nothing)
             End Function
 
-            Friend Overrides Function GetConstantValueDiagnostics(containingBinder As Binder) As DiagnosticBag
+            Friend Overrides Function GetConstantValueDiagnostics(containingBinder As Binder) As BindingDiagnosticBag
                 GetConstantValue(containingBinder)
                 Return If(_evaluatedConstant IsNot Nothing, _evaluatedConstant.Diagnostics, Nothing)
             End Function
 
-            Private Sub SetConstantExpression(type As TypeSymbol, constantValue As ConstantValue, expression As BoundExpression, diagnostics As DiagnosticBag)
+            Private Sub SetConstantExpression(type As TypeSymbol, constantValue As ConstantValue, expression As BoundExpression, diagnostics As BindingDiagnosticBag)
                 If _evaluatedConstant Is Nothing Then
                     Interlocked.CompareExchange(_evaluatedConstant, New EvaluatedConstantInfo(constantValue, type, expression, diagnostics), Nothing)
                 End If
@@ -999,7 +991,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return _originalVariable.GetConstantValue(binder)
             End Function
 
-            Friend Overrides Function GetConstantValueDiagnostics(binder As Binder) As DiagnosticBag
+            Friend Overrides Function GetConstantValueDiagnostics(binder As Binder) As BindingDiagnosticBag
                 Return _originalVariable.GetConstantValueDiagnostics(binder)
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverloadingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverloadingHelper.vb
@@ -155,7 +155,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                            container)
 
             Dim result = LookupResult.GetInstance()
-            binder.LookupMember(result, container, name, 0, LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods, useSiteDiagnostics:=Nothing)
+            binder.LookupMember(result, container, name, 0, LookupOptions.AllMethodsOfAnyArity Or LookupOptions.IgnoreExtensionMethods, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             If result.IsGoodOrAmbiguous Then
                 Dim lookupSymbols As ArrayBuilder(Of Symbol) = result.Symbols
                 If result.Kind = LookupResultKind.Ambiguous AndAlso result.HasDiagnostic AndAlso TypeOf result.Diagnostic Is AmbiguousSymbolDiagnostic Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         ''' <param name="container">Containing type to check. Should be an original definition.</param>
         ''' <param name="diagnostics">Place diagnostics here.</param>
-        Public Shared Sub CheckHidingAndOverridingForType(container As SourceMemberContainerTypeSymbol, diagnostics As DiagnosticBag)
+        Public Shared Sub CheckHidingAndOverridingForType(container As SourceMemberContainerTypeSymbol, diagnostics As BindingDiagnosticBag)
             Debug.Assert(container.IsDefinition) ' Don't do this on constructed types
 
             Select Case container.TypeKind
@@ -140,7 +140,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <param name="container">Containing type to check. Should be an original definition.</param>
         ''' <param name="diagnostics">Place diagnostics here.</param>
         ''' <remarks></remarks>
-        Private Shared Sub CheckMembersAgainstBaseType(container As SourceMemberContainerTypeSymbol, diagnostics As DiagnosticBag)
+        Private Shared Sub CheckMembersAgainstBaseType(container As SourceMemberContainerTypeSymbol, diagnostics As BindingDiagnosticBag)
             For Each member In container.GetMembers()
                 If CanOverrideOrHide(member) Then
                     Select Case member.Kind
@@ -176,7 +176,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' If "container" is a MustInherit inheriting from a MustInherit, make sure that no MustOverride members
         ''' have been shadowed.
         ''' </summary>
-        Private Shared Sub CheckAllAbstractsAreOverriddenAndNotHidden(container As NamedTypeSymbol, diagnostics As DiagnosticBag)
+        Private Shared Sub CheckAllAbstractsAreOverriddenAndNotHidden(container As NamedTypeSymbol, diagnostics As BindingDiagnosticBag)
 
             ' Check that a non-MustInherit class doesn't have any MustOverride members
             If Not (container.IsMustInherit OrElse container.IsNotInheritable) Then
@@ -316,7 +316,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Protected Shared Sub CheckShadowing(container As SourceMemberContainerTypeSymbol,
                                             member As Symbol,
-                                            diagnostics As DiagnosticBag)
+                                            diagnostics As BindingDiagnosticBag)
             Dim memberIsOverloads = member.IsOverloads()
             Dim warnForHiddenMember As Boolean = Not member.ShadowsExplicitly
 
@@ -343,13 +343,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                     member As Symbol,
                                                     memberIsOverloads As Boolean,
                                                     baseType As NamedTypeSymbol,
-                                                    diagnostics As DiagnosticBag,
+                                                    diagnostics As BindingDiagnosticBag,
                                                     ByRef warnForHiddenMember As Boolean)
             Debug.Assert(container.IsDefinition)
 
             If warnForHiddenMember Then
                 For Each hiddenMember In baseType.GetMembers(member.Name)
-                    If AccessCheck.IsSymbolAccessible(hiddenMember, container, Nothing, useSiteDiagnostics:=Nothing) AndAlso
+                    If AccessCheck.IsSymbolAccessible(hiddenMember, container, Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) AndAlso
                        (Not memberIsOverloads OrElse
                         hiddenMember.Kind <> member.Kind OrElse
                         hiddenMember.IsWithEventsProperty OrElse
@@ -380,7 +380,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Report diagnostic for one member shadowing another, but no Shadows modifier was present.
         Private Shared Sub ReportShadowingDiagnostic(hidingMember As Symbol,
                                                      hiddenMember As Symbol,
-                                                     diagnostics As DiagnosticBag)
+                                                     diagnostics As BindingDiagnosticBag)
 
             Debug.Assert(Not (hidingMember.IsAccessor() AndAlso hiddenMember.IsAccessor))
 
@@ -463,7 +463,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Report diagnostic for a member shadowing a MustOverride.
         Private Shared Sub ReportShadowingMustOverrideError(hidingMember As Symbol,
                                                             hiddenMember As Symbol,
-                                                            diagnostics As DiagnosticBag)
+                                                            diagnostics As BindingDiagnosticBag)
             Debug.Assert(hidingMember.Locations(0).IsInSource)
 
             If hidingMember.IsAccessor() Then
@@ -750,7 +750,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         )
             ' Use original definition for accessibility check, because substitutions can cause
             ' reductions in accessibility that aren't appropriate (see bug #12038 for example).
-            Dim accessible = AccessCheck.IsSymbolAccessible(sym.OriginalDefinition, overridingContainingType.OriginalDefinition, Nothing, useSiteDiagnostics:=Nothing)
+            Dim accessible = AccessCheck.IsSymbolAccessible(sym.OriginalDefinition, overridingContainingType.OriginalDefinition, Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
 
             If sym.Kind = overridingSym.Kind AndAlso
                 CanOverrideOrHide(sym) Then
@@ -839,7 +839,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' overridden members are passed in.
         Friend Shared Sub CheckOverrideMember(member As TSymbol,
                                               overriddenMembersResult As OverriddenMembersResult(Of TSymbol),
-                                              diagnostics As DiagnosticBag)
+                                              diagnostics As BindingDiagnosticBag)
             Debug.Assert(overriddenMembersResult IsNot Nothing)
 
             Dim memberIsShadows As Boolean = member.ShadowsExplicitly
@@ -918,10 +918,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     Next
 
-                    Dim useSiteErrorInfo = overriddenMember.GetUseSiteErrorInfo()
-                    If useSiteErrorInfo IsNot Nothing Then
-                        diagnostics.Add(New VBDiagnostic(useSiteErrorInfo, member.Locations(0)))
-                    ElseIf member.Kind = SymbolKind.Property Then
+                    Dim useSiteInfo = overriddenMember.GetUseSiteInfo()
+                    If Not diagnostics.Add(useSiteInfo, member.Locations(0)) AndAlso
+                       member.Kind = SymbolKind.Property Then
+
                         ' No overriding errors found in member. If its a property, its accessors might have issues.
                         Dim overridingProperty As PropertySymbol = DirectCast(DirectCast(member, Symbol), PropertySymbol)
                         Dim overriddenProperty As PropertySymbol = DirectCast(DirectCast(overriddenMember, Symbol), PropertySymbol)
@@ -982,14 +982,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Check an accessor with respect to its overridden accessor and report any diagnostics
         Friend Shared Sub CheckOverridePropertyAccessor(overridingAccessor As MethodSymbol,
                                                         overriddenAccessor As MethodSymbol,
-                                                        diagnostics As DiagnosticBag)
+                                                        diagnostics As BindingDiagnosticBag)
             ' CONSIDER: it is possible for an accessor to have a use site error even when the property
             ' does not but, in general, we have not been handling cases where property and accessor
             ' signatures are mismatched (e.g. different modopts).
             If overridingAccessor IsNot Nothing AndAlso overriddenAccessor IsNot Nothing Then
                 ' Use original definition for accessibility check, because substitutions can cause
                 ' reductions in accessibility that aren't appropriate (see bug #12038 for example).
-                If Not AccessCheck.IsSymbolAccessible(overriddenAccessor.OriginalDefinition, overridingAccessor.ContainingType, Nothing, useSiteDiagnostics:=Nothing) Then
+                If Not AccessCheck.IsSymbolAccessible(overriddenAccessor.OriginalDefinition, overridingAccessor.ContainingType, Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                     ReportBadOverriding(ERRID.ERR_CannotOverrideInAccessibleMember, overridingAccessor, overriddenAccessor, diagnostics)
                 Else
                     Dim errorId As ERRID
@@ -1005,7 +1005,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Shared Sub ReportBadOverriding(id As ERRID,
                                                overridingMember As Symbol,
                                                overriddenMember As Symbol,
-                                               diagnostics As DiagnosticBag)
+                                               diagnostics As BindingDiagnosticBag)
             diagnostics.Add(New VBDiagnostic(ErrorFactory.ErrorInfo(id, overridingMember, overriddenMember),
                                             overridingMember.Locations(0)))
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceComplexParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceComplexParameterSymbol.vb
@@ -134,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property ExplicitDefaultConstantValue(inProgress As SymbolsInProgress(Of ParameterSymbol)) As ConstantValue
             Get
                 If _lazyDefaultValue Is ConstantValue.Unset Then
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
                     If Interlocked.CompareExchange(_lazyDefaultValue, BindDefaultValue(inProgress, diagnostics), ConstantValue.Unset) Is ConstantValue.Unset Then
                         DirectCast(ContainingModule, SourceModuleSymbol).AddDiagnostics(diagnostics, CompilationStage.Declare)
                     End If
@@ -145,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Function BindDefaultValue(inProgress As SymbolsInProgress(Of ParameterSymbol), diagnostics As DiagnosticBag) As ConstantValue
+        Private Function BindDefaultValue(inProgress As SymbolsInProgress(Of ParameterSymbol), diagnostics As BindingDiagnosticBag) As ConstantValue
 
             Dim parameterSyntax = SyntaxNode
             If parameterSyntax Is Nothing Then
@@ -316,7 +316,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                 ordinal As Integer,
                                                 binder As Binder,
                                                 checkModifier As CheckParameterModifierDelegate,
-                                                diagnostics As DiagnosticBag) As ParameterSymbol
+                                                diagnostics As BindingDiagnosticBag) As ParameterSymbol
             Dim getErrorInfo As Func(Of DiagnosticInfo) = Nothing
 
             If binder.OptionStrict = OptionStrict.On Then
@@ -339,7 +339,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End If
 
                     ' 'touch' the constructor in order to generate proper diagnostics
-                    binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_ParamArrayAttribute__ctor,
+                    binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_ParamArrayAttribute__ctor,
                                                                      syntax,
                                                                      diagnostics)
                 End If
@@ -365,12 +365,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' Report diagnostic if constructors for datetime and decimal default values are not available
                 Select Case paramType.SpecialType
                     Case SpecialType.System_DateTime
-                        binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor,
+                        binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DateTimeConstantAttribute__ctor,
                                                                          syntax.Default,
                                                                          diagnostics)
 
                     Case SpecialType.System_Decimal
-                        binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor,
+                        binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor,
                                                                         syntax.Default,
                                                                         diagnostics)
                 End Select

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceDelegateMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceDelegateMethodSymbol.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                               <Out> ByRef beginInvoke As MethodSymbol,
                                               <Out> ByRef endInvoke As MethodSymbol,
                                               <Out> ByRef invoke As MethodSymbol,
-                                              diagnostics As DiagnosticBag)
+                                              diagnostics As BindingDiagnosticBag)
 
             Debug.Assert(TypeOf syntax Is DelegateStatementSyntax OrElse
                          TypeOf syntax Is EventStatementSyntax)
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Sub
 
-        Private Shared Function BindReturnType(syntax As VisualBasicSyntaxNode, binder As Binder, diagnostics As DiagnosticBag) As TypeSymbol
+        Private Shared Function BindReturnType(syntax As VisualBasicSyntaxNode, binder As Binder, diagnostics As BindingDiagnosticBag) As TypeSymbol
             If syntax.Kind = SyntaxKind.DelegateFunctionStatement Then
                 Dim delegateSyntax = DirectCast(syntax, DelegateStatementSyntax)
 
@@ -247,7 +247,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     syntax As VisualBasicSyntaxNode,
                     binder As Binder,
                     parameterListOpt As ParameterListSyntax,
-                    diagnostics As DiagnosticBag)
+                    diagnostics As BindingDiagnosticBag)
 
                 MyBase.New(delegateType,
                            syntax,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -146,7 +146,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Sub
 
-        Private Function ComputeType(diagnostics As DiagnosticBag, <Out()> ByRef isTypeInferred As Boolean, <Out()> ByRef isDelegateFromImplements As Boolean) As TypeSymbol
+        Private Function ComputeType(diagnostics As BindingDiagnosticBag, <Out()> ByRef isTypeInferred As Boolean, <Out()> ByRef isDelegateFromImplements As Boolean) As TypeSymbol
             Dim binder = CreateBinderForTypeDeclaration()
             Dim syntax = DirectCast(_syntaxRef.GetSyntax(), EventStatementSyntax)
 
@@ -243,7 +243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return type
         End Function
 
-        Private Function ComputeImplementedEvents(diagnostics As DiagnosticBag) As ImmutableArray(Of EventSymbol)
+        Private Function ComputeImplementedEvents(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of EventSymbol)
             Dim syntax = DirectCast(_syntaxRef.GetSyntax(), EventStatementSyntax)
             Dim implementsClause = syntax.ImplementsClause
 
@@ -282,12 +282,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return
             End If
 
-            Dim diagnostics As DiagnosticBag = Nothing
+            Dim diagnostics As BindingDiagnosticBag = Nothing
             Dim type = Me.Type
             For Each implemented In ExplicitInterfaceImplementations
                 If Not implemented.Type.IsSameType(type, TypeCompareKind.IgnoreTupleNames) Then
                     If diagnostics Is Nothing Then
-                        diagnostics = DiagnosticBag.GetInstance()
+                        diagnostics = BindingDiagnosticBag.GetInstance()
                     End If
 
                     Dim errLocation = GetImplementingLocation(implemented)
@@ -314,7 +314,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ' on Type which is inferred, potentially from interface
                         ' implementations which relies on DelegateParameters.
                         Dim binder = CreateBinderForTypeDeclaration()
-                        Dim diagnostics = DiagnosticBag.GetInstance()
+                        Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
                         ContainingSourceModule.AtomicStoreArrayAndDiagnostics(
                             _lazyDelegateParameters,
@@ -457,7 +457,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides ReadOnly Property Type As TypeSymbol
             Get
                 If _lazyType Is Nothing Then
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
                     Dim isTypeInferred = False
                     Dim isDelegateFromImplements = False
                     Dim eventType = ComputeType(diagnostics, isTypeInferred, isDelegateFromImplements)
@@ -508,7 +508,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides ReadOnly Property ExplicitInterfaceImplementations As ImmutableArray(Of EventSymbol)
             Get
                 If _lazyImplementedEvents.IsDefault Then
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
                     ContainingSourceModule.AtomicStoreArrayAndDiagnostics(_lazyImplementedEvents,
                                                                           ComputeImplementedEvents(diagnostics),
                                                                           diagnostics,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
@@ -262,7 +262,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                             Dim specialTypeInt64 = Me.ContainingAssembly.GetSpecialType(SpecialType.System_Int64)
                             ' NOTE: used from emit, so shouldn't have gotten here if there were errors
-                            Debug.Assert(specialTypeInt64.GetUseSiteErrorInfo() Is Nothing)
+                            Debug.Assert(specialTypeInt64.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
                             Dim compilation = Me.DeclaringCompilation
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -351,7 +351,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             m_containingModule.AtomicSetFlagAndStoreDiagnostics(m_lazyState,
                                                                 StateFlags.ReportedVarianceDiagnostics,
                                                                 0,
-                                                                diagnostics,
+                                                                If(diagnostics IsNot Nothing, New BindingDiagnosticBag(diagnostics), Nothing),
                                                                 CompilationStage.Declare)
 
             If diagnostics IsNot Nothing Then
@@ -495,7 +495,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 If TypeSymbol.Equals(iface, implementedInterface, TypeCompareKind.ConsiderEverything) Then
                     directInterface = iface
                     Exit For
-                ElseIf directInterface Is Nothing AndAlso iface.ImplementsInterface(implementedInterface, comparer:=Nothing, useSiteDiagnostics:=Nothing) Then
+                ElseIf directInterface Is Nothing AndAlso iface.ImplementsInterface(implementedInterface, comparer:=Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                     directInterface = iface
                 End If
             Next
@@ -1181,10 +1181,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     ' We need to emit an Extension attribute on the type. 
                     ' Can we locate it?
-                    Dim useSiteError As DiagnosticInfo = Nothing
-                    m_containingModule.ContainingSourceAssembly.DeclaringCompilation.GetExtensionAttributeConstructor(useSiteError:=useSiteError)
+                    Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+                    m_containingModule.ContainingSourceAssembly.DeclaringCompilation.GetExtensionAttributeConstructor(useSiteInfo:=useSiteInfo)
 
-                    If useSiteError IsNot Nothing Then
+                    If useSiteInfo.DiagnosticInfo IsNot Nothing Then
                         ' Note, we are storing false because, even though we should emit the attribute,
                         ' we can't do that due to the use site error.
                         _lazyEmitExtensionAttribute = ThreeState.False
@@ -1670,7 +1670,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Function GetMembersAndInitializers() As MembersAndInitializers
             If _lazyMembersAndInitializers Is Nothing Then
-                Dim diagBag = DiagnosticBag.GetInstance()
+                Dim diagBag = BindingDiagnosticBag.GetInstance()
                 Dim membersAndInitializers = BuildMembersAndInitializers(diagBag)
                 m_containingModule.AtomicStoreReferenceAndDiagnostics(_lazyMembersAndInitializers, membersAndInitializers, diagBag, CompilationStage.Declare)
                 Debug.Assert(_lazyMembersAndInitializers IsNot Nothing)
@@ -1704,7 +1704,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Shared s_SymbolsBuildingMembersAndInitializers As HashSet(Of SourceMemberContainerTypeSymbol)
 #End If
 
-        Private Function BuildMembersAndInitializers(diagBag As DiagnosticBag) As MembersAndInitializers
+        Private Function BuildMembersAndInitializers(diagBag As BindingDiagnosticBag) As MembersAndInitializers
 
             Dim membersAndInitializers As MembersAndInitializers
 
@@ -1750,7 +1750,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ''' <summary> Examines the members collection and builds a set of partial methods if any, otherwise returns nothing </summary>
-        Private Function FindPartialMethodDeclarations(diagnostics As DiagnosticBag, members As Dictionary(Of String, ImmutableArray(Of Symbol))) As HashSet(Of SourceMemberMethodSymbol)
+        Private Function FindPartialMethodDeclarations(diagnostics As BindingDiagnosticBag, members As Dictionary(Of String, ImmutableArray(Of Symbol))) As HashSet(Of SourceMemberMethodSymbol)
             Dim partialMethods As HashSet(Of SourceMemberMethodSymbol) = Nothing
             For Each memberGroup In members
                 For Each member In memberGroup.Value
@@ -1772,7 +1772,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return partialMethods
         End Function
 
-        Private Sub ProcessPartialMethodsIfAny(members As Dictionary(Of String, ImmutableArray(Of Symbol)), diagnostics As DiagnosticBag)
+        Private Sub ProcessPartialMethodsIfAny(members As Dictionary(Of String, ImmutableArray(Of Symbol)), diagnostics As BindingDiagnosticBag)
             '  Detect all partial method declarations
             Dim partialMethods As HashSet(Of SourceMemberMethodSymbol) = FindPartialMethodDeclarations(diagnostics, members)
             If partialMethods Is Nothing Then
@@ -1905,7 +1905,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Sub ReportErrorsOnPartialMethodImplementation(partialMethod As SourceMethodSymbol,
                                                               implMethod As SourceMethodSymbol,
                                                               implMethodLocation As Location,
-                                                              diagnostics As DiagnosticBag)
+                                                              diagnostics As BindingDiagnosticBag)
 
             ' Report 'Method '...' must be declared 'Private' in order to implement partial method '...'
             If implMethod.DeclaredAccessibility <> Accessibility.Private Then
@@ -1999,7 +1999,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     If Not Me.IsStructureType Then
                         _lazyStructureCycle = ThreeState.False
                     Else
-                        Dim diagnostics = DiagnosticBag.GetInstance()
+                        Dim diagnostics = BindingDiagnosticBag.GetInstance()
                         Dim hasCycle = Me.CheckStructureCircularity(diagnostics)
 
                         ' In either case we use AtomicStoreIntegerAndDiagnostics.
@@ -2097,7 +2097,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' depends on the declaration order. Current implementation reports all of the cycles for consistency. 
         ''' See testcases MultiplyCyclesInStructure03 and MultiplyCyclesInStructure04 (report different errors in Dev10).
         ''' </remarks>
-        Private Function CheckStructureCircularity(diagnostics As DiagnosticBag) As Boolean
+        Private Function CheckStructureCircularity(diagnostics As BindingDiagnosticBag) As Boolean
             '  Must be a structure
             Debug.Assert(Me.IsValueType AndAlso Not Me.IsTypeParameter)
 
@@ -2257,7 +2257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         End Function
 
-        Private Function DetermineDefaultPropertyName(membersByName As Dictionary(Of String, ImmutableArray(Of Symbol)), diagBag As DiagnosticBag) As String
+        Private Function DetermineDefaultPropertyName(membersByName As Dictionary(Of String, ImmutableArray(Of Symbol)), diagBag As BindingDiagnosticBag) As String
             Dim defaultPropertyName As String = Nothing
 
             For Each pair In membersByName
@@ -2308,7 +2308,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ' Check all bases of "namedType" and warn if they have a default property named "defaultPropertyName".
-        Private Sub CheckDefaultPropertyAgainstAllBases(namedType As NamedTypeSymbol, defaultPropertyName As String, location As Location, diagBag As DiagnosticBag)
+        Private Sub CheckDefaultPropertyAgainstAllBases(namedType As NamedTypeSymbol, defaultPropertyName As String, location As Location, diagBag As BindingDiagnosticBag)
             If namedType.IsInterfaceType() Then
                 For Each iface In namedType.InterfacesNoUseSiteDiagnostics
                     CheckDefaultPropertyAgainstBase(defaultPropertyName, iface, location, diagBag)
@@ -2320,7 +2320,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         ' Check and warn if "baseType" has a default property named "defaultProperty Name.
         ' If "baseType" doesn't have a default property, check its base types.
-        Private Sub CheckDefaultPropertyAgainstBase(defaultPropertyName As String, baseType As NamedTypeSymbol, location As Location, diagBag As DiagnosticBag)
+        Private Sub CheckDefaultPropertyAgainstBase(defaultPropertyName As String, baseType As NamedTypeSymbol, location As Location, diagBag As BindingDiagnosticBag)
             If baseType IsNot Nothing Then
                 Dim baseDefaultPropertyName = baseType.DefaultPropertyName
                 If baseDefaultPropertyName IsNot Nothing Then
@@ -2380,7 +2380,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <param name="membersAndInitializers"></param>
         ''' <param name="diagBag"></param>
         ''' <remarks></remarks>
-        Private Sub CheckForOverloadOverridesShadowsClashesInSameType(membersAndInitializers As MembersAndInitializers, diagBag As DiagnosticBag)
+        Private Sub CheckForOverloadOverridesShadowsClashesInSameType(membersAndInitializers As MembersAndInitializers, diagBag As BindingDiagnosticBag)
             For Each member In membersAndInitializers.Members
                 '  list may contain both properties and methods
                 Dim checkProperties As Boolean = True
@@ -2482,7 +2482,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         ' Declare all the non-type members and put them in a list.
-        Private Function BuildNonTypeMembers(diagnostics As DiagnosticBag) As MembersAndInitializers
+        Private Function BuildNonTypeMembers(diagnostics As BindingDiagnosticBag) As MembersAndInitializers
             Dim membersBuilder As New MembersAndInitializersBuilder()
 
             AddDeclaredNonTypeMembers(membersBuilder, diagnostics)
@@ -2518,20 +2518,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Protected Overridable Sub AddEntryPointIfNeeded(membersBuilder As MembersAndInitializersBuilder)
         End Sub
 
-        Protected MustOverride Sub AddDeclaredNonTypeMembers(membersBuilder As MembersAndInitializersBuilder, diagnostics As DiagnosticBag)
+        Protected MustOverride Sub AddDeclaredNonTypeMembers(membersBuilder As MembersAndInitializersBuilder, diagnostics As BindingDiagnosticBag)
 
-        Protected Overridable Sub AddGroupClassMembersIfNeeded(membersBuilder As MembersAndInitializersBuilder, diagnostics As DiagnosticBag)
+        Protected Overridable Sub AddGroupClassMembersIfNeeded(membersBuilder As MembersAndInitializersBuilder, diagnostics As BindingDiagnosticBag)
         End Sub
 
         ' Create symbol(s) for member syntax and add them to the member list
         Protected Sub AddMember(memberSyntax As StatementSyntax,
                                     binder As Binder,
-                                    diagBag As DiagnosticBag,
+                                    diagBag As BindingDiagnosticBag,
                                     members As MembersAndInitializersBuilder,
                                     ByRef staticInitializers As ArrayBuilder(Of FieldOrPropertyInitializer),
                                     ByRef instanceInitializers As ArrayBuilder(Of FieldOrPropertyInitializer),
                                     reportAsInvalid As Boolean)
 
+            Debug.Assert(diagBag.DiagnosticBag IsNot Nothing)
             ' Partial methods are implemented by a postpass that matches up the declaration with the implementation.
             ' Here we treat them as independent methods.
 
@@ -2558,7 +2559,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagBag.Add(ERRID.ERR_InvalidInNamespace, methodDecl.GetLocation())
                     End If
 
-                    Dim methodSymbol = CreateMethodMember(methodDecl, binder, diagBag)
+                    Dim methodSymbol = CreateMethodMember(methodDecl, binder, diagBag.DiagnosticBag)
                     If methodSymbol IsNot Nothing Then
                         AddMember(methodSymbol, binder, members, omitDiagnostics:=False)
                     End If
@@ -2577,7 +2578,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagBag.Add(ERRID.ERR_InvalidInNamespace, methodDecl.GetLocation())
                     End If
 
-                    Dim methodSymbol = CreateMethodMember(DirectCast(memberSyntax, MethodBaseSyntax), binder, diagBag)
+                    Dim methodSymbol = CreateMethodMember(DirectCast(memberSyntax, MethodBaseSyntax), binder, diagBag.DiagnosticBag)
                     If methodSymbol IsNot Nothing Then
                         AddMember(methodSymbol, binder, members, omitDiagnostics:=False)
                     End If
@@ -2589,7 +2590,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagBag.Add(ERRID.ERR_InvalidInNamespace, propertyDecl.PropertyStatement.GetLocation())
                     End If
 
-                    CreateProperty(propertyDecl.PropertyStatement, propertyDecl, binder, diagBag, members, staticInitializers, instanceInitializers)
+                    CreateProperty(propertyDecl.PropertyStatement, propertyDecl, binder, diagBag.DiagnosticBag, members, staticInitializers, instanceInitializers)
 
                 Case SyntaxKind.PropertyStatement
                     Dim propertyDecl = DirectCast(memberSyntax, PropertyStatementSyntax)
@@ -2598,7 +2599,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         diagBag.Add(ERRID.ERR_InvalidInNamespace, propertyDecl.GetLocation())
                     End If
 
-                    CreateProperty(propertyDecl, Nothing, binder, diagBag, members, staticInitializers, instanceInitializers)
+                    CreateProperty(propertyDecl, Nothing, binder, diagBag.DiagnosticBag, members, staticInitializers, instanceInitializers)
 
                 Case SyntaxKind.LabelStatement
                     ' TODO (tomat): should be added to the initializers
@@ -2606,11 +2607,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 Case SyntaxKind.EventStatement
                     Dim eventDecl = DirectCast(memberSyntax, EventStatementSyntax)
-                    CreateEvent(eventDecl, Nothing, binder, diagBag, members)
+                    CreateEvent(eventDecl, Nothing, binder, diagBag.DiagnosticBag, members)
 
                 Case SyntaxKind.EventBlock
                     Dim eventDecl = DirectCast(memberSyntax, EventBlockSyntax)
-                    CreateEvent(eventDecl.EventStatement, eventDecl, binder, diagBag, members)
+                    CreateEvent(eventDecl.EventStatement, eventDecl, binder, diagBag.DiagnosticBag, members)
 
                 Case Else
                     If memberSyntax.Kind = SyntaxKind.EmptyStatement OrElse TypeOf memberSyntax Is ExecutableStatementSyntax Then
@@ -2711,7 +2712,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Sub AddDefaultConstructorIfNeeded(members As MembersAndInitializersBuilder,
                                                   isShared As Boolean,
                                                   initializers As ArrayBuilder(Of ImmutableArray(Of FieldOrPropertyInitializer)),
-                                                  diagnostics As DiagnosticBag)
+                                                  diagnostics As BindingDiagnosticBag)
 
             If TypeKind = TypeKind.Submission Then
 
@@ -2758,7 +2759,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Sub
 
-        Private Sub EnsureCtor(members As MembersAndInitializersBuilder, isShared As Boolean, isDebuggable As Boolean, diagBag As DiagnosticBag)
+        Private Sub EnsureCtor(members As MembersAndInitializersBuilder, isShared As Boolean, isDebuggable As Boolean, diagBag As BindingDiagnosticBag)
 
             Dim constructorName = If(isShared, WellKnownMemberNames.StaticConstructorName, WellKnownMemberNames.InstanceConstructorName)
 
@@ -2792,7 +2793,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             AddMember(constructor, binder, members, omitDiagnostics:=False)
         End Sub
 
-        Private Sub AddWithEventsHookupConstructorsIfNeeded(members As MembersAndInitializersBuilder, diagBag As DiagnosticBag)
+        Private Sub AddWithEventsHookupConstructorsIfNeeded(members As MembersAndInitializersBuilder, diagBag As BindingDiagnosticBag)
             If TypeKind = TypeKind.Submission Then
                 'TODO: anything to do here?
 
@@ -2857,9 +2858,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     ' Set up a binder.
                                     baseBinder = If(baseBinder, BinderBuilder.CreateBinderForType(m_containingModule, methodStatement.SyntaxTree, Me))
 
-                                    Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                                    eventSym = SourceMemberMethodSymbol.FindEvent(Me.BaseTypeNoUseSiteDiagnostics, baseBinder, eventName, isThroughMyBase:=True, useSiteDiagnostics:=useSiteDiagnostics)
-                                    diagBag.Add(handlesClause.EventMember, useSiteDiagnostics)
+                                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                                    eventSym = SourceMemberMethodSymbol.FindEvent(Me.BaseTypeNoUseSiteDiagnostics, baseBinder, eventName, isThroughMyBase:=True, useSiteInfo:=useSiteInfo)
+                                    diagBag.Add(handlesClause.EventMember, useSiteInfo)
                                 End If
 
                                 ' still nothing?
@@ -2919,7 +2920,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Sub CheckMemberDiagnostics(
                              members As MembersAndInitializersBuilder,
-                             diagBag As DiagnosticBag)
+                             diagBag As BindingDiagnosticBag)
 
             If Me.Locations.Length > 1 AndAlso Not Me.IsPartial Then
                 ' Suppress conflict member diagnostics when the enclosing type is an accidental duplicate
@@ -2984,7 +2985,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Function CheckIfMemberNameConflictsWithTypeMember(sym As Symbol,
                                                                   members As MembersAndInitializersBuilder,
-                                                                  diagBag As DiagnosticBag) As Boolean
+                                                                  diagBag As BindingDiagnosticBag) As Boolean
             ' Check name for conflicts with type members
             Dim definedTypes = Me.GetTypeMembers(sym.Name)
 
@@ -2999,7 +3000,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Function CheckIfMemberNameIsDuplicate(sym As Symbol,
-                                                      diagBag As DiagnosticBag,
+                                                      diagBag As BindingDiagnosticBag,
                                                       members As MembersAndInitializersBuilder) As Boolean
             ' Check name for duplicate declarations
             Dim definedSymbols As ArrayBuilder(Of Symbol) = Nothing
@@ -3018,7 +3019,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function CheckIfMemberNameIsDuplicate(firstSymbol As Symbol,
                                           secondSymbol As Symbol,
                                           members As MembersAndInitializersBuilder,
-                                          diagBag As DiagnosticBag,
+                                          diagBag As BindingDiagnosticBag,
                                           includeKind As Boolean) As Boolean
 
             Dim firstAssociatedSymbol = secondSymbol.ImplicitlyDefinedBy(members.Members)
@@ -3184,7 +3185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' In case the passed initializers require a shared constructor, this method returns a new MethodSymbol instance for the 
         ''' shared constructor if there is not already an explicit shared constructor
         ''' </summary>
-        Friend Function CreateSharedConstructorsForConstFieldsIfRequired(binder As Binder, diagnostics As DiagnosticBag) As MethodSymbol
+        Friend Function CreateSharedConstructorsForConstFieldsIfRequired(binder As Binder, diagnostics As BindingDiagnosticBag) As MethodSymbol
             Dim lookup = Me.MemberAndInitializerLookup
             Dim staticInitializers = lookup.StaticInitializers
 
@@ -3371,7 +3372,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         '   Same symbol implemented twice
         '   Interface symbol that should have been implemented wasn't.
         '   Generic interfaces might unify.
-        Private Function MakeExplicitInterfaceImplementationMap(diagnostics As DiagnosticBag) As MultiDictionary(Of Symbol, Symbol)
+        Private Function MakeExplicitInterfaceImplementationMap(diagnostics As BindingDiagnosticBag) As MultiDictionary(Of Symbol, Symbol)
             If Me.IsClassType() OrElse Me.IsStructureType() OrElse Me.IsInterfaceType() Then
                 CheckInterfaceUnificationAndVariance(diagnostics)
             End If
@@ -3398,23 +3399,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 For Each ifaceSet In InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Values
                     For Each iface In ifaceSet
                         ' Only check interfaces that our base type does NOT implement.
-                        If Not Me.BaseTypeNoUseSiteDiagnostics.ImplementsInterface(iface, comparer:=Nothing, useSiteDiagnostics:=Nothing) Then
+                        If Not Me.BaseTypeNoUseSiteDiagnostics.ImplementsInterface(iface, comparer:=Nothing, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                             For Each ifaceMember In iface.GetMembers()
                                 If ifaceMember.RequiresImplementation() AndAlso ShouldReportImplementationError(ifaceMember) Then
                                     Dim implementingSet As MultiDictionary(Of Symbol, Symbol).ValueSet = map(ifaceMember)
-                                    Dim useSiteErrorInfo = ifaceMember.GetUseSiteErrorInfo()
+                                    Dim useSiteInfo = ifaceMember.GetUseSiteInfo()
                                     If implementingSet.Count = 0 Then
                                         'member was not implemented.
-                                        Dim diag = If(useSiteErrorInfo, ErrorFactory.ErrorInfo(ERRID.ERR_UnimplementedMember3,
-                                                                            If(Me.IsStructureType(), "Structure", "Class"),
-                                                                            CustomSymbolDisplayFormatter.ShortErrorName(Me),
-                                                                            ifaceMember,
-                                                                            CustomSymbolDisplayFormatter.ShortNameWithTypeArgs(iface)))
+                                        Dim diag = If(useSiteInfo.DiagnosticInfo, ErrorFactory.ErrorInfo(ERRID.ERR_UnimplementedMember3,
+                                                                                        If(Me.IsStructureType(), "Structure", "Class"),
+                                                                                        CustomSymbolDisplayFormatter.ShortErrorName(Me),
+                                                                                        ifaceMember,
+                                                                                        CustomSymbolDisplayFormatter.ShortNameWithTypeArgs(iface)))
                                         diagnostics.Add(New VBDiagnostic(diag, GetImplementsLocation(iface)))
 
-                                    ElseIf implementingSet.Count = 1 AndAlso ' Otherwise, a duplicate implementation error is reported above
-                                           useSiteErrorInfo IsNot Nothing Then
-                                        diagnostics.Add(New VBDiagnostic(useSiteErrorInfo, implementingSet.Single.Locations(0)))
+                                    ElseIf implementingSet.Count = 1 Then ' Otherwise, a duplicate implementation error is reported above
+                                        diagnostics.Add(useSiteInfo, implementingSet.Single.Locations(0))
                                     End If
                                 End If
                             Next
@@ -3456,7 +3456,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides ReadOnly Property ExplicitInterfaceImplementationMap As MultiDictionary(Of Symbol, Symbol)
             Get
                 If m_lazyExplicitInterfaceImplementationMap Is Nothing Then
-                    Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
                     Dim implementationMap = MakeExplicitInterfaceImplementationMap(diagnostics)
                     OverrideHidingHelper.CheckHidingAndOverridingForType(Me, diagnostics)
 
@@ -3476,7 +3476,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Reports the overloads error for this type.
         ''' </summary>
         ''' <param name="diagnostics">The diagnostics.</param>
-        Private Sub CheckForOverloadsErrors(diagnostics As DiagnosticBag)
+        Private Sub CheckForOverloadsErrors(diagnostics As BindingDiagnosticBag)
             Debug.Assert(Me.IsDefinition) ' Don't do this on constructed types
 
             ' Enums and Delegates have nothing to do.
@@ -3585,7 +3585,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             memberIndex As Integer,
             membersEnumerator As Dictionary(Of String, ImmutableArray(Of Symbol)).Enumerator,
             <[In](), Out()> ByRef operatorsKnownToHavePair As HashSet(Of MethodSymbol),
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
             Dim member As Symbol = memberList(memberIndex)
 
@@ -3713,7 +3713,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             significantDiff As SymbolComparisonResults,
             memberList As ImmutableArray(Of Symbol),
             memberIndex As Integer,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         ) As Boolean
             For nextMemberIndex = memberIndex To memberList.Length - 1
                 Dim nextMember = memberList(nextMemberIndex)
@@ -3754,7 +3754,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         '''   2) It is a warning to implement variant interfaces twice with type arguments that could cause
         '''   ambiguity during method dispatch.
         ''' </summary>
-        Private Sub CheckInterfaceUnificationAndVariance(diagnostics As DiagnosticBag)
+        Private Sub CheckInterfaceUnificationAndVariance(diagnostics As BindingDiagnosticBag)
             Dim interfaces = Me.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics
 
             If interfaces.IsEmpty OrElse
@@ -3802,7 +3802,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 ' Check for interface unification, then variance ambiguity
                                 If TypeUnification.CanUnify(Me, interface1, interface2) Then
                                     ReportInterfaceUnificationError(diagnostics, interface1, interface2)
-                                ElseIf VarianceAmbiguity.HasVarianceAmbiguity(Me, interface1, interface2, Nothing) Then
+                                ElseIf VarianceAmbiguity.HasVarianceAmbiguity(Me, interface1, interface2, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                                     ReportVarianceAmbiguityWarning(diagnostics, interface1, interface2)
                                 End If
                             End If
@@ -3817,7 +3817,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         End Sub
 
-        Private Sub ReportOverloadsErrors(comparisonResults As SymbolComparisonResults, firstMember As Symbol, secondMember As Symbol, location As Location, diagnostics As DiagnosticBag)
+        Private Sub ReportOverloadsErrors(comparisonResults As SymbolComparisonResults, firstMember As Symbol, secondMember As Symbol, location As Location, diagnostics As BindingDiagnosticBag)
             If (Me.Locations.Length > 1 AndAlso Not Me.IsPartial) Then
                 ' if there was an error with the enclosing class, suppress these diagnostics
             ElseIf comparisonResults = 0 Then
@@ -3869,7 +3869,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Interface1 and Interface2 conflict for some type arguments. Report the correct error in the correct location.
         ''' </summary>
-        Private Sub ReportInterfaceUnificationError(diagnostics As DiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
+        Private Sub ReportInterfaceUnificationError(diagnostics As BindingDiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
             If GetImplementsLocation(interface1).SourceSpan.Start > GetImplementsLocation(interface2).SourceSpan.Start Then
                 ' Report error on second implement, for consistency.
                 Dim temp = interface1
@@ -3915,11 +3915,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Interface1 and Interface2 have variable ambiguity. Report the warning in the correct location.
         ''' </summary>
-        Private Sub ReportVarianceAmbiguityWarning(diagnostics As DiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-            Dim hasVarianceAmbiguity As Boolean = VarianceAmbiguity.HasVarianceAmbiguity(Me, interface1, interface2, useSiteDiagnostics)
+        Private Sub ReportVarianceAmbiguityWarning(diagnostics As BindingDiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim hasVarianceAmbiguity As Boolean = VarianceAmbiguity.HasVarianceAmbiguity(Me, interface1, interface2, useSiteInfo)
 
-            If hasVarianceAmbiguity OrElse Not useSiteDiagnostics.IsNullOrEmpty Then
+            If hasVarianceAmbiguity OrElse Not useSiteInfo.Diagnostics.IsNullOrEmpty Then
                 If GetImplementsLocation(interface1).SourceSpan.Start > GetImplementsLocation(interface2).SourceSpan.Start Then
                     ' Report error on second implement, for consistency.
                     Dim temp = interface1
@@ -3934,7 +3934,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 location1 = GetImplementsLocation(interface1, directInterface1)
                 location2 = GetImplementsLocation(interface2, directInterface2)
 
-                If Not diagnostics.Add(location2, useSiteDiagnostics) AndAlso hasVarianceAmbiguity Then
+                If Not diagnostics.Add(location2, useSiteInfo) AndAlso hasVarianceAmbiguity Then
                     Dim diag As DiagnosticInfo
                     diag = ErrorFactory.ErrorInfo(ERRID.WRN_VarianceDeclarationAmbiguous3,
                                                       CustomSymbolDisplayFormatter.QualifiedName(directInterface2),
@@ -3942,13 +3942,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                       CustomSymbolDisplayFormatter.ErrorNameWithKind(interface1.OriginalDefinition))
                     diagnostics.Add(New VBDiagnostic(diag, location2))
                 End If
+            Else
+                diagnostics.AddDependencies(useSiteInfo)
             End If
         End Sub
 
         ''' <summary>
         ''' Interface1 and Interface2 match except for their tuple names. Report the error in the correct location.
         ''' </summary>
-        Private Sub ReportDuplicateInterfaceWithDifferentTupleNames(diagnostics As DiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
+        Private Sub ReportDuplicateInterfaceWithDifferentTupleNames(diagnostics As BindingDiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
 
             If GetImplementsLocation(interface1).SourceSpan.Start > GetImplementsLocation(interface2).SourceSpan.Start Then
                 ' Report error on second implement, for consistency.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -93,15 +93,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If syntax.HandlesClause IsNot Nothing Then
                 If container.TypeKind = TypeKind.Structure Then
                     ' Structures cannot handle events
-                    binder.ReportDiagnostic(diagBag, syntax.Identifier, ERRID.ERR_StructsCannotHandleEvents)
+                    Binder.ReportDiagnostic(diagBag, syntax.Identifier, ERRID.ERR_StructsCannotHandleEvents)
 
                 ElseIf container.IsInterface Then
                     ' Methods in interfaces cannot have an handles clause
-                    binder.ReportDiagnostic(diagBag, syntax.HandlesClause, ERRID.ERR_BadInterfaceMethodFlags1, syntax.HandlesClause.HandlesKeyword.ToString)
+                    Binder.ReportDiagnostic(diagBag, syntax.HandlesClause, ERRID.ERR_BadInterfaceMethodFlags1, syntax.HandlesClause.HandlesKeyword.ToString)
 
                 ElseIf GetTypeParameterListSyntax(syntax) IsNot Nothing Then
                     ' Generic methods cannot have 'handles' clause
-                    binder.ReportDiagnostic(diagBag, syntax.Identifier, ERRID.ERR_HandlesInvalidOnGenericMethod)
+                    Binder.ReportDiagnostic(diagBag, syntax.Identifier, ERRID.ERR_HandlesInvalidOnGenericMethod)
                 End If
 
                 ' Operators methods cannot have Handles regardless of container. 
@@ -120,7 +120,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             If methodSym.IsPartial AndAlso methodSym.IsSub Then
                 If methodSym.IsAsync Then
-                    binder.ReportDiagnostic(diagBag, syntax.Identifier, ERRID.ERR_PartialMethodsMustNotBeAsync1, name)
+                    Binder.ReportDiagnostic(diagBag, syntax.Identifier, ERRID.ERR_PartialMethodsMustNotBeAsync1, name)
                 End If
 
                 ReportPartialMethodErrors(syntax.Modifiers, binder, diagBag)
@@ -158,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 lReportErrorOnSingleToken:
                         ' Report [Partial methods must be declared 'Private' instead of '...']
-                        binder.ReportDiagnostic(diagBag, token,
+                        Binder.ReportDiagnostic(diagBag, token,
                                                 ERRID.ERR_OnlyPrivatePartialMethods1,
                                                 SyntaxFacts.GetText(token.Kind))
                         reportPartialMethodsMustBePrivate = False
@@ -178,7 +178,7 @@ lReportErrorOnTwoTokens:
                         Dim location = binder.SyntaxTree.GetLocation(New TextSpan(startLoc, endLoc - startLoc))
 
                         ' Report [Partial methods must be declared 'Private' instead of '...']
-                        binder.ReportDiagnostic(diagBag, location,
+                        Binder.ReportDiagnostic(diagBag, location,
                                                 ERRID.ERR_OnlyPrivatePartialMethods1,
                                                 token.Kind.GetText() & " " & nextToken.Kind.GetText())
 
@@ -205,7 +205,7 @@ lReportErrorOnTwoTokens:
             If reportPartialMethodsMustBePrivate Then
                 ' Report [Partial methods must be declared 'Private']
                 Debug.Assert(partialToken.Kind = SyntaxKind.PartialKeyword)
-                binder.ReportDiagnostic(diagBag, partialToken, ERRID.ERR_PartialMethodsMustBePrivate)
+                Binder.ReportDiagnostic(diagBag, partialToken, ERRID.ERR_PartialMethodsMustBePrivate)
             End If
         End Sub
 
@@ -361,7 +361,7 @@ lReportErrorOnTwoTokens:
             End Select
 
             If paramCountMismatchERRID <> 0 Then
-                binder.ReportDiagnostic(diagBag, syntax.OperatorToken, paramCountMismatchERRID, SyntaxFacts.GetText(syntax.OperatorToken.Kind))
+                Binder.ReportDiagnostic(diagBag, syntax.OperatorToken, paramCountMismatchERRID, SyntaxFacts.GetText(syntax.OperatorToken.Kind))
             End If
 
             ' ERRID.ERR_OperatorDeclaredInModule is reported by the parser.
@@ -391,7 +391,7 @@ lReportErrorOnTwoTokens:
 
                 If (syntax.ParameterList IsNot Nothing AndAlso syntax.ParameterList.Parameters.Count > 0) Then
                     ' shared constructor cannot have parameters.
-                    binder.ReportDiagnostic(diagBag, syntax.ParameterList, ERRID.ERR_SharedConstructorWithParams)
+                    Binder.ReportDiagnostic(diagBag, syntax.ParameterList, ERRID.ERR_SharedConstructorWithParams)
                 End If
             Else
                 name = WellKnownMemberNames.InstanceConstructorName
@@ -466,14 +466,14 @@ lReportErrorOnTwoTokens:
             End If
 
             If (foundFlags And SourceMemberFlags.Shared) = 0 Then
-                binder.ReportDiagnostic(diagBag, syntax.OperatorToken, ERRID.ERR_OperatorMustBeShared)
+                Binder.ReportDiagnostic(diagBag, syntax.OperatorToken, ERRID.ERR_OperatorMustBeShared)
                 computedFlags = computedFlags Or SourceMemberFlags.Shared
             End If
 
 
             If syntax.OperatorToken.Kind = SyntaxKind.CTypeKeyword Then
                 If (foundFlags And (SourceMemberFlags.Narrowing Or SourceMemberFlags.Widening)) = 0 Then
-                    binder.ReportDiagnostic(diagBag, syntax.OperatorToken, ERRID.ERR_ConvMustBeWideningOrNarrowing)
+                    Binder.ReportDiagnostic(diagBag, syntax.OperatorToken, ERRID.ERR_ConvMustBeWideningOrNarrowing)
                     computedFlags = computedFlags Or SourceMemberFlags.Narrowing
                 End If
             ElseIf (foundFlags And (SourceMemberFlags.Narrowing Or SourceMemberFlags.Widening)) <> 0 Then
@@ -891,7 +891,7 @@ lReportErrorOnTwoTokens:
         ''' The caller is expected to handle constraint checking and any caching of results.
         ''' </remarks>
         Friend Function BindTypeParameterConstraints(syntax As TypeParameterSyntax,
-                                                     diagnostics As DiagnosticBag) As ImmutableArray(Of TypeParameterConstraint)
+                                                     diagnostics As BindingDiagnosticBag) As ImmutableArray(Of TypeParameterConstraint)
 
             Dim binder As Binder = BinderBuilder.CreateBinderForType(Me.ContainingSourceModule, Me.SyntaxTree, m_containingType)
             binder = BinderBuilder.CreateBinderForGenericMethodDeclaration(Me, binder)
@@ -1175,7 +1175,7 @@ lReportErrorOnTwoTokens:
             Return If(Locations.FirstOrDefault(), NoLocation.Singleton)
         End Function
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
 
             Dim syntaxTree As SyntaxTree = Me.SyntaxTree
 
@@ -1585,6 +1585,7 @@ lReportErrorOnTwoTokens:
 
         Private Sub DecodeWellKnownAttributeAppliedToMethod(ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
             Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
+            Debug.Assert(TypeOf arguments.Diagnostics Is BindingDiagnosticBag)
 
             ' Decode well-known attributes applied to method
             Dim attrData = arguments.Attribute
@@ -1633,7 +1634,7 @@ lReportErrorOnTwoTokens:
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.MethodImplAttribute) Then
                 AttributeData.DecodeMethodImplAttribute(Of MethodWellKnownAttributeData, AttributeSyntax, VisualBasicAttributeData, AttributeLocation)(arguments, MessageProvider.Instance)
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.DllImportAttribute) Then
-                If Not IsDllImportAttributeAllowed(arguments.AttributeSyntaxOpt, arguments.Diagnostics) Then
+                If Not IsDllImportAttributeAllowed(arguments.AttributeSyntaxOpt, DirectCast(arguments.Diagnostics, BindingDiagnosticBag)) Then
                     Return
                 End If
 
@@ -1724,10 +1725,10 @@ lReportErrorOnTwoTokens:
 
                 If methodImpl IsNot Nothing AndAlso (methodImpl.IsAsync OrElse methodImpl.IsIterator) AndAlso Not methodImpl.ContainingType.IsInterfaceType() Then
                     If attrData.IsTargetAttribute(Me, AttributeDescription.SecurityCriticalAttribute) Then
-                        Binder.ReportDiagnostic(arguments.Diagnostics, arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecurityCritical")
+                        Binder.ReportDiagnostic(DirectCast(arguments.Diagnostics, BindingDiagnosticBag), arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecurityCritical")
                         Return
                     ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SecuritySafeCriticalAttribute) Then
-                        Binder.ReportDiagnostic(arguments.Diagnostics, arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecuritySafeCritical")
+                        Binder.ReportDiagnostic(DirectCast(arguments.Diagnostics, BindingDiagnosticBag), arguments.AttributeSyntaxOpt.GetLocation(), ERRID.ERR_SecurityCriticalAsync, "SecuritySafeCritical")
                         Return
                     End If
                 End If
@@ -1764,7 +1765,7 @@ lReportErrorOnTwoTokens:
             End If
         End Sub
 
-        Private Function IsDllImportAttributeAllowed(syntax As AttributeSyntax, diagnostics As DiagnosticBag) As Boolean
+        Private Function IsDllImportAttributeAllowed(syntax As AttributeSyntax, diagnostics As BindingDiagnosticBag) As Boolean
             Select Case Me.MethodKind
                 Case MethodKind.DeclareMethod
                     diagnostics.Add(ERRID.ERR_DllImportNotLegalOnDeclare, syntax.Name.GetLocation())
@@ -1819,7 +1820,7 @@ lReportErrorOnTwoTokens:
         Friend Overrides Sub PostDecodeWellKnownAttributes(
             boundAttributes As ImmutableArray(Of VisualBasicAttributeData),
             allAttributeSyntaxNodes As ImmutableArray(Of AttributeSyntax),
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             symbolPart As AttributeLocation,
             decodedData As WellKnownAttributeData)
 
@@ -2069,7 +2070,7 @@ lReportErrorOnTwoTokens:
         Private Sub EnsureSignature()
             If _lazyParameters.IsDefault Then
 
-                Dim diagBag = DiagnosticBag.GetInstance()
+                Dim diagBag = BindingDiagnosticBag.GetInstance()
                 Dim sourceModule = ContainingSourceModule
 
                 Dim params As ImmutableArray(Of ParameterSymbol) = GetParameters(sourceModule, diagBag)
@@ -2159,7 +2160,7 @@ lReportErrorOnTwoTokens:
                     End If
 
                     For Each diag In diagnosticsBuilder
-                        diagBag.Add(diag.DiagnosticInfo, errorLocation.GetLocation())
+                        diagBag.Add(diag.UseSiteInfo, errorLocation.GetLocation())
                     Next
                     diagnosticsBuilder.Free()
                 End If
@@ -2186,7 +2187,7 @@ lReportErrorOnTwoTokens:
         End Function
 
         Protected Overridable Function GetParameters(sourceModule As SourceModuleSymbol,
-                                             diagBag As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+                                             diagBag As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
 
             Dim decl = Me.DeclarationSyntax
             Dim binder As Binder = CreateBinderForMethodDeclaration(sourceModule)
@@ -2231,7 +2232,7 @@ lReportErrorOnTwoTokens:
 
         Private Function GetReturnType(sourceModule As SourceModuleSymbol,
                                        ByRef errorLocation As SyntaxNodeOrToken,
-                                       diagBag As DiagnosticBag) As TypeSymbol
+                                       diagBag As BindingDiagnosticBag) As TypeSymbol
             Dim binder As Binder = CreateBinderForMethodDeclaration(sourceModule)
 
             Select Case MethodKind

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.BoundImports.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.BoundImports.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' can be Nothing if no xmlns imports
             Public ReadOnly XmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition)
 
-            Public ReadOnly Diagnostics As DiagnosticBag
+            Public ReadOnly Diagnostics As BindingDiagnosticBag
 
             Public Sub New(memberImports As ImmutableArray(Of NamespaceOrTypeAndImportsClausePosition),
                            memberImportsInfo As ImmutableArray(Of GlobalImportInfo),
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                            aliasImports As ImmutableArray(Of AliasAndImportsClausePosition),
                            aliasImportsInfo As ImmutableArray(Of GlobalImportInfo),
                            xmlNamespaces As Dictionary(Of String, XmlNamespaceAndImportsClausePosition),
-                           diags As DiagnosticBag)
+                           diags As BindingDiagnosticBag)
                 Me.MemberImports = memberImports
                 Me.MemberImportsInfo = memberImportsInfo
                 Me.AliasImportsMap = aliasImportsMap

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -158,7 +158,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 #Region "Members"
 
-        Protected Overrides Sub AddDeclaredNonTypeMembers(membersBuilder As SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder, diagnostics As DiagnosticBag)
+        Protected Overrides Sub AddDeclaredNonTypeMembers(membersBuilder As SourceMemberContainerTypeSymbol.MembersAndInitializersBuilder, diagnostics As BindingDiagnosticBag)
             Dim accessModifiers As DeclarationModifiers = Nothing
             Dim foundModifiers As DeclarationModifiers
 
@@ -221,17 +221,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Declare all the non-type members in a single part of this type, and add them to the member list.
         Private Function AddMembersInPart(binder As Binder,
                                           node As VisualBasicSyntaxNode,
-                                          diagBag As DiagnosticBag,
+                                          diagBag As BindingDiagnosticBag,
                                           accessModifiers As DeclarationModifiers,
                                           members As MembersAndInitializersBuilder,
                                           ByRef staticInitializers As ArrayBuilder(Of FieldOrPropertyInitializer),
                                           ByRef instanceInitializers As ArrayBuilder(Of FieldOrPropertyInitializer),
                                           ByRef nodeNameIsAlreadyDefined As Boolean) As DeclarationModifiers
 
+            Debug.Assert(diagBag.DiagnosticBag IsNot Nothing)
             ' Check that the node's fully qualified name is not too long and that the type name is unique.
             CheckDeclarationNameAndTypeParameters(node, binder, diagBag, nodeNameIsAlreadyDefined)
 
-            Dim foundModifiers = CheckDeclarationModifiers(node, binder, diagBag, accessModifiers)
+            Dim foundModifiers = CheckDeclarationModifiers(node, binder, diagBag.DiagnosticBag, accessModifiers)
 
             If TypeKind = TypeKind.Delegate Then
                 ' add implicit delegate members (invoke, .ctor, begininvoke and endinvoke)
@@ -464,7 +465,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Sub CheckDeclarationNameAndTypeParameters(node As VisualBasicSyntaxNode,
                                                           binder As Binder,
-                                                          diagBag As DiagnosticBag,
+                                                          diagBag As BindingDiagnosticBag,
                                                           ByRef nodeNameIsAlreadyDeclared As Boolean)
 
             ' Check that the node's fully qualified name is not too long. Only check declarations that create types.
@@ -629,7 +630,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                             node As VisualBasicSyntaxNode,
                                             firstNode As VisualBasicSyntaxNode,
                                             foundPartial As Boolean,
-                                            diagBag As DiagnosticBag)
+                                            diagBag As BindingDiagnosticBag)
 
             ' No error or warning on the first declaration
             If node Is firstNode Then
@@ -688,7 +689,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Sub AddEnumMembers(syntax As EnumBlockSyntax,
                                    bodyBinder As Binder,
-                                   diagnostics As DiagnosticBag,
+                                   diagnostics As BindingDiagnosticBag,
                                    members As MembersAndInitializersBuilder)
 
             Dim valField = New SynthesizedFieldSymbol(
@@ -782,7 +783,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                        typeParameter As SourceTypeParameterOnTypeSymbol,
                                        <Out()> ByRef variance As VarianceKind,
                                        <Out()> ByRef constraints As ImmutableArray(Of TypeParameterConstraint),
-                                       diagnostics As DiagnosticBag)
+                                       diagnostics As BindingDiagnosticBag)
             Dim unused = GetTypeMembersDictionary()   ' forced nested types to be declared.
             Dim info As TypeParameterInfo = Nothing
 
@@ -813,7 +814,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                          typeParamListSyntax As TypeParameterListSyntax,
                                                          allowVarianceSpecifier As Boolean,
                                                          ByRef info As TypeParameterInfo,
-                                                         diagBag As DiagnosticBag)
+                                                         diagBag As BindingDiagnosticBag)
             Debug.Assert(typeParamListSyntax IsNot Nothing)
             Debug.Assert(typeParamListSyntax.Parameters.Count = Me.Arity) ' If this is false, something is really wrong with the declaration tree.
 
@@ -945,7 +946,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Friend Sub CheckForDuplicateTypeParameters(typeParameters As ImmutableArray(Of TypeParameterSymbol),
-                                                   diagBag As DiagnosticBag)
+                                                   diagBag As BindingDiagnosticBag)
             If Not typeParameters.IsDefault Then
                 Dim typeParameterSet As New HashSet(Of String)(IdentifierComparison.Comparer)
                 ' Check for duplicate type parameters
@@ -992,7 +993,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                            syntaxNode As VisualBasicSyntaxNode,
                                            ByRef baseType As NamedTypeSymbol,
                                            basesBeingResolved As BasesBeingResolved,
-                                           diagBag As DiagnosticBag)
+                                           diagBag As BindingDiagnosticBag)
 
             ' Set up a binder for this part of the type.
             Dim binder As Binder = CreateLocationSpecificBinderForType(tree, BindingLocation.BaseTypes)
@@ -1021,7 +1022,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                 syntaxNode As VisualBasicSyntaxNode,
                                                 interfaces As SetWithInsertionOrder(Of NamedTypeSymbol),
                                                 basesBeingResolved As BasesBeingResolved,
-                                                diagBag As DiagnosticBag)
+                                                diagBag As BindingDiagnosticBag)
 
             ' Set up a binder for this part of the type.
             Dim binder As Binder = CreateLocationSpecificBinderForType(tree, BindingLocation.BaseTypes)
@@ -1052,7 +1053,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Check that there are no base declarations in the given list, and report the given error if any are found.
         Private Sub CheckNoBase(Of T As InheritsOrImplementsStatementSyntax)(baseDeclList As SyntaxList(Of T),
                                 errId As ERRID,
-                                diagBag As DiagnosticBag)
+                                diagBag As BindingDiagnosticBag)
             If baseDeclList.Count > 0 Then
                 For Each baseDecl In baseDeclList
                     Binder.ReportDiagnostic(diagBag, baseDecl, errId)
@@ -1067,7 +1068,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                            baseInOtherPartial As NamedTypeSymbol,
                                            basesBeingResolved As BasesBeingResolved,
                                            binder As Binder,
-                                           diagBag As DiagnosticBag) As NamedTypeSymbol
+                                           diagBag As BindingDiagnosticBag) As NamedTypeSymbol
 
             If inheritsSyntax.Count = 0 Then Return Nothing
 
@@ -1146,7 +1147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                 basesInOtherPartials As SetWithInsertionOrder(Of NamedTypeSymbol),
                                                 basesBeingResolved As BasesBeingResolved,
                                                 binder As Binder,
-                                                diagBag As DiagnosticBag)
+                                                diagBag As BindingDiagnosticBag)
 
             If baseSyntax.Count = 0 Then Return
 
@@ -1203,7 +1204,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                   basesInOtherPartials As SetWithInsertionOrder(Of NamedTypeSymbol),
                                                   basesBeingResolved As BasesBeingResolved,
                                                   binder As Binder,
-                                                  diagBag As DiagnosticBag)
+                                                  diagBag As BindingDiagnosticBag)
 
             If baseSyntax.Count = 0 Then Return
 
@@ -1267,7 +1268,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return peType
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             ' For types nested in a source type symbol (not in a script class): 
             ' before resolving the base type ensure that enclosing type's base type is already resolved
             Dim containingSourceType = TryCast(ContainingSymbol, SourceNamedTypeSymbol)
@@ -1289,7 +1290,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return baseType
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             ' For types nested in a source type symbol (not in a script class): 
             ' before resolving the base type ensure that enclosing type's base type is already resolved
             Dim containingSourceType = TryCast(ContainingSymbol, SourceNamedTypeSymbol)
@@ -1332,8 +1333,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 binder = New BasesBeingResolvedBinder(binder, basesBeingResolved)
 
-                Dim diag = New DiagnosticBag ' unused
-
                 For Each t In inhDecl
                     If backupLocation Is Nothing Then
                         backupLocation = t.GetLocation()
@@ -1343,7 +1342,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         If(getInherits, DirectCast(t, InheritsStatementSyntax).Types, DirectCast(t, ImplementsStatementSyntax).Types)
 
                     For Each typeSyntax In types
-                        Dim bt = binder.BindTypeSyntax(typeSyntax, diag, suppressUseSiteError:=True)
+                        Dim bt = binder.BindTypeSyntax(typeSyntax, BindingDiagnosticBag.Discarded, suppressUseSiteError:=True)
                         If TypeSymbol.Equals(bt, base, TypeCompareKind.ConsiderEverything) Then
                             Return typeSyntax.GetLocation()
                         End If
@@ -1356,7 +1355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return backupLocation
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim compilation As VisualBasicCompilation = Me.DeclaringCompilation
 
             Dim declaredBase As NamedTypeSymbol = Me.GetDeclaredBase(Nothing)
@@ -1382,7 +1381,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Case TypeKind.Submission
                         ' check that System.Object is available. 
                         ' Although the submission semantically doesn't have a base class we need to emit one.
-                        ReportUseSiteDiagnosticsForBaseType(Me.DeclaringCompilation.GetSpecialType(SpecialType.System_Object), declaredBase, diagnostics)
+                        ReportUseSiteInfoForBaseType(Me.DeclaringCompilation.GetSpecialType(SpecialType.System_Object), declaredBase, diagnostics)
                         declaredOrDefaultBase = Nothing
 
                     Case TypeKind.Class
@@ -1410,7 +1409,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             If declaredOrDefaultBase IsNot Nothing Then
-                ReportUseSiteDiagnosticsForBaseType(declaredOrDefaultBase, declaredBase, diagnostics)
+                ReportUseSiteInfoForBaseType(declaredOrDefaultBase, declaredBase, diagnostics)
             End If
 
             Return declaredOrDefaultBase
@@ -1420,8 +1419,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return ContainingModule.ContainingAssembly.GetSpecialType(type)
         End Function
 
-        Private Sub ReportUseSiteDiagnosticsForBaseType(baseType As NamedTypeSymbol, declaredBase As NamedTypeSymbol, diagnostics As DiagnosticBag)
-            Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+        Private Sub ReportUseSiteInfoForBaseType(baseType As NamedTypeSymbol, declaredBase As NamedTypeSymbol, diagnostics As BindingDiagnosticBag)
+            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
             Dim current As NamedTypeSymbol = baseType
 
@@ -1430,11 +1429,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Exit Do
                 End If
 
-                current.AddUseSiteDiagnostics(useSiteDiagnostics)
+                current.AddUseSiteInfo(useSiteInfo)
                 current = current.BaseTypeNoUseSiteDiagnostics
             Loop While current IsNot Nothing
 
-            If Not useSiteDiagnostics.IsNullOrEmpty Then
+            If Not useSiteInfo.Diagnostics.IsNullOrEmpty Then
                 Dim location As Location
 
                 If declaredBase Is baseType Then
@@ -1449,11 +1448,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                   GetTypeIdentifierToken(syntax).GetLocation())
                 End If
 
-                diagnostics.Add(location, useSiteDiagnostics)
+                diagnostics.Add(location, useSiteInfo)
+            Else
+                diagnostics.AddDependencies(useSiteInfo)
             End If
         End Sub
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Dim declaredInterfaces As ImmutableArray(Of NamedTypeSymbol) = GetDeclaredInterfacesNoUseSiteDiagnostics(Nothing)
 
             Dim isInterface As Boolean = Me.IsInterfaceType()
@@ -1470,21 +1471,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Else
                     ' Error types were reported elsewhere.
                     If Not t.IsErrorType() Then
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
 
                         If t.DeclaringCompilation IsNot Me.DeclaringCompilation Then
-                            t.AddUseSiteDiagnostics(useSiteDiagnostics)
+                            t.AddUseSiteInfo(useSiteInfo)
 
                             For Each [interface] In t.AllInterfacesNoUseSiteDiagnostics
                                 If [interface].DeclaringCompilation IsNot Me.DeclaringCompilation Then
-                                    [interface].AddUseSiteDiagnostics(useSiteDiagnostics)
+                                    [interface].AddUseSiteInfo(useSiteInfo)
                                 End If
                             Next
                         End If
 
-                        If Not useSiteDiagnostics.IsNullOrEmpty Then
+                        If Not useSiteInfo.Diagnostics.IsNullOrEmpty Then
                             Dim location = If(isInterface, GetInheritsLocation(t), GetInheritsOrImplementsLocation(t, getInherits:=False))
-                            diagnostics.Add(location, useSiteDiagnostics)
+                            diagnostics.Add(location, useSiteInfo)
+                        Else
+                            diagnostics.AddDependencies(useSiteInfo)
                         End If
                     End If
 
@@ -1615,14 +1618,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return
             End If
 
-            Dim diagnostics As DiagnosticBag = Nothing
+            Dim diagnostics As BindingDiagnosticBag = Nothing
             Dim localBase = BaseTypeNoUseSiteDiagnostics
             If localBase IsNot Nothing Then
                 ' Check constraints on the first declaration with explicit bases.
                 Dim singleDeclaration = FirstDeclarationWithExplicitBases()
                 If singleDeclaration IsNot Nothing Then
                     Dim location = singleDeclaration.NameLocation
-                    diagnostics = DiagnosticBag.GetInstance()
+                    diagnostics = BindingDiagnosticBag.GetInstance()
 
                     localBase.CheckAllConstraints(location, diagnostics)
 
@@ -1631,10 +1634,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         ' This check must be done here instead of in ValidateClassBase to avoid infinite recursion when there are
                         ' cycles in the inheritance chain. In Dev10/11, the error was reported on the inherited statement, now it 
                         ' is reported on the class statement.
-                        Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                        Dim isBaseType As Boolean = DeclaringCompilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(localBase, useSiteDiagnostics)
+                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim isBaseType As Boolean = DeclaringCompilation.GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(localBase, useSiteInfo)
 
-                        diagnostics.Add(location, useSiteDiagnostics)
+                        diagnostics.Add(location, useSiteInfo)
 
                         If isBaseType Then
                             ' WARNING: in case System_Attribute was not found or has errors, the above check may 
@@ -1668,14 +1671,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return
             End If
 
-            Dim diagnostics As DiagnosticBag = Nothing
+            Dim diagnostics As BindingDiagnosticBag = Nothing
             Dim localInterfaces = InterfacesNoUseSiteDiagnostics
             If Not localInterfaces.IsEmpty Then
                 ' Check constraints on the first declaration with explicit interfaces.
                 Dim singleDeclaration = FirstDeclarationWithExplicitInterfaces()
                 If singleDeclaration IsNot Nothing Then
                     Dim location = singleDeclaration.NameLocation
-                    diagnostics = DiagnosticBag.GetInstance()
+                    diagnostics = BindingDiagnosticBag.GetInstance()
                     For Each [interface] In localInterfaces
                         [interface].CheckAllConstraints(location, diagnostics)
                     Next
@@ -1753,7 +1756,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim underlyingType = Me._lazyEnumUnderlyingType
 
                 If underlyingType Is Nothing Then
-                    Dim tempDiags = DiagnosticBag.GetInstance
+                    Dim tempDiags = BindingDiagnosticBag.GetInstance
                     Dim blockRef = SyntaxReferences(0)
                     Dim tree = blockRef.SyntaxTree
                     Dim syntax = DirectCast(blockRef.GetSyntax, EnumBlockSyntax)
@@ -1777,7 +1780,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Function BindEnumUnderlyingType(syntax As EnumBlockSyntax,
                                    bodyBinder As Binder,
-                                   diagnostics As DiagnosticBag) As NamedTypeSymbol
+                                   diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
 
             Dim underlyingType = syntax.EnumStatement.UnderlyingType
 
@@ -2103,7 +2106,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Friend NotOverridable Overrides Function GetAttributeUsageInfo() As AttributeUsageInfo
-            Debug.Assert(Me.IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute, DeclaringCompilation, Nothing) OrElse Me.SpecialType = Microsoft.CodeAnalysis.SpecialType.System_Object)
+            Debug.Assert(Me.IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute, DeclaringCompilation, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) OrElse Me.SpecialType = Microsoft.CodeAnalysis.SpecialType.System_Object)
 
             Dim data As TypeEarlyWellKnownAttributeData = Me.GetEarlyDecodedWellKnownAttributeData()
             If data IsNot Nothing AndAlso Not data.AttributeUsageInfo.IsNull Then
@@ -2140,6 +2143,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim attrData = arguments.Attribute
             Debug.Assert(Not attrData.HasErrors)
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
+            Debug.Assert(TypeOf arguments.Diagnostics Is BindingDiagnosticBag)
 
             ' If we start caching information about GuidAttribute here, implementation of HasGuidAttribute function should be changed accordingly.
             ' If we start caching information about ClassInterfaceAttribute here, implementation of HasClassInterfaceAttribute function should be changed accordingly.
@@ -2250,13 +2254,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     attrData.DecodeSecurityAttribute(Of CommonTypeWellKnownAttributeData)(Me, Me.DeclaringCompilation, arguments)
 
                 ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ClassInterfaceAttribute) Then
-                    attrData.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics)
+                    attrData.DecodeClassInterfaceAttribute(arguments.AttributeSyntaxOpt, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
 
                 ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.InterfaceTypeAttribute) Then
-                    attrData.DecodeInterfaceTypeAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics)
+                    attrData.DecodeInterfaceTypeAttribute(arguments.AttributeSyntaxOpt, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
 
                 ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.GuidAttribute) Then
-                    attrData.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics)
+                    attrData.DecodeGuidAttribute(arguments.AttributeSyntaxOpt, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
 
                 ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.WindowsRuntimeImportAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasWindowsRuntimeImportAttribute = True
@@ -2344,7 +2348,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides Sub PostDecodeWellKnownAttributes(
             boundAttributes As ImmutableArray(Of VisualBasicAttributeData),
             allAttributeSyntaxNodes As ImmutableArray(Of AttributeSyntax),
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             symbolPart As AttributeLocation,
             decodedData As WellKnownAttributeData)
 
@@ -2358,7 +2362,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             MyBase.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData)
         End Sub
 
-        Private Sub ValidateStandardModuleAttribute(diagnostics As DiagnosticBag)
+        Private Sub ValidateStandardModuleAttribute(diagnostics As BindingDiagnosticBag)
             ' If this type is a VB Module, touch the ctor for MS.VB.Globals.StandardModuleAttribute to
             ' produce any diagnostics related to that member and type.
 
@@ -2369,7 +2373,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If Me.TypeKind = TypeKind.Module Then
                 Dim useSiteError As DiagnosticInfo = Nothing
 
-                Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.Microsoft_VisualBasic_CompilerServices_StandardModuleAttribute__ctor,
+                Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.Microsoft_VisualBasic_CompilerServices_StandardModuleAttribute__ctor,
                                                                  Me.DeclaringCompilation,
                                                                  Locations(0),
                                                                  diagnostics)
@@ -2451,7 +2455,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If Not String.IsNullOrEmpty(DefaultPropertyName) AndAlso Not HasDefaultMemberAttribute() Then
                 Dim stringType = GetSpecialType(SpecialType.System_String)
                 ' NOTE: used from emit, so shouldn't have gotten here if there were errors
-                Debug.Assert(stringType.GetUseSiteErrorInfo() Is Nothing)
+                Debug.Assert(stringType.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
                 AddSynthesizedAttribute(attributes, compilation.TrySynthesizeAttribute(
                     WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor,
@@ -2575,7 +2579,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     ' Must derive from Windows.Forms.Form
                     Dim formClass As NamedTypeSymbol = DeclaringCompilation.GetWellKnownType(WellKnownType.System_Windows_Forms_Form)
 
-                    If formClass.IsErrorType() OrElse Not Me.IsOrDerivedFrom(formClass, useSiteDiagnostics:=Nothing) Then
+                    If formClass.IsErrorType() OrElse Not Me.IsOrDerivedFrom(formClass, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                         Return
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -119,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return
                 End If
 
-                Dim diagnostics = DiagnosticBag.GetInstance()
+                Dim diagnostics = BindingDiagnosticBag.GetInstance()
                 Dim interfaces As ImmutableArray(Of NamedTypeSymbol) = ImmutableArray(Of NamedTypeSymbol).Empty
                 Dim interfaceMembers = ArrayBuilder(Of KeyValuePair(Of Symbol, Integer)).GetInstance()
                 Dim eventMembers = ArrayBuilder(Of KeyValuePair(Of EventSymbol, Integer)).GetInstance()
@@ -208,26 +208,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 If ClassId IsNot Nothing OrElse
                    (InterfaceId IsNot Nothing AndAlso interfaces.Length > 0) OrElse
                    (EventId IsNot Nothing AndAlso interfaces.Length > 1) Then
-                    Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_GuidAttribute__ctor,
+                    Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_GuidAttribute__ctor,
                                                                      comClass.DeclaringCompilation,
                                                                      comClass.Locations(0),
                                                                      diagnostics)
                 End If
 
                 ' Should be able to emit ClassInterfaceAttribute.
-                Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ClassInterfaceAttribute__ctorClassInterfaceType,
+                Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ClassInterfaceAttribute__ctorClassInterfaceType,
                                                                  comClass.DeclaringCompilation,
                                                                  comClass.Locations(0),
                                                                  diagnostics)
 
                 ' Should be able to emit ComSourceInterfacesAttribute and InterfaceTypeAttribute if there is an event interface.
                 If interfaces.Length > 1 Then
-                    Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ComSourceInterfacesAttribute__ctorString,
+                    Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ComSourceInterfacesAttribute__ctorString,
                                                                      comClass.DeclaringCompilation,
                                                                      comClass.Locations(0),
                                                                      diagnostics)
 
-                    Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_InterfaceTypeAttribute__ctorInt16,
+                    Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_InterfaceTypeAttribute__ctorInt16,
                                                                      comClass.DeclaringCompilation,
                                                                      comClass.Locations(0),
                                                                      diagnostics)
@@ -235,7 +235,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 ' Should be able to emit ComVisibleAttribute on interfaces.
                 If interfaces.Length > 0 Then
-                    Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ComVisibleAttribute__ctor,
+                    Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_ComVisibleAttribute__ctor,
                                                                      comClass.DeclaringCompilation,
                                                                      comClass.Locations(0),
                                                                      diagnostics)
@@ -262,7 +262,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If synthesizeDispIds Then
                     ' Should be able to emit DispIdAttribute on members.
-                    Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_DispIdAttribute__ctor,
+                    Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_InteropServices_DispIdAttribute__ctor,
                                                                      comClass.DeclaringCompilation,
                                                                      comClass.Locations(0),
                                                                      diagnostics)
@@ -270,7 +270,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If haveDefaultProperty Then
                     ' Should be able to emit DefaultMemberAttribute.
-                    Binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor,
+                    Binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor,
                                                                      comClass.DeclaringCompilation,
                                                                      comClass.Locations(0),
                                                                      diagnostics)
@@ -283,7 +283,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 diagnostics.Free()
             End Sub
 
-            Private Shared Function ValidateComClassGuid(comClass As SourceNamedTypeSymbol, id As String, diagnostics As DiagnosticBag, <Out> Optional ByRef guidVal As Guid = Nothing) As Boolean
+            Private Shared Function ValidateComClassGuid(comClass As SourceNamedTypeSymbol, id As String, diagnostics As BindingDiagnosticBag, <Out> Optional ByRef guidVal As Guid = Nothing) As Boolean
                 If id IsNot Nothing Then
                     If Not Guid.TryParseExact(id, "D", guidVal) Then '32 digits separated by hyphens: 00000000-0000-0000-0000-000000000000 
                         Binder.ReportDiagnostic(diagnostics, comClass.Locations(0), ERRID.ERR_BadAttributeUuid2, AttributeDescription.VisualBasicComClassAttribute.Name, id)
@@ -323,7 +323,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Function
 
 
-            Private Sub CheckForNameCollisions(comClass As SourceNamedTypeSymbol, diagnostics As DiagnosticBag)
+            Private Sub CheckForNameCollisions(comClass As SourceNamedTypeSymbol, diagnostics As BindingDiagnosticBag)
                 For i As Integer = 0 To 1
                     Dim interfaceName As String = If(i = 0, "_", "__") & comClass.Name
 
@@ -363,7 +363,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 interfaceMembers As ArrayBuilder(Of KeyValuePair(Of Symbol, Integer)),
                 eventMembers As ArrayBuilder(Of KeyValuePair(Of EventSymbol, Integer)),
                 <Out> ByRef haveDefaultProperty As Boolean,
-                diagnostics As DiagnosticBag
+                diagnostics As BindingDiagnosticBag
             )
                 haveDefaultProperty = False
 
@@ -474,7 +474,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ''' Returns user defined DispId for a member or ReservedDispId.None if none specified.
             ''' Also reports errors for reserved DispIds.
             ''' </summary>
-            Private Shared Function GetUserSpecifiedDispId(target As Symbol, diagnostics As DiagnosticBag) As Integer
+            Private Shared Function GetUserSpecifiedDispId(target As Symbol, diagnostics As BindingDiagnosticBag) As Integer
                 ' So far this information is used only by ComClass feature, therefore, I do not believe
                 ' it is worth to intercept this attribute in DecodeWellKnownAttribute and cache the fact of attribute's
                 ' presence and its value. If we start caching that information, implementation of this function 
@@ -866,19 +866,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     End Get
                 End Property
 
-                Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+                Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                     Return Nothing
                 End Function
 
-                Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+                Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                     Return ImmutableArray(Of NamedTypeSymbol).Empty
                 End Function
 
-                Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+                Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
                     Return Nothing
                 End Function
 
-                Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+                Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
                     Return ImmutableArray(Of NamedTypeSymbol).Empty
                 End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_GroupClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_GroupClass.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
     Friend Partial Class SourceNamedTypeSymbol
 
-        Protected Overrides Sub AddGroupClassMembersIfNeeded(membersBuilder As MembersAndInitializersBuilder, diagnostics As DiagnosticBag)
+        Protected Overrides Sub AddGroupClassMembersIfNeeded(membersBuilder As MembersAndInitializersBuilder, diagnostics As BindingDiagnosticBag)
             ' For reference, see Bindable::IsMyGroupCollection and Bindable::CrackAttributesOnAllSymbolsInContainer in native code.
             If Me.TypeKind = TypeKind.Class AndAlso Not Me.IsGenericType Then
 
@@ -117,14 +117,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
         End Sub
 
-        Private Function GetMyGroupCollectionAttributeData(diagnostics As DiagnosticBag, <Out> ByRef binder As Binder, <Out> ByRef attributeSyntax As AttributeSyntax) As VisualBasicAttributeData
+        Private Function GetMyGroupCollectionAttributeData(diagnostics As BindingDiagnosticBag, <Out> ByRef binder As Binder, <Out> ByRef attributeSyntax As AttributeSyntax) As VisualBasicAttributeData
 
             ' Calling GetAttributes() here is likely to get us in a cycle. Also, we want this function to be 
             ' as cheap as possible, it is called for every class and we don't want to bind all attributes
             ' attached to the declaration (even when it doesn't cause a cycle) before we able to create symbol's
             ' members. So, we will have to manually bind only those attributes that potentially could be 
             ' MyGroupCollectionAttribute, by examining syntax ourselves.
-            Dim throwAwayDiagnostics = DiagnosticBag.GetInstance()
             Dim attributeLists As ImmutableArray(Of SyntaxList(Of AttributeListSyntax)) = GetAttributeDeclarations()
             Dim attributeData As VisualBasicAttributeData = Nothing
 
@@ -138,7 +137,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                             If (quickChecker.CheckAttribute(attr) And QuickAttributes.MyGroupCollection) <> 0 Then
                                 ' This attribute syntax might be an application of MyGroupCollectionAttribute.
                                 ' Let's bind it.
-                                Dim attributeType As NamedTypeSymbol = Binder.BindAttributeType(binder, attr, Me, throwAwayDiagnostics)
+                                Dim attributeType As NamedTypeSymbol = Binder.BindAttributeType(binder, attr, Me, BindingDiagnosticBag.Discarded)
                                 If Not attributeType.IsErrorType() Then
                                     If VisualBasicAttributeData.IsTargetEarlyAttribute(attributeType, attr, AttributeDescription.MyGroupCollectionAttribute) Then
                                         ' Calling GetAttribute can still get us into cycle if MyGroupCollectionAttribute is applied to itself.
@@ -197,7 +196,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
 
 DoneWithBindingAttributes:
-            throwAwayDiagnostics.Free()
 
             If attributeData Is Nothing Then
                 binder = Nothing
@@ -252,7 +250,7 @@ DoneWithBindingAttributes:
                            named.TypeKind = TypeKind.Class AndAlso
                            Not named.IsGenericType AndAlso
                            Not named.IsMustInherit AndAlso
-                           binder.IsAccessible(named, useSiteDiagnostics:=Nothing) Then
+                           binder.IsAccessible(named, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                             Dim matchingItem As Integer = FindBaseInMyGroupCollection(named, baseTypes)
 
                             If matchingItem >= 0 AndAlso
@@ -375,7 +373,7 @@ DoneWithBindingAttributes:
             membersBuilder As MembersAndInitializersBuilder,
             binder As Binder,
             attributeSyntax As AttributeSyntax,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             Dim propertyName As String
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
@@ -468,7 +468,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return
             End If
 
-            Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
+            Dim diagnostics = DiagnosticBag.GetInstance()
             Dim reportedNamespaceMismatch As Boolean = False
 
             ' Check for a few issues with namespace declaration.
@@ -495,7 +495,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 cancellationToken.ThrowIfCancellationRequested()
             Next
 
-            If _containingModule.AtomicSetFlagAndStoreDiagnostics(_lazyState, StateFlags.DeclarationValidated, 0, diagnostics, CompilationStage.Declare) Then
+            If _containingModule.AtomicSetFlagAndStoreDiagnostics(_lazyState, StateFlags.DeclarationValidated, 0, New BindingDiagnosticBag(diagnostics), CompilationStage.Declare) Then
                 DeclaringCompilation.SymbolDeclaredEvent(Me)
             End If
             diagnostics.Free()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -282,6 +282,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim attrData = arguments.Attribute
             Debug.Assert(Not attrData.HasErrors)
             Debug.Assert(arguments.SymbolPart = AttributeLocation.None)
+            Debug.Assert(TypeOf arguments.Diagnostics Is BindingDiagnosticBag)
 
             ' Differences from C#:
             '
@@ -326,7 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Sub DecodeDefaultParameterValueAttribute(description As AttributeDescription, ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
             Dim attribute = arguments.Attribute
-            Dim diagnostics = arguments.Diagnostics
+            Dim diagnostics = DirectCast(arguments.Diagnostics, BindingDiagnosticBag)
 
             Debug.Assert(arguments.AttributeSyntaxOpt IsNot Nothing)
             Debug.Assert(diagnostics IsNot Nothing)
@@ -342,7 +343,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' (DefaultParameterValueAttribute, DateTimeConstantAttribute or DecimalConstantAttribute).
         ''' If not, report ERR_ParamDefaultValueDiffersFromAttribute.
         ''' </summary>
-        Protected Sub VerifyParamDefaultValueMatchesAttributeIfAny(value As ConstantValue, syntax As VisualBasicSyntaxNode, diagnostics As DiagnosticBag)
+        Protected Sub VerifyParamDefaultValueMatchesAttributeIfAny(value As ConstantValue, syntax As VisualBasicSyntaxNode, diagnostics As BindingDiagnosticBag)
             Dim data = GetEarlyDecodedWellKnownAttributeData()
             If data IsNot Nothing Then
                 Dim attrValue = data.DefaultParameterValue

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -179,7 +179,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim retType = _lazyReturnType
                 If retType Is Nothing Then
 
-                    Dim diagBag = DiagnosticBag.GetInstance()
+                    Dim diagBag = BindingDiagnosticBag.GetInstance()
                     Dim sourceModule = ContainingSourceModule
                     Dim errorLocation As SyntaxNodeOrToken = Nothing
                     retType = GetReturnType(sourceModule, errorLocation, diagBag)
@@ -195,7 +195,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         End If
 
                         For Each diag In diagnosticsBuilder
-                            diagBag.Add(diag.DiagnosticInfo, errorLocation.GetLocation())
+                            diagBag.Add(diag.UseSiteInfo, errorLocation.GetLocation())
                         Next
                         diagnosticsBuilder.Free()
                     End If
@@ -217,7 +217,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Function GetReturnType(sourceModule As SourceModuleSymbol,
                                        ByRef errorLocation As SyntaxNodeOrToken,
-                                       diagBag As DiagnosticBag) As TypeSymbol
+                                       diagBag As BindingDiagnosticBag) As TypeSymbol
             Select Case MethodKind
                 Case MethodKind.PropertyGet
                     Dim accessorSym = DirectCast(Me, SourcePropertyAccessorSymbol)
@@ -247,7 +247,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim params = _lazyParameters
                 If params.IsDefault Then
 
-                    Dim diagBag = DiagnosticBag.GetInstance()
+                    Dim diagBag = BindingDiagnosticBag.GetInstance()
                     Dim sourceModule = ContainingSourceModule
 
                     params = GetParameters(sourceModule, diagBag)
@@ -277,7 +277,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Function GetParameters(sourceModule As SourceModuleSymbol, diagBag As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+        Private Function GetParameters(sourceModule As SourceModuleSymbol, diagBag As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
             If m_property.IsCustomProperty Then
                 Dim binder As Binder = BinderBuilder.CreateBinderForType(sourceModule, Me.SyntaxTree, Me.m_property.ContainingSourceType)
                 binder = New LocationSpecificBinder(BindingLocation.PropertyAccessorSignature, Me, binder)
@@ -385,7 +385,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                location As Location,
                                                binder As Binder,
                                                parameterListOpt As ParameterListSyntax,
-                                               diagnostics As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+                                               diagnostics As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
             Dim propertyParameters = propertySymbol.Parameters
             Dim nPropertyParameters = propertyParameters.Length
             Dim isSetter As Boolean = (method.MethodKind = MethodKind.PropertySet)
@@ -456,7 +456,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Shared ReadOnly s_checkParameterModifierCallback As Binder.CheckParameterModifierDelegate = AddressOf CheckParameterModifier
 
-        Private Shared Function CheckParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As DiagnosticBag) As SourceParameterFlags
+        Private Shared Function CheckParameterModifier(container As Symbol, token As SyntaxToken, flag As SourceParameterFlags, diagnostics As BindingDiagnosticBag) As SourceParameterFlags
             If flag <> SourceParameterFlags.ByVal Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_SetHasToBeByVal1, location, token.ToString())
@@ -465,7 +465,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return SourceParameterFlags.ByVal
         End Function
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Debug.Assert(Not m_property.IsMustOverride)
 
             If m_property.IsAutoProperty Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -229,12 +229,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                              syntaxRef As SyntaxReference,
                              modifiers As MemberModifiers,
                              firstFieldDeclarationOfType As Boolean,
-                             diagnostics As DiagnosticBag) As SourcePropertySymbol
+                             diagnostics As BindingDiagnosticBag) As SourcePropertySymbol
 
             Dim name = identifier.ValueText
 
             ' we will require AccessedThroughPropertyAttribute
-            bodyBinder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_AccessedThroughPropertyAttribute__ctor,
+            bodyBinder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Runtime_CompilerServices_AccessedThroughPropertyAttribute__ctor,
                                                     DirectCast(identifier.Parent, VisualBasicSyntaxNode),
                                                     diagnostics)
 
@@ -331,7 +331,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Function ComputeType(diagnostics As DiagnosticBag) As TypeSymbol
+        Private Function ComputeType(diagnostics As BindingDiagnosticBag) As TypeSymbol
             Dim binder = CreateBinderForTypeDeclaration()
 
             If IsWithEvents Then
@@ -728,7 +728,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Sub EnsureSignature()
             If _lazyParameters.IsDefault Then
-                Dim diagnostics = DiagnosticBag.GetInstance()
+                Dim diagnostics = BindingDiagnosticBag.GetInstance()
                 Dim sourceModule = DirectCast(ContainingModule, SourceModuleSymbol)
 
                 Dim params As ImmutableArray(Of ParameterSymbol) = ComputeParameters(diagnostics)
@@ -817,7 +817,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Function ComputeParameters(diagnostics As DiagnosticBag) As ImmutableArray(Of ParameterSymbol)
+        Private Function ComputeParameters(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of ParameterSymbol)
 
             If Me.IsWithEvents Then
                 ' no parameters
@@ -835,7 +835,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 ' 'touch' System_Reflection_DefaultMemberAttribute__ctor to make sure all diagnostics are reported
-                binder.ReportUseSiteErrorForSynthesizedAttribute(WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor,
+                binder.ReportUseSiteInfoForSynthesizedAttribute(WellKnownMember.System_Reflection_DefaultMemberAttribute__ctor,
                                                                      syntax,
                                                                      diagnostics)
             End If
@@ -860,7 +860,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides ReadOnly Property ExplicitInterfaceImplementations As ImmutableArray(Of PropertySymbol)
             Get
                 If _lazyImplementedProperties.IsDefault Then
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
                     Dim sourceModule = DirectCast(Me.ContainingModule, SourceModuleSymbol)
                     sourceModule.AtomicStoreArrayAndDiagnostics(_lazyImplementedProperties,
                                                                 ComputeExplicitInterfaceImplementations(diagnostics),
@@ -873,7 +873,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Function ComputeExplicitInterfaceImplementations(diagnostics As DiagnosticBag) As ImmutableArray(Of PropertySymbol)
+        Private Function ComputeExplicitInterfaceImplementations(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of PropertySymbol)
             Dim binder = CreateBinderForTypeDeclaration()
             Dim syntax = DirectCast(_syntaxRef.GetSyntax(), PropertyStatementSyntax)
             Return BindImplementsClause(_containingType, binder, Me, syntax, diagnostics)
@@ -1099,7 +1099,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                      bodyBinder As Binder,
                                                      prop As SourcePropertySymbol,
                                                      syntax As PropertyStatementSyntax,
-                                                     diagnostics As DiagnosticBag) As ImmutableArray(Of PropertySymbol)
+                                                     diagnostics As BindingDiagnosticBag) As ImmutableArray(Of PropertySymbol)
             If syntax.ImplementsClause IsNot Nothing Then
                 If prop.IsShared And Not containingType.IsModuleType Then
                     ' Implementing with shared methods is illegal.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedConstructorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedConstructorSymbol.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             isShared As Boolean,
             isDebuggable As Boolean,
             binder As Binder,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             MyBase.New(syntaxReference, container, isShared, binder, diagnostics)
             Me._debuggable = isDebuggable

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEntryPointSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEntryPointSymbol.vb
@@ -16,20 +16,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly _containingType As NamedTypeSymbol
         Private ReadOnly _returnType As TypeSymbol
 
-        Friend Shared Function Create(initializerMethod As SynthesizedInteractiveInitializerMethod, diagnostics As DiagnosticBag) As SynthesizedEntryPointSymbol
+        Friend Shared Function Create(initializerMethod As SynthesizedInteractiveInitializerMethod, diagnostics As BindingDiagnosticBag) As SynthesizedEntryPointSymbol
             Dim containingType = initializerMethod.ContainingType
             Dim compilation = ContainingType.DeclaringCompilation
             If compilation.IsSubmission Then
                 Dim submissionArrayType = compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Object))
-                ReportUseSiteDiagnostics(submissionArrayType, diagnostics)
+                ReportUseSiteInfo(submissionArrayType, diagnostics)
                 Return New SubmissionEntryPoint(containingType, initializerMethod.ReturnType, submissionArrayType)
             Else
                 Dim taskType = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task)
-#If DEBUG Then
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Debug.Assert(taskType.IsErrorType() OrElse initializerMethod.ReturnType.IsOrDerivedFrom(taskType, useSiteDiagnostics))
-#End If
-                ReportUseSiteDiagnostics(taskType, diagnostics)
+
+                Debug.Assert(taskType.IsErrorType() OrElse initializerMethod.ReturnType.IsOrDerivedFrom(taskType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
+
+                ReportUseSiteInfo(taskType, diagnostics)
                 Dim getAwaiterMethod = If(taskType.IsErrorType(),
                     Nothing,
                     GetRequiredMethod(taskType, WellKnownMemberNames.GetAwaiter, diagnostics))
@@ -189,14 +188,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return VisualBasicSyntaxTree.Dummy.GetRoot()
         End Function
 
-        Private Shared Sub ReportUseSiteDiagnostics(symbol As Symbol, diagnostics As DiagnosticBag)
-            Dim useSiteDiagnostic = symbol.GetUseSiteErrorInfo()
-            If useSiteDiagnostic IsNot Nothing Then
-                diagnostics.Add(useSiteDiagnostic, NoLocation.Singleton)
-            End If
+        Private Shared Sub ReportUseSiteInfo(symbol As Symbol, diagnostics As BindingDiagnosticBag)
+            diagnostics.Add(symbol.GetUseSiteInfo(), NoLocation.Singleton)
         End Sub
 
-        Private Shared Function GetRequiredMethod(type As TypeSymbol, methodName As String, diagnostics As DiagnosticBag) As MethodSymbol
+        Private Shared Function GetRequiredMethod(type As TypeSymbol, methodName As String, diagnostics As BindingDiagnosticBag) As MethodSymbol
             Dim method = TryCast(type.GetMembers(methodName).SingleOrDefault(), MethodSymbol)
             If method Is Nothing Then
                 diagnostics.Add(

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEventAccessorSymbol.vb
@@ -45,15 +45,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides ReadOnly Property Parameters As ImmutableArray(Of ParameterSymbol)
             Get
                 If _lazyParameters.IsDefault Then
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
                     Dim parameterType As TypeSymbol
                     If Me.MethodKind = MethodKind.EventRemove AndAlso m_propertyOrEvent.IsWindowsRuntimeEvent Then
                         parameterType = Me.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken)
-                        Dim useSite = Binder.GetUseSiteErrorForWellKnownType(parameterType)
-                        If useSite IsNot Nothing Then
-                            diagnostics.Add(useSite, Me.Locations(0))
-                        End If
+                        diagnostics.Add(Binder.GetUseSiteInfoForWellKnownType(parameterType), Me.Locations(0))
                     Else
                         parameterType = SourceEvent.Type
                     End If
@@ -73,22 +70,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overrides ReadOnly Property ReturnType As TypeSymbol
             Get
                 If _lazyReturnType Is Nothing Then
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
                     Dim compilation = Me.DeclaringCompilation
                     Dim type As TypeSymbol
-                    Dim useSite As DiagnosticInfo
+                    Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol)
                     If Me.IsSub Then
                         type = compilation.GetSpecialType(SpecialType.System_Void)
                         ' Don't report on add, because it will be the same for remove.
-                        useSite = If(Me.MethodKind = MethodKind.EventRemove, Binder.GetUseSiteErrorForSpecialType(type), Nothing)
+                        useSiteInfo = If(Me.MethodKind = MethodKind.EventRemove, Binder.GetUseSiteInfoForSpecialType(type), Nothing)
                     Else
                         type = compilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationToken)
-                        useSite = Binder.GetUseSiteErrorForWellKnownType(type)
+                        useSiteInfo = Binder.GetUseSiteInfoForWellKnownType(type)
                     End If
-                    If useSite IsNot Nothing Then
-                        diagnostics.Add(useSite, Me.Locations(0))
-                    End If
+
+                    diagnostics.Add(useSiteInfo, Me.Locations(0))
 
                     DirectCast(Me.ContainingModule, SourceModuleSymbol).AtomicStoreReferenceAndDiagnostics(_lazyReturnType, type, diagnostics, CompilationStage.Declare)
 
@@ -106,7 +102,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Dim compilation = Me.DeclaringCompilation
             Return ConstructFieldLikeEventAccessorBody(Me.m_propertyOrEvent, Me.MethodKind = MethodKind.EventAdd, compilation, diagnostics)
         End Function
@@ -114,7 +110,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Protected Shared Function ConstructFieldLikeEventAccessorBody(eventSymbol As SourceEventSymbol,
                                                            isAddMethod As Boolean,
                                                            compilation As VisualBasicCompilation,
-                                                           diagnostics As DiagnosticBag) As BoundBlock
+                                                           diagnostics As BindingDiagnosticBag) As BoundBlock
             Debug.Assert(eventSymbol.HasAssociatedField)
             Dim result As BoundBlock = If(eventSymbol.IsWindowsRuntimeEvent,
                        ConstructFieldLikeEventAccessorBody_WinRT(eventSymbol, isAddMethod, compilation, diagnostics),
@@ -133,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Shared Function ConstructFieldLikeEventAccessorBody_WinRT(eventSymbol As SourceEventSymbol,
                                                            isAddMethod As Boolean,
                                                            compilation As VisualBasicCompilation,
-                                                           diagnostics As DiagnosticBag) As BoundBlock
+                                                           diagnostics As BindingDiagnosticBag) As BoundBlock
             Dim syntax = eventSymbol.SyntaxReference.GetVisualBasicSyntax()
 
             Dim accessor As MethodSymbol = If(isAddMethod, eventSymbol.AddMethod, eventSymbol.RemoveMethod)
@@ -150,18 +146,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Nothing
             End If
 
-            Dim useSiteErrorInfo As DiagnosticInfo = Nothing
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
 
             Dim getOrCreateMethod As MethodSymbol = DirectCast(Binder.GetWellKnownTypeMember(
                 compilation,
                 WellKnownMember.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T__GetOrCreateEventRegistrationTokenTable,
-                useSiteErrorInfo), MethodSymbol)
+                useSiteInfo), MethodSymbol)
 
-            If useSiteErrorInfo IsNot Nothing Then
-                diagnostics.Add(useSiteErrorInfo, syntax.GetLocation())
-            Else
-                Debug.Assert(getOrCreateMethod IsNot Nothing)
-            End If
+            diagnostics.Add(useSiteInfo, syntax.GetLocation())
+            Debug.Assert(getOrCreateMethod IsNot Nothing OrElse useSiteInfo.DiagnosticInfo IsNot Nothing)
 
             If getOrCreateMethod Is Nothing Then
                 Return Nothing
@@ -173,16 +166,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 WellKnownMember.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T__AddEventHandler,
                 WellKnownMember.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T__RemoveEventHandler)
 
+            useSiteInfo = Nothing
             Dim processHandlerMethod As MethodSymbol = DirectCast(Binder.GetWellKnownTypeMember(
                 compilation,
                 processHandlerMember,
-                useSiteErrorInfo), MethodSymbol)
+                useSiteInfo), MethodSymbol)
 
-            If useSiteErrorInfo IsNot Nothing Then
-                diagnostics.Add(useSiteErrorInfo, syntax.GetLocation())
-            Else
-                Debug.Assert(processHandlerMethod IsNot Nothing)
-            End If
+            diagnostics.Add(useSiteInfo, syntax.GetLocation())
+            Debug.Assert(processHandlerMethod IsNot Nothing OrElse useSiteInfo.DiagnosticInfo IsNot Nothing)
 
             If processHandlerMethod Is Nothing Then
                 Return Nothing
@@ -274,7 +265,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Shared Function ConstructFieldLikeEventAccessorBody_Regular(eventSymbol As SourceEventSymbol,
                                                                    isAddMethod As Boolean,
                                                                    compilation As VisualBasicCompilation,
-                                                                   diagnostics As DiagnosticBag) As BoundBlock
+                                                                   diagnostics As BindingDiagnosticBag) As BoundBlock
 
 
             If Not eventSymbol.Type.IsDelegateType() Then
@@ -289,12 +280,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim updateMethodId As SpecialMember = If(isAddMethod, SpecialMember.System_Delegate__Combine, SpecialMember.System_Delegate__Remove)
 
-            Dim useSiteError As DiagnosticInfo = Nothing
-            Dim updateMethod As MethodSymbol = DirectCast(Binder.GetSpecialTypeMember(compilation.Assembly, updateMethodId, useSiteError), MethodSymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim updateMethod As MethodSymbol = DirectCast(Binder.GetSpecialTypeMember(compilation.Assembly, updateMethodId, useSiteInfo), MethodSymbol)
 
-            If useSiteError IsNot Nothing Then
-                diagnostics.Add(useSiteError, syntax.GetLocation())
-            End If
+            diagnostics.Add(useSiteInfo, syntax.GetLocation())
 
             Dim [return] As BoundStatement = New BoundReturnStatement(syntax,
                                                                       Nothing,
@@ -309,8 +298,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                   ).MakeCompilerGenerated
             End If
 
-            useSiteError = Nothing
-            Dim compareExchangeMethod As MethodSymbol = DirectCast(Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Threading_Interlocked__CompareExchange_T, useSiteError), MethodSymbol)
+            useSiteInfo = Nothing
+            Dim compareExchangeMethod As MethodSymbol = DirectCast(Binder.GetWellKnownTypeMember(compilation, WellKnownMember.System_Threading_Interlocked__CompareExchange_T, useSiteInfo), MethodSymbol)
 
             Dim fieldReceiver As BoundMeReference = If(eventSymbol.IsShared,
                                                        Nothing,
@@ -330,12 +319,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                       type:=parameterSymbol.Type).MakeCompilerGenerated
 
             Dim delegateUpdate As BoundExpression
+            Dim conversionsUseSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim conversionKind1 As ConversionKind
+            Dim conversionKind2 As ConversionKind
 
             If compareExchangeMethod Is Nothing Then
 
                 ' (DelegateType)Delegate.Combine(_event, value)
-                Debug.Assert(Conversions.ClassifyDirectCastConversion(fieldSymbol.Type, updateMethod.Parameters(0).Type, Nothing) = ConversionKind.WideningReference)
-                Debug.Assert(Conversions.ClassifyDirectCastConversion(boundParameter.Type, updateMethod.Parameters(1).Type, Nothing) = ConversionKind.WideningReference)
+                conversionKind1 = Conversions.ClassifyDirectCastConversion(fieldSymbol.Type, updateMethod.Parameters(0).Type, conversionsUseSiteInfo)
+                conversionKind2 = Conversions.ClassifyDirectCastConversion(boundParameter.Type, updateMethod.Parameters(1).Type, conversionsUseSiteInfo)
+                Debug.Assert(conversionKind1 = ConversionKind.WideningReference)
+                Debug.Assert(conversionKind2 = ConversionKind.WideningReference)
+
+                diagnostics.Add(syntax.GetLocation(), conversionsUseSiteInfo)
+
                 delegateUpdate = New BoundDirectCast(syntax,
                                                      New BoundCall(syntax,
                                                                    updateMethod,
@@ -368,9 +365,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                   ).MakeCompilerGenerated
             End If
 
-            If useSiteError IsNot Nothing Then
-                diagnostics.Add(useSiteError, syntax.GetLocation())
-            End If
+            diagnostics.Add(useSiteInfo, syntax.GetLocation())
 
             compareExchangeMethod = compareExchangeMethod.Construct(ImmutableArray.Create(Of TypeSymbol)(delegateType))
 
@@ -408,8 +403,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                                                     ).MakeCompilerGenerated
 
             ' (DelegateType)Delegate.Combine(tmp1, value)
-            Debug.Assert(Conversions.ClassifyDirectCastConversion(boundTmps(1).Type, updateMethod.Parameters(0).Type, Nothing) = ConversionKind.WideningReference)
-            Debug.Assert(Conversions.ClassifyDirectCastConversion(boundParameter.Type, updateMethod.Parameters(1).Type, Nothing) = ConversionKind.WideningReference)
+            conversionKind1 = Conversions.ClassifyDirectCastConversion(boundTmps(1).Type, updateMethod.Parameters(0).Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
+            conversionKind2 = Conversions.ClassifyDirectCastConversion(boundParameter.Type, updateMethod.Parameters(1).Type, CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
+            Debug.Assert(conversionKind1 = ConversionKind.WideningReference)
+            Debug.Assert(conversionKind2 = ConversionKind.WideningReference)
+
+            diagnostics.Add(syntax.GetLocation(), conversionsUseSiteInfo)
+
             delegateUpdate = New BoundDirectCast(syntax,
                                                  New BoundCall(syntax,
                                                                updateMethod,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEventBackingFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEventBackingFieldSymbol.vb
@@ -33,15 +33,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 If _lazyType Is Nothing Then
 
-                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim diagnostics = BindingDiagnosticBag.GetInstance()
                     Dim result = _propertyOrEvent.Type
 
                     If _propertyOrEvent.IsWindowsRuntimeEvent Then
                         Dim tokenType = Me.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Runtime_InteropServices_WindowsRuntime_EventRegistrationTokenTable_T)
-                        Dim info = Binder.GetUseSiteErrorForWellKnownType(tokenType)
-                        If info IsNot Nothing Then
-                            diagnostics.Add(info, _propertyOrEvent.Locations(0))
-                        End If
+                        diagnostics.Add(Binder.GetUseSiteInfoForWellKnownType(tokenType), _propertyOrEvent.Locations(0))
+
                         result = tokenType.Construct(result)
                     End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedInteractiveInitializerMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedInteractiveInitializerMethod.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Sub New(
             syntaxReference As SyntaxReference,
             containingType As SourceMemberContainerTypeSymbol,
-            diagnostics As DiagnosticBag)
+            diagnostics As BindingDiagnosticBag)
             MyBase.New(containingType)
 
             _syntaxReference = syntaxReference
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Dim syntax As SyntaxNode = Me.Syntax
             Return New BoundBlock(
                 syntax,
@@ -145,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private Shared Sub CalculateReturnType(
             compilation As VisualBasicCompilation,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             ByRef resultType As TypeSymbol,
             ByRef returnType As TypeSymbol)
 
@@ -155,10 +155,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim taskT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T)
-            Dim useSiteDiagnostic = taskT.GetUseSiteErrorInfo()
-            If useSiteDiagnostic IsNot Nothing Then
-                diagnostics.Add(useSiteDiagnostic, NoLocation.Singleton)
-            End If
+            diagnostics.Add(taskT.GetUseSiteInfo(), NoLocation.Singleton)
+
             ' If no explicit return type is set on ScriptCompilationInfo, default to
             ' System.Object from the target corlib. This allows cross compiling scripts
             ' to run on a target corlib that may differ from the host compiler's corlib.
@@ -166,7 +164,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If submissionReturnType Is Nothing Then
                 resultType = compilation.GetSpecialType(SpecialType.System_Object)
             Else
-                resultType = compilation.GetTypeByReflectionType(submissionReturnType, diagnostics)
+                resultType = compilation.GetTypeByReflectionType(submissionReturnType)
             End If
             returnType = taskT.Construct(resultType)
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedMyGroupCollectionPropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedMyGroupCollectionPropertyAccessorSymbol.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return name
         End Function
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, <Out()> Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, <Out()> Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
 
             Dim containingType = DirectCast(Me.ContainingType, SourceNamedTypeSymbol)
             Dim containingTypeName As String = MakeSafeName(containingType.Name)
@@ -97,7 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim typeBinder As Binder = BinderBuilder.CreateBinderForType(containingType.ContainingSourceModule, PropertyOrEvent.AttributeSyntax.SyntaxTree, containingType)
                 methodBodyBinder = BinderBuilder.CreateBinderForMethodBody(Me, accessorBlock, typeBinder)
 
-                Dim bindingDiagnostics = DiagnosticBag.GetInstance()
+                Dim bindingDiagnostics = New BindingDiagnosticBag(DiagnosticBag.GetInstance(), diagnostics.DependenciesBag)
 #If DEBUG Then
                 ' Enable DEBUG check for ordering of simple name binding.
                 methodBodyBinder.EnableSimpleNameBindingOrderChecks(True)
@@ -109,11 +109,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 methodBodyBinder.EnableSimpleNameBindingOrderChecks(False)
 #End If
 
-                For Each diag As VBDiagnostic In bindingDiagnostics.AsEnumerable()
+                For Each diag As VBDiagnostic In bindingDiagnostics.DiagnosticBag.AsEnumerable()
                     diagnostics.Add(diag.WithLocation(diagnosticLocation))
                 Next
 
-                bindingDiagnostics.Free()
+                bindingDiagnostics.DiagnosticBag.Free()
 
                 If boundStatement.Kind = BoundKind.Block Then
                     Return DirectCast(boundStatement, BoundBlock)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedSubmissionConstructorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedSubmissionConstructorSymbol.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             container As NamedTypeSymbol,
             isShared As Boolean,
             binder As Binder,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             MyBase.New(syntaxReference, container, isShared, binder, diagnostics)
             Debug.Assert(container.TypeKind = TypeKind.Submission)
@@ -29,10 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim compilation = container.DeclaringCompilation
 
             Dim submissionArrayType = compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Object))
-            Dim useSiteDiagnostic = submissionArrayType.GetUseSiteErrorInfo()
-            If useSiteDiagnostic IsNot Nothing Then
-                diagnostics.Add(useSiteDiagnostic, NoLocation.Singleton)
-            End If
+            diagnostics.Add(submissionArrayType.GetUseSiteInfo(), NoLocation.Singleton)
 
             _parameters = ImmutableArray.Create(Of ParameterSymbol)(
                 New SynthesizedParameterSymbol(Me, submissionArrayType, 0, isByRef:=False, name:="submissionArray"))
@@ -44,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Dim node As SyntaxNode = Me.Syntax
             Return New BoundBlock(
                 node,
@@ -57,8 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             syntax As SyntaxNode,
             constructor As MethodSymbol,
             synthesizedFields As SynthesizedSubmissionFields,
-            compilation As VisualBasicCompilation,
-            diagnostics As DiagnosticBag) As ImmutableArray(Of BoundStatement)
+            compilation As VisualBasicCompilation) As ImmutableArray(Of BoundStatement)
 
             Debug.Assert(constructor.ParameterCount = 1)
             Dim result = New List(Of BoundStatement)()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/UnboundLambdaParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/UnboundLambdaParameterSymbol.vb
@@ -63,7 +63,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                 flags As SourceParameterFlags,
                                                 ordinal As Integer,
                                                 binder As Binder,
-                                                diagBag As DiagnosticBag) As ParameterSymbol
+                                                diagBag As BindingDiagnosticBag) As ParameterSymbol
             If (flags And SourceParameterFlags.ParamArray) <> 0 Then
                 ' 'Lambda' parameters cannot be declared 'ParamArray'.
                 Binder.ReportDiagnostic(diagBag, GetModifierToken(syntax.Modifiers, SyntaxKind.ParamArrayKeyword), ERRID.ERR_ParamArrayIllegal1, StringConstants.Lambda)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -239,11 +239,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend NotOverridable Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend NotOverridable Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return DirectCast(OriginalDefinition.GetDeclaredBase(basesBeingResolved).InternalSubstituteTypeParameters(_substitution).AsTypeSymbolOnly(), NamedTypeSymbol)
         End Function
 
-        Friend NotOverridable Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend NotOverridable Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Dim instanceInterfaces = OriginalDefinition.GetDeclaredInterfacesNoUseSiteDiagnostics(basesBeingResolved)
 
             If instanceInterfaces.Length = 0 Then
@@ -261,7 +261,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         End Function
 
-        Friend NotOverridable Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend NotOverridable Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim fullBase = OriginalDefinition.BaseTypeNoUseSiteDiagnostics
 
             If fullBase IsNot Nothing Then
@@ -271,7 +271,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Friend NotOverridable Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend NotOverridable Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Dim instanceInterfaces = OriginalDefinition.InterfacesNoUseSiteDiagnostics
 
             If instanceInterfaces.Length = 0 Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports System.Globalization
 Imports System.Runtime.InteropServices
 Imports System.Threading
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Symbols
@@ -857,12 +858,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 #Region "Use-Site Diagnostic"
 
         ''' <summary>
-        ''' Returns error info for an error, if any, that should be reported at the use site of the symbol.
+        ''' Returns dependencies and an error info for an error, if any, that should be reported at the use site of the symbol.
         ''' </summary>
-        Friend Overridable Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overridable Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             Return Nothing
         End Function
 
+        Friend ReadOnly Property PrimaryDependency As AssemblySymbol
+            Get
+                Dim dependency As AssemblySymbol = Me.ContainingAssembly
+                If dependency IsNot Nothing AndAlso dependency.CorLibrary = dependency Then
+                    Return Nothing
+                End If
+
+                Return dependency
+            End Get
+        End Property
 
         ''' <summary>
         ''' Indicates that this symbol uses metadata that cannot be supported by the language.
@@ -890,24 +901,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         ''' <summary>
-        ''' Derive error info from a type symbol.
+        ''' Derive dependencies and error info from a type symbol.
         ''' </summary>
-        Friend Function DeriveUseSiteErrorInfoFromType(type As TypeSymbol) As DiagnosticInfo
-            Dim errorInfo As DiagnosticInfo = type.GetUseSiteErrorInfo()
+        Friend Function DeriveUseSiteInfoFromType(type As TypeSymbol) As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = type.GetUseSiteInfo()
 
-            If errorInfo IsNot Nothing Then
-                Select Case errorInfo.Code
+            If useSiteInfo.DiagnosticInfo IsNot Nothing Then
+                Select Case useSiteInfo.DiagnosticInfo.Code
                     Case ERRID.ERR_UnsupportedType1
 
                         Select Case Me.Kind
                             Case SymbolKind.Field
-                                errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedField1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedField1, CustomSymbolDisplayFormatter.ShortErrorName(Me)))
 
                             Case SymbolKind.Method
-                                errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedMethod1, CustomSymbolDisplayFormatter.ShortErrorName(Me)))
 
                             Case SymbolKind.Property
-                                errorInfo = ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedProperty1, CustomSymbolDisplayFormatter.ShortErrorName(Me))
+                                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_UnsupportedProperty1, CustomSymbolDisplayFormatter.ShortErrorName(Me)))
                         End Select
 
                     Case Else
@@ -915,7 +926,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Select
             End If
 
-            Return errorInfo
+            Return useSiteInfo
         End Function
 
         ''' <summary>
@@ -927,82 +938,95 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Function MergeUseSiteErrorInfo(first As DiagnosticInfo, second As DiagnosticInfo) As DiagnosticInfo
-            If first Is Nothing Then
-                Return second
-            End If
-
-            If second Is Nothing OrElse second.Code <> HighestPriorityUseSiteError Then
-                Return first
-            End If
-
-            Return second
+        Friend Function MergeUseSiteInfo(first As UseSiteInfo(Of AssemblySymbol), second As UseSiteInfo(Of AssemblySymbol)) As UseSiteInfo(Of AssemblySymbol)
+            MergeUseSiteInfo(first, second, HighestPriorityUseSiteError)
+            Return first
         End Function
 
-        Friend Function DeriveUseSiteErrorInfoFromParameter(param As ParameterSymbol, highestPriorityUseSiteError As Integer) As DiagnosticInfo
-            Dim errorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(param.Type)
-
-            If errorInfo IsNot Nothing AndAlso errorInfo.Code = highestPriorityUseSiteError Then
-                Return errorInfo
+        Friend Shared Function MergeUseSiteInfo(ByRef result As UseSiteInfo(Of AssemblySymbol), other As UseSiteInfo(Of AssemblySymbol), highestPriorityUseSiteError As Integer) As Boolean
+            If other.DiagnosticInfo?.Code = highestPriorityUseSiteError Then
+                result = other
+                Return True
             End If
 
-            Dim refModifiersErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromCustomModifiers(param.RefCustomModifiers)
+            If result.DiagnosticInfo Is Nothing Then
+                If other.DiagnosticInfo IsNot Nothing Then
+                    result = other
+                Else
+                    Dim primaryDependency = result.PrimaryDependency
+                    Dim secondaryDependency = result.SecondaryDependencies
 
-            If refModifiersErrorInfo IsNot Nothing AndAlso refModifiersErrorInfo.Code = highestPriorityUseSiteError Then
-                Return refModifiersErrorInfo
+                    other.MergeDependencies(primaryDependency, secondaryDependency)
+                    result = New UseSiteInfo(Of AssemblySymbol)(diagnosticInfo:=Nothing, primaryDependency, secondaryDependency)
+                End If
+
+                Return False
+            Else
+                Return result.DiagnosticInfo.Code = highestPriorityUseSiteError
             End If
-
-            Dim modifiersErrorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromCustomModifiers(param.CustomModifiers)
-
-            If modifiersErrorInfo IsNot Nothing AndAlso modifiersErrorInfo.Code = highestPriorityUseSiteError Then
-                Return modifiersErrorInfo
-            End If
-
-            Return If(errorInfo, If(refModifiersErrorInfo, modifiersErrorInfo))
         End Function
 
-        Friend Function DeriveUseSiteErrorInfoFromParameters(parameters As ImmutableArray(Of ParameterSymbol)) As DiagnosticInfo
-            Dim paramsErrorInfo As DiagnosticInfo = Nothing
+        Friend Function DeriveUseSiteInfoFromParameter(param As ParameterSymbol, highestPriorityUseSiteError As Integer) As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromType(param.Type)
+
+            If useSiteInfo.DiagnosticInfo?.Code = highestPriorityUseSiteError Then
+                Return useSiteInfo
+            End If
+
+            Dim refModifiersUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromCustomModifiers(param.RefCustomModifiers)
+
+            If refModifiersUseSiteInfo.DiagnosticInfo?.Code = highestPriorityUseSiteError Then
+                Return refModifiersUseSiteInfo
+            End If
+
+            Dim modifiersUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromCustomModifiers(param.CustomModifiers)
+
+            If modifiersUseSiteInfo.DiagnosticInfo?.Code = highestPriorityUseSiteError Then
+                Return modifiersUseSiteInfo
+            End If
+
+
+            Dim errorInfo = If(useSiteInfo.DiagnosticInfo, If(refModifiersUseSiteInfo.DiagnosticInfo, modifiersUseSiteInfo.DiagnosticInfo))
+
+            If errorInfo IsNot Nothing Then
+                Return New UseSiteInfo(Of AssemblySymbol)(errorInfo)
+            End If
+
+            Dim primaryDependency = useSiteInfo.PrimaryDependency
+            Dim secondaryDependency = useSiteInfo.SecondaryDependencies
+
+            refModifiersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+            modifiersUseSiteInfo.MergeDependencies(primaryDependency, secondaryDependency)
+
+            Return New UseSiteInfo(Of AssemblySymbol)(diagnosticInfo:=Nothing, primaryDependency, secondaryDependency)
+        End Function
+
+        Friend Function DeriveUseSiteInfoFromParameters(parameters As ImmutableArray(Of ParameterSymbol)) As UseSiteInfo(Of AssemblySymbol)
+            Dim paramsUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
             Dim highestPriorityUseSiteError As Integer = Me.HighestPriorityUseSiteError
 
             For Each param As ParameterSymbol In parameters
-                Dim errorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromParameter(param, highestPriorityUseSiteError)
-
-                If errorInfo IsNot Nothing Then
-                    If errorInfo.Code = highestPriorityUseSiteError Then
-                        Return errorInfo
-                    End If
-
-                    If paramsErrorInfo Is Nothing Then
-                        paramsErrorInfo = errorInfo
-                    End If
+                If MergeUseSiteInfo(paramsUseSiteInfo, DeriveUseSiteInfoFromParameter(param, highestPriorityUseSiteError), highestPriorityUseSiteError) Then
+                    Exit For
                 End If
             Next
 
-            Return paramsErrorInfo
+            Return paramsUseSiteInfo
         End Function
 
-        Friend Function DeriveUseSiteErrorInfoFromCustomModifiers(
+        Friend Function DeriveUseSiteInfoFromCustomModifiers(
             customModifiers As ImmutableArray(Of CustomModifier)
-        ) As DiagnosticInfo
-            Dim modifiersErrorInfo As DiagnosticInfo = Nothing
+        ) As UseSiteInfo(Of AssemblySymbol)
+            Dim modifiersUseSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
             Dim highestPriorityUseSiteError As Integer = Me.HighestPriorityUseSiteError
 
             For Each modifier As CustomModifier In customModifiers
-                Dim errorInfo As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(DirectCast(modifier.Modifier, TypeSymbol))
-
-                If errorInfo IsNot Nothing Then
-                    If errorInfo.Code = highestPriorityUseSiteError Then
-                        Return errorInfo
-                    End If
-
-                    If modifiersErrorInfo Is Nothing Then
-                        modifiersErrorInfo = errorInfo
-                    End If
+                If MergeUseSiteInfo(modifiersUseSiteInfo, DeriveUseSiteInfoFromType(DirectCast(modifier.Modifier, TypeSymbol)), highestPriorityUseSiteError) Then
+                    Exit For
                 End If
             Next
 
-            Return modifiersErrorInfo
+            Return modifiersUseSiteInfo
         End Function
 
         Friend Overloads Shared Function GetUnificationUseSiteDiagnosticRecursive(Of T As TypeSymbol)(types As ImmutableArray(Of T), owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -191,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Overridable Sub DecodeWellKnownAttribute(ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
             Dim compilation = Me.DeclaringCompilation
             MarkEmbeddedAttributeTypeReference(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation)
-            ReportExtensionAttributeUseSiteError(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation, arguments.Diagnostics)
+            ReportExtensionAttributeUseSiteInfo(arguments.Attribute, arguments.AttributeSyntaxOpt, compilation, DirectCast(arguments.Diagnostics, BindingDiagnosticBag))
         End Sub
 
         ''' <summary>
@@ -214,7 +214,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="decodedData">Decoded well known attribute data.</param>
         Friend Overridable Sub PostDecodeWellKnownAttributes(boundAttributes As ImmutableArray(Of VisualBasicAttributeData),
                                                            allAttributeSyntaxNodes As ImmutableArray(Of AttributeSyntax),
-                                                           diagnostics As DiagnosticBag,
+                                                           diagnostics As BindingDiagnosticBag,
                                                            symbolPart As AttributeLocation,
                                                            decodedData As WellKnownAttributeData)
         End Sub
@@ -233,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                              ByRef lazyCustomAttributesBag As CustomAttributesBag(Of VisualBasicAttributeData),
                                              Optional symbolPart As AttributeLocation = 0)
 
-            Dim diagnostics = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
             Dim sourceAssembly = DirectCast(If(Me.Kind = SymbolKind.Assembly, Me, Me.ContainingAssembly), SourceAssemblySymbol)
             Dim sourceModule = sourceAssembly.SourceModule
             Dim compilation = sourceAssembly.DeclaringCompilation
@@ -439,7 +439,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             binders As ImmutableArray(Of Binder),
             attributeSyntaxList As ImmutableArray(Of AttributeSyntax),
             boundAttributes As ImmutableArray(Of VisualBasicAttributeData),
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             symbolPart As AttributeLocation) As WellKnownAttributeData
 
             Debug.Assert(binders.Any())
@@ -484,13 +484,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             node As AttributeSyntax,
             compilation As VisualBasicCompilation,
             symbolPart As AttributeLocation,
-            diagnostics As DiagnosticBag,
+            diagnostics As BindingDiagnosticBag,
             uniqueAttributeTypes As HashSet(Of NamedTypeSymbol)) As Boolean
 
             Dim attributeType As NamedTypeSymbol = attribute.AttributeClass
             Debug.Assert(attributeType IsNot Nothing)
             Debug.Assert(Not attributeType.IsErrorType())
-            Debug.Assert(attributeType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute, compilation, Nothing))
+            Debug.Assert(attributeType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute, compilation, CompoundUseSiteInfo(Of AssemblySymbol).Discarded))
 
             ' Get attribute usage for this attribute
             Dim attributeUsage As AttributeUsageInfo = attributeType.GetAttributeUsageInfo()
@@ -583,15 +583,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return True
         End Function
 
-        Private Sub ReportExtensionAttributeUseSiteError(attribute As VisualBasicAttributeData, nodeOpt As AttributeSyntax, compilation As VisualBasicCompilation, diagnostics As DiagnosticBag)
+        Private Sub ReportExtensionAttributeUseSiteInfo(attribute As VisualBasicAttributeData, nodeOpt As AttributeSyntax, compilation As VisualBasicCompilation, diagnostics As BindingDiagnosticBag)
             ' report issues with a custom extension attribute everywhere, where the attribute is used in source
             ' (we will not report in location where it's implicitly used (like the containing module or assembly of extension methods)
-            Dim useSiteError As DiagnosticInfo = Nothing
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Nothing
             If attribute.AttributeConstructor IsNot Nothing AndAlso
-                attribute.AttributeConstructor Is compilation.GetExtensionAttributeConstructor(useSiteError) Then
-                If useSiteError IsNot Nothing Then
-                    diagnostics.Add(useSiteError, If(nodeOpt IsNot Nothing, nodeOpt.GetLocation(), NoLocation.Singleton))
-                End If
+                attribute.AttributeConstructor Is compilation.GetExtensionAttributeConstructor(useSiteInfo) Then
+                diagnostics.Add(useSiteInfo, If(nodeOpt IsNot Nothing, nodeOpt.GetLocation(), NoLocation.Singleton))
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedAttributeData.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Optional namedArguments As ImmutableArray(Of KeyValuePair(Of String, TypedConstant)) = Nothing) As SynthesizedAttributeData
 
             ' If we reach here, unlikely a VBCore scenario.  Will result in ERR_MissingRuntimeHelper diagnostic            
-            If Binder.GetUseSiteErrorForWellKnownTypeMember(constructorSymbol, constructor, False) IsNot Nothing Then
+            If Binder.GetUseSiteInfoForWellKnownTypeMember(constructorSymbol, constructor, False).DiagnosticInfo IsNot Nothing Then
                 If WellKnownMembers.IsSynthesizedAttributeOptional(constructor) Then
                     Return Nothing
                 Else

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedConstructorBase.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedConstructorBase.vb
@@ -33,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             container As NamedTypeSymbol,
             isShared As Boolean,
             binder As Binder,
-            diagnostics As DiagnosticBag
+            diagnostics As BindingDiagnosticBag
         )
             MyBase.New(container)
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedEventDelegateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedEventDelegateSymbol.vb
@@ -54,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim sourceModule = DirectCast(Me.ContainingModule, SourceModuleSymbol)
             Dim binder As binder = BinderBuilder.CreateBinderForType(sourceModule, _syntaxRef.SyntaxTree, Me.ContainingType)
 
-            Dim diagBag = DiagnosticBag.GetInstance()
+            Dim diagBag = BindingDiagnosticBag.GetInstance()
 
             Dim syntax = Me.EventSyntax
             Dim paramListOpt = syntax.ParameterList
@@ -226,19 +226,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return MakeDeclaredBase(Nothing, diagnostics)
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return _containingType.ContainingAssembly.GetSpecialType(Microsoft.CodeAnalysis.SpecialType.System_MulticastDelegate)
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
@@ -380,7 +380,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             cancellationToken.ThrowIfCancellationRequested()
 
-            Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance()
 
             ' Force parameters and return value of Invoke method to be bound and errors reported.
             ' Parameters on other delegate methods are derived from Invoke so we don't need to call those.

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethod.vb
@@ -93,7 +93,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim type = ContainingAssembly.GetSpecialType(SpecialType.System_Void)
                 ' WARN: We assume that if System_Void was not found we would never reach 
                 '       this point because the error should have been/processed generated earlier
-                Debug.Assert(type.GetUseSiteErrorInfo() Is Nothing)
+                Debug.Assert(type.GetUseSiteInfo().DiagnosticInfo Is Nothing)
                 Return type
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedPropertyAccessorBase.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedPropertyAccessorBase.vb
@@ -11,7 +11,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend MustOverride ReadOnly Property BackingFieldSymbol As FieldSymbol
 
-        Friend Overloads Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overloads Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
             Return SynthesizedPropertyAccessorHelper.GetBoundMethodBody(Me, Me.BackingFieldSymbol, methodBodyBinder)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -119,8 +119,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Return Me._useSiteDiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Return New UseSiteInfo(Of AssemblySymbol)(Me._useSiteDiagnosticInfo)
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleEventSymbol.vb
@@ -80,10 +80,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Me._containingType = container
         End Sub
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Dim useSiteDiagnostic As DiagnosticInfo = MyBase.GetUseSiteErrorInfo
-            MyBase.MergeUseSiteErrorInfo(useSiteDiagnostic, Me._underlyingEvent.GetUseSiteErrorInfo())
-            Return useSiteDiagnostic
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MyBase.GetUseSiteInfo
+            MyBase.MergeUseSiteInfo(useSiteInfo, Me._underlyingEvent.GetUseSiteInfo())
+            Return useSiteInfo
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -95,10 +95,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Me._underlyingField.GetAttributes()
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Dim useSiteDiagnostic As DiagnosticInfo = MyBase.GetUseSiteErrorInfo
-            MyBase.MergeUseSiteErrorInfo(useSiteDiagnostic, Me._underlyingField.GetUseSiteErrorInfo())
-            Return useSiteDiagnostic
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MyBase.GetUseSiteInfo
+            MyBase.MergeUseSiteInfo(useSiteInfo, Me._underlyingField.GetUseSiteInfo())
+            Return useSiteInfo
         End Function
 
         Public Overrides Function GetHashCode() As Integer
@@ -231,13 +231,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Me._cannotUse = cannotUse
         End Sub
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             If _cannotUse Then
-                Return ErrorFactory.ErrorInfo(ERRID.ERR_TupleInferredNamesNotAvailable, _name,
-                                              New VisualBasicRequiredLanguageVersion(LanguageVersion.VisualBasic15_3))
+                Return New UseSiteInfo(Of AssemblySymbol)(ErrorFactory.ErrorInfo(ERRID.ERR_TupleInferredNamesNotAvailable, _name,
+                                                                                 New VisualBasicRequiredLanguageVersion(LanguageVersion.VisualBasic15_3)))
             End If
 
-            Return MyBase.GetUseSiteErrorInfo()
+            Return MyBase.GetUseSiteInfo()
         End Function
 
         Public Overrides ReadOnly Property Name As String

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
@@ -126,10 +126,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Dim useSiteDiagnostic As DiagnosticInfo = MyBase.GetUseSiteErrorInfo()
-            MyBase.MergeUseSiteErrorInfo(useSiteDiagnostic, Me._underlyingMethod.GetUseSiteErrorInfo())
-            Return useSiteDiagnostic
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MyBase.GetUseSiteInfo()
+            MyBase.MergeUseSiteInfo(useSiteInfo, Me._underlyingMethod.GetUseSiteInfo())
+            Return useSiteInfo
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TuplePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TuplePropertySymbol.vb
@@ -108,10 +108,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Me._underlyingProperty.Parameters.SelectAsArray(Of ParameterSymbol)(Function(p) New TupleParameterSymbol(Me, p))
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Dim useSiteDiagnostic As DiagnosticInfo = MyBase.GetUseSiteErrorInfo
-            MyBase.MergeUseSiteErrorInfo(useSiteDiagnostic, Me._underlyingProperty.GetUseSiteErrorInfo())
-            Return useSiteDiagnostic
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = MyBase.GetUseSiteInfo
+            MyBase.MergeUseSiteInfo(useSiteInfo, Me._underlyingProperty.GetUseSiteInfo())
+            Return useSiteInfo
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -357,7 +357,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                      shouldCheckConstraints As Boolean,
                                      errorPositions As ImmutableArray(Of Boolean),
                                      Optional syntax As SyntaxNode = Nothing,
-                                     Optional diagnostics As DiagnosticBag = Nothing) As TupleTypeSymbol
+                                     Optional diagnostics As BindingDiagnosticBag = Nothing) As TupleTypeSymbol
             Debug.Assert(Not shouldCheckConstraints OrElse syntax IsNot Nothing)
             Debug.Assert(elementNames.IsDefault OrElse elementTypes.Length = elementNames.Length)
             Dim length As Integer = elementTypes.Length
@@ -367,9 +367,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim tupleUnderlyingType As NamedTypeSymbol = TupleTypeSymbol.GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics)
-            If diagnostics IsNot Nothing AndAlso DirectCast(compilation.SourceModule, SourceModuleSymbol).AnyReferencedAssembliesAreLinked Then
+            If diagnostics?.DiagnosticBag IsNot Nothing AndAlso DirectCast(compilation.SourceModule, SourceModuleSymbol).AnyReferencedAssembliesAreLinked Then
                 ' Complain about unembeddable types from linked assemblies.
-                Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(tupleUnderlyingType, syntax, diagnostics)
+                Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(tupleUnderlyingType, syntax, diagnostics.DiagnosticBag)
             End If
 
             Dim constructedType = TupleTypeSymbol.Create(locationOpt, tupleUnderlyingType, elementLocations, elementNames, errorPositions)
@@ -536,7 +536,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return (numElements - 1) \ (RestPosition - 1) + 1
         End Function
 
-        Private Shared Function GetTupleUnderlyingType(elementTypes As ImmutableArray(Of TypeSymbol), syntax As SyntaxNode, compilation As VisualBasicCompilation, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Private Shared Function GetTupleUnderlyingType(elementTypes As ImmutableArray(Of TypeSymbol), syntax As SyntaxNode, compilation As VisualBasicCompilation, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Dim numElements As Integer = elementTypes.Length
             Dim remainder As Integer
             Dim chainLength As Integer = TupleTypeSymbol.NumberOfValueTuples(numElements, remainder)
@@ -544,7 +544,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim wellKnownType As NamedTypeSymbol = compilation.GetWellKnownType(TupleTypeSymbol.GetTupleType(remainder))
 
             If diagnostics IsNot Nothing AndAlso syntax IsNot Nothing Then
-                Binder.ReportUseSiteError(diagnostics, syntax, wellKnownType)
+                Binder.ReportUseSite(diagnostics, syntax, wellKnownType)
             End If
 
             Dim namedTypeSymbol As NamedTypeSymbol = wellKnownType.Construct(ImmutableArray.Create(Of TypeSymbol)(elementTypes, (chainLength - 1) * (TupleTypeSymbol.RestPosition - 1), remainder))
@@ -553,7 +553,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim wellKnownType2 As NamedTypeSymbol = compilation.GetWellKnownType(TupleTypeSymbol.GetTupleType(TupleTypeSymbol.RestPosition))
 
                 If diagnostics IsNot Nothing AndAlso syntax IsNot Nothing Then
-                    Binder.ReportUseSiteError(diagnostics, syntax, wellKnownType2)
+                    Binder.ReportUseSite(diagnostics, syntax, wellKnownType2)
                 End If
                 Do
                     Dim typeArguments As ImmutableArray(Of TypeSymbol) = ImmutableArray.Create(Of TypeSymbol)(elementTypes, ([loop] - 1) * (TupleTypeSymbol.RestPosition - 1), TupleTypeSymbol.RestPosition - 1).Add(namedTypeSymbol)
@@ -564,16 +564,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return namedTypeSymbol
         End Function
 
-        Friend Shared Sub VerifyTupleTypePresent(cardinality As Integer, syntax As VisualBasicSyntaxNode, compilation As VisualBasicCompilation, diagnostics As DiagnosticBag)
+        Friend Shared Sub VerifyTupleTypePresent(cardinality As Integer, syntax As VisualBasicSyntaxNode, compilation As VisualBasicCompilation, diagnostics As BindingDiagnosticBag)
             Debug.Assert(diagnostics IsNot Nothing AndAlso syntax IsNot Nothing)
             Dim arity As Integer
             Dim num As Integer = TupleTypeSymbol.NumberOfValueTuples(cardinality, arity)
             Dim wellKnownType As NamedTypeSymbol = compilation.GetWellKnownType(TupleTypeSymbol.GetTupleType(arity))
-            Binder.ReportUseSiteError(diagnostics, syntax, wellKnownType)
+            Binder.ReportUseSite(diagnostics, syntax, wellKnownType)
 
             If num > 1 Then
                 Dim wellKnownType2 As NamedTypeSymbol = compilation.GetWellKnownType(TupleTypeSymbol.GetTupleType(TupleTypeSymbol.RestPosition))
-                Binder.ReportUseSiteError(diagnostics, syntax, wellKnownType2)
+                Binder.ReportUseSite(diagnostics, syntax, wellKnownType2)
             End If
         End Sub
 
@@ -637,17 +637,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return VisualBasicCompilation.GetRuntimeMember(type, descriptor, VisualBasicCompilation.SpecialMembersSignatureComparer.Instance, Nothing)
         End Function
 
-        Friend Shared Function GetWellKnownMemberInType(type As NamedTypeSymbol, relativeMember As WellKnownMember, diagnostics As DiagnosticBag, syntax As SyntaxNode) As Symbol
+        Friend Shared Function GetWellKnownMemberInType(type As NamedTypeSymbol, relativeMember As WellKnownMember, diagnostics As BindingDiagnosticBag, syntax As SyntaxNode) As Symbol
             Dim wellKnownMemberInType As Symbol = TupleTypeSymbol.GetWellKnownMemberInType(type, relativeMember)
 
             If wellKnownMemberInType Is Nothing Then
                 Dim descriptor As MemberDescriptor = WellKnownMembers.GetDescriptor(relativeMember)
                 Binder.ReportDiagnostic(diagnostics, syntax, ERRID.ERR_MissingRuntimeHelper, type.Name & "."c & descriptor.Name)
             Else
-                Dim useSiteDiagnostic As DiagnosticInfo = wellKnownMemberInType.GetUseSiteErrorInfo
-                If useSiteDiagnostic IsNot Nothing AndAlso useSiteDiagnostic.Severity = DiagnosticSeverity.[Error] Then
-                    diagnostics.Add(useSiteDiagnostic, syntax.GetLocation())
-                End If
+                Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = wellKnownMemberInType.GetUseSiteInfo
+                diagnostics.Add(useSiteInfo, syntax.GetLocation())
             End If
             Return wellKnownMemberInType
         End Function
@@ -1002,8 +1000,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Me._underlyingType.GetHashCode()
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Return Me._underlyingType.GetUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Return Me._underlyingType.GetUseSiteInfo()
         End Function
 
         Friend Overrides Function GetUnificationUseSiteDiagnosticRecursive(owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo
@@ -1064,19 +1062,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return New TypeWithModifiers(tupleType, Nothing)
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Me._underlyingType.MakeDeclaredBase(basesBeingResolved, diagnostics)
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return Me._underlyingType.MakeDeclaredInterfaces(basesBeingResolved, diagnostics)
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Me._underlyingType.MakeAcyclicBaseType(diagnostics)
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return Me._underlyingType.MakeAcyclicInterfaces(diagnostics)
         End Function
 
@@ -1090,7 +1088,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
         End Function
 
-        Friend Shared Sub ReportNamesMismatchesIfAny(destination As TypeSymbol, literal As BoundTupleLiteral, diagnostics As DiagnosticBag)
+        Friend Shared Sub ReportNamesMismatchesIfAny(destination As TypeSymbol, literal As BoundTupleLiteral, diagnostics As BindingDiagnosticBag)
             Dim sourceNames = literal.ArgumentNamesOpt
 
             If sourceNames.IsDefault Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeParameterSymbol.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Public MustOverride ReadOnly Property Ordinal As Integer
 
-        Friend Overridable Function GetConstraintsUseSiteErrorInfo() As DiagnosticInfo
+        Friend Overridable Function GetConstraintsUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             Return Nothing
         End Function
 
@@ -59,13 +59,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend MustOverride ReadOnly Property ConstraintTypesNoUseSiteDiagnostics As ImmutableArray(Of TypeSymbol)
 
-        Friend Function ConstraintTypesWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of TypeSymbol)
+        Friend Function ConstraintTypesWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of TypeSymbol)
             Dim result = ConstraintTypesNoUseSiteDiagnostics
 
-            Me.AddConstraintsUseSiteDiagnostics(useSiteDiagnostics)
+            Me.AddConstraintsUseSiteInfo(useSiteInfo)
 
             For Each constraint In result
-                constraint.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                constraint.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
             Next
 
             Return result

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -92,22 +92,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         Friend MustOverride ReadOnly Property BaseTypeNoUseSiteDiagnostics As NamedTypeSymbol
 
-        Friend Function BaseTypeWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As NamedTypeSymbol
+        Friend Function BaseTypeWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As NamedTypeSymbol
             Dim result = BaseTypeNoUseSiteDiagnostics
 
             If result IsNot Nothing Then
-                result.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                result.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
             End If
 
             Return result
         End Function
 
-        Friend Function BaseTypeOriginalDefinition(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As NamedTypeSymbol
+        Friend Function BaseTypeOriginalDefinition(<[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As NamedTypeSymbol
             Dim result = BaseTypeNoUseSiteDiagnostics
 
             If result IsNot Nothing Then
                 result = result.OriginalDefinition
-                result.AddUseSiteDiagnostics(useSiteDiagnostics)
+                result.AddUseSiteInfo(useSiteInfo)
             End If
 
             Return result
@@ -139,14 +139,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Friend Function AllInterfacesWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Function AllInterfacesWithDefinitionUseSiteDiagnostics(<[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As ImmutableArray(Of NamedTypeSymbol)
             Dim result = AllInterfacesNoUseSiteDiagnostics
 
             ' Since bases affect content of AllInterfaces set, we need to make sure they all are good.
-            Me.AddUseSiteDiagnosticsForBaseDefinitions(useSiteDiagnostics)
+            Me.AddUseSiteDiagnosticsForBaseDefinitions(useSiteInfo)
 
             For Each iface In result
-                iface.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                iface.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
             Next
 
             Return result
@@ -266,7 +266,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Gets the kind of this type.
         ''' </summary>
-        Public MustOverride ReadOnly Property TypeKind As TYPEKIND
+        Public MustOverride ReadOnly Property TypeKind As TypeKind
 
         ''' <summary>
         ''' Gets corresponding special TypeId of this type.
@@ -426,11 +426,11 @@ Done:
             Return BaseTypeNoUseSiteDiagnostics
         End Function
 
-        Friend Overridable Function GetDirectBaseTypeWithDefinitionUseSiteDiagnostics(basesBeingResolved As BasesBeingResolved, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As NamedTypeSymbol
+        Friend Overridable Function GetDirectBaseTypeWithDefinitionUseSiteDiagnostics(basesBeingResolved As BasesBeingResolved, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As NamedTypeSymbol
             Dim result = GetDirectBaseTypeNoUseSiteDiagnostics(basesBeingResolved)
 
             If result IsNot Nothing Then
-                result.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                result.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
             End If
 
             Return result
@@ -511,7 +511,7 @@ Done:
 
         Public NotOverridable Overrides ReadOnly Property HasUnsupportedMetadata As Boolean
             Get
-                Dim info As DiagnosticInfo = GetUseSiteErrorInfo()
+                Dim info As DiagnosticInfo = GetUseSiteInfo().DiagnosticInfo
                 Return info IsNot Nothing AndAlso info.Code = ERRID.ERR_UnsupportedType1
             End Get
         End Property
@@ -621,7 +621,7 @@ Done:
             End If
 
             If Not interfaceMember.ContainingType.IsInterfaceType() OrElse
-               Not Me.ImplementsInterface(interfaceMember.ContainingType, comparer:=EqualsIgnoringComparer.InstanceCLRSignatureCompare, useSiteDiagnostics:=Nothing) Then
+               Not Me.ImplementsInterface(interfaceMember.ContainingType, comparer:=EqualsIgnoringComparer.InstanceCLRSignatureCompare, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                 Return Nothing
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -596,11 +596,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Function CanContainUserDefinedOperators(this As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function CanContainUserDefinedOperators(this As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
 
             If this.Kind = SymbolKind.TypeParameter Then
-                For Each constraint In DirectCast(this, TypeParameterSymbol).ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
-                    If CanContainUserDefinedOperators(constraint, useSiteDiagnostics) Then
+                For Each constraint In DirectCast(this, TypeParameterSymbol).ConstraintTypesWithDefinitionUseSiteDiagnostics(useSiteInfo)
+                    If CanContainUserDefinedOperators(constraint, useSiteInfo) Then
                         Return True
                     End If
                 Next
@@ -655,12 +655,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Function ImplementsInterface(subType As TypeSymbol, superInterface As TypeSymbol, comparer As EqualityComparer(Of TypeSymbol), <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function ImplementsInterface(subType As TypeSymbol, superInterface As TypeSymbol, comparer As EqualityComparer(Of TypeSymbol), <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             If comparer Is Nothing Then
                 comparer = EqualityComparer(Of TypeSymbol).Default
             End If
 
-            For Each [interface] In subType.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+            For Each [interface] In subType.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
 
                 If [interface].IsInterface AndAlso
                    comparer.Equals([interface], superInterface) Then
@@ -673,56 +673,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Sub AddUseSiteDiagnostics(
+        Public Sub AddUseSiteInfo(
             type As TypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
-            Dim errorInfo As DiagnosticInfo = type.GetUseSiteErrorInfo()
-
-            If errorInfo IsNot Nothing Then
-                If useSiteDiagnostics Is Nothing Then
-                    useSiteDiagnostics = New HashSet(Of DiagnosticInfo)()
-                End If
-
-                useSiteDiagnostics.Add(errorInfo)
-            End If
+            useSiteInfo.Add(type.GetUseSiteInfo())
         End Sub
 
         <Extension()>
         Public Sub AddUseSiteDiagnosticsForBaseDefinitions(
             source As TypeSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
             Dim current As TypeSymbol = source
 
             Do
-                current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
             Loop While current IsNot Nothing
         End Sub
 
         <Extension()>
-        Public Sub AddConstraintsUseSiteDiagnostics(
+        Public Sub AddConstraintsUseSiteInfo(
             type As TypeParameterSymbol,
-            <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
+            <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
-            Dim errorInfo As DiagnosticInfo = type.GetConstraintsUseSiteErrorInfo()
-
-            If errorInfo IsNot Nothing Then
-                If useSiteDiagnostics Is Nothing Then
-                    useSiteDiagnostics = New HashSet(Of DiagnosticInfo)()
-                End If
-
-                useSiteDiagnostics.Add(errorInfo)
-            End If
+            useSiteInfo.Add(type.GetConstraintsUseSiteInfo())
         End Sub
 
         <Extension()>
-        Public Function IsBaseTypeOf(superType As TypeSymbol, subType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function IsBaseTypeOf(superType As TypeSymbol, subType As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Dim current As TypeSymbol = subType
 
             While current IsNot Nothing
                 If current IsNot subType Then
-                    current.OriginalDefinition.AddUseSiteDiagnostics(useSiteDiagnostics)
+                    current.OriginalDefinition.AddUseSiteInfo(useSiteInfo)
                 End If
 
                 If current.IsSameTypeIgnoringAll(superType) Then
@@ -736,33 +720,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Function IsOrDerivedFrom(derivedType As NamedTypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function IsOrDerivedFrom(derivedType As NamedTypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Dim current = derivedType
             While current IsNot Nothing
                 If current.IsSameTypeIgnoringAll(baseType) Then
                     Return True
                 End If
 
-                current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                current = current.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
             End While
 
             Return False
         End Function
 
         <Extension()>
-        Public Function IsOrDerivedFrom(derivedType As TypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function IsOrDerivedFrom(derivedType As TypeSymbol, baseType As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Debug.Assert(Not baseType.IsInterfaceType()) ' Not checking interfaces below.
 
             While (derivedType IsNot Nothing)
                 Select Case derivedType.TypeKind
                     Case TypeKind.Array
-                        derivedType = derivedType.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteDiagnostics)
+                        derivedType = derivedType.BaseTypeWithDefinitionUseSiteDiagnostics(useSiteInfo)
                     Case TypeKind.TypeParameter
                         ' Use GetNonInterfaceConstraint rather than GetClassConstraint
                         ' in case the well-known type is a specific structure or enum.
-                        derivedType = DirectCast(derivedType, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteDiagnostics)
+                        derivedType = DirectCast(derivedType, TypeParameterSymbol).GetNonInterfaceConstraint(useSiteInfo)
                     Case Else
-                        Return DirectCast(derivedType, NamedTypeSymbol).IsOrDerivedFrom(baseType, useSiteDiagnostics)
+                        Return DirectCast(derivedType, NamedTypeSymbol).IsOrDerivedFrom(baseType, useSiteInfo)
                 End Select
             End While
 
@@ -770,8 +754,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Function IsOrDerivedFromWellKnownClass(derivedType As TypeSymbol, wellKnownBaseType As WellKnownType, compilation As VisualBasicCompilation, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
-            Return derivedType.IsOrDerivedFrom(compilation.GetWellKnownType(wellKnownBaseType), useSiteDiagnostics)
+        Public Function IsOrDerivedFromWellKnownClass(derivedType As TypeSymbol, wellKnownBaseType As WellKnownType, compilation As VisualBasicCompilation, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
+            Return derivedType.IsOrDerivedFrom(compilation.GetWellKnownType(wellKnownBaseType), useSiteInfo)
         End Function
 
         ''' <summary>
@@ -782,7 +766,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <returns><c>True</c> if type can be assigned to a IEnumerable(Of <para>typeArgument</para>); otherwise <c>False</c>.</returns>
         ''' <remarks>This is not a general purpose helper.</remarks>
         <Extension()>
-        Public Function IsCompatibleWithGenericIEnumerableOfType(type As TypeSymbol, typeArgument As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function IsCompatibleWithGenericIEnumerableOfType(type As TypeSymbol, typeArgument As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             If typeArgument.IsErrorType Then
                 Return False
             End If
@@ -806,19 +790,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim matchingInterfaces As New HashSet(Of NamedTypeSymbol)()
 
             ' first find all implementations of IEnumerable(Of T)
-            If Binder.IsOrInheritsFromOrImplementsInterface(type, genericIEnumerable, useSiteDiagnostics, matchingInterfaces) Then
+            If Binder.IsOrInheritsFromOrImplementsInterface(type, genericIEnumerable, useSiteInfo, matchingInterfaces) Then
                 If matchingInterfaces.Count > 0 Then
 
                     ' now check if the type argument is compatible with the given type
                     For Each matchingInterface In matchingInterfaces
                         Call Global.System.Diagnostics.Debug.Assert(matchingInterface.Arity = 1)
-                        Dim matchingTypeArgument = matchingInterface.TypeArgumentWithDefinitionUseSiteDiagnostics(0, useSiteDiagnostics)
+                        Dim matchingTypeArgument = matchingInterface.TypeArgumentWithDefinitionUseSiteDiagnostics(0, useSiteInfo)
 
                         If matchingTypeArgument.IsErrorType Then
                             Return False
                         End If
 
-                        Dim conversion = Global.Microsoft.CodeAnalysis.VisualBasic.Conversions.ClassifyDirectCastConversion(matchingTypeArgument, typeArgument, useSiteDiagnostics)
+                        Dim conversion = Global.Microsoft.CodeAnalysis.VisualBasic.Conversions.ClassifyDirectCastConversion(matchingTypeArgument, typeArgument, useSiteInfo)
                         If Global.Microsoft.CodeAnalysis.VisualBasic.Conversions.IsWideningConversion(conversion) Then
                             Return True
                         End If
@@ -830,17 +814,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Function IsOrImplementsIEnumerableOfXElement(type As TypeSymbol, compilation As VisualBasicCompilation, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function IsOrImplementsIEnumerableOfXElement(type As TypeSymbol, compilation As VisualBasicCompilation, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Dim xmlType = compilation.GetWellKnownType(WellKnownType.System_Xml_Linq_XElement)
-            Return type.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteDiagnostics)
+            Return type.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteInfo)
         End Function
 
         <Extension()>
-        Public Function IsBaseTypeOrInterfaceOf(superType As TypeSymbol, subType As TypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Function IsBaseTypeOrInterfaceOf(superType As TypeSymbol, subType As TypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             If superType.IsInterfaceType() Then
-                Return subType.ImplementsInterface(superType, EqualsIgnoringComparer.InstanceCLRSignatureCompare, useSiteDiagnostics)
+                Return subType.ImplementsInterface(superType, EqualsIgnoringComparer.InstanceCLRSignatureCompare, useSiteInfo)
             Else
-                Return superType.IsBaseTypeOf(subType, useSiteDiagnostics)
+                Return superType.IsBaseTypeOf(subType, useSiteInfo)
             End If
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
@@ -250,11 +250,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend MustOverride Overrides Function InternalSubstituteTypeParameters(additionalSubstitution As TypeSubstitution) As TypeWithModifiers
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Nothing
         End Function
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return Nothing
         End Function
 
@@ -266,11 +266,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
@@ -278,8 +278,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
-            Return OriginalDefinition.GetUseSiteErrorInfo()
+        Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
+            Return OriginalDefinition.GetUseSiteInfo()
         End Function
 
         Public MustOverride Overrides Function Equals(obj As Object) As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -31,7 +31,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private _lazyExtensionAttributeConstructorErrorInfo As Object 'Actually, DiagnosticInfo
 
 #Region "Synthesized Attributes"
-        Friend Function GetExtensionAttributeConstructor(<Out> ByRef useSiteError As DiagnosticInfo) As MethodSymbol
+        Friend Function GetExtensionAttributeConstructor(<Out> ByRef useSiteInfo As UseSiteInfo(Of AssemblySymbol)) As MethodSymbol
+
+            Dim attributeCtor As MethodSymbol = Nothing
+            Dim ctorError As DiagnosticInfo = Nothing
+
             If _lazyExtensionAttributeConstructor Is ErrorTypeSymbol.UnknownResultType Then
 
                 Dim system_Runtime_CompilerServices = Me.GlobalNamespace.LookupNestedNamespace(ImmutableArray.Create(MetadataHelpers.SystemString, "Runtime", "CompilerServices"))
@@ -45,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim ambiguity As Boolean = False
 
                     For Each candidate As NamedTypeSymbol In candidates
-                        If Not sourceModuleBinder.IsAccessible(candidate, useSiteDiagnostics:=Nothing) Then
+                        If Not sourceModuleBinder.IsAccessible(candidate, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                             Continue For
                         End If
 
@@ -78,17 +82,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     End If
                 End If
 
-                Dim attributeCtor As MethodSymbol = Nothing
-
                 If attributeType IsNot Nothing AndAlso
                    Not attributeType.IsStructureType AndAlso
                    Not attributeType.IsMustInherit AndAlso
-                   GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(attributeType, Nothing) AndAlso
-                   sourceModuleBinder.IsAccessible(attributeType, useSiteDiagnostics:=Nothing) Then
+                   GetWellKnownType(WellKnownType.System_Attribute).IsBaseTypeOf(attributeType, CompoundUseSiteInfo(Of AssemblySymbol).Discarded) AndAlso
+                   sourceModuleBinder.IsAccessible(attributeType, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
 
                     For Each ctor In attributeType.InstanceConstructors
                         If ctor.ParameterCount = 0 Then
-                            If sourceModuleBinder.IsAccessible(ctor, useSiteDiagnostics:=Nothing) Then
+                            If sourceModuleBinder.IsAccessible(ctor, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded) Then
                                 attributeCtor = ctor
                             End If
 
@@ -96,8 +98,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         End If
                     Next
                 End If
-
-                Dim ctorError As DiagnosticInfo = Nothing
 
                 If attributeCtor Is Nothing Then
                     ' TODO (tomat): It is not clear under what circumstances is this error reported since the binder already reports errors when the conditions above are not satisfied.
@@ -110,8 +110,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Const requiredTargets As AttributeTargets = AttributeTargets.Assembly Or AttributeTargets.Class Or AttributeTargets.Method
                     If (attributeUsage.ValidTargets And requiredTargets) <> requiredTargets Then
                         ctorError = ErrorFactory.ErrorInfo(ERRID.ERR_ExtensionAttributeInvalid)
-                    Else
-                        ctorError = If(attributeCtor.GetUseSiteErrorInfo(), attributeCtor.ContainingType.GetUseSiteErrorInfo())
                     End If
                 End If
 
@@ -122,8 +120,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             DirectCast(ErrorTypeSymbol.UnknownResultType, Symbol))
             End If
 
-            useSiteError = DirectCast(Volatile.Read(_lazyExtensionAttributeConstructorErrorInfo), DiagnosticInfo)
-            Return DirectCast(_lazyExtensionAttributeConstructor, MethodSymbol)
+            attributeCtor = DirectCast(_lazyExtensionAttributeConstructor, MethodSymbol)
+            ctorError = DirectCast(Volatile.Read(_lazyExtensionAttributeConstructorErrorInfo), DiagnosticInfo)
+
+            If ctorError IsNot Nothing Then
+                useSiteInfo = New UseSiteInfo(Of AssemblySymbol)(ctorError)
+            Else
+                useSiteInfo = Binder.GetUseSiteInfoForMemberAndContainingType(attributeCtor)
+            End If
+
+            Return attributeCtor
         End Function
 
         ''' <summary>
@@ -150,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim constructorSymbol = TryCast(GetWellKnownTypeMember(constructor), MethodSymbol)
             If constructorSymbol Is Nothing OrElse
-               Binder.GetUseSiteErrorForWellKnownTypeMember(constructorSymbol, constructor, False) IsNot Nothing Then
+               Binder.GetUseSiteInfoForWellKnownTypeMember(constructorSymbol, constructor, False).DiagnosticInfo IsNot Nothing Then
                 Return ReturnNothingOrThrowIfAttributeNonOptional(constructor, isOptionalUse)
             End If
 
@@ -167,7 +173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim wellKnownMember = GetWellKnownTypeMember(arg.Key)
                     If wellKnownMember Is Nothing OrElse
                        TypeOf wellKnownMember Is ErrorTypeSymbol OrElse
-                       Binder.GetUseSiteErrorForWellKnownTypeMember(wellKnownMember, arg.Key, False) IsNot Nothing Then
+                       Binder.GetUseSiteInfoForWellKnownTypeMember(wellKnownMember, arg.Key, False).DiagnosticInfo IsNot Nothing Then
                         Return ReturnNothingOrThrowIfAttributeNonOptional(constructor)
                     Else
                         builder.Add(New KeyValuePair(Of String, TypedConstant)(wellKnownMember.Name, arg.Value))
@@ -188,11 +194,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Function SynthesizeExtensionAttribute() As SynthesizedAttributeData
-            Dim constructor As MethodSymbol = GetExtensionAttributeConstructor(useSiteError:=Nothing)
+            Dim constructor As MethodSymbol = GetExtensionAttributeConstructor(useSiteInfo:=Nothing)
 
             Debug.Assert(constructor IsNot Nothing AndAlso
-                         constructor.GetUseSiteErrorInfo() Is Nothing AndAlso
-                         constructor.ContainingType.GetUseSiteErrorInfo() Is Nothing)
+                         constructor.GetUseSiteInfo().DiagnosticInfo Is Nothing AndAlso
+                         constructor.ContainingType.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
             Return SynthesizedAttributeData.Create(constructor, WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor)
         End Function
@@ -226,10 +232,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             value.GetBits(isNegative, scale, low, mid, high)
 
             Dim specialTypeByte = GetSpecialType(SpecialType.System_Byte)
-            Debug.Assert(specialTypeByte.GetUseSiteErrorInfo() Is Nothing)
+            Debug.Assert(specialTypeByte.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
             Dim specialTypeUInt32 = GetSpecialType(SpecialType.System_UInt32)
-            Debug.Assert(specialTypeUInt32.GetUseSiteErrorInfo() Is Nothing)
+            Debug.Assert(specialTypeUInt32.GetUseSiteInfo().DiagnosticInfo Is Nothing)
 
             Return TrySynthesizeAttribute(
                 WellKnownMember.System_Runtime_CompilerServices_DecimalConstantAttribute__ctor,
@@ -348,7 +354,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return False
             End If
 
-            Return DirectCast(type, NamedTypeSymbol).IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute, Me, useSiteDiagnostics:=Nothing)
+            Return DirectCast(type, NamedTypeSymbol).IsOrDerivedFromWellKnownClass(WellKnownType.System_Attribute, Me, useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Utilities/VarianceAmbiguity.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/VarianceAmbiguity.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Otherwise, if ambiguity wasn't caused in any positions, then left/right are fine.
         ''' Otherwise, left/right have an ambiguity.
         ''' </summary>
-        Public Shared Function HasVarianceAmbiguity(containingType As NamedTypeSymbol, i1 As NamedTypeSymbol, i2 As NamedTypeSymbol, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As Boolean
+        Public Shared Function HasVarianceAmbiguity(containingType As NamedTypeSymbol, i1 As NamedTypeSymbol, i2 As NamedTypeSymbol, <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)) As Boolean
             Debug.Assert(i1.IsInterfaceType() AndAlso i2.IsInterfaceType())
             Debug.Assert(i1.IsGenericType AndAlso i2.IsGenericType)
             Debug.Assert(TypeSymbol.Equals(i1.OriginalDefinition, i2.OriginalDefinition, TypeCompareKind.ConsiderEverything))
@@ -66,10 +66,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' Below call passes "causesAmbiguity" and "preventsAmbiguity" by reference.
                     CheckCorrespondingTypeArguments(containingType,
                                                     nestingType1.TypeParameters(iTypeParameter).Variance,
-                                                    nestingType1.TypeArgumentWithDefinitionUseSiteDiagnostics(iTypeParameter, useSiteDiagnostics),
-                                                    nestingType2.TypeArgumentWithDefinitionUseSiteDiagnostics(iTypeParameter, useSiteDiagnostics),
+                                                    nestingType1.TypeArgumentWithDefinitionUseSiteDiagnostics(iTypeParameter, useSiteInfo),
+                                                    nestingType2.TypeArgumentWithDefinitionUseSiteDiagnostics(iTypeParameter, useSiteInfo),
                                                     causesAmbiguity, preventsAmbiguity,
-                                                    useSiteDiagnostics)
+                                                    useSiteInfo)
                 Next
                 nestingType1 = nestingType1.ContainingType
                 nestingType2 = nestingType2.ContainingType
@@ -115,13 +115,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                            typeArgument2 As TypeSymbol,
                                                            ByRef causesAmbiguity As Boolean,
                                                            ByRef preventsAmbiguity As Boolean,
-                                                           <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                                           <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             If Not typeArgument1.IsSameTypeIgnoringAll(typeArgument2) Then
                 Select Case variance
                     Case VarianceKind.In
                         Dim bothAreClasses = (typeArgument1.IsClassType() AndAlso typeArgument2.IsClassType())
                         Dim oneDerivesFromOther = bothAreClasses AndAlso
-                                (Conversions.ClassifyDirectCastConversion(typeArgument1, typeArgument2, useSiteDiagnostics) And ConversionKind.Reference) <> 0
+                                (Conversions.ClassifyDirectCastConversion(typeArgument1, typeArgument2, useSiteInfo) And ConversionKind.Reference) <> 0
 
                         ' (Note that value types are always NotInheritable)
                         If Not typeArgument1.IsNotInheritable() AndAlso Not typeArgument2.IsNotInheritable() AndAlso

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/FieldInitializerBindingTests.vb
@@ -1576,7 +1576,7 @@ String
 
         Private Shared Function BindInitializersWithoutDiagnostics(typeSymbol As SourceNamedTypeSymbol, initializers As ImmutableArray(Of ImmutableArray(Of FieldOrPropertyInitializer))) As ImmutableArray(Of BoundInitializer)
             Dim diagnostics As DiagnosticBag = DiagnosticBag.GetInstance()
-            Dim processedFieldInitializers = Binder.BindFieldAndPropertyInitializers(typeSymbol, initializers, Nothing, diagnostics)
+            Dim processedFieldInitializers = Binder.BindFieldAndPropertyInitializers(typeSymbol, initializers, Nothing, New BindingDiagnosticBag(diagnostics))
             Dim sealedDiagnostics = diagnostics.ToReadOnlyAndFree()
             For Each d In sealedDiagnostics
                 Console.WriteLine(d)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
                 Return OverloadResolution.MethodInvocationOverloadResolution(
                         methodGroup, arguments, argumentNames, binder, includeEliminatedCandidates:=includeEliminatedCandidates, lateBindingIsAllowed:=lateBindingIsAllowed, callerInfoOpt:=Nothing,
-                        useSiteDiagnostics:=Nothing)
+                        useSiteInfo:=CompoundUseSiteInfo(Of AssemblySymbol).Discarded)
             End Function
         End Module
     End Namespace

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/DocCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/DocCommentTests.vb
@@ -47,7 +47,7 @@ End Class
                     comp,
                     assemblyName:=Nothing,
                     xmlDocStream:=badStream,
-                    diagnostics:=diags,
+                    diagnostics:=New BindingDiagnosticBag(diags),
                     cancellationToken:=Nothing)
 
                 AssertTheseDiagnostics(diags.ToReadOnlyAndFree(),
@@ -12534,7 +12534,7 @@ End Class
                     comp,
                     assemblyName:=Nothing,
                     xmlDocStream:=Nothing,
-                    diagnostics:=diags,
+                    diagnostics:=New BindingDiagnosticBag(diags),
                     cancellationToken:=Nothing,
                     filterTree:=comp.SyntaxTrees(0))
 
@@ -12551,7 +12551,7 @@ BC42312: XML documentation comments must precede member or type declarations.
                     comp,
                     assemblyName:=Nothing,
                     xmlDocStream:=Nothing,
-                    diagnostics:=diags,
+                    diagnostics:=New BindingDiagnosticBag(diags),
                     cancellationToken:=Nothing,
                     filterTree:=comp.SyntaxTrees(0),
                     filterSpanWithinTree:=New Text.TextSpan(0, 0))
@@ -12564,7 +12564,7 @@ BC42312: XML documentation comments must precede member or type declarations.
                     comp,
                     assemblyName:=Nothing,
                     xmlDocStream:=Nothing,
-                    diagnostics:=diags,
+                    diagnostics:=New BindingDiagnosticBag(diags),
                     cancellationToken:=Nothing,
                     filterTree:=comp.SyntaxTrees(1))
 
@@ -12581,7 +12581,7 @@ BC42312: XML documentation comments must precede member or type declarations.
                     comp,
                     assemblyName:=Nothing,
                     xmlDocStream:=Nothing,
-                    diagnostics:=diags,
+                    diagnostics:=New BindingDiagnosticBag(diags),
                     cancellationToken:=Nothing,
                     filterTree:=Nothing)
 
@@ -12601,7 +12601,7 @@ BC42312: XML documentation comments must precede member or type declarations.
                     comp,
                     assemblyName:=Nothing,
                     xmlDocStream:=Nothing,
-                    diagnostics:=diags,
+                    diagnostics:=New BindingDiagnosticBag(diags),
                     cancellationToken:=Nothing,
                     filterTree:=Nothing,
                     filterSpanWithinTree:=New Text.TextSpan(0, 0))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -1425,7 +1425,7 @@ End Module
             Assert.True(module1.ContainingAssembly.MightContainExtensionMethods)
 
             Dim containsExtensions As Boolean
-            DirectCast(module1.ContainingModule, SourceModuleSymbol).GetAllDeclarationErrors(Nothing, containsExtensions)
+            DirectCast(module1.ContainingModule, SourceModuleSymbol).GetAllDeclarationErrors(BindingDiagnosticBag.Discarded, Nothing, containsExtensions)
 
             Assert.False(module1.MightContainExtensionMethods)
             Assert.False(module1.ContainingModule.MightContainExtensionMethods)
@@ -1469,7 +1469,7 @@ End Module
             Assert.True(module1.ContainingAssembly.MightContainExtensionMethods)
 
             Dim containsExtensions As Boolean
-            DirectCast(module1.ContainingModule, SourceModuleSymbol).GetAllDeclarationErrors(Nothing, containsExtensions)
+            DirectCast(module1.ContainingModule, SourceModuleSymbol).GetAllDeclarationErrors(BindingDiagnosticBag.Discarded, Nothing, containsExtensions)
 
             Assert.False(module1.MightContainExtensionMethods)
             Assert.False(module1.ContainingModule.MightContainExtensionMethods)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/EENamedTypeBinder.vb
@@ -46,11 +46,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 name As String, arity As Integer,
                 options As LookupOptions,
                 originalBinder As Binder,
-                <[In]> <Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                <[In]> <Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             Debug.Assert(lookupResult.IsClear) ' We don't require this - it just indicates that we're not wasting effort re-mapping results from other binders.
 
-            _sourceBinder.LookupInSingleBinder(lookupResult, name, arity, options, originalBinder, useSiteDiagnostics)
+            _sourceBinder.LookupInSingleBinder(lookupResult, name, arity, options, originalBinder, useSiteInfo)
 
             Dim substitutedSourceType = Me.ContainingType
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/ParametersAndLocalsBinder.vb
@@ -79,14 +79,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                                               arity As Integer,
                                               options As LookupOptions,
                                               originalBinder As Binder,
-                                              <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+                                              <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
             Debug.Assert(lookupResult.IsClear)
 
             ' Parameters and locals always have arity 0 and are not namespaces or types.
             If (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly Or LookupOptions.MustNotBeLocalOrParameter)) = 0 Then
                 Dim symbol As Symbol = Nothing
                 If _nameToSymbolMap.TryGetValue(name, symbol) Then
-                    lookupResult.SetFrom(CheckViability(symbol, arity, options, Nothing, useSiteDiagnostics))
+                    lookupResult.SetFrom(CheckViability(symbol, arity, options, Nothing, useSiteInfo))
                 End If
             End If
         End Sub

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             arity As Integer,
             options As LookupOptions,
             originalBinder As Binder,
-            <[In]> <Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo))
+            <[In]> <Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol))
 
             If (options And (LookupOptions.NamespacesOrTypesOnly Or LookupOptions.LabelsOnly Or LookupOptions.MustNotBeLocalOrParameter)) <> 0 Then
                 Return
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Dim local As LocalSymbol = Nothing
             If _implicitDeclarations.TryGetValue(name, local) Then
-                result.SetFrom(CheckViability(local, arity, options, Nothing, useSiteDiagnostics))
+                result.SetFrom(CheckViability(local, arity, options, Nothing, useSiteInfo))
             End If
         End Sub
 
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Public Overrides Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As DiagnosticBag) As LocalSymbol
+        Public Overrides Function DeclareImplicitLocalVariable(nameSyntax As IdentifierNameSyntax, diagnostics As BindingDiagnosticBag) As LocalSymbol
             Debug.Assert(_allowImplicitDeclarations)
             Debug.Assert(_implicitDeclarations IsNot Nothing)
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -198,6 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim objectType = Me.Compilation.GetSpecialType(SpecialType.System_Object)
             Dim allTypeParameters = GetAllTypeParameters(_currentFrame)
             Dim additionalTypes = ArrayBuilder(Of NamedTypeSymbol).GetInstance()
+            Dim syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken))
 
             Dim typeVariablesType As EENamedTypeSymbol = Nothing
             If Not argumentsOnly AndAlso allTypeParameters.Length > 0 Then
@@ -207,7 +208,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 typeVariablesType = New EENamedTypeSymbol(
                     Me.Compilation.SourceModule.GlobalNamespace,
                     objectType,
-                    Nothing,
+                    syntax,
                     _currentFrame,
                     ExpressionCompilerConstants.TypeVariablesClassName,
                     Function(m, t)
@@ -223,7 +224,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Dim synthesizedType As New EENamedTypeSymbol(
                 Me.Compilation.SourceModule.GlobalNamespace,
                 objectType,
-                Nothing,
+                syntax,
                 _currentFrame,
                 typeName,
                 Function(m, container)
@@ -240,10 +241,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                                 End If
 
                                 Dim methodName = GetNextMethodName(methodBuilder)
-                                Dim syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken))
                                 Dim local = PlaceholderLocalSymbol.Create(typeNameDecoder, _currentFrame, [alias])
                                 ' Skip pseudo-variables with errors.
-                                If local.GetUseSiteErrorInfo()?.Severity = DiagnosticSeverity.Error Then
+                                If local.GetUseSiteInfo().DiagnosticInfo?.Severity = DiagnosticSeverity.Error Then
                                     Continue For
                                 End If
                                 Dim aliasMethod = Me.CreateMethod(
@@ -486,7 +486,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Private Shared Function BindExpression(binder As Binder, syntax As ExpressionSyntax, diagnostics As DiagnosticBag, <Out> ByRef resultProperties As ResultProperties) As BoundStatement
-            Dim expression = binder.BindExpression(syntax, diagnostics)
+            Dim bindingDiagnostics = New BindingDiagnosticBag(diagnostics)
+            Dim expression = binder.BindExpression(syntax, bindingDiagnostics)
 
             Dim flags = DkmClrCompilationResultFlags.None
             If Not IsAssignableExpression(binder, expression) Then
@@ -502,9 +503,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Try
 
             If IsStatement(expression) Then
-                expression = binder.ReclassifyInvocationExpressionAsStatement(expression, diagnostics)
+                expression = binder.ReclassifyInvocationExpressionAsStatement(expression, bindingDiagnostics)
             Else
-                expression = binder.MakeRValue(expression, diagnostics)
+                expression = binder.MakeRValue(expression, bindingDiagnostics)
             End If
 
             Select Case expression.Type.SpecialType
@@ -521,7 +522,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Private Shared Function IsAssignableExpression(binder As Binder, expression As BoundExpression) As Boolean
-            Dim diagnostics = DiagnosticBag.GetInstance()
+            Dim diagnostics = New BindingDiagnosticBag(DiagnosticBag.GetInstance())
             Dim value = binder.ReclassifyAsValue(expression, diagnostics)
             Dim result = False
             If Binder.IsValidAssignmentTarget(value) AndAlso Not diagnostics.HasAnyErrors() Then
@@ -552,7 +553,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Private Shared Function BindStatement(binder As Binder, syntax As StatementSyntax, diagnostics As DiagnosticBag, <Out> ByRef resultProperties As ResultProperties) As BoundStatement
             resultProperties = New ResultProperties(DkmClrCompilationResultFlags.PotentialSideEffect Or DkmClrCompilationResultFlags.ReadOnlyResult)
-            Return binder.BindStatement(syntax, diagnostics).MakeCompilerGenerated()
+            Return binder.BindStatement(syntax, New BindingDiagnosticBag(diagnostics)).MakeCompilerGenerated()
         End Function
 
         Private Shared Function CreateBinderChain(
@@ -767,9 +768,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     Else
                         Debug.Assert(importRecord.Alias Is Nothing) ' Represented as ImportTargetKind.NamespaceOrType in old-format PDBs.
 
-                        Dim unusedDiagnostics = DiagnosticBag.GetInstance()
-                        typeSymbol = importBinder.BindTypeSyntax(targetSyntax, unusedDiagnostics)
-                        unusedDiagnostics.Free()
+                        typeSymbol = importBinder.BindTypeSyntax(targetSyntax, BindingDiagnosticBag.Discarded)
 
                         Debug.Assert(typeSymbol IsNot Nothing)
 
@@ -807,9 +806,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         Return False
                     End If
 
-                    Dim unusedDiagnostics = DiagnosticBag.GetInstance()
-                    Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, unusedDiagnostics)
-                    unusedDiagnostics.Free()
+                    Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, BindingDiagnosticBag.Discarded)
 
                     Debug.Assert(namespaceOrTypeSymbol IsNot Nothing)
 
@@ -840,9 +837,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     End If
 
                 Case ImportTargetKind.NamespaceOrType ' Aliased namespace or type (native PDB only)
-                    Dim unusedDiagnostics = DiagnosticBag.GetInstance()
-                    Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, unusedDiagnostics)
-                    unusedDiagnostics.Free()
+                    Dim namespaceOrTypeSymbol = importBinder.BindNamespaceOrTypeSyntax(targetSyntax, BindingDiagnosticBag.Discarded)
 
                     Debug.Assert(namespaceOrTypeSymbol IsNot Nothing)
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEConstructorSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEConstructorSymbol.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             MyBase.New(container)
         End Sub
 
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, <Out> ByRef Optional methodBodyBinder As Binder = Nothing) As BoundBlock
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, <Out> ByRef Optional methodBodyBinder As Binder = Nothing) As BoundBlock
             Return New BoundBlock(
                 Me.Syntax,
                 Nothing,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.vb
@@ -51,11 +51,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Friend NotOverridable Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
+        Friend NotOverridable Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)
             Dim localType As TypeSymbol = Me.Type
 
-            Dim info As DiagnosticInfo = DeriveUseSiteErrorInfoFromType(localType)
-            If info IsNot Nothing Then
+            Dim info As UseSiteInfo(Of AssemblySymbol) = DeriveUseSiteInfoFromType(localType)
+            If info.DiagnosticInfo IsNot Nothing Then
                 Return info
             End If
 
@@ -63,7 +63,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 ' If the member is in an assembly with unified references,
                 ' we check if its definition depends on a type from a unified reference.
                 Dim unificationCheckedTypes As HashSet(Of TypeSymbol) = Nothing
-                Return localType.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes)
+                Return New UseSiteInfo(Of AssemblySymbol)(localType.GetUnificationUseSiteDiagnosticRecursive(Me, unificationCheckedTypes))
             End If
 
             Return Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -447,8 +447,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         ''' In VB, the caller (of this method) does that.
         ''' </remarks>
 #Enable Warning CA1200 ' Avoid using cref tags with a prefix
-        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, <Out> ByRef Optional methodBodyBinder As Binder = Nothing) As BoundBlock
-            Dim body = _generateMethodBody(Me, diagnostics, _lazyResultProperties)
+        Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, <Out> ByRef Optional methodBodyBinder As Binder = Nothing) As BoundBlock
+            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
+
+            Dim body = _generateMethodBody(Me, diagnostics.DiagnosticBag, _lazyResultProperties)
             Debug.Assert(body IsNot Nothing)
 
             _lazyReturnType = CalculateReturnType(body)
@@ -484,14 +486,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Return newBody
             End If
 
-            DiagnosticsPass.IssueDiagnostics(newBody, diagnostics, Me)
+            DiagnosticsPass.IssueDiagnostics(newBody, diagnostics.DiagnosticBag, Me)
             If diagnostics.HasAnyErrors() Then
                 Return newBody
             End If
 
             ' Check for use-site errors (e.g. missing types in the signature).
-            Dim useSiteInfo As DiagnosticInfo = Me.CalculateUseSiteErrorInfo()
-            If useSiteInfo IsNot Nothing Then
+            Dim useSiteInfo As UseSiteInfo(Of AssemblySymbol) = Me.CalculateUseSiteInfo()
+            If useSiteInfo.DiagnosticInfo IsNot Nothing Then
                 diagnostics.Add(useSiteInfo, _locations(0))
                 Return newBody
             End If
@@ -506,7 +508,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 newBody = LocalDeclarationRewriter.Rewrite(_compilation, _container, newBody)
 
                 ' Rewrite pseudo-variable references to helper method calls.
-                newBody = DirectCast(PlaceholderLocalRewriter.Rewrite(_compilation, _container, newBody, diagnostics), BoundBlock)
+                newBody = DirectCast(PlaceholderLocalRewriter.Rewrite(_compilation, _container, newBody, diagnostics.DiagnosticBag), BoundBlock)
                 If diagnostics.HasAnyErrors() Then
                     Return newBody
                 End If
@@ -559,7 +561,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
                     displayClassVariables,
                     newBody,
-                    diagnostics), BoundBlock)
+                    diagnostics.DiagnosticBag), BoundBlock)
 
                 If diagnostics.HasAnyErrors() Then
                     Return newBody

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
@@ -44,6 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             sourceTypeParameters As ImmutableArray(Of TypeParameterSymbol),
             getTypeParameters As Func(Of NamedTypeSymbol, EENamedTypeSymbol, ImmutableArray(Of TypeParameterSymbol)))
 
+            Debug.Assert(syntax IsNot Nothing)
             _container = container
             _baseType = baseType
             _syntax = syntax
@@ -293,19 +294,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Friend Overrides Function MakeAcyclicBaseType(diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeAcyclicBaseType(diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return _baseType
         End Function
 
-        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Friend Overrides Function MakeDeclaredBase(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As NamedTypeSymbol
             Return _baseType
         End Function
 
-        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeAcyclicInterfaces(diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 
-        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As DiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
+        Friend Overrides Function MakeDeclaredInterfaces(basesBeingResolved As BasesBeingResolved, diagnostics As BindingDiagnosticBag) As ImmutableArray(Of NamedTypeSymbol)
             Return ImmutableArray(Of NamedTypeSymbol).Empty
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
@@ -121,17 +121,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Dim conversionKind As ConversionKind
             If type.IsErrorType() Then
-                diagnostics.Add(type.GetUseSiteErrorInfo(), syntax.GetLocation())
+                diagnostics.Add(type.GetUseSiteInfo().DiagnosticInfo, syntax.GetLocation())
                 conversionKind = Nothing
             ElseIf exprType.IsErrorType() Then
-                diagnostics.Add(exprType.GetUseSiteErrorInfo(), syntax.GetLocation())
+                diagnostics.Add(exprType.GetUseSiteInfo().DiagnosticInfo, syntax.GetLocation())
                 conversionKind = Nothing
             Else
-                Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
-                Dim pair = Conversions.ClassifyConversion(exprType, type, useSiteDiagnostics)
-                Debug.Assert(useSiteDiagnostics Is Nothing, "If this happens, please add a test")
+                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim pair = Conversions.ClassifyConversion(exprType, type, useSiteInfo)
+                Debug.Assert(useSiteInfo.Diagnostics Is Nothing, "If this happens, please add a test")
 
-                diagnostics.Add(syntax, useSiteDiagnostics)
+                diagnostics.Add(syntax, useSiteInfo.Diagnostics)
 
                 Debug.Assert(pair.Value Is Nothing) ' Conversion method.
                 conversionKind = pair.Key

--- a/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
@@ -261,37 +261,37 @@ namespace Roslyn.Test.Utilities
             throw new NotImplementedException();
         }
 
-        public override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
+        protected override void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute)
         {
             throw new NotImplementedException();
         }
 
-        public override void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
+        protected override void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName)
         {
             throw new NotImplementedException();
         }
 
-        public override void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex)
+        protected override void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex)
         {
             throw new NotImplementedException();
         }
 
-        public override void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
+        protected override void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
             throw new NotImplementedException();
         }
 
-        public override void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
+        protected override void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute)
         {
             throw new NotImplementedException();
         }
 
-        public override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)
+        protected override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName)
         {
             throw new NotImplementedException();
         }
 
-        public override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2)
+        protected override void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This change is continuing work started in https://github.com/dotnet/roslyn/pull/40560. It makes similar changes on VB side.