### PR TITLE
Ignore casing when looking up Naming Rules/Styles/Symbols

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -93,12 +93,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 ["dotnet_naming_style.pascal_case_style.capitalization"] = "pascal_case"
             };
             var result = ParseDictionary(dictionary);
-            Assert.Single(result.NamingRules);
-            var namingRule = result.NamingRules.Single();
-            Assert.Single(result.NamingStyles);
-            var namingStyle = result.NamingStyles.Single();
-            Assert.Single(result.SymbolSpecifications);
-            var symbolSpec = result.SymbolSpecifications.Single();
+            var namingRule = Assert.Single(result.NamingRules);
+            var namingStyle = Assert.Single(result.NamingStyles);
+            var symbolSpec = Assert.Single(result.SymbolSpecifications);
             Assert.Equal(namingStyle.ID, namingRule.NamingStyleID);
             Assert.Equal(symbolSpec.ID, namingRule.SymbolSpecificationID);
             Assert.Equal(ReportDiagnostic.Warn, namingRule.EnforcementLevel);

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -80,6 +80,31 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
         }
 
         [Fact]
+        [WorkItem(40705, "https://github.com/dotnet/roslyn/issues/40705")]
+        public static void TestPascalCaseRuleWithKeyCapitalization()
+        {
+            var dictionary = new Dictionary<string, string>()
+            {
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity"] = "warning",
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.symbols"] = "Method_and_Property_symbols",
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.style"] = "Pascal_Case_style",
+                ["dotnet_naming_symbols.method_and_property_symbols.applicable_kinds"] = "method,property",
+                ["dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities"] = "*",
+                ["dotnet_naming_style.pascal_case_style.capitalization"] = "pascal_case"
+            };
+            var result = ParseDictionary(dictionary);
+            Assert.Single(result.NamingRules);
+            var namingRule = result.NamingRules.Single();
+            Assert.Single(result.NamingStyles);
+            var namingStyle = result.NamingStyles.Single();
+            Assert.Single(result.SymbolSpecifications);
+            var symbolSpec = result.SymbolSpecifications.Single();
+            Assert.Equal(namingStyle.ID, namingRule.NamingStyleID);
+            Assert.Equal(symbolSpec.ID, namingRule.SymbolSpecificationID);
+            Assert.Equal(ReportDiagnostic.Warn, namingRule.EnforcementLevel);
+        }
+
+        [Fact]
         public static void TestAsyncMethodsAndLocalFunctionsRule()
         {
             var dictionary = new Dictionary<string, string>()

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -127,8 +127,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         private static Dictionary<string, string> TrimDictionary(IReadOnlyDictionary<string, string> allRawConventions)
         {
-            // At this point, keys have been lowercased but values have not. So, for example, to
-            // make a naming style called "Pascal_Case_style" match up correctly with
+            // At this point, keys have been lowercased. So, for example, to make a naming style
+            // called "Pascal_Case_style" match up correctly with the key
             // "dotnet_naming_style.pascal_case_style.capitalization", we have to ignore casing for
             // lookups in this dictionary.
             var trimmedDictionary = new Dictionary<string, string>(allRawConventions.Count, StringComparer.OrdinalIgnoreCase);

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -127,7 +127,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         private static Dictionary<string, string> TrimDictionary(IReadOnlyDictionary<string, string> allRawConventions)
         {
-            var trimmedDictionary = new Dictionary<string, string>(allRawConventions.Count);
+            // At this point, keys have been lowercased but values have not. So, for example, to
+            // make a naming style called "Pascal_Case_style" match up correctly with
+            // "dotnet_naming_style.pascal_case_style.capitalization", we have to ignore casing for
+            // lookups in this dictionary.
+            var trimmedDictionary = new Dictionary<string, string>(allRawConventions.Count, StringComparer.OrdinalIgnoreCase);
             foreach (var item in allRawConventions)
             {
                 var key = item.Key.Trim();

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             // called "Pascal_Case_style" match up correctly with the key
             // "dotnet_naming_style.pascal_case_style.capitalization", we have to ignore casing for
             // lookups in this dictionary.
-            var trimmedDictionary = new Dictionary<string, string>(allRawConventions.Count, StringComparer.OrdinalIgnoreCase);
+            var trimmedDictionary = new Dictionary<string, string>(allRawConventions.Count, AnalyzerConfigOptions.KeyComparer);
             foreach (var item in allRawConventions)
             {
                 var key = item.Key.Trim();

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser.cs
@@ -127,10 +127,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         private static Dictionary<string, string> TrimDictionary(IReadOnlyDictionary<string, string> allRawConventions)
         {
-            // At this point, keys have been lowercased. So, for example, to make a naming style
-            // called "Pascal_Case_style" match up correctly with the key
-            // "dotnet_naming_style.pascal_case_style.capitalization", we have to ignore casing for
-            // lookups in this dictionary.
+            // Keys have been lowercased, but values have not. Because values here reference key
+            // names we need any comparisons to ignore case.
+            // For example, to make a naming style called "Pascal_Case_style" match up correctly
+            // with the key "dotnet_naming_style.pascal_case_style.capitalization", we have to
+            // ignore casing for that lookup.
             var trimmedDictionary = new Dictionary<string, string>(allRawConventions.Count, AnalyzerConfigOptions.KeyComparer);
             foreach (var item in allRawConventions)
             {

--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/NamingStylePreferenceEditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/NamingStylePreferenceEditorConfigStorageLocationTests.cs
@@ -67,8 +67,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [InlineData("B", "a", "a", "*", "*")]
         [InlineData("A", "B", "A", "*", "*")]
         [InlineData("B", "A", "A", "*", "*")]
-        [InlineData("a", "A", "A", "*", "*")]
-        [InlineData("A", "a", "A", "*", "*")]
         public static void TestOrderedByAccessibilityBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstAccessibility, string secondAccessibility)
         {
             var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
@@ -113,8 +111,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [InlineData("B", "a", "a", "", "")]
         [InlineData("A", "B", "A", "", "")]
         [InlineData("B", "A", "A", "", "")]
-        [InlineData("a", "A", "A", "*", "*")]
-        [InlineData("A", "a", "A", "*", "*")]
         public static void TestOrderedByModifiersBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstModifiers, string secondModifiers)
         {
             var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
@@ -159,8 +155,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [InlineData("B", "a", "a", "*", "*")]
         [InlineData("A", "B", "A", "*", "*")]
         [InlineData("B", "A", "A", "*", "*")]
-        [InlineData("a", "A", "A", "*", "*")]
-        [InlineData("A", "a", "A", "*", "*")]
         public static void TestOrderedBySymbolsBeforeName(string firstName, string secondName, string firstNameAfterOrdering, string firstSymbols, string secondSymbols)
         {
             var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();


### PR DESCRIPTION
Fixes #40705 