### PR TITLE
WIP [tests] Re-enable Mono CI testing, and test MultipleTypeForwardersToTheSameAssemblyShouldNotResultInMultipleForwardError

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,11 +183,10 @@ jobs:
         _args: --testCoreClr --docker
         _name: CoreClr
         _configuration: Debug
-# Disabling Mono while https://github.com/mono/mono/issues/16373 is worked out
-#      mono:
-#        _args: --testMono --docker
-#        _name: Mono
-#        _configuration: Debug
+      mono:
+        _args: --testMono --docker
+        _name: Mono
+        _configuration: Debug
   timeoutInMinutes: 90
   steps:
     - script: ./eng/cibuild.sh --configuration $(_configuration) --prepareMachine --skipAnalyzers $(_args)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -20139,7 +20139,7 @@ namespace A
                 Diagnostic(ErrorCode.ERR_TypeForwardedToMultipleAssemblies, "ClassB.MethodB").WithArguments("CModule.dll", "C, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "C.ClassC", "D1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "D2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
         }
 
-        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/mono/mono/issues/10332")]
+        [Fact]
         [WorkItem(16484, "https://github.com/dotnet/roslyn/issues/16484")]
         public void MultipleTypeForwardersToTheSameAssemblyShouldNotResultInMultipleForwardError()
         {


### PR DESCRIPTION
Re-enable testing on CI with Mono - the issue https://github.com/mono/mono/issues/16373 that prevented testing was fixed in September 2019.

---

Re-enable`MultipleTypeForwardersToTheSameAssemblyShouldNotResultInMultipleForwardError` for Mono. The Mono issue https://github.com/mono/mono/issues/10332 has been fixed on 
6.8 (2019-10), 6.10 (2019-12) and master.

Tested with Mono 6.8.0.92 and Mono 6.10.0.40