### PR TITLE
Add EnumCastDefinitelyCantBeRemoved edge case for casts to numeric types

### DIFF
--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -236,12 +236,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return false;
         }
 
-        private static bool EnumCastDefinitelyCantBeRemoved(CastExpressionSyntax cast, ITypeSymbol expressionType)
+        private static bool EnumCastDefinitelyCantBeRemoved(CastExpressionSyntax cast, ITypeSymbol expressionType, ITypeSymbol castType)
         {
-            if (expressionType != null
-                && expressionType.IsEnumType()
-                && cast.WalkUpParentheses().IsParentKind(SyntaxKind.UnaryMinusExpression, SyntaxKind.UnaryPlusExpression))
+            if (expressionType is null || !expressionType.IsEnumType())
             {
+                return false;
+            }
+
+            var outerExpression = cast.WalkUpParentheses();
+            if (outerExpression.IsParentKind(SyntaxKind.UnaryMinusExpression, SyntaxKind.UnaryPlusExpression))
+            {
+                // -(NumericType)value
+                // +(NumericType)value
+                return true;
+            }
+
+            if (castType.IsNumericType() && !outerExpression.IsParentKind(SyntaxKind.CastExpression))
+            {
+                if (outerExpression.Parent is BinaryExpressionSyntax
+                    || outerExpression.Parent is PrefixUnaryExpressionSyntax)
+                {
+                    // Let the parent code handle this, since it could be something like this:
+                    //
+                    //   (int)enumValue > 0
+                    //   ~(int)enumValue
+                    return false;
+                }
+
+                // Explicit enum cast to numeric type, but not part of a chained cast or binary expression
                 return true;
             }
 
@@ -344,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var expressionTypeInfo = semanticModel.GetTypeInfo(cast.Expression, cancellationToken);
             var expressionType = expressionTypeInfo.Type;
 
-            if (EnumCastDefinitelyCantBeRemoved(cast, expressionType))
+            if (EnumCastDefinitelyCantBeRemoved(cast, expressionType, castType))
             {
                 return false;
             }


### PR DESCRIPTION
This change updates the `EnumCastDefinitelyCantBeRemoved` fast-path for `IsUnnecessaryCast` to report that a cast from an enum type to a numeric type cannot be removed if the parent of the cast is not another cast (generalization of 1), a binary expression (generalization of 2), or a prefix unary expression (generalization of 3).

Known cases where the cast from an enum value to a numeric type can be removed:

1. The cast is part of anther cast, e.g.:

    ```csharp
    (StringComparison)(int)StringComparison.Ordinal
    ```

2. The cast is part of a comparison with constant 0, e.g.:

    ```csharp
    (int)StringComparison.Ordinal < 0
    ```

3. The cast is part of a bitwise negation, e.g.:

    ```csharp
    ~(int)StringComparison.Ordinal
    ```

Test scenario: CSharpRemoveUnnecessaryCastDiagnosticAnalyzer and VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer on Roslyn.sln

Test outcome: Wall clock execution time improved by 252 seconds (79%), memory allocation improved by 25.3GiB (22%). The dramatic improvement is largely due to improvements in the handling of [WellKnownMembers.cs](https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/WellKnownMembers.cs).

Performance prior to this change (the first line is wall clock time, and the breakdown is analyzer callback thread times):

```
Found 3300 diagnostics in 319466ms (126436751776 bytes allocated)
Execution times (ms):
CSharpRemoveUnnecessaryCastDiagnosticAnalyzer:       601262
VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer:   84772
```

Performance with this change applied:

```
Found 3300 diagnostics in 67119ms (99245280096 bytes allocated)
Execution times (ms):
CSharpRemoveUnnecessaryCastDiagnosticAnalyzer:       264277
VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer:  112973
```
