### PR TITLE
Fix language client activation

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/InProcLanguageServer.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 
@@ -52,11 +53,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         [JsonRpcMethod(Methods.InitializeName)]
         public Task<InitializeResult> Initialize(JToken input, CancellationToken cancellationToken)
         {
+            // The VS LSP protocol package changed the type of 'tagSupport' from bool to an object.
+            // Our version of the LSP protocol package is older and assumes that the type is bool, so deserialization fails.
+            // Since we don't really read this field, just no-op the error until we can update our package references.
+            // https://github.com/dotnet/roslyn/issues/40829 tracks updating this.
+            var settings = new JsonSerializerSettings
+            {
+                Error = (sender, args) =>
+                {
+                    if (object.Equals(args.ErrorContext.Member, "tagSupport") && args.ErrorContext.OriginalObject.GetType() == typeof(PublishDiagnosticsSetting))
+                    {
+                        args.ErrorContext.Handled = true;
+                    }
+                }
+            };
+            var serializer = JsonSerializer.Create(settings);
+
             // InitializeParams only references ClientCapabilities, but the VS LSP client
             // sends additional VS specific capabilities, so directly deserialize them into the VSClientCapabilities
             // to avoid losing them.
-            _clientCapabilities = input["capabilities"].ToObject<VSClientCapabilities>();
-            return _protocol.InitializeAsync(_workspace.CurrentSolution, input.ToObject<InitializeParams>(), _clientCapabilities, cancellationToken);
+            _clientCapabilities = input["capabilities"].ToObject<VSClientCapabilities>(serializer);
+            return _protocol.InitializeAsync(_workspace.CurrentSolution, input.ToObject<InitializeParams>(serializer), _clientCapabilities, cancellationToken);
         }
 
         [JsonRpcMethod(Methods.InitializedName)]

--- a/src/VisualStudio/Core/Test.Next/Services/LanguageServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/LanguageServiceTests.cs
@@ -96,7 +96,7 @@ End Class";
             {
                 var result = await jsonRpc.InvokeWithCancellationAsync<JObject>(
                     Methods.InitializeName,
-                    new object[] { Process.GetCurrentProcess().Id, "test", new Uri("file://test"), new ClientCapabilities(), TraceSetting.Off },
+                    new object[] { new InitializeParams() },
                     CancellationToken.None);
 
                 Assert.True(result["capabilities"]["workspaceStreamingSymbolProvider"].ToObject<bool>());

--- a/src/Workspaces/Remote/ServiceHub/Services/LanguageServer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/LanguageServer.cs
@@ -10,8 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Newtonsoft.Json;
-using Roslyn.Utilities;
+using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -41,17 +40,15 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         [JsonRpcMethod(Methods.InitializeName)]
-        public object Initialize(int? processId, string rootPath, Uri rootUri, ClientCapabilities capabilities, TraceSetting trace, CancellationToken cancellationToken)
+        public Task<InitializeResult> Initialize(JToken input, CancellationToken cancellationToken)
         {
-            // our LSP server only supports WorkspaceStreamingSymbolProvider capability
-            // for now
-            return new InitializeResult()
+            return Task.FromResult(new InitializeResult()
             {
                 Capabilities = new VSServerCapabilities()
                 {
                     WorkspaceStreamingSymbolProvider = true
                 }
-            };
+            });
         }
 
         [JsonRpcMethod(Methods.InitializedName)]


### PR DESCRIPTION
The VS LSP client changed the type of a json parameter.  Until we can upgrade to the latest protocol packages, implement this workaround.


Ask mode template-
****Customer and scenario info****
**Who is impacted by this bug?**
VS search (cntrl + Q) in C#/VB and liveshare scenarios in C# and VB.
**What is the workaround?**
None
**How was the bug found?**
Automated testing by VS editor
**If this fix is for a regression 
Overview of the fix?**
The VS LSP client team changed the type of a json field.  Since we do not use the field, we ignore it during deserialization until we can upgrade to the latest LSP client packages.
**What feature areas are impacted by the fix?**
 VS search and liveshare
**What is the risk of the code change?**
 low, non-intrusive change to ignore a particular json field.
**Does this change have impact on anything else (e.g., setup, perf, stress, ux, visual freeze, go live, breaking -change, samples)?**
no
**What testing/validation was done on the fix, and what were the results?**
 manual testing to confirm that VS search and liveshare both activate.
