### PR TITLE
Add Missing Cases for Nullable Enums

### DIFF
--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchExpressionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.PopulateSwitch;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwitch
@@ -995,6 +996,56 @@ class MyClass
         };
     }
 }");
+        }
+
+        [Fact]
+        [WorkItem(40240, "https://github.com/dotnet/roslyn/issues/40240")]
+        public async Task TestAddMissingCasesForNullableEnum()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class Program
+{
+    void Main() 
+    {
+        var bar = Bar.Option1;
+        var b = bar [||]switch
+        {
+            Bar.Option1 => 1,
+            Bar.Option2 => 2,
+            null => null,
+        };
+    }
+
+    public enum Bar
+{
+    Option1, 
+    Option2, 
+    Option3,
+}
+}
+",
+@"public class Program
+{
+    void Main() 
+    {
+        var bar = Bar.Option1;
+        var b = bar switch
+        {
+            Bar.Option1 => 1,
+            Bar.Option2 => 2,
+            null => null,
+            _ => throw new System.NotImplementedException(),
+        };
+    }
+
+    public enum Bar
+{
+    Option1, 
+    Option2, 
+    Option3,
+}
+}
+");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchStatementTests.cs
@@ -976,5 +976,62 @@ class MyClass
     }
 }");
         }
+
+        [Fact]
+        [WorkItem(40240, "https://github.com/dotnet/roslyn/issues/40240")]
+        public async Task TestAddMissingCasesForNullableEnum()
+        {
+            await TestInRegularAndScriptAsync(
+@"public class Program
+{
+    void Main() 
+    {
+        Bar? bar;
+        [||]switch (bar)
+        {
+            case Bar.Option1:
+                break;
+            case Bar.Option2:
+                break;
+            case null:
+                break;
+        }
+    }
+}
+
+public enum Bar
+{
+    Option1, 
+    Option2, 
+    Option3,
+}
+",
+@"public class Program
+{
+    void Main() 
+    {
+        Bar? bar;
+        switch (bar)
+        {
+            case Bar.Option1:
+                break;
+            case Bar.Option2:
+                break;
+            case null:
+                break;
+            case Bar.Option3:
+                break;
+        }
+    }
+}
+
+public enum Bar
+{
+    Option1, 
+    Option2, 
+    Option3,
+}
+");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchStatementTests.vb
@@ -686,5 +686,60 @@ End Class
 
             Await TestAsync(markup, expected)
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        <WorkItem(40240, "https://github.com/dotnet/roslyn/issues/40240")>
+        Public Async Function TestAddMissingCasesForNullableEnum As Task
+            Dim markup =
+<File>
+Module Program
+    Sub Main(args As String())
+        Dim bar As Bar? = Program.Bar.Option1
+
+        [||]Select Case bar
+            Case Program.Bar.Option1
+                Exit Select
+            Case Program.Bar.Option2
+                Exit Select
+            Case vbNull
+                Exit Select
+        End Select
+    End Sub
+
+    Enum Bar
+        Option1 = 1
+        Option2 = 2
+        Option3 = 3
+    End Enum
+End Module
+</File>
+            Dim expected =
+<File>
+Module Program
+    Sub Main(args As String())
+        Dim bar As Bar? = Program.Bar.Option1
+
+        Select Case bar
+            Case Program.Bar.Option1
+                Exit Select
+            Case Program.Bar.Option2
+                Exit Select
+            Case vbNull
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+
+    Enum Bar
+        Option1 = 1
+        Option2 = 2
+        Option3 = 3
+    End Enum
+End Module
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                 // and check if it is of enum type
                 switchExpression?.Type.IsNullable(out switchExpressionType);
             }
+
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {
                 if (!PopulateSwitchStatementHelpers.TryGetAllEnumMembers(switchExpressionType, enumMembers) ||

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -21,13 +21,10 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 
             var enumMembers = new Dictionary<long, ISymbol>();
 
-            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
-            {
-                // Check if the type of the expression is a nullable INamedTypeSymbol
-                // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
-                // and check if it is of enum type
-                switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
-            }
+            // Check if the type of the expression is a nullable INamedTypeSymbol
+            // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
+            // and check if it is of enum type
+            switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
             {
                 // Check if the type of the expression is a nullable INamedTypeSymbol
-                // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
+                // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
                 // and check if it is of enum type
                 switchExpression?.Type.IsNullable(out switchExpressionType);
             }

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -20,13 +21,12 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 
             var enumMembers = new Dictionary<long, ISymbol>();
 
-            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
-                && switchExpressionType is INamedTypeSymbol)
+            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
             {
                 // Check if the type of the expression is a nullable INamedTypeSymbol
                 // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
                 // and check if it is of enum type
-                switchExpressionType = ((INamedTypeSymbol)switchExpressionType).TypeArguments[0];
+                switchExpression?.Type.IsNullable(out switchExpressionType);
             }
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                 // Check if the type of the expression is a nullable INamedTypeSymbol
                 // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
                 // and check if it is of enum type
-                switchExpression?.Type.IsNullable(out switchExpressionType);
+                switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
             }
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -24,7 +24,8 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             // Check if the type of the expression is a nullable INamedTypeSymbol
             // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
             // and check if it is of enum type
-            switchExpressionType = switchExpressionType.IsNullable(out var underlyingType) ? underlyingType : switchExpressionType;
+            if (switchExpressionType != null)
+                switchExpressionType = switchExpressionType.IsNullable(out var underlyingType) ? underlyingType : switchExpressionType;
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchExpressionHelpers.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             // Check if the type of the expression is a nullable INamedTypeSymbol
             // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
             // and check if it is of enum type
-            switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
+            switchExpressionType = switchExpressionType.IsNullable(out var underlyingType) ? underlyingType : switchExpressionType;
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -51,7 +51,8 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             // Check if the type of the expression is a nullable INamedTypeSymbol
             // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
             // and check if it is of enum type
-            switchExpressionType = switchExpressionType.IsNullable(out var underlyingType) ? underlyingType : switchExpressionType;
+            if (switchExpressionType != null)
+                switchExpressionType = switchExpressionType.IsNullable(out var underlyingType) ? underlyingType : switchExpressionType;
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -43,22 +43,22 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
         public static ICollection<ISymbol> GetMissingEnumMembers(ISwitchOperation switchStatement)
         {
             var switchExpression = switchStatement.Value;
-            var switchExpressionType = (INamedTypeSymbol?)switchExpression?.Type;
+            var switchExpressionType = switchExpression?.Type;
 
             var enumMembers = new Dictionary<long, ISymbol>();
+
+            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                && switchExpressionType is INamedTypeSymbol)
+            {
+                // Check if the type of the expression is a nullable INamedTypeSymbol
+                // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
+                // and check if it is of enum type
+                switchExpressionType = ((INamedTypeSymbol)switchExpressionType).TypeArguments[0];
+            }
+
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {
                 if (!TryGetAllEnumMembers(switchExpressionType, enumMembers) ||
-                    !TryRemoveExistingEnumMembers(switchStatement, enumMembers))
-                {
-                    return SpecializedCollections.EmptyCollection<ISymbol>();
-                }
-            }
-            else if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
-                        switchExpressionType?.TypeArguments[0].TypeKind == TypeKind.Enum)
-            {
-                var underlyingEnum = switchExpressionType.TypeArguments[0];
-                if (!TryGetAllEnumMembers(underlyingEnum, enumMembers) ||
                     !TryRemoveExistingEnumMembers(switchStatement, enumMembers))
                 {
                     return SpecializedCollections.EmptyCollection<ISymbol>();

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                 // Check if the type of the expression is a nullable INamedTypeSymbol
                 // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
                 // and check if it is of enum type
-                switchExpression?.Type.IsNullable(out switchExpressionType);
+                switchExpressionType  = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
             }
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -48,13 +48,10 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 
             var enumMembers = new Dictionary<long, ISymbol>();
 
-            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
-            {
-                // Check if the type of the expression is a nullable INamedTypeSymbol
-                // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
-                // and check if it is of enum type
-                switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
-            }
+            // Check if the type of the expression is a nullable INamedTypeSymbol
+            // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
+            // and check if it is of enum type
+            switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             // Check if the type of the expression is a nullable INamedTypeSymbol
             // if the type is both nullable and an INamedTypeSymbol extract the type argument from the nullable
             // and check if it is of enum type
-            switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
+            switchExpressionType = switchExpressionType.IsNullable(out var underlyingType) ? underlyingType : switchExpressionType;
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)
             {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                 // Check if the type of the expression is a nullable INamedTypeSymbol
                 // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
                 // and check if it is of enum type
-                switchExpressionType  = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
+                switchExpressionType = switchExpressionType.IsNullable(out underlyingType) ? underlyingType : switchExpressionType;
             }
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchStatementHelpers.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
@@ -47,13 +48,12 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 
             var enumMembers = new Dictionary<long, ISymbol>();
 
-            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
-                && switchExpressionType is INamedTypeSymbol)
+            if (switchExpressionType?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
             {
                 // Check if the type of the expression is a nullable INamedTypeSymbol
                 // if the type is both nullable and an INamedTypeSymbol extact the type argument from the nullable
                 // and check if it is of enum type
-                switchExpressionType = ((INamedTypeSymbol)switchExpressionType).TypeArguments[0];
+                switchExpression?.Type.IsNullable(out switchExpressionType);
             }
 
             if (switchExpressionType?.TypeKind == TypeKind.Enum)


### PR DESCRIPTION
Fixes #40240.

This PR fixes the 'add missing cases' action to add missing cases to switch statements where the switch expression type is a Nullable Enum.

In C# everything works as expected and the code action performs exactly the same with nullable and non-nullable enum types. However, in Visual Basic there is an issue because the Constant Expressions for the enum values are not being evaluated properly. I have confirmed that everything works as expected with non-nullable enum types. 

I have filed a separate issue to track the above at #40675. I'm not sure if it's related to the fix but I suspect its something else as it works as expected in C#