### PR TITLE
Change the default value of ObjectWriter leaveOpen parameter.

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Deserialize a syntax node from the byte stream.
         /// </summary>
-        public static SyntaxNode DeserializeFrom(Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+        public static SyntaxNode DeserializeFrom(Stream stream, CancellationToken cancellationToken = default)
         {
             if (stream == null)
             {
@@ -192,16 +192,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new InvalidOperationException(CodeAnalysisResources.TheStreamCannotBeReadFrom);
             }
 
-            using (var reader = ObjectReader.TryGetReader(stream, cancellationToken: cancellationToken))
-            {
-                if (reader == null)
-                {
-                    throw new ArgumentException(CodeAnalysisResources.Stream_contains_invalid_data, nameof(stream));
-                }
+            using var reader = ObjectReader.TryGetReader(stream, leaveOpen: true, cancellationToken);
 
-                var root = (Syntax.InternalSyntax.CSharpSyntaxNode)reader.ReadValue();
-                return root.CreateRed();
+            if (reader == null)
+            {
+                throw new ArgumentException(CodeAnalysisResources.Stream_contains_invalid_data, nameof(stream));
             }
+
+            var root = (Syntax.InternalSyntax.CSharpSyntaxNode)reader.ReadValue();
+            return root.CreateRed();
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -41,8 +41,8 @@ namespace Roslyn.Utilities
         ///
         /// These are not readonly because they're structs and we mutate them.
         /// </summary>
-        private ReaderReferenceMap<object> _objectReferenceMap;
-        private ReaderReferenceMap<string> _stringReferenceMap;
+        private readonly ReaderReferenceMap<object> _objectReferenceMap;
+        private readonly ReaderReferenceMap<string> _stringReferenceMap;
 
         /// <summary>
         /// Copy of the global binder data that maps from Types to the appropriate reading-function
@@ -58,16 +58,18 @@ namespace Roslyn.Utilities
         /// Creates a new instance of a <see cref="ObjectReader"/>.
         /// </summary>
         /// <param name="stream">The stream to read objects from.</param>
+        /// <param name="leaveOpen">True to leave the <paramref name="stream"/> open after the <see cref="ObjectWriter"/> is disposed.</param>
         /// <param name="cancellationToken"></param>
         private ObjectReader(
             Stream stream,
+            bool leaveOpen,
             CancellationToken cancellationToken)
         {
             // String serialization assumes both reader and writer to be of the same endianness.
             // It can be adjusted for BigEndian if needed.
             Debug.Assert(BitConverter.IsLittleEndian);
 
-            _reader = new BinaryReader(stream, Encoding.UTF8);
+            _reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen);
             _objectReferenceMap = ReaderReferenceMap<object>.Create();
             _stringReferenceMap = ReaderReferenceMap<string>.Create();
 
@@ -85,6 +87,7 @@ namespace Roslyn.Utilities
         /// </summary>
         public static ObjectReader TryGetReader(
             Stream stream,
+            bool leaveOpen = false,
             CancellationToken cancellationToken = default)
         {
             if (stream == null)
@@ -98,7 +101,7 @@ namespace Roslyn.Utilities
                 return null;
             }
 
-            return new ObjectReader(stream, cancellationToken);
+            return new ObjectReader(stream, leaveOpen, cancellationToken);
         }
 
         public void Dispose()

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -38,8 +38,6 @@ namespace Roslyn.Utilities
 
         /// <summary>
         /// Map of reference id's to deserialized objects.
-        ///
-        /// These are not readonly because they're structs and we mutate them.
         /// </summary>
         private readonly ReaderReferenceMap<object> _objectReferenceMap;
         private readonly ReaderReferenceMap<string> _stringReferenceMap;
@@ -249,11 +247,12 @@ namespace Roslyn.Utilities
         /// <summary>
         /// An reference-id to object map, that can share base data efficiently.
         /// </summary>
-        private struct ReaderReferenceMap<T> where T : class
+        private struct ReaderReferenceMap<T> : IDisposable
+            where T : class
         {
             private readonly List<T> _values;
 
-            internal static readonly ObjectPool<List<T>> s_objectListPool
+            private static readonly ObjectPool<List<T>> s_objectListPool
                 = new ObjectPool<List<T>>(() => new List<T>(20));
 
             private ReaderReferenceMap(List<T> values)
@@ -267,7 +266,6 @@ namespace Roslyn.Utilities
                 _values.Clear();
                 s_objectListPool.Free(_values);
             }
-
 
             public int GetNextObjectId()
             {

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -73,7 +73,7 @@ namespace Roslyn.Utilities
         /// <param name="cancellationToken">Cancellation token.</param>
         public ObjectWriter(
             Stream stream,
-            bool leaveOpen = true,
+            bool leaveOpen = false,
             CancellationToken cancellationToken = default)
         {
             // String serialization assumes both reader and writer to be of the same endianness.

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -1239,7 +1239,11 @@ recurse:
             return IsEquivalentToCore(node, topLevel);
         }
 
-        public virtual void SerializeTo(Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Serializes the node to the given <paramref name="stream"/>.
+        /// Leaves the <paramref name="stream"/> open for further writes.
+        /// </summary>
+        public virtual void SerializeTo(Stream stream, CancellationToken cancellationToken = default)
         {
             if (stream == null)
             {
@@ -1251,10 +1255,8 @@ recurse:
                 throw new InvalidOperationException(CodeAnalysisResources.TheStreamCannotBeWrittenTo);
             }
 
-            using (var writer = new ObjectWriter(stream, cancellationToken: cancellationToken))
-            {
-                writer.WriteValue(this.Green);
-            }
+            using var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken);
+            writer.WriteValue(Green);
         }
 
         #region Core Methods

--- a/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/VisualBasicSyntaxNode.vb
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New InvalidOperationException(CodeAnalysisResources.TheStreamCannotBeReadFrom)
             End If
 
-            Using reader = ObjectReader.TryGetReader(stream, cancellationToken:=cancellationToken)
+            Using reader = ObjectReader.TryGetReader(stream, leaveOpen:=True, cancellationToken:=cancellationToken)
                 If reader Is Nothing Then
                     Throw New ArgumentException(CodeAnalysisResources.Stream_contains_invalid_data, NameOf(stream))
                 End If

--- a/src/EditorFeatures/Test/Utilities/BloomFilterTests.cs
+++ b/src/EditorFeatures/Test/Utilities/BloomFilterTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var stream = new MemoryStream();
             var bloomFilter = new BloomFilter(0.001, false, new[] { "Hello, World" });
 
-            using (var writer = new ObjectWriter(stream))
+            using (var writer = new ObjectWriter(stream, leaveOpen: true))
             {
                 bloomFilter.WriteTo(writer);
             }
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             var stream = new MemoryStream();
             var bloomFilter = new BloomFilter(0.001, new[] { "Hello, World" }, new long[] { long.MaxValue, -1, 0, 1, long.MinValue });
 
-            using (var writer = new ObjectWriter(stream))
+            using (var writer = new ObjectWriter(stream, leaveOpen: true))
             {
                 bloomFilter.WriteTo(writer);
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var result = await session.Connection.InvokeAsync(
                     nameof(IRemoteDiagnosticAnalyzerService.CalculateDiagnosticsAsync),
                     new object[] { argument },
-                    (s, c) => ReadCompilerAnalysisResultAsync(s, analyzerMap, project, c), cancellationToken).ConfigureAwait(false);
+                    (stream, cancellationToken) => ReadCompilerAnalysisResultAsync(stream, analyzerMap, project, cancellationToken), cancellationToken).ConfigureAwait(false);
 
                 ReportAnalyzerExceptions(project, result.Exceptions);
 
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // handling of cancellation and exception
                 var version = await GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
 
-                using var reader = ObjectReader.TryGetReader(stream);
+                using var reader = ObjectReader.TryGetReader(stream, leaveOpen: true, cancellationToken);
 
                 // We only get a reader for data transmitted between live processes.
                 // This data should always be correct as we're never persisting the data between sessions.

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeState.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeState.cs
@@ -51,19 +51,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             protected override Data TryGetExistingData(Stream stream, Document value, CancellationToken cancellationToken)
             {
-                using (var reader = ObjectReader.TryGetReader(stream))
-                {
-                    if (reader != null)
-                    {
-                        var format = reader.ReadString();
-                        if (string.Equals(format, FormatVersion, StringComparison.InvariantCulture))
-                        {
-                            var textVersion = VersionStamp.ReadFrom(reader);
-                            var dataVersion = VersionStamp.ReadFrom(reader);
-                            var designerAttributeArgument = reader.ReadString();
+                using var reader = ObjectReader.TryGetReader(stream, leaveOpen: true, cancellationToken);
 
-                            return new Data(textVersion, dataVersion, designerAttributeArgument);
-                        }
+                if (reader != null)
+                {
+                    var format = reader.ReadString();
+                    if (string.Equals(format, FormatVersion, StringComparison.InvariantCulture))
+                    {
+                        var textVersion = VersionStamp.ReadFrom(reader);
+                        var dataVersion = VersionStamp.ReadFrom(reader);
+                        var designerAttributeArgument = reader.ReadString();
+
+                        return new Data(textVersion, dataVersion, designerAttributeArgument);
                     }
                 }
 
@@ -72,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             protected override void WriteTo(Stream stream, Data data, CancellationToken cancellationToken)
             {
-                using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
+                using var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken);
                 writer.WriteString(FormatVersion);
                 data.TextVersion.WriteTo(writer);
                 data.SemanticVersion.WriteTo(writer);

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataSerializer.cs
@@ -45,9 +45,11 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             Contract.ThrowIfFalse(document == null || document.Project == project);
 
             using var stream = SerializableBytes.CreateWritableStream();
-            using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
 
-            WriteDiagnosticData(writer, items, cancellationToken);
+            using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+            {
+                WriteDiagnosticData(writer, items, cancellationToken);
+            }
 
             using var storage = persistentService.GetStorage(project.Solution);
 

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -90,29 +90,31 @@ namespace Microsoft.CodeAnalysis.Execution
             cancellationToken.ThrowIfCancellationRequested();
 
             using var stream = SerializableBytes.CreateWritableStream();
-            using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
 
-            switch (reference)
+            using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
             {
-                case AnalyzerFileReference file:
-                    WriteAnalyzerFileReferenceMvid(file, writer, usePathFromAssembly, cancellationToken);
-                    break;
+                switch (reference)
+                {
+                    case AnalyzerFileReference file:
+                        WriteAnalyzerFileReferenceMvid(file, writer, usePathFromAssembly, cancellationToken);
+                        break;
 
-                case UnresolvedAnalyzerReference unresolved:
-                    WriteUnresolvedAnalyzerReferenceTo(unresolved, writer);
-                    break;
+                    case UnresolvedAnalyzerReference unresolved:
+                        WriteUnresolvedAnalyzerReferenceTo(unresolved, writer);
+                        break;
 
-                case AnalyzerReference analyzerReference when analyzerReference.GetType().FullName == VisualStudioUnresolvedAnalyzerReference:
-                    WriteUnresolvedAnalyzerReferenceTo(analyzerReference, writer);
-                    break;
+                    case AnalyzerReference analyzerReference when analyzerReference.GetType().FullName == VisualStudioUnresolvedAnalyzerReference:
+                        WriteUnresolvedAnalyzerReferenceTo(analyzerReference, writer);
+                        break;
 
-                case AnalyzerImageReference _:
-                    // TODO: think a way to support this or a way to deal with this kind of situation.
-                    // https://github.com/dotnet/roslyn/issues/15783
-                    throw new NotSupportedException(nameof(AnalyzerImageReference));
+                    case AnalyzerImageReference _:
+                        // TODO: think a way to support this or a way to deal with this kind of situation.
+                        // https://github.com/dotnet/roslyn/issues/15783
+                        throw new NotSupportedException(nameof(AnalyzerImageReference));
 
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(reference);
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(reference);
+                }
             }
 
             stream.Position = 0;
@@ -281,10 +283,12 @@ namespace Microsoft.CodeAnalysis.Execution
         private Checksum CreatePortableExecutableReferenceChecksum(PortableExecutableReference reference, CancellationToken cancellationToken)
         {
             using var stream = SerializableBytes.CreateWritableStream();
-            using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
 
-            WritePortableExecutableReferencePropertiesTo(reference, writer, cancellationToken);
-            WriteMvidsTo(TryGetMetadata(reference), writer, cancellationToken);
+            using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+            {
+                WritePortableExecutableReferencePropertiesTo(reference, writer, cancellationToken);
+                WriteMvidsTo(TryGetMetadata(reference), writer, cancellationToken);
+            }
 
             stream.Position = 0;
             return Checksum.Create(stream);

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -42,10 +42,14 @@ namespace Microsoft.CodeAnalysis.Execution
         private static Checksum CreateChecksumFromStreamWriter(WellKnownSynchronizationKind kind, Action<ObjectWriter, CancellationToken> writer)
         {
             using var stream = SerializableBytes.CreateWritableStream();
-            using var objectWriter = new ObjectWriter(stream);
 
-            objectWriter.WriteInt32((int)kind);
-            writer(objectWriter, CancellationToken.None);
+            using (var objectWriter = new ObjectWriter(stream, leaveOpen: true))
+            {
+                objectWriter.WriteInt32((int)kind);
+                writer(objectWriter, CancellationToken.None);
+            }
+
+            stream.Position = 0;
             return Checksum.Create(stream);
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Serialization.cs
@@ -106,9 +106,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     Contract.ThrowIfNull(result);
 
                     using (var stream = SerializableBytes.CreateWritableStream())
-                    using (var writer = new ObjectWriter(stream, cancellationToken: cancellationToken))
                     {
-                        result.WriteTo(writer);
+                        using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+                        {
+                            result.WriteTo(writer);
+                        }
+
                         stream.Position = 0;
 
                         await storage.WriteStreamAsync(key, stream, checksum, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -75,9 +75,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 using var storage = persistentStorageService.GetStorage(solution, checkBranchId: false);
                 using var stream = SerializableBytes.CreateWritableStream();
-                using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
 
-                this.WriteTo(writer);
+                using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+                {
+                    WriteTo(writer);
+                }
 
                 stream.Position = 0;
                 return await storage.WriteStreamAsync(document, PersistenceName, stream, this.Checksum, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage.Accessor.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage.Accessor.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             public async Task<Checksum> ReadChecksumAsync(TKey key, CancellationToken cancellationToken)
             {
                 using (var stream = await ReadBlobColumnAsync(key, ChecksumColumnName, checksumOpt: null, cancellationToken).ConfigureAwait(false))
-                using (var reader = ObjectReader.TryGetReader(stream, cancellationToken))
+                using (var reader = ObjectReader.TryGetReader(stream, leaveOpen: false, cancellationToken))
                 {
                     if (reader != null)
                     {
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.SQLite
             private bool ChecksumsMatch_MustRunInTransaction(SqlConnection connection, long rowId, Checksum checksum, CancellationToken cancellationToken)
             {
                 using var checksumStream = connection.ReadBlob_MustRunInTransaction(DataTableName, ChecksumColumnName, rowId);
-                using var reader = ObjectReader.TryGetReader(checksumStream, cancellationToken);
+                using var reader = ObjectReader.TryGetReader(checksumStream, leaveOpen: false, cancellationToken);
                 return reader != null && Checksum.ReadFrom(reader) == checksum;
             }
 

--- a/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_Helpers.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/SQLitePersistentStorage_Helpers.cs
@@ -34,8 +34,12 @@ namespace Microsoft.CodeAnalysis.SQLite
             }
 
             using var stream = SerializableBytes.CreateWritableStream();
-            using var writer = new ObjectWriter(stream, cancellationToken: cancellationToken);
-            checksumOpt.WriteTo(writer);
+
+            using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+            {
+                checksumOpt.WriteTo(writer);
+            }
+
             stream.Position = 0;
             return GetBytes(stream);
         }

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
@@ -679,7 +679,7 @@ Inner i;
                 project, Checksum.Null, cancellationToken: CancellationToken.None);
 
             using var writerStream = new MemoryStream();
-            using (var writer = new ObjectWriter(writerStream))
+            using (var writer = new ObjectWriter(writerStream, leaveOpen: true))
             {
                 info.WriteTo(writer);
             }

--- a/src/Workspaces/CoreTest/SerializationTests.cs
+++ b/src/Workspaces/CoreTest/SerializationTests.cs
@@ -39,10 +39,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void VersionStamp_RoundTripText()
         {
-            using var writerStream = new MemoryStream();
-            using var writer = new ObjectWriter(writerStream);
             var versionStamp = VersionStamp.Create();
-            versionStamp.WriteTo(writer);
+
+            using var writerStream = new MemoryStream();
+
+            using (var writer = new ObjectWriter(writerStream, leaveOpen: true))
+            {
+                versionStamp.WriteTo(writer);
+            }
 
             using var readerStream = new MemoryStream(writerStream.ToArray());
             using var reader = ObjectReader.TryGetReader(readerStream);

--- a/src/Workspaces/CoreTest/UtilityTest/SourceTextSerializationTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SourceTextSerializationTests.cs
@@ -25,8 +25,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 var originalText = CreateSourceText(sb, i);
 
                 using var stream = SerializableBytes.CreateWritableStream();
-                using var writer = new ObjectWriter(stream);
-                originalText.WriteTo(writer, CancellationToken.None);
+
+                using (var writer = new ObjectWriter(stream, leaveOpen: true))
+                {
+                    originalText.WriteTo(writer, CancellationToken.None);
+                }
 
                 stream.Position = 0;
 

--- a/src/Workspaces/CoreTestUtilities/Extensions.cs
+++ b/src/Workspaces/CoreTestUtilities/Extensions.cs
@@ -23,10 +23,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.Execution
             var syncObject = (await syncService.TestOnly_GetRemotableDataAsync(checksum, CancellationToken.None).ConfigureAwait(false))!;
 
             using var stream = SerializableBytes.CreateWritableStream();
-            using var writer = new ObjectWriter(stream);
-
-            // serialize asset to bits
-            await syncObject.WriteObjectToAsync(writer, CancellationToken.None).ConfigureAwait(false);
+            using (var writer = new ObjectWriter(stream, leaveOpen: true))
+            {
+                await syncObject.WriteObjectToAsync(writer, CancellationToken.None).ConfigureAwait(false);
+            }
 
             stream.Position = 0;
             using var reader = ObjectReader.TryGetReader(stream);

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         return _owner.EndPoint.InvokeAsync(
                             WellKnownServiceHubServices.AssetService_RequestAssetAsync,
                             new object[] { scopeId, checksums.ToArray() },
-                            (s, c) => Task.FromResult(ReadAssets(s, scopeId, checksums, serializerService, c)),
+                            (stream, cancellationToken) => Task.FromResult(ReadAssets(stream, scopeId, checksums, serializerService, cancellationToken)),
                             cancellationToken);
                     }
                 }, cancellationToken).ConfigureAwait(false);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var results = new List<(Checksum, object)>();
 
-                using var reader = ObjectReader.TryGetReader(stream, cancellationToken);
+                using var reader = ObjectReader.TryGetReader(stream, leaveOpen: true, cancellationToken);
 
                 // We only get a reader for data transmitted between live processes.
                 // This data should always be correct as we're never persisting the data between sessions.


### PR DESCRIPTION
The default now matches `BinaryWriter` and other similar .NET types.

Add `leaveOpen` to `ObjectReader` as well.
Make sure we close the writer before reading the stream.

Follow up on PR feedback https://github.com/dotnet/roslyn/pull/40395#discussion_r363477396.