### PR TITLE
Don't throw in GetMetadataReference for an unexpected assembly type

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1118,7 +1118,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private protected override MetadataReference CommonGetMetadataReference(IAssemblySymbol assemblySymbol)
         {
-            return GetMetadataReference(assemblySymbol.EnsureCSharpSymbolOrNull(nameof(assemblySymbol)));
+            if (assemblySymbol is Symbols.PublicModel.Symbol { UnderlyingSymbol: AssemblySymbol underlyingSymbol })
+            {
+                return GetMetadataReference(underlyingSymbol);
+            }
+
+            return null;
         }
 
         internal MetadataReference GetMetadataReference(AssemblySymbol assemblySymbol)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private protected override MetadataReference CommonGetMetadataReference(IAssemblySymbol assemblySymbol)
         {
-            if (assemblySymbol is Symbols.PublicModel.Symbol { UnderlyingSymbol: AssemblySymbol underlyingSymbol })
+            if (assemblySymbol is Symbols.PublicModel.AssemblySymbol { UnderlyingAssemblySymbol: var underlyingSymbol })
             {
                 return GetMetadataReference(underlyingSymbol);
             }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -2682,6 +2682,22 @@ public class C { public static FrameworkName Goo() { return null; }}";
             Assert.Throws<ArgumentException>(() => genericMethod.Construct(typeArguments, default));
         }
 
+        [Fact]
+        [WorkItem(40466, "https://github.com/dotnet/roslyn/issues/40466")]
+        public void GetMetadataReference_VisualBasicSymbols()
+        {
+            var vbComp = CreateVisualBasicCompilation("", referencedAssemblies: TargetFrameworkUtil.GetReferences(TargetFramework.Standard));
+
+            var comp = CreateCompilation("");
+
+            var assembly = (IAssemblySymbol)vbComp.GetBoundReferenceManager().GetReferencedAssemblies().First().Value;
+            var metadataRef = comp.GetMetadataReference(assembly);
+            Assert.Null(metadataRef);
+
+            metadataRef = comp.GetMetadataReference(vbComp.Assembly);
+            Assert.Null(metadataRef);
+        }
+
         #region Script return values
 
         [ConditionalFact(typeof(DesktopOnly))]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -2268,6 +2268,20 @@ public class C { public static FrameworkName Goo() { return null; }}";
         }
 
         [Fact]
+        [WorkItem(40466, "https://github.com/dotnet/roslyn/issues/40466")]
+        public void GetMetadataReference_VisualBasicSymbols()
+        {
+            var comp = CreateCompilation("");
+
+            var vbComp = CreateVisualBasicCompilation("", referencedAssemblies: TargetFrameworkUtil.GetReferences(TargetFramework.Standard));
+            var assembly = (IAssemblySymbol)vbComp.GetBoundReferenceManager().GetReferencedAssemblies().First().Value;
+
+            Assert.Null(comp.GetMetadataReference(assembly));
+            Assert.Null(comp.GetMetadataReference(vbComp.Assembly));
+            Assert.Null(comp.GetMetadataReference((IAssemblySymbol)null));
+        }
+
+        [Fact]
         public void ConsistentParseOptions()
         {
             var tree1 = SyntaxFactory.ParseSyntaxTree("", CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6));
@@ -2680,22 +2694,6 @@ public class C { public static FrameworkName Goo() { return null; }}";
             comp = CreateVisualBasicCompilation("");
             typeArguments = ImmutableArray.Create<ITypeSymbol>(comp.GetSpecialType(SpecialType.System_Object), comp.GetSpecialType(SpecialType.System_String));
             Assert.Throws<ArgumentException>(() => genericMethod.Construct(typeArguments, default));
-        }
-
-        [Fact]
-        [WorkItem(40466, "https://github.com/dotnet/roslyn/issues/40466")]
-        public void GetMetadataReference_VisualBasicSymbols()
-        {
-            var vbComp = CreateVisualBasicCompilation("", referencedAssemblies: TargetFrameworkUtil.GetReferences(TargetFramework.Standard));
-
-            var comp = CreateCompilation("");
-
-            var assembly = (IAssemblySymbol)vbComp.GetBoundReferenceManager().GetReferencedAssemblies().First().Value;
-            var metadataRef = comp.GetMetadataReference(assembly);
-            Assert.Null(metadataRef);
-
-            metadataRef = comp.GetMetadataReference(vbComp.Assembly);
-            Assert.Null(metadataRef);
         }
 
         #region Script return values

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1232,7 +1232,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Protected Overrides Function CommonGetMetadataReference(assemblySymbol As IAssemblySymbol) As MetadataReference
-            Return GetMetadataReference(assemblySymbol.EnsureVbSymbolOrNothing(Of AssemblySymbol)(NameOf(assemblySymbol)))
+            Dim symbol = TryCast(assemblySymbol, AssemblySymbol)
+            If symbol IsNot Nothing Then
+                Return GetMetadataReference(symbol)
+            End If
+
+            Return Nothing
         End Function
 
         Public Overrides ReadOnly Property ReferencedAssemblyNames As IEnumerable(Of AssemblyIdentity)

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -2257,6 +2257,19 @@ End Class
             Assert.NotNull(reference2)
         End Sub
 
+        <WorkItem(40466, "https://github.com/dotnet/roslyn/issues/40466")>
+        <Fact>
+        Public Sub GetMetadataReference_CSharpSymbols()
+            Dim comp As Compilation = CreateCompilation("")
+
+            Dim csComp = CreateCSharpCompilation("", referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.Standard))
+            Dim assembly = csComp.GetBoundReferenceManager().GetReferencedAssemblies().First().Value
+
+            Assert.Null(comp.GetMetadataReference(DirectCast(assembly.GetISymbol(), IAssemblySymbol)))
+            Assert.Null(comp.GetMetadataReference(csComp.Assembly))
+            Assert.Null(comp.GetMetadataReference(Nothing))
+        End Sub
+
 
         <Fact()>
         Public Sub EqualityOfMergedNamespaces()

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AssemblyAndNamespaceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AssemblyAndNamespaceTests.vb
@@ -571,20 +571,6 @@ BC30560: 'Task' is ambiguous in the namespace 'System.Threading.Tasks'.
                 </expected>)
         End Sub
 
-        <WorkItem(40466, "https://github.com/dotnet/roslyn/issues/40466")>
-        <Fact>
-        Public Sub GetMetadataReference_CSCompilation()
-            Dim csComp = CreateCSharpCompilation("", referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.Standard))
-            Dim assembly = csComp.GetBoundReferenceManager().GetReferencedAssemblies().First().Value
-
-            Dim comp As Compilation = CreateCompilation("")
-            Dim metadataRef = comp.GetMetadataReference(DirectCast(assembly.GetISymbol(), IAssemblySymbol))
-            Assert.Null(metadataRef)
-
-            metadataRef = comp.GetMetadataReference(csComp.Assembly)
-            Assert.Null(metadataRef)
-        End Sub
-
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AssemblyAndNamespaceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/AssemblyAndNamespaceTests.vb
@@ -571,6 +571,20 @@ BC30560: 'Task' is ambiguous in the namespace 'System.Threading.Tasks'.
                 </expected>)
         End Sub
 
+        <WorkItem(40466, "https://github.com/dotnet/roslyn/issues/40466")>
+        <Fact>
+        Public Sub GetMetadataReference_CSCompilation()
+            Dim csComp = CreateCSharpCompilation("", referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.Standard))
+            Dim assembly = csComp.GetBoundReferenceManager().GetReferencedAssemblies().First().Value
+
+            Dim comp As Compilation = CreateCompilation("")
+            Dim metadataRef = comp.GetMetadataReference(DirectCast(assembly.GetISymbol(), IAssemblySymbol))
+            Assert.Null(metadataRef)
+
+            metadataRef = comp.GetMetadataReference(csComp.Assembly)
+            Assert.Null(metadataRef)
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Closes #40466
