### PR TITLE
Target netcoreapp3.1

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -20,7 +20,7 @@ The minimal required version of .NET Framework is 4.7.2.
     - Ensure Visual Studio is on Version "16.3" or greater
     - Ensure "Use previews of the .NET Core SDK" is checked in Tools -> Options -> Environment -> Preview Features
     - Restart Visual Studio
-1. [.NET Core SDK 3.0](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-3.0.100-windows-x64-installer )
+1. [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.0) [Windows x64 installer](https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-windows-x64-installer)
 1. [PowerShell 5.0 or newer](https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell). If you are on Windows 10, you are fine; you'll only need to upgrade if you're on earlier versions of Windows. The download link is under the ["Upgrading existing Windows PowerShell"](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-windows-powershell?view=powershell-6#upgrading-existing-windows-powershell) heading.
 1. Run Restore.cmd
 1. Open Roslyn.sln

--- a/docs/infrastructure/cross-platform.md
+++ b/docs/infrastructure/cross-platform.md
@@ -17,7 +17,7 @@ The script will install .NET Core to `.dotnet` directory if it is not found on `
 
 ## Using the compiler
 
-After building, there will be a `csc` in the `artifacts/bin/csc/Debug/netcoreapp2.1` and `artifacts/bin/csc/Debug/net472` directories. Use the former to run on .NET Core and the latter on Mono.
+After building, there will be a `csc` in the `artifacts/bin/csc/Debug/netcoreapp3.1` and `artifacts/bin/csc/Debug/net472` directories. Use the former to run on .NET Core and the latter on Mono.
 
 ### Running `csc.exe` on Mono
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -185,7 +185,7 @@
     <SystemDrawingCommonVersion>4.5.0</SystemDrawingCommonVersion>
     <SystemIOFileSystemVersion>4.3.0</SystemIOFileSystemVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>
-    <SystemIOPipesAccessControlVersion>4.3.0</SystemIOPipesAccessControlVersion>
+    <SystemIOPipesAccessControlVersion>4.5.1</SystemIOPipesAccessControlVersion>
     <SystemMemoryVersion>4.5.3</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>4.6.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,7 +159,7 @@
     <MicrosoftVisualStudioValidationVersion>15.5.31</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
-    <MicrosoftWin32RegistryVersion>4.6.0</MicrosoftWin32RegistryVersion>
+    <MicrosoftWin32RegistryVersion>4.7.0</MicrosoftWin32RegistryVersion>
     <MSBuildStructuredLoggerVersion>2.0.61</MSBuildStructuredLoggerVersion>
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>4.4.0</MonoOptionsVersion>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -218,7 +218,7 @@ function BuildSolution() {
   $enableAnalyzers = !$skipAnalyzers
   $toolsetBuildProj = InitializeToolset
 
-  $testTargetFrameworks = if ($testCoreClr) { "netcoreapp3.0%3Bnetcoreapp2.1" } else { "" }
+  $testTargetFrameworks = if ($testCoreClr) { "netcoreapp3.1" } else { "" }
   
   $ibcSourceBranchName = GetIbcSourceBranchName
   $ibcDropId = if ($officialIbcDropId -ne "default") { $officialIbcDropId } else { "" }
@@ -608,10 +608,6 @@ try {
 
     $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
     InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
-
-    # Make sure a 2.1 runtime is installed so we can run our tests. Most of them still 
-    # target netcoreapp2.1.
-    InstallDotNetSdk $global:_DotNetInstallDir "2.1.503"
   }
 
   try

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -607,7 +607,6 @@ try {
     }
 
     $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
-    InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
   }
 
   try

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -607,6 +607,7 @@ try {
     }
 
     $global:_DotNetInstallDir = Join-Path $RepoRoot ".dotnet"
+    InstallDotNetSdk $global:_DotNetInstallDir $GlobalJson.tools.dotnet
   }
 
   try

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -254,7 +254,7 @@ function BuildSolution {
     test_runtime_args="--debug"
   elif [[ "$test_core_clr" == true ]]; then
     test=true
-    test_runtime="/p:TestRuntime=Core /p:TestTargetFrameworks=netcoreapp3.0%3Bnetcoreapp2.1"
+    test_runtime="/p:TestRuntime=Core /p:TestTargetFrameworks=netcoreapp3.1"
     mono_tool=""
   fi
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -287,9 +287,6 @@ function BuildSolution {
 
 InitializeDotNetCli $restore
 
-# Make sure we have a 2.1 runtime available for running our tests
-InstallDotNetSdk $_InitializeDotNetCli 2.1.503
-
 bootstrap_dir=""
 if [[ "$bootstrap" == true ]]; then
   MakeBootstrapBuild

--- a/eng/common/templates/job/performance.yml
+++ b/eng/common/templates/job/performance.yml
@@ -7,7 +7,7 @@ parameters:
   container: ''                   # required -- name of the container
   osGroup: ''                     # required -- operating system for the job
   extraSetupParameters: ''        # optional -- extra arguments to pass to the setup script
-  frameworks: ['netcoreapp3.1']   # optional -- list of frameworks to run against
+  frameworks: ['netcoreapp3.0']   # optional -- list of frameworks to run against
   continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
   dependsOn: ''                   # optional -- dependencies of the job
   timeoutInMinutes: 320           # optional -- timeout for the job

--- a/eng/common/templates/job/performance.yml
+++ b/eng/common/templates/job/performance.yml
@@ -7,7 +7,7 @@ parameters:
   container: ''                   # required -- name of the container
   osGroup: ''                     # required -- operating system for the job
   extraSetupParameters: ''        # optional -- extra arguments to pass to the setup script
-  frameworks: ['netcoreapp3.0']   # optional -- list of frameworks to run against
+  frameworks: ['netcoreapp3.1']   # optional -- list of frameworks to run against
   continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
   dependsOn: ''                   # optional -- dependencies of the job
   timeoutInMinutes: 320           # optional -- timeout for the job

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -11,7 +11,7 @@
       Only generate our runtimeconfig.json files for net core apps. It's unnecessary in desktop projects
       but gets included in lots of output items like VSIX.
     -->
-    <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp1.1' AND '$(TargetFramework)' != 'netcoreapp3.1'">false</GenerateRuntimeConfigurationFiles>
+    <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp3.1'">false</GenerateRuntimeConfigurationFiles>
 
     <!--
       When building a .NET Core exe make sure to include the template runtimeconfig.json file 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -11,7 +11,7 @@
       Only generate our runtimeconfig.json files for net core apps. It's unnecessary in desktop projects
       but gets included in lots of output items like VSIX.
     -->
-    <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp1.1' AND '$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'">false</GenerateRuntimeConfigurationFiles>
+    <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp1.1' AND '$(TargetFramework)' != 'netcoreapp3.1'">false</GenerateRuntimeConfigurationFiles>
 
     <!--
       When building a .NET Core exe make sure to include the template runtimeconfig.json file 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -11,9 +11,9 @@
       Only generate our runtimeconfig.json files for net core apps. It's unnecessary in desktop projects
       but gets included in lots of output items like VSIX.
     -->
-    <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp1.1' AND '$(TargetFramework)' != 'netcoreapp2.1' AND '$(TargetFramework)' != 'netcoreapp3.0'">false</GenerateRuntimeConfigurationFiles>
+    <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp1.1' AND '$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'">false</GenerateRuntimeConfigurationFiles>
 
-    <!-- 
+    <!--
       When building a .NET Core exe make sure to include the template runtimeconfig.json file 
       which has all of our global settings 
     -->

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -16,7 +16,7 @@
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
-    <RoslynPortableTargetFrameworks>net472;netcoreapp3.1</RoslynPortableTargetFrameworks>
+    <RoslynPortableTargetFrameworks>netcoreapp3.1;net472</RoslynPortableTargetFrameworks>
     <RoslynCheckCodeStyle Condition="'$(ContinuousIntegrationBuild)' != 'true' or '$(RoslynEnforceCodeStyle)' == 'true'">true</RoslynCheckCodeStyle>
     <UseSharedCompilation>true</UseSharedCompilation>
 

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -16,8 +16,7 @@
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
-    <RoslynNetCoreTargetFramework>netcoreapp3.1</RoslynNetCoreTargetFramework>
-    <RoslynPortableTargetFrameworks>net472;$(RoslynNetCoreTargetFramework)</RoslynPortableTargetFrameworks>
+    <RoslynPortableTargetFrameworks>net472;netcoreapp3.1</RoslynPortableTargetFrameworks>
     <RoslynCheckCodeStyle Condition="'$(ContinuousIntegrationBuild)' != 'true' or '$(RoslynEnforceCodeStyle)' == 'true'">true</RoslynCheckCodeStyle>
     <UseSharedCompilation>true</UseSharedCompilation>
 

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -16,8 +16,8 @@
     <!-- Disable the implicit nuget fallback folder as it makes it hard to locate and copy ref assemblies to the test output folder -->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
-
-    <RoslynPortableTargetFrameworks>netcoreapp2.1;net472</RoslynPortableTargetFrameworks>
+    <RoslynNetCoreTargetFramework>netcoreapp3.1</RoslynNetCoreTargetFramework>
+    <RoslynPortableTargetFrameworks>net472;$(RoslynNetCoreTargetFramework)</RoslynPortableTargetFrameworks>
     <RoslynCheckCodeStyle Condition="'$(ContinuousIntegrationBuild)' != 'true' or '$(RoslynEnforceCodeStyle)' == 'true'">true</RoslynCheckCodeStyle>
     <UseSharedCompilation>true</UseSharedCompilation>
 
@@ -69,7 +69,7 @@
       These may be overridden by projects that need to be skipped.
     -->
     <TestTargetFrameworks Condition="'$(TestRuntime)' == 'Mono'">net46;net472</TestTargetFrameworks>
-    <TestTargetFrameworks Condition="'$(TestRuntime)' == 'Core'">netcoreapp2.1</TestTargetFrameworks>
+    <TestTargetFrameworks Condition="'$(TestRuntime)' == 'Core'">netcoreapp3.1</TestTargetFrameworks>
 
     <XUnitDesktopSettingsFile>$(MSBuildThisFileDirectory)..\config\xunit.runner.json</XUnitDesktopSettingsFile>
     <XUnitCoreSettingsFile>$(MSBuildThisFileDirectory)..\config\xunit.runner.json</XUnitCoreSettingsFile>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5849,7 +5849,7 @@ public class CS1698_a {}
             CleanupAllGeneratedFiles(binaryPath);
         }
 
-#if !NETCOREAPP2_1
+#if !NETCOREAPP3_1
         [WorkItem(530221, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530221")]
         [WorkItem(5660, "https://github.com/dotnet/roslyn/issues/5660")]
         [ConditionalFact(typeof(WindowsOnly), typeof(IsEnglishLocal))]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -4743,7 +4743,7 @@ class C
         }
 
         [WorkItem(546621, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546621")]
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/41280")]
         public void TestUnicodeAttributeArgumentsStrings()
         {
             string HighSurrogateCharacter = "\uD800";

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -2270,7 +2270,7 @@ public class C
             }
         }
 
-#if !NETCOREAPP2_1
+#if !NETCOREAPP3_1
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(399, "https://github.com/dotnet/roslyn/issues/399")]
         public void Bug399()

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -360,7 +360,7 @@ public class Test
             Assert.Equal((int)ErrorCode.ERR_PublicKeyContainerFailure, err.Code);
             Assert.Equal(2, err.Arguments.Count);
             Assert.Equal("goo", err.Arguments[0]);
-            Assert.True(((string)err.Arguments[1]).EndsWith(" HRESULT: 0x80090016)", StringComparison.Ordinal));
+            Assert.True(((string)err.Arguments[1]).EndsWith("0x80090016)", StringComparison.Ordinal), (string)err.Arguments[1]);
 
             Assert.True(other.Assembly.Identity.PublicKey.IsEmpty);
         }
@@ -1452,7 +1452,7 @@ public class Z
             Assert.Equal((int)ErrorCode.ERR_PublicKeyContainerFailure, err.Code);
             Assert.Equal(2, err.Arguments.Count);
             Assert.Equal("bogus", err.Arguments[0]);
-            Assert.True(((string)err.Arguments[1]).EndsWith(" HRESULT: 0x80090016)", StringComparison.Ordinal));
+            Assert.True(((string)err.Arguments[1]).EndsWith("0x80090016)", StringComparison.Ordinal), (string)err.Arguments[1]);
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -10676,7 +10676,7 @@ public class MyClass {
         [WorkItem(568494, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/568494")]
         [WorkItem(32576, "https://github.com/dotnet/roslyn/issues/32576")]
         [WorkItem(375, "https://github.com/dotnet/roslyn/issues/375")]
-        [ConditionalFact(typeof(DesktopOnly), Reason = "Working with Tanner to track down the issue")]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/coreclr/issues/22046")]
         public void DecimalLiteral_BreakingChange()
         {
             string source =

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -10676,7 +10676,7 @@ public class MyClass {
         [WorkItem(568494, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/568494")]
         [WorkItem(32576, "https://github.com/dotnet/roslyn/issues/32576")]
         [WorkItem(375, "https://github.com/dotnet/roslyn/issues/375")]
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "Working with Tanner to track down the issue")]
         public void DecimalLiteral_BreakingChange()
         {
             string source =
@@ -12905,7 +12905,7 @@ class C
                 Diagnostic(ErrorCode.ERR_ConstOutOfRange, "(decimal)-4e30f").WithArguments("-4E+30", "decimal"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/metadata-tools/issues/30")]
         [WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")]
         public void Bug14064()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -9819,7 +9819,7 @@ class MyClass
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/metadata-tools/issues/30")]
         [WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")]
         [WorkItem(538246, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538246"), WorkItem(543655, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543655")]
         public void FloatDoubleInfinity()
@@ -11342,7 +11342,7 @@ class C
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/runtime/issues/1611")]
         [WorkItem(32576, "https://github.com/dotnet/roslyn/issues/32576")]
         [WorkItem(34198, "https://github.com/dotnet/roslyn/issues/34198")]
         public void DecimalBinaryOp_03()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -929,8 +929,15 @@ class C
 
             var actual = ParseAndGetConstantFoldingSteps(source);
 
+#if NET472
+            var longValue = "-9.22337203685478E+18";
+#else
+            var longValue = "-9.223372036854776E+18";
+#endif
+
+
             var expected =
-@"(sbyte)(sbyte.MaxValue + 0.1) --> 127
+$@"(sbyte)(sbyte.MaxValue + 0.1) --> 127
 sbyte.MaxValue + 0.1 --> 127.1
 sbyte.MaxValue --> 127
 sbyte.MaxValue --> 127
@@ -979,8 +986,8 @@ uint.MinValue - 0.1 --> -0.1
 uint.MinValue --> 0
 uint.MinValue --> 0
 (long)(long.MinValue - 0.1) --> -9223372036854775808
-long.MinValue - 0.1 --> -9.22337203685478E+18
-long.MinValue --> -9.22337203685478E+18
+long.MinValue - 0.1 --> {longValue}
+long.MinValue --> {longValue}
 long.MinValue --> -9223372036854775808
 (ulong)(ulong.MinValue - 0.1) --> 0
 ulong.MinValue - 0.1 --> -0.1

--- a/src/Compilers/CSharp/Test/Symbol/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests</RootNamespace>
     <NoStdLib>true</NoStdLib>
-    <TargetFrameworks>netcoreapp3.0;net472;</TargetFrameworks>
+    <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("x,y,z", list2.ToString());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/40875")]
         [WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")]
         [WorkItem(720708, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/720708")]
         public void TestLiteralDefaultStringValues()

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -139,7 +139,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Equal($"Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Identifier or Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VerbatimIdentifier to create identifier tokens.{Environment.NewLine}Parameter name: kind", e.Message);
                     Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
 
@@ -151,7 +150,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Equal($"Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create character literal tokens.{Environment.NewLine}Parameter name: kind", e.Message);
                     Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
 
@@ -163,7 +161,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
                 catch (ArgumentException e)
                 {
-                    Assert.Equal($"Use Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Literal to create numeric literal tokens.{Environment.NewLine}Parameter name: kind", e.Message);
                     Assert.Contains(typeof(SyntaxFactory).ToString(), e.Message); // Make sure the class/namespace aren't updated without also updating the exception message
                 }
             }
@@ -276,7 +273,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal("x,y,z", list2.ToString());
         }
 
-        [ConditionalFact(typeof(DesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/40875")]
+        [Fact]
         [WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")]
         [WorkItem(720708, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/720708")]
         public void TestLiteralDefaultStringValues()
@@ -335,7 +332,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // float
             CheckLiteralToString(0F, @"0F");
             CheckLiteralToString(0.012345F, @"0.012345F");
+#if NET472
             CheckLiteralToString(float.MaxValue, @"3.40282347E+38F");
+#else
+            CheckLiteralToString(float.MaxValue, @"3.4028235E+38F");
+#endif
 
             // double
             CheckLiteralToString(0D, @"0");

--- a/src/Compilers/CSharp/Test/WinRT/PEParameterSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/PEParameterSymbolTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class PEParameterSymbolTests : CSharpTestBase
     {
-#if !NETCOREAPP2_1
+#if !NETCOREAPP3_1
         [Fact]
         public void NoParameterNames()
         {

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -10,6 +10,7 @@
     <StartupObject>Microsoft.CodeAnalysis.CSharp.CommandLine.Program</StartupObject>
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <UseAppHost>false</UseAppHost>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/CSharp/csc/csc.csproj
+++ b/src/Compilers/CSharp/csc/csc.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerAssemblyLoaderTests.cs
@@ -10,7 +10,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 
 // The ShadowCopyAnalyzerAssemblyLoader type is only defined for the below platforms
-#if NET472 || NETCOREAPP2_1
+#if NET472 || NETCOREAPP3_1
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {

--- a/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ShadowCopyAnalyzerAssemblyLoaderTests.cs
@@ -9,9 +9,6 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-// The ShadowCopyAnalyzerAssemblyLoader type is only defined for the below platforms
-#if NET472 || NETCOREAPP3_1
-
 namespace Microsoft.CodeAnalysis.UnitTests
 {
     public sealed class ShadowCopyAnalyzerAssemblyLoaderTests : TestBase
@@ -99,7 +96,3 @@ public sealed class TestAnalyzer : AbstractTestAnalyzer
         }
     }
 }
-
-#else
-#error unsupported configuration
-#endif

--- a/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
+++ b/src/Compilers/Core/CommandLine/CompilerServerLogger.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             try
             {
                 // Check if the environment
-                string loggingFileName = Environment.GetEnvironmentVariable(environmentVariable);
+                string? loggingFileName = Environment.GetEnvironmentVariable(environmentVariable);
 
                 if (loggingFileName != null)
                 {
@@ -75,15 +75,15 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <summary>
         /// Log an exception. Also logs information about inner exceptions.
         /// </summary>
-        public static void LogException(Exception e, string reason)
+        public static void LogException(Exception exception, string reason)
         {
             if (s_loggingStream != null)
             {
-                Log("Exception '{0}' occurred during '{1}'. Stack trace:\r\n{2}", e.Message, reason, e.StackTrace);
+                Log("Exception '{0}' occurred during '{1}'. Stack trace:\r\n{2}", exception.Message, reason, exception.StackTrace);
 
                 int innerExceptionLevel = 0;
 
-                e = e.InnerException;
+                Exception? e = exception.InnerException;
                 while (e != null)
                 {
                     Log("Inner exception[{0}] '{1}'. Stack trace: \r\n{1}", innerExceptionLevel, e.Message, e.StackTrace);

--- a/src/Compilers/Core/MSBuildTask/MapSourceRoots.cs
+++ b/src/Compilers/Core/MSBuildTask/MapSourceRoots.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         private void MergeSourceRootMetadata(ITaskItem left, ITaskItem right)
         {
-            foreach (string metadataName in right.MetadataNames)
+            foreach (string? metadataName in right.MetadataNames)
             {
                 var leftValue = left.GetMetadata(metadataName);
                 var rightValue = right.GetMetadata(metadataName);

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -61,7 +61,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis.UnitTests" />

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -12,7 +12,7 @@
     <AssemblyVersion/>
     <!-- CA1819 (Properties should not return arrays) disabled as it is very common across this project. -->
     <NoWarn>$(NoWarn);CA1819</NoWarn>
-
+    
     <!-- NuGet -->
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.Build.Tasks</PackageId>
@@ -23,6 +23,12 @@
     </PackageDescription>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
+
+  <!-- Disable the nullable warnings when not compiling for netcoreapp3.1 -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="*.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -61,7 +61,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis.UnitTests" />

--- a/src/Compilers/Core/MSBuildTask/MvidReader.cs
+++ b/src/Compilers/Core/MSBuildTask/MvidReader.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     return s_empty;
                 }
 
-                if (name.Length == 8 && name[0] == '.' &&
+                if (name!.Length == 8 && name[0] == '.' &&
                     name[1] == 'm' && name[2] == 'v' && name[3] == 'i' && name[4] == 'd' && name[5] == '\0')
                 {
                     // Section: VirtualSize (4)
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 return s_empty;
             }
 
-            return new Guid(guidBytes);
+            return new Guid(guidBytes!);
         }
 
         private static bool ReadUInt16(BinaryReader reader, out ushort output)
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return true;
         }
 
-        private static bool ReadBytes(BinaryReader reader, int count, [NotNullWhen(true)] out byte[]? output)
+        private static bool ReadBytes(BinaryReader reader, int count, out byte[]? output)
         {
             if (reader.BaseStream.Position + count >= reader.BaseStream.Length)
             {

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -178,8 +178,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
 
             return RuntimeHostInfo.IsDesktopRuntime
-                ? Path.Combine(assemblyDirectory, toolName)
-                : Path.Combine(assemblyDirectory, "bincore", toolName);
+                ? Path.Combine(assemblyDirectory!, toolName)
+                : Path.Combine(assemblyDirectory!, "bincore", toolName);
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         public string? TasksAssemblyFullPath
         {
             get { return _tasksAssemblyFullPath; }
-            set { _tasksAssemblyFullPath = NormalizePath(Path.GetFullPath(value)); }
+            set { _tasksAssemblyFullPath = NormalizePath(Path.GetFullPath(value!)); }
         }
 
         public ValidateBootstrap()
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             return path;
         }
 
-        private string GetDirectory(Assembly assembly) => Path.GetDirectoryName(Utilities.TryGetAssemblyPath(assembly));
+        private string? GetDirectory(Assembly assembly) => Path.GetDirectoryName(Utilities.TryGetAssemblyPath(assembly));
 
         internal static void AddFailedLoad(AssemblyName name)
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/NullableAttributes.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NullableAttributes.cs
@@ -5,6 +5,7 @@
 // This was copied from https://github.com/dotnet/coreclr/blob/60f1e6265bd1039f023a82e0643b524d6aaf7845/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.
 
+#if NETSTANDARD2_0 || NET472 || NET20 || NETSTANDARD1_3 || NET45
 #nullable enable
 
 namespace System.Diagnostics.CodeAnalysis
@@ -86,3 +87,8 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ParameterValue { get; }
     }
 }
+
+#elif NETCOREAPP3_1
+#else
+#error "Unsupported configuration"
+#endif

--- a/src/Compilers/Core/Portable/InternalUtilities/NullableAttributes.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NullableAttributes.cs
@@ -5,7 +5,7 @@
 // This was copied from https://github.com/dotnet/coreclr/blob/60f1e6265bd1039f023a82e0643b524d6aaf7845/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.
 
-#if NETSTANDARD2_0 || NET472 || NET20 || NETSTANDARD1_3 || NET45
+#if !NETCOREAPP
 #nullable enable
 
 namespace System.Diagnostics.CodeAnalysis
@@ -88,7 +88,4 @@ namespace System.Diagnostics.CodeAnalysis
     }
 }
 
-#elif NETCOREAPP3_1
-#else
-#error "Unsupported configuration"
 #endif

--- a/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
@@ -131,6 +131,7 @@ namespace Roslyn.Utilities
             }
             catch (TargetInvocationException e)
             {
+                Debug.Assert(e.InnerException is object);
                 ExceptionDispatchInfo.Capture(e.InnerException).Throw();
                 Debug.Assert(false, "Unreachable");
                 return default!;
@@ -142,9 +143,10 @@ namespace Roslyn.Utilities
             return constructorInfo.InvokeConstructor<object?>(args);
         }
 
+        [return: MaybeNull]
         public static T Invoke<T>(this MethodInfo methodInfo, object obj, params object[] args)
         {
-            return (T)methodInfo.Invoke(obj, args);
+            return (T)methodInfo.Invoke(obj, args)!;
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -16,8 +16,8 @@
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
+    <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -8,6 +8,7 @@
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <UseAppHost>false</UseAppHost>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.csproj
@@ -16,8 +16,8 @@
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompiler.UnitTests.csproj
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompiler.UnitTests.csproj
@@ -29,8 +29,8 @@
     <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'" />
-    <Reference Include="System.Xml" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'" />
+    <Reference Include="System" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <Reference Include="System.Xml" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompiler.UnitTests.csproj
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompiler.UnitTests.csproj
@@ -29,8 +29,8 @@
     <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
-    <Reference Include="System.Xml" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
+    <Reference Include="System" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'" />
+    <Reference Include="System.Xml" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
     /// communication layer which is shared between MSBuild and non-MSBuild components. This is the problem that 
     /// BuildPathsAlt fixes as the type lives with the build server communication code.
     /// </summary>
-    internal readonly struct BuildPathsAlt
+    internal sealed class BuildPathsAlt
     {
         /// <summary>
         /// The path which contains the compiler binaries and response files.
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// <summary>
         /// Determines if the compiler server is supported in this environment.
         /// </summary>
-        internal static bool IsCompilerServerSupported(string tempPath) => GetPipeNameForPathOpt("") is object;
+        internal static bool IsCompilerServerSupported => GetPipeNameForPathOpt("") is object;
 
         public static Task<BuildResponse> RunServerCompilation(
             RequestLanguage language,
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             List<string> arguments,
             BuildPathsAlt buildPaths,
             string? keepAlive,
-            string libEnvVariable,
+            string? libEnvVariable,
             CancellationToken cancellationToken)
         {
             var pipeNameOpt = sharedCompilationId ?? GetPipeNameForPathOpt(buildPaths.ClientDirectory);
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             BuildPathsAlt buildPaths,
             string? pipeName,
             string? keepAlive,
-            string libEnvVariable,
+            string? libEnvVariable,
             int? timeoutOverride,
             CreateServerFunc createServerFunc,
             CancellationToken cancellationToken)
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// is <paramref name="workingDir"/>.  This function must emulate <see cref="Path.GetTempPath"/> as 
         /// closely as possible.
         /// </summary>
-        public static string GetTempPath(string? workingDir)
+        public static string? GetTempPath(string? workingDir)
         {
             if (PlatformInformation.IsUnix)
             {
@@ -656,7 +656,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         internal static string GetMutexDirectory()
         {
             var tempPath = BuildServerConnection.GetTempPath(null);
-            var result = Path.Combine(tempPath, ".roslyn");
+            var result = Path.Combine(tempPath!, ".roslyn");
             Directory.CreateDirectory(result);
             return result;
         }

--- a/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP2_1
+#if NETCOREAPP3_1
 
 using System.Diagnostics;
 using System.Reflection;

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis
             return security;
         }
 
-#elif NETCOREAPP2_1
+#elif NETCOREAPP3_1
 
         private static PipeOptions CurrentUserOption = PipeOptions.CurrentUserOnly;
 

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
             if (IsDotNetHost(out string? pathToDotNet))
             {
                 commandLineArguments = $@"exec ""{toolFilePath}"" {commandLineArguments}";
-                return (pathToDotNet, commandLineArguments, toolFilePath);
+                return (pathToDotNet!, commandLineArguments, toolFilePath);
             }
             else
             {
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis
 
         private static string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";
 
-        private static bool IsDotNetHost([NotNullWhen(true)] out string? pathToDotNet)
+        private static bool IsDotNetHost(out string? pathToDotNet)
         {
             pathToDotNet = GetDotNetPathOrDefault();
             return true;

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
         internal static NamedPipeClientStream CreateNamedPipeClient(string serverName, string pipeName, PipeDirection direction, PipeOptions options) =>
             new NamedPipeClientStream(serverName, pipeName, direction, options);
 
-#elif NETCOREAPP2_1
+#elif NETCOREAPP3_1
         internal static bool IsDesktopRuntime => false;
 
         private static string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";

--- a/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-// The ShadowCopyAnalyzerAssemblyLoader derives from DesktopAnalyzerAssemblyLoader (NET472) OR CoreClrAnalyzerAssemblyLoader (NETCOREAPP2_1)
-#if NET472 || NETCOREAPP2_1
+// The ShadowCopyAnalyzerAssemblyLoader derives from DesktopAnalyzerAssemblyLoader (NET472) OR CoreClrAnalyzerAssemblyLoader (NETCOREAPP3_1)
+#if NET472 || NETCOREAPP3_1
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -504,9 +504,7 @@ End Class
         Assert.Equal(2, err.Arguments.Count)
         Assert.Equal("goo", DirectCast(err.Arguments(0), String))
         Dim errorText = DirectCast(err.Arguments(1), String)
-        Assert.True(
-            errorText.Contains("HRESULT") AndAlso
-            errorText.Contains("0x80090016"))
+        Assert.True(errorText.Contains("0x80090016"))
 
         Assert.True(other.Assembly.Identity.PublicKey.IsEmpty)
     End Sub
@@ -662,9 +660,7 @@ End Class
         Assert.Equal(2, err.Arguments.Count)
         Assert.Equal("bogus", DirectCast(err.Arguments(0), String))
         Dim errorText = DirectCast(err.Arguments(1), String)
-        Assert.True(
-            errorText.Contains("HRESULT") AndAlso
-            errorText.Contains("0x80090016"))
+        Assert.True(errorText.Contains("0x80090016"))
     End Sub
 
     <Theory>
@@ -1798,9 +1794,7 @@ End Class
         Assert.Equal(2, err.Arguments.Count)
         Assert.Equal(s_keyPairFile, DirectCast(err.Arguments(0), String))
         Dim errorText = DirectCast(err.Arguments(1), String)
-        Assert.True(
-            errorText.Contains("HRESULT") AndAlso
-            errorText.Contains("0x80131423"))
+        Assert.True(errorText.Contains("0x80131423"))
     End Sub
 
     <Theory>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenConstLocal.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenConstLocal.vb
@@ -181,7 +181,7 @@ End Module
 
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(DesktopOnly), Reason:="https://github.com/dotnet/metadata-tools/issues/30")>
         <WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")>
         Public Sub TestDoubleConstLocal()
             Dim verifier = CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForLoops.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenForLoops.vb
@@ -328,7 +328,7 @@ End Class
 
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(DesktopOnly), Reason:="https://github.com/dotnet/metadata-tools/issues/30")>
         <WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")>
         Public Sub ForLoopStepIsFloatNegativeVar()
             Dim TEMP = CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
@@ -1119,6 +1119,7 @@ public class B
             F(New B(), a)
         Catch e As System.Exception
             System.Console.Write(e.Message)
+            System.Console.WriteLine(e.StackTrace)
         Finally
             System.Threading.Thread.CurrentThread.CurrentCulture = saveCulture
         End Try

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
@@ -1119,7 +1119,6 @@ public class B
             F(New B(), a)
         Catch e As System.Exception
             System.Console.Write(e.Message)
-            System.Console.WriteLine(e.StackTrace)
         Finally
             System.Threading.Thread.CurrentThread.CurrentCulture = saveCulture
         End Try

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -628,7 +628,7 @@ expectedOutput:=<![CDATA[
         <WorkItem(568520, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/568520")>
         <WorkItem(32576, "https://github.com/dotnet/roslyn/issues/32576")>
         <WorkItem(375, "https://github.com/dotnet/roslyn/issues/375")>
-        <Fact>
+        <ConditionalFact(GetType(DesktopOnly))>
         Public Sub DecimalLiteral_BreakingChange()
 
             CompileAndVerify(
@@ -5283,11 +5283,11 @@ Class MyArray
         Static B01#(3), B02!(idx), B03$(fidx)
         B01(0) = 1.1#
         B01#(2) = 2.2!
-        Console.WriteLine(B01(0).ToString(cul))
-        Console.WriteLine(B01(2).ToString(cul))
+        Console.WriteLine(B01(0).ToString("G15", cul))
+        Console.WriteLine(B01(2).ToString("G15", cul))
 
         B02!(idx - 1) = 0.123
-        Console.WriteLine(B02(idx - 1).ToString(cul))
+        Console.WriteLine(B02(idx - 1).ToString("G6", cul))
 
         B03$(fidx - 1) = "c c"
         Console.WriteLine(B03(1))
@@ -13824,7 +13824,7 @@ End Module
 ]]>)
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(DesktopOnly), Reason:="https://github.com/dotnet/metadata-tools/issues/30")>
         <WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")>
         <WorkItem(7148, "https://github.com/dotnet/roslyn/issues/7148")>
         Public Sub Issue7148_1()
@@ -13870,7 +13870,7 @@ End Class
 ]]>)
         End Sub
 
-        <Fact>
+        <ConditionalFact(GetType(DesktopOnly), Reason:="https://github.com/dotnet/metadata-tools/issues/30")>
         <WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")>
         <WorkItem(7148, "https://github.com/dotnet/roslyn/issues/7148")>
         Public Sub Issue7148_2()

--- a/src/Compilers/VisualBasic/Test/Emit/Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj
@@ -5,12 +5,6 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <RootNamespace></RootNamespace>
-    <!-- 
-      Current version of the SDK doesn't emit constants properly for VB
-      https://github.com/dotnet/sdk/pull/2117
-    -->
-    <DefineConstants Condition="'$(TargetFramework)' == 'net472'">$(FinalDefineConstants),NET472=-1</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(FinalDefineConstants),NETCOREAPP2_1=-1</DefineConstants>
 
     <!-- Disabling on assumption -->
     <SkipTests Condition="'$(TestRuntime)' == 'Mono'">true</SkipTests>

--- a/src/Compilers/VisualBasic/Test/Emit/Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj
@@ -8,6 +8,8 @@
 
     <!-- Disabling on assumption -->
     <SkipTests Condition="'$(TestRuntime)' == 'Mono'">true</SkipTests>
+
+    <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\..\Test\PdbUtilities\Roslyn.Test.PdbUtilities.csproj" />

--- a/src/Compilers/VisualBasic/Test/Emit/Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
-    <PackageReference Include="Microsoft.VisualBasic" Version="$(MicrosoftVisualBasicVersion)" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="$(MicrosoftVisualBasicVersion)" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resource.Designer.vb">

--- a/src/Compilers/VisualBasic/Test/Semantic/Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj
@@ -28,7 +28,7 @@
     <ProjectReference Include="..\..\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" Condition="$(TargetFramework) == 'netcoreapp2.1'" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" Condition="$(TargetFramework) == '$(RoslynNetCoreTargetFramework)'" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="My Project\" />

--- a/src/Compilers/VisualBasic/Test/Semantic/Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj
@@ -28,7 +28,7 @@
     <ProjectReference Include="..\..\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" Condition="$(TargetFramework) == '$(RoslynNetCoreTargetFramework)'" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" Condition="$(TargetFramework) == 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="My Project\" />

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UnaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UnaryOperators.vb
@@ -195,7 +195,7 @@ Module Module1
         System.Console.WriteLine("Decimal: {0}", val)
     End Sub
     Sub PrintResult(val As Single)
-        System.Console.WriteLine("Single: {0}", val.ToString(System.Globalization.CultureInfo.InvariantCulture))
+        System.Console.WriteLine("Single: {0}", val.ToString("G7", System.Globalization.CultureInfo.InvariantCulture))
     End Sub
     Sub PrintResult(val As Double)
         System.Console.WriteLine("Double: {0}", val)

--- a/src/Compilers/VisualBasic/Test/Symbol/Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.vbproj
+++ b/src/Compilers/VisualBasic/Test/Symbol/Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.vbproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <RootNamespace></RootNamespace>
 
     <!-- A zillion test failures + crash. See https://github.com/mono/mono/issues/10756. -->

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
@@ -84,7 +84,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             ' float
             CheckLiteralToString(0.0F, "0F")
             CheckLiteralToString(0.012345F, "0.012345F")
+#If NET472 Then
             CheckLiteralToString(Single.MaxValue, "3.40282347E+38F")
+#Else
+            CheckLiteralToString(Single.MaxValue, "3.4028235E+38F")
+#End If
+
 
             ' double
             CheckLiteralToString(0.0, "0")

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -9,6 +9,7 @@
     <StartupObject>Microsoft.CodeAnalysis.VisualBasic.CommandLine.Program</StartupObject>
     <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <UseAppHost>false</UseAppHost>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Compilers/VisualBasic/vbc/vbc.csproj
+++ b/src/Compilers/VisualBasic/vbc/vbc.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="$(SystemIOPipesAccessControlVersion)" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Shared\RuntimeHostInfo.cs" />

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="csi.coreclr.rsp" Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <None Include="csi.coreclr.rsp" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'">
       <Link>csi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="csi.desktop.rsp" Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+    <None Include="csi.desktop.rsp" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'">
       <Link>csi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="csi.coreclr.rsp" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'">
+    <None Include="csi.coreclr.rsp" Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
       <Link>csi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="csi.desktop.rsp" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'">
+    <None Include="csi.desktop.rsp" Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
       <Link>csi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -19,11 +19,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="vbi.coreclr.rsp" Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <None Include="vbi.coreclr.rsp" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'">
       <Link>vbi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="vbi.desktop.rsp" Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+    <None Include="vbi.desktop.rsp" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'">
       <Link>vbi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -19,11 +19,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="vbi.coreclr.rsp" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'">
+    <None Include="vbi.coreclr.rsp" Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
       <Link>vbi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="vbi.desktop.rsp" Condition="'$(TargetFramework)' != '$(RoslynNetCoreTargetFramework)'">
+    <None Include="vbi.desktop.rsp" Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
       <Link>vbi.rsp</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
+++ b/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
@@ -1,7 +1,7 @@
 ﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.NETCore.Compilers</NuspecPackageId>

--- a/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
+++ b/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
@@ -1,7 +1,7 @@
 ﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.NETCore.Compilers</NuspecPackageId>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
@@ -3,9 +3,9 @@
 <Project>
   <Target Name="InitializeCoreClrCompilerArtifacts">
     <ItemGroup>
-      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\*.targets" />
-      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\Microsoft.Build.Tasks.CodeAnalysis.dll" />
-      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" />
+      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\netcoreapp3.1\publish\*.targets" />
+      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\netcoreapp3.1\publish\Microsoft.Build.Tasks.CodeAnalysis.dll" />
+      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\netcoreapp3.1\publish\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll" />
@@ -16,23 +16,23 @@
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.VisualBasic.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll" />
 
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\csc.dll" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\csc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\csc.runtimeconfig.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp3.1\publish\csc.dll" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp3.1\publish\csc.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp3.1\publish\csc.runtimeconfig.json" />
 
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\vbc.dll" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\vbc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\vbc.runtimeconfig.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\netcoreapp3.1\publish\vbc.dll" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\netcoreapp3.1\publish\vbc.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\netcoreapp3.1\publish\vbc.runtimeconfig.json" />
 
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\VBCSCompiler.dll" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\VBCSCompiler.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\VBCSCompiler.runtimeconfig.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\netcoreapp3.1\publish\VBCSCompiler.dll" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\netcoreapp3.1\publish\VBCSCompiler.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\netcoreapp3.1\publish\VBCSCompiler.runtimeconfig.json" />
 
       <!-- References that are either not in the target framework or are a higher version -->
       <!-- N.B.: The backslashes below cannot be replaced with forward slashes.
          https://github.com/NuGet/Home/issues/3584 -->
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\System.*.dll"/>
-      <CoreClrCompilerBinRuntimesArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\runtimes\**" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp3.1\publish\System.*.dll"/>
+      <CoreClrCompilerBinRuntimesArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp3.1\publish\runtimes\**" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/CoreClrCompilerArtifacts.targets
@@ -3,9 +3,9 @@
 <Project>
   <Target Name="InitializeCoreClrCompilerArtifacts">
     <ItemGroup>
-      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\netcoreapp2.1\publish\*.targets" />
-      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\netcoreapp2.1\publish\Microsoft.Build.Tasks.CodeAnalysis.dll" />
-      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\netcoreapp2.1\publish\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" />
+      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\*.targets" />
+      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\Microsoft.Build.Tasks.CodeAnalysis.dll" />
+      <CoreClrCompilerToolsArtifact Include="$(ArtifactsBinDir)Microsoft.Build.Tasks.CodeAnalysis\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\**\Microsoft.Build.Tasks.CodeAnalysis.resources.dll" />
 
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.resources.dll" />
@@ -16,23 +16,23 @@
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\Microsoft.CodeAnalysis.VisualBasic.dll" />
       <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.VisualBasic\$(Configuration)\netstandard2.0\**\Microsoft.CodeAnalysis.VisualBasic.resources.dll" />
 
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp2.1\publish\csc.dll" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp2.1\publish\csc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp2.1\publish\csc.runtimeconfig.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\csc.dll" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\csc.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\csc.runtimeconfig.json" />
 
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\netcoreapp2.1\publish\vbc.dll" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\netcoreapp2.1\publish\vbc.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\netcoreapp2.1\publish\vbc.runtimeconfig.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\vbc.dll" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\vbc.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)vbc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\vbc.runtimeconfig.json" />
 
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\netcoreapp2.1\publish\VBCSCompiler.dll" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\netcoreapp2.1\publish\VBCSCompiler.deps.json" />
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\netcoreapp2.1\publish\VBCSCompiler.runtimeconfig.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\VBCSCompiler.dll" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\VBCSCompiler.deps.json" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)VBCSCompiler\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\VBCSCompiler.runtimeconfig.json" />
 
       <!-- References that are either not in the target framework or are a higher version -->
       <!-- N.B.: The backslashes below cannot be replaced with forward slashes.
          https://github.com/NuGet/Home/issues/3584 -->
-      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp2.1\publish\System.*.dll"/>
-      <CoreClrCompilerBinRuntimesArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\netcoreapp2.1\publish\runtimes\**" />
+      <CoreClrCompilerBinArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\System.*.dll"/>
+      <CoreClrCompilerBinRuntimesArtifact Include="$(ArtifactsBinDir)csc\$(Configuration)\$(RoslynNetCoreTargetFramework)\publish\runtimes\**" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -24,7 +24,7 @@
     <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
 
     <_DependsOn Condition="'$(TargetFramework)' == 'net472'">InitializeDesktopCompilerArtifacts</_DependsOn>
-    <_DependsOn Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'">InitializeCoreClrCompilerArtifacts</_DependsOn>
+    <_DependsOn Condition="'$(TargetFramework)' == 'netcoreapp3.1'">InitializeCoreClrCompilerArtifacts</_DependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,18 +38,18 @@
                       Targets="Publish"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
-                      Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'"
-                      SetTargetFramework="TargetFramework=$(RoslynNetCoreTargetFramework)" />
+                      Condition="'$(TargetFramework)' == 'netcoreapp3.1'"
+                      SetTargetFramework="TargetFramework=netcoreapp3.1" />
   </ItemGroup>
 
   <Target Name="_GetFilesToPackage" DependsOnTargets="$(_DependsOn)">
     <ItemGroup>
       <_File Include="@(DesktopCompilerArtifact)" TargetDir="tasks/net472"/>
       <_File Include="@(DesktopCompilerResourceArtifact)" TargetDir="tasks/net472"/>
-      <_File Include="@(CoreClrCompilerBuildArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)"/>
-      <_File Include="@(CoreClrCompilerToolsArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)"/>
-      <_File Include="@(CoreClrCompilerBinArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)/bincore"/>
-      <_File Include="@(CoreClrCompilerBinRuntimesArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)/bincore/runtimes"/>
+      <_File Include="@(CoreClrCompilerBuildArtifact)" TargetDir="tasks/netcoreapp3.1"/>
+      <_File Include="@(CoreClrCompilerToolsArtifact)" TargetDir="tasks/netcoreapp3.1"/>
+      <_File Include="@(CoreClrCompilerBinArtifact)" TargetDir="tasks/netcoreapp3.1/bincore"/>
+      <_File Include="@(CoreClrCompilerBinRuntimesArtifact)" TargetDir="tasks/netcoreapp3.1/bincore/runtimes"/>
      
       <_File Include="$(MSBuildProjectDirectory)\build\**\*.*" Condition="'$(TargetFramework)' == 'net472'" TargetDir="build" />
      
@@ -58,5 +58,5 @@
   </Target>
 
   <Import Project="DesktopCompilerArtifacts.targets" Condition="'$(TargetFramework)' == 'net472'" />
-  <Import Project="CoreClrCompilerArtifacts.targets" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
+  <Import Project="CoreClrCompilerArtifacts.targets" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
@@ -1,7 +1,7 @@
 ﻿<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>$(RoslynPortableTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <NuspecPackageId>Microsoft.Net.Compilers.Toolset</NuspecPackageId>
@@ -24,7 +24,7 @@
     <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
 
     <_DependsOn Condition="'$(TargetFramework)' == 'net472'">InitializeDesktopCompilerArtifacts</_DependsOn>
-    <_DependsOn Condition="'$(TargetFramework)' == 'netcoreapp2.1'">InitializeCoreClrCompilerArtifacts</_DependsOn>
+    <_DependsOn Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'">InitializeCoreClrCompilerArtifacts</_DependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,18 +38,18 @@
                       Targets="Publish"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"
-                      Condition="'$(TargetFramework)' == 'netcoreapp2.1'"
-                      SetTargetFramework="TargetFramework=netcoreapp2.1" />
+                      Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'"
+                      SetTargetFramework="TargetFramework=$(RoslynNetCoreTargetFramework)" />
   </ItemGroup>
 
   <Target Name="_GetFilesToPackage" DependsOnTargets="$(_DependsOn)">
     <ItemGroup>
       <_File Include="@(DesktopCompilerArtifact)" TargetDir="tasks/net472"/>
       <_File Include="@(DesktopCompilerResourceArtifact)" TargetDir="tasks/net472"/>
-      <_File Include="@(CoreClrCompilerBuildArtifact)" TargetDir="tasks/netcoreapp2.1"/>
-      <_File Include="@(CoreClrCompilerToolsArtifact)" TargetDir="tasks/netcoreapp2.1"/>
-      <_File Include="@(CoreClrCompilerBinArtifact)" TargetDir="tasks/netcoreapp2.1/bincore"/>
-      <_File Include="@(CoreClrCompilerBinRuntimesArtifact)" TargetDir="tasks/netcoreapp2.1/bincore/runtimes"/>
+      <_File Include="@(CoreClrCompilerBuildArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)"/>
+      <_File Include="@(CoreClrCompilerToolsArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)"/>
+      <_File Include="@(CoreClrCompilerBinArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)/bincore"/>
+      <_File Include="@(CoreClrCompilerBinRuntimesArtifact)" TargetDir="tasks/$(RoslynNetCoreTargetFramework)/bincore/runtimes"/>
      
       <_File Include="$(MSBuildProjectDirectory)\build\**\*.*" Condition="'$(TargetFramework)' == 'net472'" TargetDir="build" />
      
@@ -58,5 +58,5 @@
   </Target>
 
   <Import Project="DesktopCompilerArtifacts.targets" Condition="'$(TargetFramework)' == 'net472'" />
-  <Import Project="CoreClrCompilerArtifacts.targets" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+  <Import Project="CoreClrCompilerArtifacts.targets" Condition="'$(TargetFramework)' == '$(RoslynNetCoreTargetFramework)'" />
 </Project>

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/build/Microsoft.Net.Compilers.Toolset.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/build/Microsoft.Net.Compilers.Toolset.props
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_RoslynTargetDirectoryName>   
+    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' == 'Core'">$(RoslynNetCoreTargetFramework)</_RoslynTargetDirectoryName>   
     <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_RoslynTargetDirectoryName>   
     <_RoslynTasksDirectory>$(MSBuildThisFileDirectory)..\tasks\$(_RoslynTargetDirectoryName)\</_RoslynTasksDirectory>
     <RoslynTasksAssembly>$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll</RoslynTasksAssembly> 

--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/build/Microsoft.Net.Compilers.Toolset.props
+++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/build/Microsoft.Net.Compilers.Toolset.props
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' == 'Core'">$(RoslynNetCoreTargetFramework)</_RoslynTargetDirectoryName>   
+    <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp3.1</_RoslynTargetDirectoryName>   
     <_RoslynTargetDirectoryName Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_RoslynTargetDirectoryName>   
     <_RoslynTasksDirectory>$(MSBuildThisFileDirectory)..\tasks\$(_RoslynTargetDirectoryName)\</_RoslynTasksDirectory>
     <RoslynTasksAssembly>$(_RoslynTasksDirectory)Microsoft.Build.Tasks.CodeAnalysis.dll</RoslynTasksAssembly> 

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -170,7 +170,7 @@ $@"{ logoOutput }
 >", runner.Console.Out.ToString());
         }
 
-        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30924")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30924")]
         [WorkItem(33564, "https://github.com/dotnet/roslyn/issues/33564")]
         [WorkItem(7133, "http://github.com/dotnet/roslyn/issues/7133")]
         public void TestDisplayResultsWithCurrentUICulture2()

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1598,7 +1598,7 @@ new List<ArgumentException>()
             Assert.Equal(1, r1.Result);
         }
 
-        [ConditionalFact(typeof(ClrOnly), Reason = "https://github.com/dotnet/roslyn/issues/30303")]
+        [ConditionalFact(typeof(WindowsDesktopOnly), Reason = "https://github.com/dotnet/roslyn/issues/30303")]
         public void HostObjectAssemblyReference1()
         {
             var scriptCompilation = CSharpScript.Create(

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\net472\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>
-    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\netcoreapp2.1\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>
+    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\$(RoslynNetCoreTargetFramework)\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\net472\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>
-    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\$(RoslynNetCoreTargetFramework)\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>
+    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)microsoft.dotnet.nugetrepack.tasks\$(MicrosoftDotnetNuGetRepackTasksVersion)\tools\netcoreapp3.1\Microsoft.DotNet.NuGetRepack.Tasks.dll</_NuGetRepackAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.GetAssemblyFullName" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
+++ b/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         internal static bool IsDesktopRuntime =>
 #if NET472
             true;
-#elif NETCOREAPP2_1
+#elif NETCOREAPP3_1
             false;
 #elif NETSTANDARD2_0
             throw new PlatformNotSupportedException();
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
 #if NET472
             return new Roslyn.Test.Utilities.Desktop.DesktopRuntimeEnvironmentFactory();
-#elif NETCOREAPP2_1
+#elif NETCOREAPP3_1
             return new Roslyn.Test.Utilities.CoreClr.CoreCLRRuntimeEnvironmentFactory();
 #elif NETSTANDARD2_0
             throw new PlatformNotSupportedException();
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
 #if NET472
             return new DesktopAnalyzerAssemblyLoader();
-#elif NETCOREAPP2_1
+#elif NETCOREAPP3_1
             return new CoreClrAnalyzerAssemblyLoader();
 #elif NETSTANDARD2_0
             return new ThrowingAnalyzerAssemblyLoader();

--- a/src/Test/Utilities/Portable/FX/CappedStringWriter.cs
+++ b/src/Test/Utilities/Portable/FX/CappedStringWriter.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _expectedLength = expectedLength;
                 _remaining = Math.Max(256, expectedLength * 4);
             }
+            _remaining = int.MaxValue;
         }
 
         private void CapReached()

--- a/src/Test/Utilities/Portable/FX/CappedStringWriter.cs
+++ b/src/Test/Utilities/Portable/FX/CappedStringWriter.cs
@@ -31,7 +31,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _expectedLength = expectedLength;
                 _remaining = Math.Max(256, expectedLength * 4);
             }
-            _remaining = int.MaxValue;
         }
 
         private void CapReached()

--- a/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironment.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#if NETCOREAPP2_1
+#if NETCOREAPP3_1
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironmentFactory.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironmentFactory.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP2_1
+#if NETCOREAPP3_1
 
 using System;
 using System.Collections.Generic;

--- a/src/Test/Utilities/Portable/Platform/CoreClr/SharedConsoleOutWriter.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/SharedConsoleOutWriter.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_1
+﻿#if NETCOREAPP3_1
 
 using System;
 using System.IO;

--- a/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -25,9 +25,7 @@ namespace Roslyn.Test.Utilities.CoreClr
 
         public TestExecutionLoadContext(IList<ModuleData> dependencies)
         {
-            _dependencies = dependencies
-                .Select(x => new KeyValuePair<string, ModuleData>(x.FullName, x))
-                .ToImmutableDictionary(StringComparer.Ordinal);
+            _dependencies = dependencies.ToImmutableDictionary(d => d.FullName, StringComparer.Ordinal);
         }
 
         protected override Assembly Load(AssemblyName assemblyName)

--- a/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#if NETCOREAPP2_1
+#if NETCOREAPP3_1
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
+++ b/src/Tools/AnalyzerRunner/AnalyzerRunner.csproj
@@ -4,7 +4,7 @@
   <Import Project="$(RepositoryEngineeringDir)targets\GenerateCompilerExecutableBindingRedirects.targets" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <!-- https://github.com/dotnet/runtime/issues/1713 -->
@@ -21,6 +21,7 @@
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -131,7 +131,7 @@ namespace BuildBoss
             {
                 var folder = asset.IsDesktop
                     ? @"net472"
-                    : @"netcoreapp2.1";
+                    : @"netcoreapp3.1";
                 var fileRelativeName = Path.Combine(folder, asset.FileRelativeName);
                 list.Add(fileRelativeName);
             }
@@ -238,9 +238,9 @@ namespace BuildBoss
                 textWriter,
                 isDesktop: false,
                 coreClrAssets,
-                $@"csc\{Configuration}\netcoreapp2.1\publish",
-                $@"vbc\{Configuration}\netcoreapp2.1\publish",
-                $@"VBCSCompiler\{Configuration}\netcoreapp2.1\publish");
+                $@"csc\{Configuration}\netcoreapp3.1\publish",
+                $@"vbc\{Configuration}\netcoreapp3.1\publish",
+                $@"VBCSCompiler\{Configuration}\netcoreapp3.1\publish");
 
             // The native DLLs ship inside the runtime specific directories but build deploys it at the 
             // root as well. That copy is unnecessary.
@@ -256,7 +256,7 @@ namespace BuildBoss
                 textWriter,
                 isDesktop: false,
                 coreClrAssets,
-                $@"Microsoft.Build.Tasks.CodeAnalysis\{Configuration}\netcoreapp2.1\publish");
+                $@"Microsoft.Build.Tasks.CodeAnalysis\{Configuration}\netcoreapp3.1\publish");
 
             packageAssets.AddRange(desktopAssets);
             packageAssets.AddRange(coreClrAssets);

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -323,7 +323,6 @@ namespace BuildBoss
                 {
                     case "net20":
                     case "net472":
-                    case "netcoreapp1.1":
                     case "netcoreapp2.1":
                     case "netcoreapp3.0":
                     case "netcoreapp3.1":

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -326,6 +326,7 @@ namespace BuildBoss
                     case "netcoreapp1.1":
                     case "netcoreapp2.1":
                     case "netcoreapp3.0":
+                    case "netcoreapp3.1":
                     case "$(RoslynPortableTargetFrameworks)":
                         continue;
                 }

--- a/src/Tools/CompilerBenchmarks/CompilerBenchmarks.csproj
+++ b/src/Tools/CompilerBenchmarks/CompilerBenchmarks.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 

--- a/src/Tools/CompilerBenchmarks/CompilerBenchmarks.csproj
+++ b/src/Tools/CompilerBenchmarks/CompilerBenchmarks.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/CompilersBoundTreeGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/CompilersBoundTreeGenerator.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Roslyn.Compilers.Internal.BoundTreeGenerator</RootNamespace>
     <AssemblyName>BoundTreeGenerator</AssemblyName>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/CompilersBoundTreeGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/CompilersBoundTreeGenerator.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Roslyn.Compilers.Internal.BoundTreeGenerator</RootNamespace>
     <AssemblyName>BoundTreeGenerator</AssemblyName>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/CSharpErrorFactsGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/CSharpErrorFactsGenerator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Roslyn.Compilers.CSharp.Internal.CSharpErrorFactsGenerator</RootNamespace>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/CSharpErrorFactsGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/CSharpErrorFactsGenerator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Roslyn.Compilers.CSharp.Internal.CSharpErrorFactsGenerator</RootNamespace>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Roslyn.Compilers.CSharp.Internal.CSharpSyntaxGenerator</RootNamespace>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <IsShipping>false</IsShipping>
   </PropertyGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/CSharpSyntaxGenerator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Roslyn.Compilers.CSharp.Internal.CSharpSyntaxGenerator</RootNamespace>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
     <IsShipping>false</IsShipping>
   </PropertyGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/CompilersIOperationGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/CompilersIOperationGenerator.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Roslyn.Compilers.Internal.IOperationGenerator</RootNamespace>
     <AssemblyName>IOperationGenerator</AssemblyName>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsShipping>false</IsShipping>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/CompilersIOperationGenerator.csproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/CompilersIOperationGenerator.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Roslyn.Compilers.Internal.IOperationGenerator</RootNamespace>
     <AssemblyName>IOperationGenerator</AssemblyName>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <IsShipping>false</IsShipping>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
@@ -10,7 +10,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Internal.VBErrorFactsGenerator</RootNamespace>
     <AssemblyName>VBErrorFactsGenerator</AssemblyName>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
@@ -10,7 +10,7 @@
     <RootNamespace>Microsoft.CodeAnalysis.VisualBasic.Internal.VBErrorFactsGenerator</RootNamespace>
     <AssemblyName>VBErrorFactsGenerator</AssemblyName>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 </Project>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
@@ -11,7 +11,7 @@
     <AssemblyName>VBSyntaxGenerator</AssemblyName>
     <OptionStrict>Off</OptionStrict>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
@@ -11,7 +11,7 @@
     <AssemblyName>VBSyntaxGenerator</AssemblyName>
     <OptionStrict>Off</OptionStrict>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
-    <TargetFramework>$(RoslynNetCoreTargetFramework)</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Workspaces/Core/MSBuild/Host/SimpleAnalyzerAssemblyLoaderService.cs
+++ b/src/Workspaces/Core/MSBuild/Host/SimpleAnalyzerAssemblyLoaderService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Host
     {
 #if NET472
         private readonly DesktopAnalyzerAssemblyLoader _loader = new DesktopAnalyzerAssemblyLoader();
-#elif NETCOREAPP1_1 || NETCOREAPP2_1
+#elif NETCOREAPP1_1 || NETCOREAPP3_1
         private readonly CoreClrAnalyzerAssemblyLoader _loader = new CoreClrAnalyzerAssemblyLoader();
 #endif
 


### PR DESCRIPTION
This unifies our .NET Core assets to be targeting `netcoreapp3.1` where previously it was a mix of `netcoreapp2.1` and `netcoreapp3.0`.