### PR TITLE
Annotate SyntaxNode and SyntaxToken

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,6 +29,7 @@
         "args": [
           "msbuild",
           "-p:UseRoslynAnalyzers=false",
+          "-p:GenerateFullPaths=true",
           "src/Compilers/CSharp/csc/csc.csproj"
         ],
         "problemMatcher": "$msCompile",

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -961,11 +961,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// If <paramref name="nameSyntax"/> resolves to an alias name, return the AliasSymbol corresponding
         /// to A. Otherwise return null.
         /// </summary>
-<<<<<<< HEAD
         public static IAliasSymbol? GetAliasInfo(this SemanticModel? semanticModel, IdentifierNameSyntax nameSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IAliasSymbol? GetAliasInfo(this SemanticModel semanticModel, IdentifierNameSyntax nameSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetAliasInfo(nameSyntax, cancellationToken);
@@ -975,11 +971,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Binds the name in the context of the specified location and sees if it resolves to an
         /// alias name. If it does, return the AliasSymbol corresponding to it. Otherwise, return null.
         /// </summary>
-<<<<<<< HEAD
         public static IAliasSymbol? GetSpeculativeAliasInfo(this SemanticModel? semanticModel, int position, IdentifierNameSyntax nameSyntax, SpeculativeBindingOption bindingOption)
-=======
-        public static IAliasSymbol? GetSpeculativeAliasInfo(this SemanticModel semanticModel, int position, IdentifierNameSyntax nameSyntax, SpeculativeBindingOption bindingOption)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetSpeculativeAliasInfo(position, nameSyntax, bindingOption);
@@ -988,11 +980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze control-flow within a part of a method body.
         /// </summary>
-<<<<<<< HEAD
         public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel? semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
-=======
-        public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeControlFlow(firstStatement, lastStatement);
@@ -1001,11 +989,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze control-flow within a part of a method body.
         /// </summary>
-<<<<<<< HEAD
         public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel? semanticModel, StatementSyntax statement)
-=======
-        public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel semanticModel, StatementSyntax statement)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeControlFlow(statement);
@@ -1014,11 +998,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze data-flow within an expression.
         /// </summary>
-<<<<<<< HEAD
         public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel? semanticModel, ExpressionSyntax expression)
-=======
-        public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel semanticModel, ExpressionSyntax expression)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeDataFlow(expression);
@@ -1027,11 +1007,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze data-flow within a part of a method body.
         /// </summary>
-<<<<<<< HEAD
         public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel? semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
-=======
-        public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeDataFlow(firstStatement, lastStatement);
@@ -1040,11 +1016,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze data-flow within a part of a method body.
         /// </summary>
-<<<<<<< HEAD
         public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel? semanticModel, StatementSyntax statement)
-=======
-        public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel semanticModel, StatementSyntax statement)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeDataFlow(statement);
@@ -1055,11 +1027,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Given <paramref name="position"/> must lie within an existing method body of the Root syntax node for this SemanticModel.
         /// Locals and labels declared within this existing method body are not considered to be in scope of the speculated method body.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModelForMethodBody([NotNullWhen(true)] this SemanticModel? semanticModel, int position, BaseMethodDeclarationSyntax method, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModelForMethodBody(this SemanticModel semanticModel, int position, BaseMethodDeclarationSyntax method, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1078,11 +1046,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Given <paramref name="position"/> must lie within an existing method body of the Root syntax node for this SemanticModel.
         /// Locals and labels declared within this existing method body are not considered to be in scope of the speculated method body.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModelForMethodBody([NotNullWhen(true)] this SemanticModel? semanticModel, int position, AccessorDeclarationSyntax accessor, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModelForMethodBody(this SemanticModel semanticModel, int position, AccessorDeclarationSyntax accessor, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1101,11 +1065,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a type syntax that did not appear in source code.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, TypeSyntax type, [NotNullWhen(true)] out SemanticModel? speculativeModel, SpeculativeBindingOption bindingOption = SpeculativeBindingOption.BindAsExpression)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, TypeSyntax type, [NotNullWhen(true)] out SemanticModel? speculativeModel, SpeculativeBindingOption bindingOption = SpeculativeBindingOption.BindAsExpression)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1124,11 +1084,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a cref syntax that did not appear in source code.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, CrefSyntax crefSyntax, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, CrefSyntax crefSyntax, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1147,11 +1103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a statement that did not appear in source code.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, StatementSyntax statement, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, StatementSyntax statement, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1170,11 +1122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a field initializer or default parameter value that did not appear in source code.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, EqualsValueClauseSyntax initializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, EqualsValueClauseSyntax initializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1193,11 +1141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of an expression body that did not appear in source code.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, ArrowExpressionClauseSyntax expressionBody, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, ArrowExpressionClauseSyntax expressionBody, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1218,11 +1162,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///
         /// NOTE: This will only work in locations where there is already a constructor initializer.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, ConstructorInitializerSyntax constructorInitializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, ConstructorInitializerSyntax constructorInitializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1241,11 +1181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of an attribute that did not appear in source code.
         /// </summary>
-<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, AttributeSyntax attribute, [NotNullWhen(true)] out SemanticModel? speculativeModel)
-=======
-        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, AttributeSyntax attribute, [NotNullWhen(true)] out SemanticModel? speculativeModel)
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1298,11 +1234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a member declaration syntax, get the corresponding symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1312,11 +1244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Given a namespace declaration syntax node, get the corresponding namespace symbol for
         /// the declaration assembly.
         /// </summary>
-<<<<<<< HEAD
         public static INamespaceSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, NamespaceDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static INamespaceSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, NamespaceDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1325,11 +1253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a type declaration, get the corresponding type symbol.
         /// </summary>
-<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, BaseTypeDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, BaseTypeDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1338,11 +1262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a delegate declaration, get the corresponding type symbol.
         /// </summary>
-<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, DelegateDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, DelegateDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1351,11 +1271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a enum member declaration, get the corresponding field symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IFieldSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, EnumMemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IFieldSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, EnumMemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1364,11 +1280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a base method declaration syntax, get the corresponding method symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, BaseMethodDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, BaseMethodDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1377,11 +1289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a property, indexer or an event, get the corresponding declared symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, BasePropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, BasePropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1390,11 +1298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a property, get the corresponding declared symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, PropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel semanticModel, PropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1403,11 +1307,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares an indexer, get the corresponding declared symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, IndexerDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel semanticModel, IndexerDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1416,11 +1316,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a (custom) event, get the corresponding event symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IEventSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, EventDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IEventSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, EventDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1429,11 +1325,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of anonymous object creation initializer, get the anonymous object property symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, AnonymousObjectMemberDeclaratorSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel semanticModel, AnonymousObjectMemberDeclaratorSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1442,11 +1334,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of anonymous object creation expression, get the anonymous object type symbol.
         /// </summary>
-<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, AnonymousObjectCreationExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, AnonymousObjectCreationExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1455,11 +1343,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of tuple expression, get the tuple type symbol.
         /// </summary>
-<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, TupleExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, TupleExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1468,11 +1352,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of a tuple argument, get the tuple element symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ArgumentSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ArgumentSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1481,11 +1361,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a property or member accessor, get the corresponding symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, AccessorDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, AccessorDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1494,11 +1370,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a variable declarator syntax, get the corresponding symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, SingleVariableDesignationSyntax designationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, SingleVariableDesignationSyntax designationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(designationSyntax, cancellationToken);
@@ -1507,11 +1379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a variable declarator syntax, get the corresponding symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, VariableDeclaratorSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, VariableDeclaratorSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1520,11 +1388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a tuple element syntax, get the corresponding symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, TupleElementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, TupleElementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1533,11 +1397,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a labeled statement syntax, get the corresponding label symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, LabeledStatementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, LabeledStatementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1546,11 +1406,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a switch label syntax, get the corresponding label symbol.
         /// </summary>
-<<<<<<< HEAD
         public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, SwitchLabelSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, SwitchLabelSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1559,11 +1415,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a using declaration get the corresponding symbol for the using alias that was introduced.
         /// </summary>
-<<<<<<< HEAD
         public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, UsingDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, UsingDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1572,11 +1424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given an extern alias declaration get the corresponding symbol for the alias that was introduced.
         /// </summary>
-<<<<<<< HEAD
         public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ExternAliasDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ExternAliasDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1585,11 +1433,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a parameter declaration syntax node, get the corresponding symbol.
         /// </summary>
-<<<<<<< HEAD
         public static IParameterSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ParameterSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IParameterSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ParameterSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1598,11 +1442,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a type parameter declaration (field or method), get the corresponding symbol
         /// </summary>
-<<<<<<< HEAD
         public static ITypeParameterSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, TypeParameterSyntax typeParameter, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ITypeParameterSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, TypeParameterSyntax typeParameter, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(typeParameter, cancellationToken);
@@ -1611,11 +1451,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a foreach statement, get the symbol for the iteration variable
         /// </summary>
-<<<<<<< HEAD
         public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ForEachStatementSyntax forEachStatement, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ForEachStatementSyntax forEachStatement, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(forEachStatement, cancellationToken);
@@ -1624,21 +1460,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a catch declaration, get the symbol for the exception variable
         /// </summary>
-<<<<<<< HEAD
         public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, CatchDeclarationSyntax catchDeclaration, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, CatchDeclarationSyntax catchDeclaration, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(catchDeclaration, cancellationToken);
         }
 
-<<<<<<< HEAD
         public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, QueryClauseSyntax queryClause, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, QueryClauseSyntax queryClause, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(queryClause, cancellationToken);
@@ -1647,11 +1475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Get the query range variable declared in a join into clause.
         /// </summary>
-<<<<<<< HEAD
         public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, JoinIntoClauseSyntax node, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, JoinIntoClauseSyntax node, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(node, cancellationToken);
@@ -1660,11 +1484,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Get the query range variable declared in a query continuation clause.
         /// </summary>
-<<<<<<< HEAD
         public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, QueryContinuationSyntax node, CancellationToken cancellationToken = default(CancellationToken))
-=======
-        public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, QueryContinuationSyntax node, CancellationToken cancellationToken = default(CancellationToken))
->>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(node, cancellationToken);

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static Syntax.InternalSyntax.DirectiveStack ApplyDirectives(this SyntaxToken token, Syntax.InternalSyntax.DirectiveStack stack)
         {
-            return ((Syntax.InternalSyntax.CSharpSyntaxNode)token.Node).ApplyDirectives(stack);
+            return ((Syntax.InternalSyntax.CSharpSyntaxNode)token.Node!).ApplyDirectives(stack);
         }
 
         internal static Syntax.InternalSyntax.DirectiveStack ApplyDirectives(this SyntaxNodeOrToken nodeOrToken, Syntax.InternalSyntax.DirectiveStack stack)

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -961,7 +961,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// If <paramref name="nameSyntax"/> resolves to an alias name, return the AliasSymbol corresponding
         /// to A. Otherwise return null.
         /// </summary>
+<<<<<<< HEAD
         public static IAliasSymbol? GetAliasInfo(this SemanticModel? semanticModel, IdentifierNameSyntax nameSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IAliasSymbol? GetAliasInfo(this SemanticModel semanticModel, IdentifierNameSyntax nameSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetAliasInfo(nameSyntax, cancellationToken);
@@ -971,7 +975,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Binds the name in the context of the specified location and sees if it resolves to an
         /// alias name. If it does, return the AliasSymbol corresponding to it. Otherwise, return null.
         /// </summary>
+<<<<<<< HEAD
         public static IAliasSymbol? GetSpeculativeAliasInfo(this SemanticModel? semanticModel, int position, IdentifierNameSyntax nameSyntax, SpeculativeBindingOption bindingOption)
+=======
+        public static IAliasSymbol? GetSpeculativeAliasInfo(this SemanticModel semanticModel, int position, IdentifierNameSyntax nameSyntax, SpeculativeBindingOption bindingOption)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetSpeculativeAliasInfo(position, nameSyntax, bindingOption);
@@ -980,7 +988,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze control-flow within a part of a method body.
         /// </summary>
+<<<<<<< HEAD
         public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel? semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
+=======
+        public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeControlFlow(firstStatement, lastStatement);
@@ -989,7 +1001,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze control-flow within a part of a method body.
         /// </summary>
+<<<<<<< HEAD
         public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel? semanticModel, StatementSyntax statement)
+=======
+        public static ControlFlowAnalysis? AnalyzeControlFlow(this SemanticModel semanticModel, StatementSyntax statement)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeControlFlow(statement);
@@ -998,7 +1014,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze data-flow within an expression.
         /// </summary>
+<<<<<<< HEAD
         public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel? semanticModel, ExpressionSyntax expression)
+=======
+        public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel semanticModel, ExpressionSyntax expression)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeDataFlow(expression);
@@ -1007,7 +1027,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze data-flow within a part of a method body.
         /// </summary>
+<<<<<<< HEAD
         public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel? semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
+=======
+        public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel semanticModel, StatementSyntax firstStatement, StatementSyntax lastStatement)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeDataFlow(firstStatement, lastStatement);
@@ -1016,7 +1040,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Analyze data-flow within a part of a method body.
         /// </summary>
+<<<<<<< HEAD
         public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel? semanticModel, StatementSyntax statement)
+=======
+        public static DataFlowAnalysis? AnalyzeDataFlow(this SemanticModel semanticModel, StatementSyntax statement)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.AnalyzeDataFlow(statement);
@@ -1027,7 +1055,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Given <paramref name="position"/> must lie within an existing method body of the Root syntax node for this SemanticModel.
         /// Locals and labels declared within this existing method body are not considered to be in scope of the speculated method body.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModelForMethodBody([NotNullWhen(true)] this SemanticModel? semanticModel, int position, BaseMethodDeclarationSyntax method, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModelForMethodBody(this SemanticModel semanticModel, int position, BaseMethodDeclarationSyntax method, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1046,7 +1078,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Given <paramref name="position"/> must lie within an existing method body of the Root syntax node for this SemanticModel.
         /// Locals and labels declared within this existing method body are not considered to be in scope of the speculated method body.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModelForMethodBody([NotNullWhen(true)] this SemanticModel? semanticModel, int position, AccessorDeclarationSyntax accessor, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModelForMethodBody(this SemanticModel semanticModel, int position, AccessorDeclarationSyntax accessor, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1065,7 +1101,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a type syntax that did not appear in source code.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, TypeSyntax type, [NotNullWhen(true)] out SemanticModel? speculativeModel, SpeculativeBindingOption bindingOption = SpeculativeBindingOption.BindAsExpression)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, TypeSyntax type, [NotNullWhen(true)] out SemanticModel? speculativeModel, SpeculativeBindingOption bindingOption = SpeculativeBindingOption.BindAsExpression)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1084,7 +1124,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a cref syntax that did not appear in source code.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, CrefSyntax crefSyntax, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, CrefSyntax crefSyntax, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1103,7 +1147,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a statement that did not appear in source code.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, StatementSyntax statement, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, StatementSyntax statement, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1122,7 +1170,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of a field initializer or default parameter value that did not appear in source code.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, EqualsValueClauseSyntax initializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, EqualsValueClauseSyntax initializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1141,7 +1193,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of an expression body that did not appear in source code.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, ArrowExpressionClauseSyntax expressionBody, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, ArrowExpressionClauseSyntax expressionBody, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1162,7 +1218,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///
         /// NOTE: This will only work in locations where there is already a constructor initializer.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, ConstructorInitializerSyntax constructorInitializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, ConstructorInitializerSyntax constructorInitializer, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1181,7 +1241,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// this source code. This can be used to get detailed semantic information about sub-parts
         /// of an attribute that did not appear in source code.
         /// </summary>
+<<<<<<< HEAD
         public static bool TryGetSpeculativeSemanticModel([NotNullWhen(true)] this SemanticModel? semanticModel, int position, AttributeSyntax attribute, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+=======
+        public static bool TryGetSpeculativeSemanticModel(this SemanticModel semanticModel, int position, AttributeSyntax attribute, [NotNullWhen(true)] out SemanticModel? speculativeModel)
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             if (csmodel != null)
@@ -1234,7 +1298,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a member declaration syntax, get the corresponding symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1244,7 +1312,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Given a namespace declaration syntax node, get the corresponding namespace symbol for
         /// the declaration assembly.
         /// </summary>
+<<<<<<< HEAD
         public static INamespaceSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, NamespaceDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static INamespaceSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, NamespaceDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1253,7 +1325,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a type declaration, get the corresponding type symbol.
         /// </summary>
+<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, BaseTypeDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, BaseTypeDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1262,7 +1338,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a delegate declaration, get the corresponding type symbol.
         /// </summary>
+<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, DelegateDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, DelegateDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1271,7 +1351,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a enum member declaration, get the corresponding field symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IFieldSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, EnumMemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IFieldSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, EnumMemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1280,7 +1364,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a base method declaration syntax, get the corresponding method symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, BaseMethodDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, BaseMethodDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1289,7 +1377,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a property, indexer or an event, get the corresponding declared symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, BasePropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, BasePropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1298,7 +1390,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a property, get the corresponding declared symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, PropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel semanticModel, PropertyDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1307,7 +1403,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares an indexer, get the corresponding declared symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, IndexerDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel semanticModel, IndexerDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1316,7 +1416,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a (custom) event, get the corresponding event symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IEventSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, EventDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IEventSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, EventDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1325,7 +1429,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of anonymous object creation initializer, get the anonymous object property symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, AnonymousObjectMemberDeclaratorSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IPropertySymbol? GetDeclaredSymbol(this SemanticModel semanticModel, AnonymousObjectMemberDeclaratorSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1334,7 +1442,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of anonymous object creation expression, get the anonymous object type symbol.
         /// </summary>
+<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, AnonymousObjectCreationExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, AnonymousObjectCreationExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1343,7 +1455,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of tuple expression, get the tuple type symbol.
         /// </summary>
+<<<<<<< HEAD
         public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, TupleExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static INamedTypeSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, TupleExpressionSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1352,7 +1468,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node of a tuple argument, get the tuple element symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ArgumentSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ArgumentSyntax declaratorSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declaratorSyntax, cancellationToken);
@@ -1361,7 +1481,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a syntax node that declares a property or member accessor, get the corresponding symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, AccessorDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IMethodSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, AccessorDeclarationSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1370,7 +1494,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a variable declarator syntax, get the corresponding symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, SingleVariableDesignationSyntax designationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, SingleVariableDesignationSyntax designationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(designationSyntax, cancellationToken);
@@ -1379,7 +1507,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a variable declarator syntax, get the corresponding symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, VariableDeclaratorSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, VariableDeclaratorSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1388,7 +1520,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a tuple element syntax, get the corresponding symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ISymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, TupleElementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ISymbol? GetDeclaredSymbol(this SemanticModel semanticModel, TupleElementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1397,7 +1533,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a labeled statement syntax, get the corresponding label symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, LabeledStatementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, LabeledStatementSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1406,7 +1546,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a switch label syntax, get the corresponding label symbol.
         /// </summary>
+<<<<<<< HEAD
         public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, SwitchLabelSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ILabelSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, SwitchLabelSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1415,7 +1559,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a using declaration get the corresponding symbol for the using alias that was introduced.
         /// </summary>
+<<<<<<< HEAD
         public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, UsingDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, UsingDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1424,7 +1572,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given an extern alias declaration get the corresponding symbol for the alias that was introduced.
         /// </summary>
+<<<<<<< HEAD
         public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ExternAliasDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IAliasSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ExternAliasDirectiveSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1433,7 +1585,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a parameter declaration syntax node, get the corresponding symbol.
         /// </summary>
+<<<<<<< HEAD
         public static IParameterSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ParameterSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IParameterSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ParameterSyntax declarationSyntax, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(declarationSyntax, cancellationToken);
@@ -1442,7 +1598,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a type parameter declaration (field or method), get the corresponding symbol
         /// </summary>
+<<<<<<< HEAD
         public static ITypeParameterSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, TypeParameterSyntax typeParameter, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ITypeParameterSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, TypeParameterSyntax typeParameter, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(typeParameter, cancellationToken);
@@ -1451,7 +1611,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a foreach statement, get the symbol for the iteration variable
         /// </summary>
+<<<<<<< HEAD
         public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, ForEachStatementSyntax forEachStatement, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, ForEachStatementSyntax forEachStatement, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(forEachStatement, cancellationToken);
@@ -1460,13 +1624,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Given a catch declaration, get the symbol for the exception variable
         /// </summary>
+<<<<<<< HEAD
         public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, CatchDeclarationSyntax catchDeclaration, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static ILocalSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, CatchDeclarationSyntax catchDeclaration, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(catchDeclaration, cancellationToken);
         }
 
+<<<<<<< HEAD
         public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, QueryClauseSyntax queryClause, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, QueryClauseSyntax queryClause, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(queryClause, cancellationToken);
@@ -1475,7 +1647,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Get the query range variable declared in a join into clause.
         /// </summary>
+<<<<<<< HEAD
         public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, JoinIntoClauseSyntax node, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, JoinIntoClauseSyntax node, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(node, cancellationToken);
@@ -1484,7 +1660,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Get the query range variable declared in a query continuation clause.
         /// </summary>
+<<<<<<< HEAD
         public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel? semanticModel, QueryContinuationSyntax node, CancellationToken cancellationToken = default(CancellationToken))
+=======
+        public static IRangeVariableSymbol? GetDeclaredSymbol(this SemanticModel semanticModel, QueryContinuationSyntax node, CancellationToken cancellationToken = default(CancellationToken))
+>>>>>>> Annotate SyntaxNode
         {
             var csmodel = semanticModel as CSharpSemanticModel;
             return csmodel?.GetDeclaredSymbol(node, cancellationToken);

--- a/src/Compilers/CSharp/Portable/CSharpExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpExtensions.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Returns <see cref="SyntaxKind"/> for <see cref="SyntaxNode"/> from <see cref="SyntaxNode.RawKind"/> property.
         /// </summary>
-        public static SyntaxKind Kind(this SyntaxNode node)
+        public static SyntaxKind Kind([NotNull] this SyntaxNode node)
         {
             var rawKind = node.RawKind;
             return IsCSharpKind(rawKind) ? (SyntaxKind)rawKind : SyntaxKind.None;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (sourceName != null && !wasInferred && (allMissing || string.CompareOrdinal(destinationNames[i], sourceName) != 0))
                 {
-                    diagnostics.Add(ErrorCode.WRN_TupleLiteralNameMismatch, literal.Arguments[i].Syntax.Parent.Location, sourceName, destination);
+                    diagnostics.Add(ErrorCode.WRN_TupleLiteralNameMismatch, literal.Arguments[i].Syntax.Parent!.Location, sourceName, destination);
                 }
             }
         }

--- a/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/SourceLocation.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         public SourceLocation(in SyntaxToken token)
-            : this(token.SyntaxTree, token.Span)
+            : this(token.SyntaxTree!, token.Span)
         {
         }
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -21,13 +23,13 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public abstract partial class SyntaxNode
     {
-        private readonly SyntaxNode _parent;
-        internal SyntaxTree _syntaxTree;
+        private readonly SyntaxNode? _parent;
+        internal SyntaxTree? _syntaxTree;
 
-        internal SyntaxNode(GreenNode green, SyntaxNode parent, int position)
+        internal SyntaxNode(GreenNode green, SyntaxNode? parent, int position)
         {
-            Debug.Assert(position >= 0, "position cannot be negative");
-            Debug.Assert(parent?.Green.IsList != true, "list cannot be a parent");
+            RoslynDebug.Assert(position >= 0, "position cannot be negative");
+            RoslynDebug.Assert(parent?.Green.IsList != true, "list cannot be a parent");
 
             Position = position;
             Green = green;
@@ -130,7 +132,7 @@ namespace Microsoft.CodeAnalysis
         internal int FullWidth => this.Green.FullWidth;
 
         // this is used in cases where we know that a child is a node of particular type.
-        internal SyntaxNode GetRed(ref SyntaxNode field, int slot)
+        internal SyntaxNode? GetRed(ref SyntaxNode? field, int slot)
         {
             var result = field;
 
@@ -148,7 +150,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // special case of above function where slot = 0, does not need GetChildPosition 
-        internal SyntaxNode GetRedAtZero(ref SyntaxNode field)
+        internal SyntaxNode? GetRedAtZero(ref SyntaxNode? field)
         {
             var result = field;
 
@@ -165,7 +167,7 @@ namespace Microsoft.CodeAnalysis
             return result;
         }
 
-        protected T GetRed<T>(ref T field, int slot) where T : SyntaxNode
+        protected T? GetRed<T>(ref T? field, int slot) where T : SyntaxNode
         {
             var result = field;
 
@@ -183,7 +185,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // special case of above function where slot = 0, does not need GetChildPosition 
-        protected T GetRedAtZero<T>(ref T field) where T : SyntaxNode
+        protected T? GetRedAtZero<T>(ref T? field) where T : SyntaxNode
         {
             var result = field;
 
@@ -205,7 +207,7 @@ namespace Microsoft.CodeAnalysis
         /// The only difference is that the public parent of the node is not the list, 
         /// but the list's parent. (element's grand parent).
         /// </summary>
-        internal SyntaxNode GetRedElement(ref SyntaxNode element, int slot)
+        internal SyntaxNode? GetRedElement(ref SyntaxNode? element, int slot)
         {
             Debug.Assert(this.IsList);
 
@@ -225,7 +227,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// special cased helper for 2 and 3 children lists where child #1 may map to a token
         /// </summary>
-        internal SyntaxNode GetRedElementIfNotToken(ref SyntaxNode element)
+        internal SyntaxNode? GetRedElementIfNotToken(ref SyntaxNode? element)
         {
             Debug.Assert(this.IsList);
 
@@ -245,19 +247,19 @@ namespace Microsoft.CodeAnalysis
             return result;
         }
 
-        internal SyntaxNode GetWeakRedElement(ref WeakReference<SyntaxNode> slot, int index)
+        internal SyntaxNode GetWeakRedElement(ref WeakReference<SyntaxNode>? slot, int index)
         {
-            SyntaxNode value = null;
+            SyntaxNode? value = null;
             if (slot?.TryGetTarget(out value) == true)
             {
-                return value;
+                return value!;
             }
 
             return CreateWeakItem(ref slot, index);
         }
 
         // handle a miss
-        private SyntaxNode CreateWeakItem(ref WeakReference<SyntaxNode> slot, int index)
+        private SyntaxNode CreateWeakItem(ref WeakReference<SyntaxNode>? slot, int index)
         {
             var greenChild = this.Green.GetSlot(index);
             var newNode = greenChild.CreateRed(this.Parent, GetChildPosition(index));
@@ -265,11 +267,11 @@ namespace Microsoft.CodeAnalysis
 
             while (true)
             {
-                SyntaxNode previousNode = null;
-                WeakReference<SyntaxNode> previousWeakReference = slot;
+                SyntaxNode? previousNode = null;
+                WeakReference<SyntaxNode>? previousWeakReference = slot;
                 if (previousWeakReference?.TryGetTarget(out previousNode) == true)
                 {
-                    return previousNode;
+                    return previousNode!;
                 }
 
                 if (Interlocked.CompareExchange(ref slot, newWeakReference, previousWeakReference) == previousWeakReference)
@@ -320,7 +322,7 @@ namespace Microsoft.CodeAnalysis
         /// Hash algorithm to use to calculate checksum of the text that's saved to PDB.
         /// </param>
         /// <exception cref="ArgumentException"><paramref name="checksumAlgorithm"/> is not supported.</exception>
-        public SourceText GetText(Encoding encoding = null, SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
+        public SourceText GetText(Encoding? encoding = null, SourceHashAlgorithm checksumAlgorithm = SourceHashAlgorithm.Sha1)
         {
             var builder = new StringBuilder();
             this.WriteTo(new StringWriter(builder));
@@ -364,7 +366,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool IsPartOfStructuredTrivia()
         {
-            for (var node = this; node != null; node = node.Parent)
+            for (SyntaxNode? node = this; node != null; node = node.Parent)
             {
                 if (node.IsStructuredTrivia)
                     return true;
@@ -432,7 +434,7 @@ namespace Microsoft.CodeAnalysis
         /// Determines if the specified node is a descendant of this node.
         /// Returns true for current node.
         /// </summary>
-        public bool Contains(SyntaxNode node)
+        public bool Contains(SyntaxNode? node)
         {
             if (node == null || !this.FullSpan.Contains(node.FullSpan))
             {
@@ -489,7 +491,7 @@ namespace Microsoft.CodeAnalysis
         /// Gets a node at given node index without forcing its creation.
         /// If node was not created it would return null.
         /// </summary>
-        internal abstract SyntaxNode GetCachedSlot(int index);
+        internal abstract SyntaxNode? GetCachedSlot(int index);
 
         internal int GetChildIndex(int slot)
         {
@@ -562,7 +564,7 @@ namespace Microsoft.CodeAnalysis
                 // In future, if we decide to support this, we will need some mechanism to distinguish between scenarios (a) and (b) here.
 
                 var tree = this.SyntaxTree;
-                Debug.Assert(tree != null);
+                RoslynDebug.Assert(tree != null);
                 return !tree.SupportsLocations ? NoLocation.Singleton : new SourceLocation(this);
             }
         }
@@ -592,7 +594,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The node that contains this node in its <see cref="ChildNodes"/> collection.
         /// </summary>
-        public SyntaxNode Parent
+        public SyntaxNode? Parent
         {
             get
             {
@@ -608,7 +610,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal SyntaxNode ParentOrStructuredTriviaParent
+        internal SyntaxNode? ParentOrStructuredTriviaParent
         {
             get
             {
@@ -642,7 +644,7 @@ namespace Microsoft.CodeAnalysis
         /// Gets node at given node index. 
         /// This WILL force node creation if node has not yet been created.
         /// </summary>
-        internal abstract SyntaxNode GetNodeSlot(int slot);
+        internal abstract SyntaxNode? GetNodeSlot(int slot);
 
         /// <summary>
         /// Gets a list of the child nodes in prefix document order.
@@ -673,13 +675,13 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public IEnumerable<SyntaxNode> AncestorsAndSelf(bool ascendOutOfTrivia = true)
         {
-            for (var node = this; node != null; node = GetParent(node, ascendOutOfTrivia))
+            for (SyntaxNode? node = this; node != null; node = GetParent(node, ascendOutOfTrivia))
             {
                 yield return node;
             }
         }
 
-        private static SyntaxNode GetParent(SyntaxNode node, bool ascendOutOfTrivia)
+        private static SyntaxNode? GetParent(SyntaxNode node, bool ascendOutOfTrivia)
         {
             var parent = node.Parent;
             if (parent == null && ascendOutOfTrivia)
@@ -697,10 +699,10 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets the first node of type TNode that matches the predicate.
         /// </summary>
-        public TNode FirstAncestorOrSelf<TNode>(Func<TNode, bool> predicate = null, bool ascendOutOfTrivia = true)
+        public TNode? FirstAncestorOrSelf<TNode>(Func<TNode, bool>? predicate = null, bool ascendOutOfTrivia = true)
             where TNode : SyntaxNode
         {
-            for (var node = this; node != null; node = GetParent(node, ascendOutOfTrivia))
+            for (SyntaxNode? node = this; node != null; node = GetParent(node, ascendOutOfTrivia))
             {
                 var tnode = node as TNode;
                 if (tnode != null && (predicate == null || predicate(tnode)))
@@ -717,7 +719,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodes(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodes(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -728,7 +730,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodes(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodes(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -738,7 +740,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -749,7 +751,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -759,7 +761,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokens(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokens(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -770,7 +772,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokens(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokens(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -780,7 +782,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokensAndSelf(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokensAndSelf(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -791,7 +793,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokensAndSelf(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNodeOrToken> DescendantNodesAndTokensAndSelf(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -817,7 +819,7 @@ namespace Microsoft.CodeAnalysis
                 .Parent
                 .FirstAncestorOrSelf<SyntaxNode>(a => a.FullSpan.Contains(span));
 
-            var cuRoot = node.SyntaxTree?.GetRoot();
+            SyntaxNode? cuRoot = node!.SyntaxTree?.GetRoot();
 
             // Tie-breaking.
             if (!getInnermostNodeForTie)
@@ -887,7 +889,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets a list of all the tokens in the span of this node.
         /// </summary>
-        public IEnumerable<SyntaxToken> DescendantTokens(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxToken> DescendantTokens(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return this.DescendantNodesAndTokens(descendIntoChildren, descendIntoTrivia).Where(sn => sn.IsToken).Select(sn => sn.AsToken());
         }
@@ -895,7 +897,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets a list of all the tokens in the full span of this node.
         /// </summary>
-        public IEnumerable<SyntaxToken> DescendantTokens(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxToken> DescendantTokens(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return this.DescendantNodesAndTokens(span, descendIntoChildren, descendIntoTrivia).Where(sn => sn.IsToken).Select(sn => sn.AsToken());
         }
@@ -943,7 +945,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="stepInto">Specifies a function that determines per trivia node, whether to
         /// descend into structured trivia of that node.</param>
         /// <returns></returns>
-        public SyntaxTrivia FindTrivia(int position, Func<SyntaxTrivia, bool> stepInto)
+        public SyntaxTrivia FindTrivia(int position, Func<SyntaxTrivia, bool>? stepInto)
         {
             if (this.FullSpan.Contains(position))
             {
@@ -953,7 +955,7 @@ namespace Microsoft.CodeAnalysis
             return default(SyntaxTrivia);
         }
 
-        internal static SyntaxTrivia FindTriviaByOffset(SyntaxNode node, int textOffset, Func<SyntaxTrivia, bool> stepInto = null)
+        internal static SyntaxTrivia FindTriviaByOffset(SyntaxNode node, int textOffset, Func<SyntaxTrivia, bool>? stepInto = null)
         {
 recurse:
             if (textOffset >= 0)
@@ -1024,7 +1026,7 @@ recurse:
         /// <summary>
         /// Get a list of all the trivia associated with the descendant nodes and tokens.
         /// </summary>
-        public IEnumerable<SyntaxTrivia> DescendantTrivia(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxTrivia> DescendantTrivia(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantTriviaImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia);
         }
@@ -1032,7 +1034,7 @@ recurse:
         /// <summary>
         /// Get a list of all the trivia associated with the descendant nodes and tokens.
         /// </summary>
-        public IEnumerable<SyntaxTrivia> DescendantTrivia(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxTrivia> DescendantTrivia(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantTriviaImpl(span, descendIntoChildren, descendIntoTrivia);
         }
@@ -1204,7 +1206,7 @@ recurse:
         /// modification, even if the type of a node changes.
         /// </para>
         /// </remarks>
-        public T CopyAnnotationsTo<T>(T node) where T : SyntaxNode
+        public T? CopyAnnotationsTo<T>(T? node) where T : SyntaxNode
         {
             if (node == null)
             {
@@ -1417,12 +1419,12 @@ recurse:
         /// Creates a new tree of nodes with the specified nodes, tokens or trivia replaced.
         /// </summary>
         protected internal abstract SyntaxNode ReplaceCore<TNode>(
-            IEnumerable<TNode> nodes = null,
-            Func<TNode, TNode, SyntaxNode> computeReplacementNode = null,
-            IEnumerable<SyntaxToken> tokens = null,
-            Func<SyntaxToken, SyntaxToken, SyntaxToken> computeReplacementToken = null,
-            IEnumerable<SyntaxTrivia> trivia = null,
-            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null)
+            IEnumerable<TNode>? nodes = null,
+            Func<TNode, TNode, SyntaxNode>? computeReplacementNode = null,
+            IEnumerable<SyntaxToken>? tokens = null,
+            Func<SyntaxToken, SyntaxToken, SyntaxToken>? computeReplacementToken = null,
+            IEnumerable<SyntaxTrivia>? trivia = null,
+            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? computeReplacementTrivia = null)
             where TNode : SyntaxNode;
 
         protected internal abstract SyntaxNode ReplaceNodeInListCore(SyntaxNode originalNode, IEnumerable<SyntaxNode> replacementNodes);

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -817,7 +817,7 @@ namespace Microsoft.CodeAnalysis
 
             var node = FindToken(span.Start, findInsideTrivia)
                 .Parent
-                .FirstAncestorOrSelf<SyntaxNode>(a => a.FullSpan.Contains(span));
+                !.FirstAncestorOrSelf<SyntaxNode>(a => a.FullSpan.Contains(span));
 
             SyntaxNode? cuRoot = node!.SyntaxTree?.GetRoot();
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -819,7 +819,8 @@ namespace Microsoft.CodeAnalysis
                 .Parent
                 !.FirstAncestorOrSelf<SyntaxNode>(a => a.FullSpan.Contains(span));
 
-            SyntaxNode? cuRoot = node!.SyntaxTree?.GetRoot();
+            RoslynDebug.Assert(node is object);
+            SyntaxNode? cuRoot = node.SyntaxTree?.GetRoot();
 
             // Tie-breaking.
             if (!getInnermostNodeForTie)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly Func<SyntaxToken, bool> NonZeroWidth = t => t.Width > 0;
         internal static readonly Func<SyntaxToken, bool> Any = t => true;
 
-        internal SyntaxToken(SyntaxNode parent, GreenNode token, int position, int index)
+        internal SyntaxToken(SyntaxNode? parent, GreenNode? token, int position, int index)
         {
             Debug.Assert(parent == null || !parent.Green.IsList, "list cannot be a parent");
             Debug.Assert(token == null || token.IsToken, "token must be a token");
@@ -35,7 +36,7 @@ namespace Microsoft.CodeAnalysis
             Index = index;
         }
 
-        internal SyntaxToken(GreenNode token)
+        internal SyntaxToken(GreenNode? token)
             : this()
         {
             Debug.Assert(token == null || token.IsToken, "token must be a token");
@@ -72,9 +73,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The node that contains this token in its Children collection.
         /// </summary>
-        public SyntaxNode Parent { get; }
+        public SyntaxNode? Parent { get; }
 
-        internal GreenNode Node { get; }
+        internal GreenNode? Node { get; }
 
         internal int Index { get; }
 
@@ -133,13 +134,13 @@ namespace Microsoft.CodeAnalysis
         /// Returns the value of the token. For example, if the token represents an integer literal, then this property
         /// would return the actual integer.
         /// </summary>
-        public object Value => Node?.GetValue();
+        public object? Value => Node?.GetValue();
 
         /// <summary>
         /// Returns the text representation of the value of the token. For example, if the token represents an integer
         /// literal, then this property would return a string representing the integer.
         /// </summary>
-        public string ValueText => Node?.GetValueText();
+        public string? ValueText => Node?.GetValueText();
 
         public string Text => ToString();
 
@@ -590,7 +591,7 @@ namespace Microsoft.CodeAnalysis
         /// true.</param>
         /// <param name="stepInto">Delegate applied to trivia.  If this delegate is present then trailing trivia is
         /// included in the search.</param>
-        internal SyntaxToken GetNextToken(Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool> stepInto = null)
+        internal SyntaxToken GetNextToken(Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool>? stepInto = null)
         {
             if (Node == null)
             {
@@ -621,7 +622,7 @@ namespace Microsoft.CodeAnalysis
         /// true.</param>
         /// <param name="stepInto">Delegate applied to trivia.  If this delegate is present then trailing trivia is
         /// included in the search.</param>
-        internal SyntaxToken GetPreviousToken(Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool> stepInto = null)
+        internal SyntaxToken GetPreviousToken(Func<SyntaxToken, bool> predicate, Func<SyntaxTrivia, bool>? stepInto = null)
         {
             return SyntaxNavigator.Instance.GetPreviousToken(this, predicate, stepInto);
         }
@@ -629,7 +630,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The SyntaxTree that contains this token.
         /// </summary>
-        public SyntaxTree SyntaxTree => Parent?.SyntaxTree;
+        public SyntaxTree? SyntaxTree => Parent?.SyntaxTree;
 
         /// <summary>
         /// Gets the location for this token.

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
             // mess with it if it's inside a line.
             if (token.IsKind(SyntaxKind.OpenBraceToken))
             {
-                var text = await token.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                var text = await token.SyntaxTree!.GetTextAsync(cancellationToken).ConfigureAwait(false);
                 if (!token.IsFirstTokenOnLine(text))
                 {
                     return true;

--- a/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeNamespace
                 .OfType<NamespaceDeclarationSyntax>().Any();
         }
 
-        private static string? GetAliasQualifier(SyntaxNode name)
+        private static string? GetAliasQualifier(SyntaxNode? name)
         {
             while (true)
             {

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -291,27 +291,27 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 position = declarationBody.SpanStart;
             }
 
-            SyntaxNode? node;
+            SyntaxNode node;
             if (partnerDeclarationBody != null)
             {
                 SyntaxUtilities.FindLeafNodeAndPartner(declarationBody, position, partnerDeclarationBody, out node, out partner);
             }
             else
             {
-                node = declarationBody.FindToken(position).Parent;
+                node = declarationBody.FindToken(position).Parent!;
                 partner = null;
             }
 
-            while (node != declarationBody && !StatementSyntaxComparer.HasLabel(node!) && !LambdaUtilities.IsLambdaBodyStatementOrExpression(node))
+            while (node != declarationBody && !StatementSyntaxComparer.HasLabel(node) && !LambdaUtilities.IsLambdaBodyStatementOrExpression(node))
             {
-                node = node!.Parent;
+                node = node.Parent!;
                 if (partner != null)
                 {
                     partner = partner.Parent;
                 }
             }
 
-            switch (node!.Kind())
+            switch (node.Kind())
             {
                 case SyntaxKind.Block:
                     statementPart = (int)GetStatementPart((BlockSyntax)node!, position);
@@ -3218,7 +3218,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 RoslynDebug.Assert(node is object);
                 RoslynDebug.Assert(node.Parent is object);
-                switch (node.Parent!.Kind())
+                switch (node.Parent.Kind())
                 {
                     case SyntaxKind.ForStatement:
                     case SyntaxKind.ForEachStatement:

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                    from node in root.DescendantNodesAndSelf()
                    where node.IsKind(SyntaxKind.IdentifierName)
                    let nameSyntax = (IdentifierNameSyntax)node
-                   where (string)nameSyntax.Identifier.Value == localOrParameter.Name &&
+                   where (string?)nameSyntax.Identifier.Value == localOrParameter.Name &&
                          (model.GetSymbolInfo(nameSyntax, cancellationToken).Symbol?.Equals(localOrParameter) ?? false)
                    select node;
         }
@@ -302,9 +302,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 partner = null;
             }
 
-            while (node != declarationBody && !StatementSyntaxComparer.HasLabel(node) && !LambdaUtilities.IsLambdaBodyStatementOrExpression(node))
+            while (node != declarationBody && !StatementSyntaxComparer.HasLabel(node!) && !LambdaUtilities.IsLambdaBodyStatementOrExpression(node))
             {
-                node = node.Parent!;
+                node = node!.Parent;
                 if (partner != null)
                 {
                     partner = partner.Parent;
@@ -314,12 +314,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             switch (node!.Kind())
             {
                 case SyntaxKind.Block:
-                    statementPart = (int)GetStatementPart((BlockSyntax)node, position);
+                    statementPart = (int)GetStatementPart((BlockSyntax)node!, position);
                     break;
 
                 case SyntaxKind.ForEachStatement:
                 case SyntaxKind.ForEachVariableStatement:
-                    statementPart = (int)GetStatementPart((CommonForEachStatementSyntax)node, position);
+                    statementPart = (int)GetStatementPart((CommonForEachStatementSyntax)node!, position);
                     break;
 
                 case SyntaxKind.VariableDeclaration:
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     // 
                     // The compiler places sequence points after each local variable initialization.
                     // The TypeSyntax is considered to be part of the first sequence span.
-                    node = ((VariableDeclarationSyntax)node).Variables.First();
+                    node = ((VariableDeclarationSyntax)node!).Variables.First();
 
                     if (partner != null)
                     {
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     break;
             }
 
-            return node;
+            return node!;
         }
 
         private static BlockPart GetStatementPart(BlockSyntax node, int position)

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -832,10 +832,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     if (leftCatch.Declaration == null && leftCatch.Filter == null &&
                         rightCatch.Declaration == null && rightCatch.Filter == null)
                     {
-                        var leftTry = (TryStatementSyntax?)leftCatch.Parent;
-                        var rightTry = (TryStatementSyntax?)rightCatch.Parent;
+                        RoslynDebug.Assert(leftCatch.Parent is object);
+                        RoslynDebug.Assert(rightCatch.Parent is object);
+                        var leftTry = (TryStatementSyntax)leftCatch.Parent;
+                        var rightTry = (TryStatementSyntax)rightCatch.Parent;
 
-                        distance = 0.5 * ComputeValueDistance(leftTry?.Block, rightTry?.Block) +
+                        distance = 0.5 * ComputeValueDistance(leftTry.Block, rightTry.Block) +
                                    0.5 * ComputeValueDistance(leftBlock, rightBlock);
                     }
                     else

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -35,7 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
         #region Tree Traversal
 
-        protected internal override bool TryGetParent(SyntaxNode node, out SyntaxNode parent)
+#pragma warning disable 8610 // Making the out parameter nullable
+        protected internal override bool TryGetParent(SyntaxNode node, [NotNullWhen(true)] out SyntaxNode? parent)
         {
             parent = node.Parent;
             while (parent != null && !HasLabel(parent))
@@ -45,6 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             return parent != null;
         }
+#pragma warning restore 8610
 
         protected internal override IEnumerable<SyntaxNode>? GetChildren(SyntaxNode node)
         {
@@ -830,10 +832,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     if (leftCatch.Declaration == null && leftCatch.Filter == null &&
                         rightCatch.Declaration == null && rightCatch.Filter == null)
                     {
-                        var leftTry = (TryStatementSyntax)leftCatch.Parent;
-                        var rightTry = (TryStatementSyntax)rightCatch.Parent;
+                        var leftTry = (TryStatementSyntax?)leftCatch.Parent;
+                        var rightTry = (TryStatementSyntax?)rightCatch.Parent;
 
-                        distance = 0.5 * ComputeValueDistance(leftTry.Block, rightTry.Block) +
+                        distance = 0.5 * ComputeValueDistance(leftTry?.Block, rightTry?.Block) +
                                    0.5 * ComputeValueDistance(leftBlock, rightBlock);
                     }
                     else

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -832,10 +832,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     if (leftCatch.Declaration == null && leftCatch.Filter == null &&
                         rightCatch.Declaration == null && rightCatch.Filter == null)
                     {
-                        RoslynDebug.Assert(leftCatch.Parent is object);
-                        RoslynDebug.Assert(rightCatch.Parent is object);
-                        var leftTry = (TryStatementSyntax)leftCatch.Parent;
-                        var rightTry = (TryStatementSyntax)rightCatch.Parent;
+                        var leftTry = (TryStatementSyntax)leftCatch.Parent!;
+                        var rightTry = (TryStatementSyntax)rightCatch.Parent!;
 
                         distance = 0.5 * ComputeValueDistance(leftTry.Block, rightTry.Block) +
                                    0.5 * ComputeValueDistance(leftBlock, rightBlock);

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return ComputeValueDistance(oldNode, newNode);
         }
 
-        internal static double ComputeValueDistance(SyntaxNode oldNode, SyntaxNode newNode)
+        internal static double ComputeValueDistance(SyntaxNode? oldNode, SyntaxNode? newNode)
         {
             if (SyntaxFactory.AreEquivalent(oldNode, newNode))
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -91,7 +91,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 // regular case. always use ConvertedType to get implicit conversion right.
                 var expression = node.GetUnparenthesizedExpression();
-                RoslynDebug.Assert(expression is object);
 
                 var info = semanticModel.GetTypeInfo(expression);
                 var conv = semanticModel.GetConversion(expression);

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.ExpressionResult.cs
@@ -91,6 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 // regular case. always use ConvertedType to get implicit conversion right.
                 var expression = node.GetUnparenthesizedExpression();
+                RoslynDebug.Assert(expression is object);
 
                 var info = semanticModel.GetTypeInfo(expression);
                 var conv = semanticModel.GetConversion(expression);

--- a/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/AbstractChangeImplementionCodeRefactoringProvider.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
 
         private static (SyntaxNode?, ExplicitInterfaceSpecifierSyntax?, SyntaxToken) GetContainer(SyntaxToken token)
         {
-            for (var node = token.Parent; node != null; node = node.Parent)
+            for (SyntaxNode? node = token.Parent; node != null; node = node.Parent)
             {
                 var result = node switch
                 {

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
 {
@@ -90,9 +91,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
                 ? identifierName.Parent
                 : identifierName;
 
+            RoslynDebug.Assert(node is object);
             if (syntaxFacts.IsInvocationExpression(node.Parent))
                 node = node.Parent;
 
+            RoslynDebug.Assert(node is object);
             var operation = semanticModel.GetOperation(node);
             var instance = operation switch
             {

--- a/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ImplementInterface/CSharpImplementExplicitlyCodeRefactoringProvider.cs
@@ -95,7 +95,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ImplementInterface
             if (syntaxFacts.IsInvocationExpression(node.Parent))
                 node = node.Parent;
 
-            RoslynDebug.Assert(node is object);
             var operation = semanticModel.GetOperation(node);
             var instance = operation switch
             {

--- a/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
+++ b/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
@@ -27,11 +27,15 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
         public static bool TryGetCaputuredSymbols(LocalFunctionStatementSyntax localFunction, SemanticModel semanticModel, out ImmutableArray<ISymbol> captures)
         {
             var dataFlow = semanticModel.AnalyzeDataFlow(localFunction);
+<<<<<<< HEAD
             if (dataFlow is null)
             {
                 captures = default;
                 return false;
             }
+=======
+            captures = dataFlow!.CapturedInside;
+>>>>>>> Annotate SyntaxNode
 
             captures = dataFlow.CapturedInside;
             return dataFlow.Succeeded;

--- a/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
+++ b/src/Features/CSharp/Portable/MakeLocalFunctionStatic/MakeLocalFunctionStaticHelper.cs
@@ -27,15 +27,11 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
         public static bool TryGetCaputuredSymbols(LocalFunctionStatementSyntax localFunction, SemanticModel semanticModel, out ImmutableArray<ISymbol> captures)
         {
             var dataFlow = semanticModel.AnalyzeDataFlow(localFunction);
-<<<<<<< HEAD
             if (dataFlow is null)
             {
                 captures = default;
                 return false;
             }
-=======
-            captures = dataFlow!.CapturedInside;
->>>>>>> Annotate SyntaxNode
 
             captures = dataFlow.CapturedInside;
             return dataFlow.Succeeded;

--- a/src/Features/Core/Portable/CodeRefactoringHelpers.cs
+++ b/src/Features/Core/Portable/CodeRefactoringHelpers.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis
             // or the last child starts after the selection ends (i.e. one of them is completely on the outside of selection).
             // It's a crude heuristic but it allows omitting parts of nodes or trivial tokens from the beginning/end 
             // but fires up e.g.: `1 + [|2 + 3|]`.
-            return beginningNode.Span.End <= selection.Start || endNode.Span.Start >= selection.End;
+            return beginningNode!.Span.End <= selection.Start || endNode!.Span.Start >= selection.End;
         }
 
 

--- a/src/Features/Core/Portable/CodeRefactoringHelpers.cs
+++ b/src/Features/Core/Portable/CodeRefactoringHelpers.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -81,6 +82,8 @@ namespace Microsoft.CodeAnalysis
 
             var beginningNode = node.FindToken(node.Span.Start).Parent;
             var endNode = node.FindToken(node.Span.End - 1).Parent;
+            RoslynDebug.Assert(beginningNode is object);
+            RoslynDebug.Assert(endNode is object);
 
             // Node is underselected if either the first (lowest) child doesn't contain start of selection
             // of the last child doesn't intersect with the end.
@@ -89,7 +92,7 @@ namespace Microsoft.CodeAnalysis
             // or the last child starts after the selection ends (i.e. one of them is completely on the outside of selection).
             // It's a crude heuristic but it allows omitting parts of nodes or trivial tokens from the beginning/end 
             // but fires up e.g.: `1 + [|2 + 3|]`.
-            return beginningNode!.Span.End <= selection.Start || endNode!.Span.Start >= selection.End;
+            return beginningNode.Span.End <= selection.Start || endNode.Span.Start >= selection.End;
         }
 
 

--- a/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             // there could be multiple (n) tokens to the left if first n-1 are Empty -> iterate over all of them
             while (tokenToLeft != default)
             {
-                SyntaxNode? leftNode = tokenToLeft.Parent;
+                SyntaxNode? leftNode = tokenToLeft.Parent!;
                 do
                 {
                     // Consider either a Node that is:
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         {
             if (tokenToRightOrIn != default)
             {
-                SyntaxNode? rightNode = tokenToRightOrIn.Parent;
+                SyntaxNode? rightNode = tokenToRightOrIn.Parent!;
                 do
                 {
                     // Consider either a Node that is:

--- a/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AbstractRefactoringHelpersService.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             // there could be multiple (n) tokens to the left if first n-1 are Empty -> iterate over all of them
             while (tokenToLeft != default)
             {
-                var leftNode = tokenToLeft.Parent;
+                SyntaxNode? leftNode = tokenToLeft.Parent;
                 do
                 {
                     // Consider either a Node that is:
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         {
             if (tokenToRightOrIn != default)
             {
-                var rightNode = tokenToRightOrIn.Parent;
+                SyntaxNode? rightNode = tokenToRightOrIn.Parent;
                 do
                 {
                     // Consider either a Node that is:
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 
         private void AddRelevantNodesForSelection<TSyntaxNode>(ISyntaxFactsService syntaxFacts, SyntaxNode root, TextSpan selectionTrimmed, ArrayBuilder<TSyntaxNode> relevantNodesBuilder, CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
         {
-            var selectionNode = root.FindNode(selectionTrimmed, getInnermostNodeForTie: true);
+            SyntaxNode? selectionNode = root.FindNode(selectionTrimmed, getInnermostNodeForTie: true);
             var prevNode = selectionNode;
             do
             {
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             var token = root.FindTokenOnRightOfPosition(position, true);
 
             // traverse upwards and add all parents if of correct type
-            var ancestor = token.Parent;
+            SyntaxNode? ancestor = token.Parent;
             while (ancestor != null)
             {
                 if (ancestor is TSyntaxNode correctTypeNode)

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         private HashSet<string> GetNamespacesInScope(Document document, SyntaxContext syntaxContext, CancellationToken cancellationToken)
         {
             var semanticModel = syntaxContext.SemanticModel;
-            var importedNamespaces = GetImportedNamespaces(syntaxContext.LeftToken.Parent, semanticModel, cancellationToken);
+            var importedNamespaces = GetImportedNamespaces(syntaxContext.LeftToken.Parent!, semanticModel, cancellationToken);
 
             // This hashset will be used to match namespace names, so it must have the same case-sensitivity as the source language.
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var importNode = CreateImport(document, containingNamespace);
 
-            var rootWithImport = addImportService.AddImport(compilation, root, addImportContextNode, importNode, placeSystemNamespaceFirst, cancellationToken);
+            var rootWithImport = addImportService.AddImport(compilation, root, addImportContextNode!, importNode, placeSystemNamespaceFirst, cancellationToken);
             var documentWithImport = document.WithSyntaxRoot(rootWithImport);
             // This only formats the annotated import we just added, not the entire document.
             var formattedDocumentWithImport = await Formatter.FormatAsync(documentWithImport, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1225,7 +1225,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             var oldAncestors = GetExceptionHandlingAncestors(oldStatementSyntax, isNonLeaf);
-            var newAncestors = GetExceptionHandlingAncestors(newStatementSyntax, isNonLeaf);
+            var newAncestors = GetExceptionHandlingAncestors(newStatementSyntax!, isNonLeaf);
 
             if (oldAncestors.Count > 0 || newAncestors.Count > 0)
             {
@@ -1568,7 +1568,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
             var textSpan = text.Lines.GetTextSpanSafe(activeStatementSpan);
             var token = syntaxRoot.FindToken(textSpan.Start);
-            var ancestors = GetExceptionHandlingAncestors(token.Parent, isNonLeaf);
+            var ancestors = GetExceptionHandlingAncestors(token.Parent!, isNonLeaf);
             return GetExceptionRegions(ancestors, text, out isCovered);
         }
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// or null if the node isn't contained in a lambda. If a node is returned it must uniquely represent the lambda,
         /// i.e. be no two distinct nodes may represent the same lambda.
         /// </summary>
-        protected abstract SyntaxNode? FindEnclosingLambdaBody(SyntaxNode? container, SyntaxNode? node);
+        protected abstract SyntaxNode? FindEnclosingLambdaBody(SyntaxNode? container, SyntaxNode node);
 
         /// <summary>
         /// Given a node that represents a lambda body returns all nodes of the body in a syntax list.
@@ -744,7 +744,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                         // The tracking span might have been moved outside of lambda.
                         // It is not an error to move the statement - we just ignore it.
-                        var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldMember.FindToken(adjustedOldStatementStart).Parent);
+                        var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldMember.FindToken(adjustedOldStatementStart).Parent!);
                         var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody, trackedStatement);
                         if (oldEnclosingLambdaBody == newEnclosingLambdaBody)
                         {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1756,7 +1756,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         protected static bool HasEdit(Dictionary<SyntaxNode, EditKind> editMap, SyntaxNode? node, EditKind editKind)
         {
-            return 
+            return
                 node is object &&
                 editMap.TryGetValue(node, out var parentEdit) &&
                 parentEdit == editKind;

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1955,19 +1955,20 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return -1;
         }
 
-        private static List<SyntaxNode?>? GetAncestors(SyntaxNode? root, SyntaxNode? node, Func<SyntaxNode, bool> nodeSelector)
+        private static List<SyntaxNode?>? GetAncestors(SyntaxNode? root, SyntaxNode node, Func<SyntaxNode, bool> nodeSelector)
         {
             List<SyntaxNode?>? list = null;
+            SyntaxNode? current = node;
 
-            while (node is object && node != root)
+            while (current is object && current != root)
             {
-                if (nodeSelector(node))
+                if (nodeSelector(current))
                 {
                     list ??= new List<SyntaxNode?>();
-                    list.Add(node);
+                    list.Add(current);
                 }
 
-                node = node.Parent;
+                current = current.Parent;
             }
 
             list?.Reverse();

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
         }
 
         private static string? GetClassificationForTypeDeclarationIdentifier(SyntaxToken identifier)
-            => identifier.Parent.Kind() switch
+            => identifier.Parent!.Kind() switch
             {
                 SyntaxKind.ClassDeclaration => ClassificationTypeNames.ClassName,
                 SyntaxKind.EnumDeclaration => ClassificationTypeNames.EnumName,

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -249,7 +249,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 // Handle nested Tuple deconstruction
                 while (parent.IsKind(SyntaxKind.ParenthesizedVariableDesignation))
                 {
-                    parent = parent.Parent;
+                    // https://github.com/dotnet/roslyn/issues/40509
+                    parent = parent!.Parent;
                 }
 
                 // Checking for DeclarationExpression covers the following cases:
@@ -315,7 +316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
         public static bool IsStaticallyDeclared(SyntaxToken token)
         {
-            var parentNode = token.Parent;
+            SyntaxNode? parentNode = token.Parent;
 
             if (parentNode.IsKind(SyntaxKind.EnumMemberDeclaration))
             {
@@ -328,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             {
                 // The parent of a VariableDeclarator is a VariableDeclarationSyntax node.
                 // It's parent will be the declaration syntax node.
-                parentNode = parentNode.Parent.Parent;
+                parentNode = parentNode!.Parent!.Parent;
 
                 // Check if this is a field constant declaration 
                 if (parentNode.GetModifiers().Any(SyntaxKind.ConstKeyword))

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -249,8 +249,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 // Handle nested Tuple deconstruction
                 while (parent.IsKind(SyntaxKind.ParenthesizedVariableDesignation))
                 {
-                    // https://github.com/dotnet/roslyn/issues/40509
-                    parent = parent!.Parent;
+                    parent = parent.Parent;
                 }
 
                 // Checking for DeclarationExpression covers the following cases:

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
@@ -5,6 +5,7 @@
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification
 {
@@ -173,7 +174,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             }
             else if (token.Kind() != SyntaxKind.XmlTextLiteralNewLineToken)
             {
-                switch (token.Parent!.Kind())
+                RoslynDebug.Assert(token.Parent is object);
+                switch (token.Parent.Kind())
                 {
                     case SyntaxKind.XmlText:
                         AddClassification(token, ClassificationTypeNames.XmlDocCommentText);

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             }
             else if (token.Kind() != SyntaxKind.XmlTextLiteralNewLineToken)
             {
-                switch (token.Parent.Kind())
+                switch (token.Parent!.Kind())
                 {
                     case SyntaxKind.XmlText:
                         AddClassification(token, ClassificationTypeNames.XmlDocCommentText);

--- a/src/Workspaces/CSharp/Portable/Extensions/ILocalSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ILocalSymbolExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             return true;
 
-            bool HasTypeParameterWithName(SyntaxNode node, string name)
+            bool HasTypeParameterWithName(SyntaxNode? node, string name)
             {
                 SeparatedSyntaxList<TypeParameterSyntax>? typeParameters;
                 switch (node)

--- a/src/Workspaces/CSharp/Portable/Extensions/ILocalSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ILocalSymbolExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             return true;
 
-            bool HasTypeParameterWithName(SyntaxNode? node, string name)
+            static bool HasTypeParameterWithName(SyntaxNode? node, string name)
             {
                 SeparatedSyntaxList<TypeParameterSyntax>? typeParameters;
                 switch (node)

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         private static IEnumerable<UsingDirectiveSyntax> GetApplicableUsings(int position, SyntaxNode root)
         {
-            var namespaceUsings = root.FindToken(position).Parent.GetAncestors<NamespaceDeclarationSyntax>().SelectMany(n => n.Usings);
+            var namespaceUsings = root.FindToken(position).Parent!.GetAncestors<NamespaceDeclarationSyntax>().SelectMany(n => n.Usings);
             var allUsings = root is CompilationUnitSyntax
                 ? ((CompilationUnitSyntax)root).Usings.Concat(namespaceUsings)
                 : namespaceUsings;

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -156,10 +156,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return SyntaxFacts.IsAttributeName(node);
         }
 
-        public bool IsInvocationExpression(SyntaxNode node)
+#nullable enable
+        public bool IsInvocationExpression(SyntaxNode? node)
         {
             return node is InvocationExpressionSyntax;
         }
+#nullable restore
 
         public bool IsAnonymousFunction(SyntaxNode node)
         {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -140,11 +140,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return name.IsRightSideOfQualifiedName();
         }
 
-        public bool IsNameOfMemberAccessExpression(SyntaxNode node)
+#nullable enable
+        public bool IsNameOfMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node)
         {
             var name = node as SimpleNameSyntax;
             return name.IsMemberAccessExpressionName();
         }
+#nullable restore
 
         public bool IsObjectCreationExpressionType(SyntaxNode node)
         {
@@ -559,8 +561,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool IsPostfixUnaryExpression(SyntaxNode node)
             => node is PostfixUnaryExpressionSyntax;
 
-        public bool IsMemberBindingExpression(SyntaxNode node)
+#nullable enable
+        public bool IsMemberBindingExpression([NotNullWhen(true)] SyntaxNode? node)
             => node is MemberBindingExpressionSyntax;
+#nullable restore
 
         public bool IsPointerMemberAccessExpression(SyntaxNode node)
             => (node as MemberAccessExpressionSyntax)?.Kind() == SyntaxKind.PointerMemberAccessExpression;

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -157,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #nullable enable
-        public bool IsInvocationExpression(SyntaxNode? node)
+        public bool IsInvocationExpression([NotNullWhen(true)] SyntaxNode? node)
         {
             return node is InvocationExpressionSyntax;
         }

--- a/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
+++ b/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
@@ -168,13 +168,15 @@ namespace Microsoft.CodeAnalysis.AddImports
         private static SyntaxNode? GetFirstApplicableContainer(SyntaxNode contextNode)
         {
             var usingDirective = contextNode.GetAncestor<TUsingOrAliasSyntax>();
+
+            SyntaxNode? node = contextNode;
             if (usingDirective != null)
             {
-                contextNode = usingDirective.Parent!;
+                node = usingDirective.Parent!;
             }
 
-            return contextNode.GetAncestor<TNamespaceDeclarationSyntax>() ??
-                   (SyntaxNode?)contextNode.GetAncestorOrThis<TCompilationUnitSyntax>();
+            return node.GetAncestor<TNamespaceDeclarationSyntax>() ??
+                   (SyntaxNode?)node.GetAncestorOrThis<TCompilationUnitSyntax>();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
+++ b/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
@@ -169,12 +169,7 @@ namespace Microsoft.CodeAnalysis.AddImports
         {
             var usingDirective = contextNode.GetAncestor<TUsingOrAliasSyntax>();
 
-            SyntaxNode? node = contextNode;
-            if (usingDirective != null)
-            {
-                node = usingDirective.Parent!;
-            }
-
+            SyntaxNode? node = usingDirective != null ? usingDirective.Parent! : contextNode;
             return node.GetAncestor<TNamespaceDeclarationSyntax>() ??
                    (SyntaxNode?)node.GetAncestorOrThis<TCompilationUnitSyntax>();
         }

--- a/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
+++ b/src/Workspaces/Core/Portable/AddImports/AbstractAddImportsService.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.AddImports
             var usingDirective = contextNode.GetAncestor<TUsingOrAliasSyntax>();
             if (usingDirective != null)
             {
-                contextNode = usingDirective.Parent;
+                contextNode = usingDirective.Parent!;
             }
 
             return contextNode.GetAncestor<TNamespaceDeclarationSyntax>() ??

--- a/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
+++ b/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         /// <summary>
         /// Returns a parent for the specified node.
         /// </summary>
-        protected internal abstract bool TryGetParent(TNode node, [NotNullWhen(true)][AllowNull] out TNode parent);
+        protected internal abstract bool TryGetParent(TNode node, [MaybeNullWhen(false)] out TNode parent);
 
         internal TNode GetParent(TNode node)
         {

--- a/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
+++ b/src/Workspaces/Core/Portable/Differencing/TreeComparer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
 #nullable enable
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         /// <summary>
         /// Returns a parent for the specified node.
         /// </summary>
-        protected internal abstract bool TryGetParent(TNode node, out TNode parent);
+        protected internal abstract bool TryGetParent(TNode node, [NotNullWhen(true)][AllowNull] out TNode parent);
 
         internal TNode GetParent(TNode node)
         {

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/AbstractSyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/AbstractSyntaxFactsService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -607,7 +608,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         public bool IsReturnStatement(SyntaxNode node)
             => node?.RawKind == SyntaxKinds.ReturnStatement;
 
-        public bool IsExpressionStatement(SyntaxNode node)
+#nullable enable
+        public bool IsExpressionStatement([NotNullWhen(true)] SyntaxNode? node)
             => node?.RawKind == SyntaxKinds.ExpressionStatement;
+#nullable restore
     }
 }

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
@@ -133,7 +134,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsCastExpression(SyntaxNode node);
         void GetPartsOfCastExpression(SyntaxNode node, out SyntaxNode type, out SyntaxNode expression);
 
-        bool IsInvocationExpression(SyntaxNode node);
+#nullable enable
+        bool IsInvocationExpression(SyntaxNode? node);
+#nullable restore
+
         bool IsExpressionOfInvocationExpression(SyntaxNode node);
         void GetPartsOfInvocationExpression(SyntaxNode node, out SyntaxNode expression, out SyntaxNode argumentList);
 
@@ -303,7 +307,11 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// functions.
         /// </summary>
         bool IsMethodBody(SyntaxNode node);
-        bool IsExpressionStatement(SyntaxNode node);
+
+        #nullable enable
+        bool IsExpressionStatement([NotNullWhen(true)] SyntaxNode? node);
+        #nullable restore
+
         bool IsReturnStatement(SyntaxNode node);
         SyntaxNode GetExpressionOfReturnStatement(SyntaxNode node);
 

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -308,9 +308,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// </summary>
         bool IsMethodBody(SyntaxNode node);
 
-        #nullable enable
+#nullable enable
         bool IsExpressionStatement([NotNullWhen(true)] SyntaxNode? node);
-        #nullable restore
+#nullable restore
 
         bool IsReturnStatement(SyntaxNode node);
         SyntaxNode GetExpressionOfReturnStatement(SyntaxNode node);

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         void GetPartsOfCastExpression(SyntaxNode node, out SyntaxNode type, out SyntaxNode expression);
 
 #nullable enable
-        bool IsInvocationExpression(SyntaxNode? node);
+        bool IsInvocationExpression([NotNullWhen(true)] SyntaxNode? node);
 #nullable restore
 
         bool IsExpressionOfInvocationExpression(SyntaxNode node);

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -199,7 +199,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsRightSideOfQualifiedName(SyntaxNode node);
         bool IsLeftSideOfExplicitInterfaceSpecifier(SyntaxNode node);
 
-        bool IsNameOfMemberAccessExpression(SyntaxNode node);
+#nullable enable
+        bool IsNameOfMemberAccessExpression([NotNullWhen(true)] SyntaxNode? node);
+#nullable restore
         bool IsExpressionOfMemberAccessExpression(SyntaxNode node);
 
         SyntaxNode GetNameOfMemberAccessExpression(SyntaxNode node);
@@ -239,7 +241,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsConditionalAccessExpression(SyntaxNode node);
         void GetPartsOfConditionalAccessExpression(SyntaxNode node, out SyntaxNode expression, out SyntaxToken operatorToken, out SyntaxNode whenNotNull);
 
-        bool IsMemberBindingExpression(SyntaxNode node);
+#nullable enable
+        bool IsMemberBindingExpression([NotNullWhen(true)] SyntaxNode? node);
+#nullable restore
         bool IsPostfixUnaryExpression(SyntaxNode node);
 
         bool IsParenthesizedExpression(SyntaxNode node);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis.Extensions
             // "(large * large) * small.  And that could easily overflow to Inf (and 
             // other badness).
             var parentBinary = parenthesizedExpression.Parent;
+            if (parentBinary is null)
+            {
+                return false;
+            }
+
             var outerTypeInfo = semanticModel.GetTypeInfo(parentBinary);
             if (IsFloatingPoint(innerTypeInfo) || IsFloatingPoint(outerTypeInfo))
             {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SemanticModelExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         /// <param name="cancellationToken">A cancellation token.</param>
         public static SymbolInfo GetSymbolInfo(this SemanticModel semanticModel, SyntaxToken token, CancellationToken cancellationToken)
         {
-            return semanticModel.GetSymbolInfo(token.Parent, cancellationToken);
+            return semanticModel.GetSymbolInfo(token.Parent!, cancellationToken);
         }
 
         public static TSymbol? GetEnclosingSymbol<TSymbol>(this SemanticModel semanticModel, int position, CancellationToken cancellationToken)
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
             else
             {
-                aliasSymbol = semanticModel.GetAliasInfo(token.Parent, cancellationToken);
+                aliasSymbol = semanticModel.GetAliasInfo(token.Parent!, cancellationToken);
                 var bindableParent = syntaxFacts.GetBindableParent(token);
                 var typeInfo = semanticModel.GetTypeInfo(bindableParent, cancellationToken);
                 type = typeInfo.Type;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/SyntaxTokenExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var nextToken = token.GetNextToken(includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
 
             return nextToken.RawKind == 0
-                ? ((ICompilationUnitSyntax)token.Parent.SyntaxTree.GetRoot(CancellationToken.None)).EndOfFileToken
+                ? ((ICompilationUnitSyntax)token.Parent!.SyntaxTree!.GetRoot(CancellationToken.None)).EndOfFileToken
                 : nextToken;
         }
 


### PR DESCRIPTION
This PR adds nullable annotations for `SyntaxNode` and `SyntaxToken`. 

A good chunk of this change is dealing with the fallout of the `Parent` properties of both types now being nullable instead of non-nullable. The CSharpEditAndContinueAnalyzer in particular has a strong assertion that these are non-nullable. This is generally "okay" because it understands that it won't be null given the context in which it operates. 

Unfortunately though there are many places where I've had to use `!` due to the lack of assertions around `Parent` uses. I'm sure there will be plenty of feedback on the different approaches I took here. All is very welcome because I'm unsure of the best path in several places.