### PR TITLE
Adopt latest roslyn analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -205,3 +205,7 @@ csharp_space_between_square_brackets = false
 csharp_prefer_braces = true:silent
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
+
+# error RS0037: PublicAPI.txt is missing '#nullable enable'
+dotnet_diagnostic.RS0037.severity = none
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -206,6 +206,5 @@ csharp_prefer_braces = true:silent
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
-# error RS0037: PublicAPI.txt is missing '#nullable enable'
+# warning RS0037: PublicAPI.txt is missing '#nullable enable'
 dotnet_diagnostic.RS0037.severity = none
-

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->
-    <RoslynDiagnosticsNugetPackageVersion>2.9.6</RoslynDiagnosticsNugetPackageVersion>
+    <RoslynDiagnosticsNugetPackageVersion>3.0.0-beta2.20059.3+77df2220</RoslynDiagnosticsNugetPackageVersion>
     <CodeStyleLayerCodeAnalysisVersion>2.8.2</CodeStyleLayerCodeAnalysisVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.0.0-beta1-63310-01</MicrosoftCodeAnalysisTestingVersion>
     <CodeStyleAnalyzerVersion>3.3.1-beta3-19454-05</CodeStyleAnalyzerVersion>

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                 return base.GetSpansToTag(textView, subjectBuffer);
             }
 
-            return new[] { visibleSpanOpt.Value };
+            return SpecializedCollections.SingletonEnumerable(visibleSpanOpt.Value);
         }
 
         protected override Task ProduceTagsAsync(TaggerContext<IClassificationTag> context)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         protected virtual IEnumerable<SnapshotSpan> GetSpansToTag(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {
             // For a standard tagger, the spans to tag is the span of the entire snapshot.
-            return new[] { subjectBuffer.CurrentSnapshot.GetFullSpan() };
+            return SpecializedCollections.SingletonEnumerable(subjectBuffer.CurrentSnapshot.GetFullSpan());
         }
 
         /// <summary>

--- a/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Roslyn.Utilities;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -31,13 +32,13 @@ namespace Roslyn.Test.Utilities
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
             var testCase = new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow);
-            return new[] { testCase };
+            return SpecializedCollections.SingletonEnumerable(testCase);
         }
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
             var testCase = new WpfTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
-            return new[] { testCase };
+            return SpecializedCollections.SingletonEnumerable(testCase);
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/KeywordHighlighting/AbstractVisualBasicKeywordHighlighterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/KeywordHighlighting/AbstractVisualBasicKeywordHighlighterTests.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.KeywordHighlightin
         Inherits AbstractKeywordHighlighterTests
 
         Protected Overrides Function GetOptions() As IEnumerable(Of ParseOptions)
-            Return {TestOptions.Regular}
+            Return SpecializedCollections.SingletonEnumerable(TestOptions.Regular)
         End Function
 
         Protected Overloads Function TestAsync(element As XElement) As Threading.Tasks.Task

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -674,7 +674,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
         protected override IEnumerable<AbstractFormattingRule> GetFormattingRules(Document document)
         {
-            return new[] { new ChangeSignatureFormattingRule() }.Concat(Formatter.GetDefaultFormattingRules(document));
+            return SpecializedCollections.SingletonEnumerable(new ChangeSignatureFormattingRule()).Concat(Formatter.GetDefaultFormattingRules(document));
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -604,7 +604,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
         End Function
 
         Protected Overrides Function GetFormattingRules(document As Document) As IEnumerable(Of AbstractFormattingRule)
-            Return New AbstractFormattingRule() {New ChangeSignatureFormattingRule()}.Concat(Formatter.GetDefaultFormattingRules(document))
+            Return SpecializedCollections.SingletonEnumerable(Of AbstractFormattingRule)(New ChangeSignatureFormattingRule()).
+                Concat(Formatter.GetDefaultFormattingRules(document))
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Declarations/GetSetKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Declarations/GetSetKeywordRecommender.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Decl
             ' If we have modifiers which exclude it, then definitely not
             Dim modifiers = context.ModifierCollectionFacts
             If Not modifiers.CouldApplyToOneOf(PossibleDeclarationTypes.Accessor) Then
-                Return Enumerable.Empty(Of RecommendedKeyword)()
+                Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()
             End If
 
             Dim targetToken = context.TargetToken

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Declarations/ParameterModifiersKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Declarations/ParameterModifiersKeywordRecommender.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Decl
                     ' If a previous one had a ParamArray, then nothing is valid anymore, since the ParamArray must
                     ' always be the last parameter
                     If parameter.Modifiers.Any(Function(modifier) modifier.Kind = SyntaxKind.ParamArrayKeyword) Then
-                        Return Enumerable.Empty(Of RecommendedKeyword)()
+                        Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()
                     End If
 
                     ' If a previous one had an Optional, then all following must be optional. Following Dev10 behavior,

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/LambdaKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/LambdaKeywordRecommender.vb
@@ -22,7 +22,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
             Dim targetToken = context.TargetToken
             If context.SyntaxTree.IsExpressionContext(targetToken.SpanStart, cancellationToken, context.SemanticModel) Then
                 If targetToken.IsKindOrHasMatchingText(SyntaxKind.IteratorKeyword) Then
-                    Return {New RecommendedKeyword("Function", VBFeaturesResources.Defines_a_lambda_expression_that_calculates_and_returns_a_single_value_Can_be_used_wherever_a_delegate_type_is_expected_Function_parameterList_expression)}
+                    Return SpecializedCollections.SingletonEnumerable(
+                        New RecommendedKeyword("Function", VBFeaturesResources.Defines_a_lambda_expression_that_calculates_and_returns_a_single_value_Can_be_used_wherever_a_delegate_type_is_expected_Function_parameterList_expression))
                 ElseIf targetToken.IsKindOrHasMatchingText(SyntaxKind.AsyncKeyword) Then
                     Return {New RecommendedKeyword("Function", VBFeaturesResources.Defines_a_lambda_expression_that_calculates_and_returns_a_single_value_Can_be_used_wherever_a_delegate_type_is_expected_Function_parameterList_expression),
                             New RecommendedKeyword("Sub", VBFeaturesResources.Defines_a_lambda_expression_that_can_execute_statements_and_does_not_return_a_value_Can_be_used_wherever_a_delegate_type_is_expected_Sub_parameterList_statement)}

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/NameOfKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/NameOfKeywordRecommender.vb
@@ -11,13 +11,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
 
         Protected Overrides Function RecommendKeywords(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As IEnumerable(Of RecommendedKeyword)
             If context.IsAnyExpressionContext Then
-                Return {CreateRecommendedKeywordForIntrinsicOperator(
+                Return SpecializedCollections.SingletonEnumerable(CreateRecommendedKeywordForIntrinsicOperator(
                     SyntaxKind.NameOfKeyword,
                     VBFeaturesResources.NameOf_function,
                     Glyph.MethodPublic,
                     New NameOfExpressionDocumentation(),
                     context.SemanticModel,
-                    context.Position)}
+                    context.Position))
             End If
 
             Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -271,12 +271,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     ' Property: Attributes Modifiers [|Identifier$ Initializer|] ImplementsClause
                     Dim propertyStatement = DirectCast(node, PropertyStatementSyntax)
                     If propertyStatement.Initializer IsNot Nothing Then
-                        Return {propertyStatement.Identifier}.Concat(If(propertyStatement.AsClause?.DescendantTokens(),
+                        Return SpecializedCollections.SingletonEnumerable(propertyStatement.Identifier).Concat(If(propertyStatement.AsClause?.DescendantTokens(),
                                                                      Array.Empty(Of SyntaxToken))).Concat(propertyStatement.Initializer.DescendantTokens())
                     End If
 
                     If HasAsNewClause(propertyStatement) Then
-                        Return {propertyStatement.Identifier}.Concat(propertyStatement.AsClause.DescendantTokens())
+                        Return SpecializedCollections.SingletonEnumerable(propertyStatement.Identifier).Concat(propertyStatement.AsClause.DescendantTokens())
                     End If
 
                     Return Nothing

--- a/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -572,7 +572,9 @@ namespace Microsoft.CodeAnalysis
         public sealed class AnalyzerWithCSharpCompilerDiagnosticId : DiagnosticAnalyzer
         {
             public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+#pragma warning disable RS1029 // Do not use reserved diagnostic IDs.
                 "CS101",
+#pragma warning restore RS1029 // Do not use reserved diagnostic IDs.
                 "Title1",
                 "Message1",
                 "Category1",
@@ -591,7 +593,9 @@ namespace Microsoft.CodeAnalysis
         public sealed class AnalyzerWithBasicCompilerDiagnosticId : DiagnosticAnalyzer
         {
             public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+#pragma warning disable RS1029 // Do not use reserved diagnostic IDs.
                 "BC101",
+#pragma warning restore RS1029 // Do not use reserved diagnostic IDs.
                 "Title1",
                 "Message1",
                 "Category1",

--- a/src/Test/Utilities/Portable/Diagnostics/TestDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/TestDiagnosticAnalyzer.cs
@@ -23,7 +23,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         // protected static readonly ImmutableArray<string> AllAbstractMemberNames = ImmutableArray<string>.Empty.AddRange(GetAbstractMemberNames(typeof(CompilationStartAnalysisScope)).Distinct());
 
         protected static readonly DiagnosticDescriptor DefaultDiagnostic =
+#pragma warning disable RS1029 // Do not use reserved diagnostic IDs.
             new DiagnosticDescriptor("CA7777", "CA7777_AnalyzerTestDiagnostic", "I'm here for test purposes", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+#pragma warning restore RS1029 // Do not use reserved diagnostic IDs.
 
         private static ImmutableArray<T> GetAllEnumValues<T>()
         {

--- a/src/VisualStudio/Core/SolutionExplorerShim/BaseItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/BaseItem.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Shell;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
 {
@@ -43,7 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
         {
             get
             {
-                return Enumerable.Empty<string>();
+                return SpecializedCollections.EmptyEnumerable<string>();
             }
         }
 

--- a/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
+++ b/src/VisualStudio/Core/Test/AnalyzerSupport/AnalyzerDependencyCheckerTests.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.Implementation
 Imports Microsoft.Win32
 Imports Roslyn.Test.Utilities
+Imports Roslyn.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
     <[UseExportProvider]>
@@ -22,7 +23,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
             Dim mscorlib As AssemblyIdentity = Nothing
             AssemblyIdentity.TryParseDisplayName(s_mscorlibDisplayName, mscorlib)
 
-            Return {New IgnorableAssemblyIdentityList({mscorlib})}
+            Return SpecializedCollections.SingletonEnumerable(
+                New IgnorableAssemblyIdentityList(SpecializedCollections.SingletonEnumerable(mscorlib)))
         End Function
 
         <Fact>

--- a/src/VisualStudio/LiveShare/Impl/Client/Debugging/CSharpLspPackage.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Debugging/CSharpLspPackage.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Debugging
 {
@@ -22,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Debugging
 
         protected override IEnumerable<IVsEditorFactory> CreateEditorFactories()
         {
-            return new IVsEditorFactory[] { };
+            return SpecializedCollections.EmptyEnumerable<IVsEditorFactory>();
         }
 
         protected override CSharpLspLanguageService CreateLanguageService() => new CSharpLspLanguageService(this);

--- a/src/VisualStudio/LiveShare/Impl/Client/Tagger/AbstractAsyncClassificationTaggerProvider.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Tagger/AbstractAsyncClassificationTaggerProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
 {
@@ -69,7 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
             if (textView == null)
             {
                 var currentSnapshot = subjectBuffer.CurrentSnapshot;
-                return new[] { new SnapshotSpan(currentSnapshot, Span.FromBounds(0, currentSnapshot.Length)) };
+                return SpecializedCollections.SingletonEnumerable(new SnapshotSpan(currentSnapshot, Span.FromBounds(0, currentSnapshot.Length)));
             }
 
             // Determine the range of text that is visible in the view.  Then map this down to our
@@ -86,7 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
                 // are no visible spans in the buffer return the full snapshot.
                 // This can occur in an HTML file with script blocks when the user
                 // scrolls down and the script blocks are no longer visible in view.
-                return new[] { new SnapshotSpan(snapshot, 0, snapshot.Length) };
+                return SpecializedCollections.SingletonEnumerable(new SnapshotSpan(snapshot, 0, snapshot.Length));
             }
 
             var visibleStart = visibleSpansInBuffer.First().Start;
@@ -105,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
 
             var span = new SnapshotSpan(snapshot, Span.FromBounds(start, end));
 
-            return new[] { span };
+            return SpecializedCollections.SingletonEnumerable(span);
         }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -298,7 +298,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Select(Function(n) semanticModel.GetDeclaredSymbol(n, cancellationToken))
             End If
 
-            Return {semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken)}
+            Return SpecializedCollections.SingletonEnumerable(semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken))
         End Function
 
         Public Function FindParameterForArgument(semanticModel As SemanticModel, argumentNode As SyntaxNode, cancellationToken As CancellationToken) As IParameterSymbol Implements ISemanticFactsService.FindParameterForArgument


### PR DESCRIPTION
I'm holding off using `#nullable enable` in any project because there is a bug in that analyzer. After adding nullable annotations to the public API files, the analyzer complains with RS0016 and RS0017...