### PR TITLE
Reduce allocations in Diagnostic.HasIntersectingLocation

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/CSDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/CSDiagnosticInfo.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static readonly DiagnosticInfo EmptyErrorInfo = new CSDiagnosticInfo(0);
         public static readonly DiagnosticInfo VoidDiagnosticInfo = new CSDiagnosticInfo(ErrorCode.Void);
 
-        private readonly ImmutableArray<Location> _additionalLocations;
+        private readonly IReadOnlyList<Location> _additionalLocations;
 
         internal CSDiagnosticInfo(ErrorCode code)
             : this(code, Array.Empty<object>(), ImmutableArray<Symbol>.Empty, ImmutableArray<Location>.Empty)
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Internal errors are abnormal and should not occur except where there are bugs in the compiler.
             Debug.Assert(code != ErrorCode.ERR_InternalError);
-            _additionalLocations = additionalLocations;
+            _additionalLocations = additionalLocations.IsDefaultOrEmpty ? SpecializedCollections.EmptyReadOnlyList<Location>() : additionalLocations;
         }
 
         public override IReadOnlyList<Location> AdditionalLocations => _additionalLocations;

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -474,6 +474,10 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns true if the diagnostic location (or any additional location) is within the given tree and intersects with the filterSpanWithinTree, if non-null.
         /// </summary>
+        [PerformanceSensitive(
+            "https://github.com/dotnet/roslyn/issues/26778",
+            Constraint = "In most cases, AdditionalLocations is empty.",
+            AllowCaptures = false)]
         internal bool HasIntersectingLocation(SyntaxTree tree, TextSpan? filterSpanWithinTree = null)
         {
             if (isLocationWithinSpan(Location, tree, filterSpanWithinTree))
@@ -497,7 +501,6 @@ namespace Microsoft.CodeAnalysis
 
             return false;
 
-            // Local functions
             static bool isLocationWithinSpan(Location location, SyntaxTree tree, TextSpan? filterSpan)
             {
                 if (location.SourceTree != tree)

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -3,6 +3,7 @@
 #nullable enable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -489,23 +490,9 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        private IEnumerable<Location> GetDiagnosticLocationsWithinTree(SyntaxTree tree)
+        private DiagnosticLocationsWithinTreeEnumerable GetDiagnosticLocationsWithinTree(SyntaxTree tree)
         {
-            if (this.Location.SourceTree == tree)
-            {
-                yield return this.Location;
-            }
-
-            if (this.AdditionalLocations != null)
-            {
-                foreach (var additionalLocation in this.AdditionalLocations)
-                {
-                    if (additionalLocation.SourceTree == tree)
-                    {
-                        yield return additionalLocation;
-                    }
-                }
-            }
+            return new DiagnosticLocationsWithinTreeEnumerable(this, tree);
         }
 
         internal Diagnostic? WithReportDiagnostic(ReportDiagnostic reportAction)
@@ -578,6 +565,112 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool IsUnsuppressedError
             => Severity == DiagnosticSeverity.Error && !IsSuppressed;
+
+        /// <summary>
+        /// Implements the following enumerator without allocations:
+        ///
+        /// <code>
+        /// if (this.Location.SourceTree == tree)
+        /// {
+        ///     yield return this.Location;
+        /// }
+        /// 
+        /// if (this.AdditionalLocations != null)
+        /// {
+        ///     foreach (var additionalLocation in this.AdditionalLocations)
+        ///     {
+        ///         if (additionalLocation.SourceTree == tree)
+        ///         {
+        ///             yield return additionalLocation;
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </summary>
+        private readonly struct DiagnosticLocationsWithinTreeEnumerable : IEnumerable<Location>
+        {
+            private readonly Diagnostic _diagnostic;
+            private readonly SyntaxTree _tree;
+
+            public DiagnosticLocationsWithinTreeEnumerable(Diagnostic diagnostic, SyntaxTree tree)
+            {
+                _diagnostic = diagnostic;
+                _tree = tree;
+            }
+
+            public Enumerator GetEnumerator()
+                => new Enumerator(this);
+
+            IEnumerator<Location> IEnumerable<Location>.GetEnumerator()
+                => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => GetEnumerator();
+
+            public struct Enumerator : IEnumerator<Location>
+            {
+                private readonly DiagnosticLocationsWithinTreeEnumerable _enumerable;
+
+                private Location? _current;
+                private IEnumerator<Location>? _additionalLocations;
+
+                public Enumerator(DiagnosticLocationsWithinTreeEnumerable enumerable)
+                {
+                    _enumerable = enumerable;
+                    _current = null;
+                    _additionalLocations = null;
+                }
+
+                public Location Current => _current!;
+                object IEnumerator.Current => Current;
+
+                public bool MoveNext()
+                {
+                    if (_additionalLocations is object)
+                    {
+                        while (true)
+                        {
+                            if (!_additionalLocations.MoveNext())
+                            {
+                                _current = null;
+                                return false;
+                            }
+
+                            _current = _additionalLocations.Current;
+                            if (_current.SourceTree == _enumerable._tree)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    else if (_current is object)
+                    {
+                        // Already reviewed _enumerable._diagnostic.Location. Initialize _additionalLocations and call
+                        // MoveNext() again.
+                        _additionalLocations = _enumerable._diagnostic.AdditionalLocations?.GetEnumerator() ?? SpecializedCollections.EmptyEnumerator<Location>();
+                        return MoveNext();
+                    }
+                    else
+                    {
+                        if (_enumerable._diagnostic.Location.SourceTree == _enumerable._tree)
+                        {
+                            _current = _enumerable._diagnostic.Location;
+                            return true;
+                        }
+                        else
+                        {
+                            // Skip straight to _additionalLocations and call MoveNext() again.
+                            _additionalLocations = _enumerable._diagnostic.AdditionalLocations?.GetEnumerator() ?? SpecializedCollections.EmptyEnumerator<Location>();
+                            return MoveNext();
+                        }
+                    }
+                }
+
+                void IDisposable.Dispose() { }
+
+                void IEnumerator.Reset() => throw new NotSupportedException();
+            }
+        }
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -507,14 +507,11 @@ namespace Microsoft.CodeAnalysis
                     yield return location;
                 }
 
-                if (additionalLocations is object && additionalLocations.Count > 0)
+                foreach (var additionalLocation in additionalLocations)
                 {
-                    foreach (var additionalLocation in additionalLocations)
+                    if (additionalLocation.SourceTree == tree)
                     {
-                        if (additionalLocation.SourceTree == tree)
-                        {
-                            yield return additionalLocation;
-                        }
+                        yield return additionalLocation;
                     }
                 }
             }


### PR DESCRIPTION
Allocations were identified under scenario #26778.

* Avoid iterator allocations in Diagnostic.HasIntersectingLocation (1.9GB)
* Avoid boxing allocations in CSDiagnosticInfo.AdditionalLocations (1.4GB)