### PR TITLE
Allow setting /iter:0 in AnalyzerRunner

### DIFF
--- a/src/Tools/AnalyzerRunner/DiagnosticAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/DiagnosticAnalyzerRunner.cs
@@ -379,6 +379,11 @@ namespace AnalyzerRunner
 
         private static void WriteTelemetry(ImmutableDictionary<ProjectId, AnalysisResult> dictionary)
         {
+            if (dictionary.IsEmpty)
+            {
+                return;
+            }
+
             var telemetryInfoDictionary = new Dictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo>();
             foreach (var analysisResult in dictionary.Values)
             {


### PR DESCRIPTION
This is useful when testing scope-limited `/edititer` for very slow analyzers.