### PR TITLE
Avoid adding null GlobalImport entries

### DIFF
--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1703,8 +1703,11 @@ lVbRuntimePlus:
             For Each importNamespace In importsArray
                 Dim importDiagnostics As ImmutableArray(Of Diagnostic) = Nothing
                 Dim import = GlobalImport.Parse(importNamespace, importDiagnostics)
+                Debug.Assert(import IsNot Nothing OrElse Not importDiagnostics.IsEmpty)
                 errors.AddRange(importDiagnostics)
-                globalImports.Add(import)
+                If import IsNot Nothing Then
+                    globalImports.Add(import)
+                End If
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -272,6 +272,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 metadataImportOptions:=metadataImportOptions,
                 referencesSupersedeLowerVersions:=referencesSupersedeLowerVersions)
 
+            Debug.Assert(globalImports Is Nothing OrElse Not globalImports.Any(Function(x) x Is Nothing))
             _globalImports = globalImports.AsImmutableOrEmpty()
             _rootNamespace = If(rootNamespace, String.Empty)
             _optionStrict = optionStrict
@@ -522,6 +523,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me
             End If
 
+            Debug.Assert(Not globalImports.Contains(Nothing))
             Return New VisualBasicCompilationOptions(Me) With {._globalImports = globalImports}
         End Function
 
@@ -531,6 +533,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="globalImports">A collection of Global Imports <see cref="GlobalImport"/>.</param>        
         ''' <returns>A new instance of VisualBasicCompilationOptions.</returns>        
         Public Function WithGlobalImports(globalImports As IEnumerable(Of GlobalImport)) As VisualBasicCompilationOptions
+            Debug.Assert(globalImports Is Nothing OrElse Not globalImports.Any(Function(x) x Is Nothing))
             Return New VisualBasicCompilationOptions(Me) With {._globalImports = globalImports.AsImmutableOrEmpty()}
         End Function
 


### PR DESCRIPTION
Fixes an error that appears when attempting to run AnalyzerRunner on Roslyn.sln with netcoreapp3.0 (#40824).

```
Failed to analyze Microsoft.CodeAnalysis.UnitTests(net472) with System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceModuleSymbol.BindImports(CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Source\SourceModuleSymbol.vb:line 373
   at Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceModuleSymbol.EnsureImportsAreBound(CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Source\SourceModuleSymbol.vb:line 351
   at Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceModuleSymbol.get_MemberImports() in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Source\SourceModuleSymbol.vb:line 508
   at Microsoft.CodeAnalysis.VisualBasic.BinderBuilder.CreateBinderForSourceFile(SourceModuleSymbol moduleSymbol, SyntaxTree tree) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Binding\BinderBuilder.vb:line 88
   at Microsoft.CodeAnalysis.VisualBasic.BinderBuilder.CreateBinderForNamespace(SourceModuleSymbol moduleSymbol, SyntaxTree tree, NamespaceSymbol nsSymbol) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Binding\BinderBuilder.vb:line 178
   at Microsoft.CodeAnalysis.VisualBasic.BinderBuilder.CreateBinderForProjectLevelNamespace(SourceModuleSymbol moduleSymbol, SyntaxTree tree) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Binding\BinderBuilder.vb:line 154
   at Microsoft.CodeAnalysis.VisualBasic.Symbol.GetAttributeBinder(SyntaxList`1 syntaxList, SourceModuleSymbol sourceModule) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Symbol_Attributes.vb:line 353
   at Microsoft.CodeAnalysis.VisualBasic.Symbol.GetAttributesToBind(OneOrMany`1 attributeDeclarationSyntaxLists, AttributeLocation symbolPart, VisualBasicCompilation compilation, ImmutableArray`1& binders) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Symbol_Attributes.vb:line 325
   at Microsoft.CodeAnalysis.VisualBasic.Symbol.LoadAndValidateAttributes(OneOrMany`1 attributeBlockSyntaxList, CustomAttributesBag`1& lazyCustomAttributesBag, AttributeLocation symbolPart) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Symbol_Attributes.vb:line 246
   at Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceAssemblySymbol.EnsureAttributesAreBound() in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Source\SourceAssemblySymbol.vb:line 791
   at Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceAssemblySymbol.get_IsDelaySigned() in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Symbols\Source\SourceAssemblySymbol.vb:line 1361
   at Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.get_IsDelaySigned() in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Compilation\VisualBasicCompilation.vb:line 2194
   at Microsoft.CodeAnalysis.Compilation.get_HasStrongName() in C:\dev\roslyn\src\Compilers\Core\Portable\Compilation\Compilation.cs:line 2003
   at Microsoft.CodeAnalysis.Compilation.ConstructModuleSerializationProperties(EmitOptions emitOptions, String targetRuntimeVersion, Guid moduleVersionId) in C:\dev\roslyn\src\Compilers\Core\Portable\Compilation\Compilation.cs:line 1868
   at Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.CreateModuleBuilder(EmitOptions emitOptions, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, IEnumerable`1 manifestResources, CompilationTestData testData, DiagnosticBag diagnostics, ImmutableArray`1 additionalTypes, CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Compilation\VisualBasicCompilation.vb:line 2242
   at Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.CreateModuleBuilder(EmitOptions emitOptions, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, IEnumerable`1 manifestResources, CompilationTestData testData, DiagnosticBag diagnostics, CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\VisualBasic\Portable\Compilation\VisualBasicCompilation.vb:line 2214
   at Microsoft.CodeAnalysis.Compilation.CheckOptionsAndCreateModuleBuilder(DiagnosticBag diagnostics, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, CompilationTestData testData, CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\Core\Portable\Compilation\Compilation.cs:line 2684
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream metadataPEStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, CompilationTestData testData, CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\Core\Portable\Compilation\Compilation.cs:line 2471
   at Microsoft.CodeAnalysis.Compilation.Emit(Stream peStream, Stream pdbStream, Stream xmlDocumentationStream, Stream win32Resources, IEnumerable`1 manifestResources, EmitOptions options, IMethodSymbol debugEntryPoint, Stream sourceLinkStream, IEnumerable`1 embeddedTexts, Stream metadataPEStream, CancellationToken cancellationToken) in C:\dev\roslyn\src\Compilers\Core\Portable\Compilation\Compilation.cs:line 2431
   at Microsoft.CodeAnalysis.MetadataOnlyImage.Create(Workspace workspace, ITemporaryStorageService service, Compilation compilation, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\MetadataOnlyImage.cs:line 45
   at Microsoft.CodeAnalysis.MetadataOnlyReference.GetOrBuildReference(SolutionState solution, ProjectReference projectReference, Compilation finalCompilation, VersionStamp version, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\MetadataOnlyReference.cs:line 45
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetMetadataOnlyImageReferenceAsync(SolutionState solution, ProjectReference projectReference, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 780
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetMetadataReferenceAsync(SolutionState solution, ProjectState fromProject, ProjectReference projectReference, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 724
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.FinalizeCompilationAsync(SolutionState solution, Compilation compilation, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 640
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoFromScratchAsync(SolutionState solution, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 492
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetOrBuildCompilationInfoAsync(SolutionState solution, Boolean lockGate, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 425
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetCompilationSlowAsync(SolutionState solution, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 339
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetMetadataReferenceAsync(SolutionState solution, ProjectState fromProject, ProjectReference projectReference, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 718
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.FinalizeCompilationAsync(SolutionState solution, Compilation compilation, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 640
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoFromScratchAsync(SolutionState solution, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 492
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetOrBuildCompilationInfoAsync(SolutionState solution, Boolean lockGate, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 425
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetCompilationSlowAsync(SolutionState solution, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 339
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetMetadataReferenceAsync(SolutionState solution, ProjectState fromProject, ProjectReference projectReference, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 718
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.FinalizeCompilationAsync(SolutionState solution, Compilation compilation, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 640
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoFromScratchAsync(SolutionState solution, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 492
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetOrBuildCompilationInfoAsync(SolutionState solution, Boolean lockGate, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 425
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetCompilationSlowAsync(SolutionState solution, CancellationToken cancellationToken) in C:\dev\roslyn\src\Workspaces\Core\Portable\Workspace\Solution\SolutionState.CompilationTracker.cs:line 339
   at AnalyzerRunner.DiagnosticAnalyzerRunner.GetProjectAnalysisResultAsync(ImmutableArray`1 analyzers, Project project, Options analyzerOptionsInternal, CancellationToken cancellationToken) in C:\dev\roslyn\src\Tools\AnalyzerRunner\DiagnosticAnalyzerRunner.cs:line 365
```