### PR TITLE
Remove Dispose(disposing) from objects without finalization

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticDataSerializerTests.cs
@@ -343,13 +343,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                         return SpecializedTasks.True;
                     }
 
-                    protected virtual void Dispose(bool disposing)
+                    public virtual void Dispose()
                     {
-                    }
-
-                    public void Dispose()
-                    {
-                        Dispose(true);
                     }
                 }
             }

--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -103,14 +103,14 @@ namespace Roslyn.Test.Utilities.Remote
         {
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Dispose()
         {
             // we are asked to disconnect. unsubscribe and dispose to disconnect
             _endPoint.Disconnected -= OnDisconnected;
             _endPoint.Dispose();
             _remotableDataRpc.Dispose();
 
-            base.Dispose(disposing);
+            base.Dispose();
         }
 
         private void OnDisconnected(JsonRpcDisconnectedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RunningDocumentTableEventTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RunningDocumentTableEventTracker.cs
@@ -236,26 +236,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return false;
         }
 
-        #region IDisposable Support
-        private void Dispose(bool disposing)
-        {
-            if (!_isDisposed)
-            {
-                if (disposing)
-                {
-                    var runningDocumentTableForEvents = (IVsRunningDocumentTable)_runningDocumentTable;
-                    runningDocumentTableForEvents.UnadviseRunningDocTableEvents(_runningDocumentTableEventsCookie);
-                    _runningDocumentTableEventsCookie = 0;
-                }
-
-                _isDisposed = true;
-            }
-        }
-
         public void Dispose()
         {
-            Dispose(true);
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            var runningDocumentTableForEvents = (IVsRunningDocumentTable)_runningDocumentTable;
+            runningDocumentTableForEvents.UnadviseRunningDocTableEvents(_runningDocumentTableEventsCookie);
+            _runningDocumentTableEventsCookie = 0;
+
+            _isDisposed = true;
         }
-        #endregion
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcConnection.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/JsonRpcConnection.cs
@@ -52,17 +52,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         public override Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> directStreamReader, CancellationToken cancellationToken)
             => _serviceEndPoint.InvokeAsync(targetName, arguments, directStreamReader, cancellationToken);
 
-        protected override void Dispose(bool disposing)
+        protected override void DisposeImpl()
         {
-            if (disposing)
-            {
-                // dispose service and snapshot channels
-                _serviceEndPoint.UnexpectedExceptionThrown -= UnexpectedExceptionThrown;
-                _serviceEndPoint.Dispose();
-                _remoteDataRpc.Dispose();
-            }
+            // dispose service and snapshot channels
+            _serviceEndPoint.UnexpectedExceptionThrown -= UnexpectedExceptionThrown;
+            _serviceEndPoint.Dispose();
+            _remoteDataRpc.Dispose();
 
-            base.Dispose(disposing);
+            base.DisposeImpl();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.PooledConnection.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.PooledConnection.cs
@@ -35,14 +35,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 public override Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> directStreamReader, CancellationToken cancellationToken)
                     => _connection.InvokeAsync(targetName, arguments, directStreamReader, cancellationToken);
 
-                protected override void Dispose(bool disposing)
+                protected override void DisposeImpl()
                 {
-                    if (disposing)
-                    {
-                        _connectionManager.Free(_serviceName, _connection);
-                    }
-
-                    base.Dispose(disposing);
+                    _connectionManager.Free(_serviceName, _connection);
+                    base.DisposeImpl();
                 }
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             RegisterGlobalOperationNotifications();
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Dispose()
         {
             // cancel all pending async work
             _shutdownCancellationTokenSource.Cancel();
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             _connectionManager.Dispose();
 
-            base.Dispose(disposing);
+            base.Dispose();
         }
 
         public HostGroup HostGroup

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -333,11 +333,9 @@ End Class";
             public override Workspace Workspace => _workspace;
         }
 
-        private class InvokeThrowsCancellationConnection : RemoteHostClient.Connection
+        private sealed class InvokeThrowsCancellationConnection : RemoteHostClient.Connection
         {
             private readonly CancellationTokenSource _source;
-
-            public bool Disposed = false;
 
             public InvokeThrowsCancellationConnection(CancellationTokenSource source)
             {
@@ -360,13 +358,6 @@ End Class";
             public override Task<T> InvokeAsync<T>(
                 string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync, CancellationToken cancellationToken)
                 => throw new NotImplementedException();
-
-            protected override void Dispose(bool disposing)
-            {
-                base.Dispose(disposing);
-
-                Disposed = true;
-            }
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
@@ -77,12 +77,6 @@ namespace Roslyn.VisualStudio.IntegrationTests
             return Task.CompletedTask;
         }
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
         protected virtual MessageFilter RegisterMessageFilter()
             => new MessageFilter();
 
@@ -93,17 +87,13 @@ namespace Roslyn.VisualStudio.IntegrationTests
         }
 
         /// <summary>
-        /// This method provides the implementation for <see cref="IDisposable.Dispose"/>. This method via the
-        /// <see cref="IDisposable"/> interface (i.e. <paramref name="disposing"/> is <see langword="true"/>) if the
-        /// constructor completes successfully. The <see cref="InitializeAsync"/> may or may not have completed
-        /// successfully.
+        /// This method provides the implementation for <see cref="IDisposable.Dispose"/>.
+        /// This method is called via the <see cref="IDisposable"/> interface if the constructor completes successfully.
+        /// The <see cref="InitializeAsync"/> may or may not have completed successfully.
         /// </summary>
-        protected virtual void Dispose(bool disposing)
+        public virtual void Dispose()
         {
-            if (disposing)
-            {
-                _messageFilter.Dispose();
-            }
+            _messageFilter.Dispose();
         }
 
         protected KeyPress Ctrl(VirtualKey virtualKey)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Harness/MessageFilter.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Harness/MessageFilter.cs
@@ -8,9 +8,9 @@ using SERVERCALL = Microsoft.VisualStudio.OLE.Interop.SERVERCALL;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Harness
 {
-    public class MessageFilter : IMessageFilter, IDisposable
+    public sealed class MessageFilter : IMessageFilter, IDisposable
     {
-        protected const uint CancelCall = ~0U;
+        private const uint CancelCall = ~0U;
 
         private readonly MessageFilterSafeHandle _messageFilterRegistration;
         private readonly TimeSpan _timeout;
@@ -28,12 +28,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Harness
             _messageFilterRegistration = MessageFilterSafeHandle.Register(this);
         }
 
-        public virtual uint HandleInComingCall(uint dwCallType, IntPtr htaskCaller, uint dwTickCount, INTERFACEINFO[] lpInterfaceInfo)
+        public uint HandleInComingCall(uint dwCallType, IntPtr htaskCaller, uint dwTickCount, INTERFACEINFO[] lpInterfaceInfo)
         {
             return (uint)SERVERCALL.SERVERCALL_ISHANDLED;
         }
 
-        public virtual uint RetryRejectedCall(IntPtr htaskCallee, uint dwTickCount, uint dwRejectType)
+        public uint RetryRejectedCall(IntPtr htaskCallee, uint dwTickCount, uint dwRejectType)
         {
             if ((SERVERCALL)dwRejectType != SERVERCALL.SERVERCALL_RETRYLATER
                 && (SERVERCALL)dwRejectType != SERVERCALL.SERVERCALL_REJECTED)
@@ -49,23 +49,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Harness
             return (uint)_retryDelay.TotalMilliseconds;
         }
 
-        public virtual uint MessagePending(IntPtr htaskCallee, uint dwTickCount, uint dwPendingType)
+        public uint MessagePending(IntPtr htaskCallee, uint dwTickCount, uint dwPendingType)
         {
             return (uint)PENDINGMSG.PENDINGMSG_WAITDEFPROCESS;
         }
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _messageFilterRegistration.Dispose();
-            }
-        }
-
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            _messageFilterRegistration.Dispose();
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -53,12 +53,7 @@ namespace Microsoft.CodeAnalysis.Remote
             OnStatusChanged(started: true);
         }
 
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-        }
-
-        protected virtual void Dispose(bool disposing)
+        public virtual void Dispose()
         {
             OnStatusChanged(started: false);
         }
@@ -220,7 +215,7 @@ namespace Microsoft.CodeAnalysis.Remote
             public abstract Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken);
             public abstract Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync, CancellationToken cancellationToken);
 
-            protected virtual void Dispose(bool disposing)
+            protected virtual void DisposeImpl()
             {
                 // do nothing
             }
@@ -234,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 _disposed = true;
 
-                Dispose(disposing: true);
+                DisposeImpl();
                 GC.SuppressFinalize(this);
             }
 

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedInfo.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedInfo.cs
@@ -169,18 +169,9 @@ namespace Microsoft.CodeAnalysis.Host
 
             public void Dispose()
             {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-
-            private void Dispose(bool disposing)
-            {
-                if (disposing)
-                {
-                    // See remarks on field for relation between _memoryMappedFile and the views/streams. There is no
-                    // need to write _weakReadAccessor here since lifetime of the target is not owned by this instance.
-                    _memoryMappedFile.Dispose();
-                }
+                // See remarks on field for relation between _memoryMappedFile and the views/streams. There is no
+                // need to write _weakReadAccessor here since lifetime of the target is not owned by this instance.
+                _memoryMappedFile.Dispose();
             }
 
             private unsafe sealed class SharedReadableStream : Stream, ISupportDirectMemoryAccess


### PR DESCRIPTION
Follow up on feedback on https://github.com/dotnet/roslyn/pull/40395.

The rules on which dispose patterns to use:

The base type that implements IDisposable chooses whether to implement the legacy pattern (with `protected virtual void Dispose(bool)`) or the new pattern (with `public virtual void Dispose()`)
- A type using the new pattern must not add a finalizer
- A type derived from a type that uses the new pattern must not add a finalizer

