### PR TITLE
Speed up ISemanticFactsService.GetDeclaredSymbol

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -145,16 +145,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function GetDeclaredSymbol(semanticModel As SemanticModel, token As SyntaxToken, cancellationToken As CancellationToken) As ISymbol Implements ISemanticFactsService.GetDeclaredSymbol
             Dim location = token.GetLocation()
 
-            Dim q = From node In token.GetAncestors(Of SyntaxNode)()
-                    Where Not TypeOf node Is AggregationRangeVariableSyntax AndAlso
-                          Not TypeOf node Is CollectionRangeVariableSyntax AndAlso
-                          Not TypeOf node Is ExpressionRangeVariableSyntax AndAlso
-                          Not TypeOf node Is InferredFieldInitializerSyntax
-                    Let symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken)
-                    Where symbol IsNot Nothing AndAlso symbol.Locations.Contains(location)
-                    Select symbol
+            For Each ancestor In token.GetAncestors(Of SyntaxNode)()
+                If Not TypeOf ancestor Is AggregationRangeVariableSyntax AndAlso
+                   Not TypeOf ancestor Is CollectionRangeVariableSyntax AndAlso
+                   Not TypeOf ancestor Is ExpressionRangeVariableSyntax AndAlso
+                   Not TypeOf ancestor Is InferredFieldInitializerSyntax Then
 
-            Return q.FirstOrDefault()
+                    Dim symbol = semanticModel.GetDeclaredSymbol(ancestor)
+
+                    If symbol IsNot Nothing Then
+                        If symbol.Locations.Contains(location) Then
+                            Return symbol
+                        End If
+
+                        ' We found some symbol, but it defined something else. We're not going to have a higher node defining _another_ symbol with this token, so we can stop now.
+                        Return Nothing
+                    End If
+
+                    ' If we hit an executable statement syntax and didn't find anything yet, we can just stop now -- anything higher would be a member declaration which won't be defined by something inside a statement.
+                    If SyntaxFactsService.IsExecutableStatement(ancestor) Then
+                        Return Nothing
+                    End If
+                End If
+            Next
+
+            Return Nothing
         End Function
 
         Public Function LastEnumValueHasInitializer(namedTypeSymbol As INamedTypeSymbol) As Boolean Implements ISemanticFactsService.LastEnumValueHasInitializer


### PR DESCRIPTION
This method tries to find the symbol that's defined by a particular token, instead of a particular node. The approach was simply to bind parent nodes until it found a symbol that had as the location the original token. If it found a symbol that didn't match by location it kept going up, so binding any identifier that doesn't define anything would have always been fetching (and then throwing away) the symbols for the containing members and type.

This tweaks it that once we find a symbol that doesn't match, we just stop since we don't have a case where one symbol is contained in another but the outer symbol is defined by some token inside the inner one. There's definitely better ways to do this too but this is a fairly straightforward improvement that doesn't require a fundamentally different approach.

This is to aid #40574 which is effectively calling GetDeclaredSymbol for every single identifier in an entire solution, and speeds up that specific part of the code by over 50%.