### PR TITLE
Documentation Update

### DIFF
--- a/docs/compilers/CSharp/Nullability Public API Design Notes.md
+++ b/docs/compilers/CSharp/Nullability Public API Design Notes.md
@@ -95,8 +95,7 @@ We add the new APIs for retreiving and interacting with nullability:
 ```C#
 public enum NullableAnnotation : byte
 {
-    NotApplicable,
-    Disabled,
+    None,
     NotAnnotated,
     Annotated
 }


### PR DESCRIPTION
The documentation for `NullableAnnotation` got out of date with the
actual type definition.