### PR TITLE
Avoid setting BuildingInsideVisualStudio on .NET Core builds

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs
@@ -28,7 +28,13 @@ namespace Microsoft.CodeAnalysis.MSBuild.Build
             { PropertyNames.DesignTimeBuild, bool.TrueString },
 
             // this will force CoreCompile task to execute even if all inputs and outputs are up to date
+#if NETCOREAPP
+            { PropertyNames.NonExistentFile, "__NonExistentSubDir__\\__NonExistentFile__" },
+#else
+            // Setting `BuildingInsideVisualStudio` indirectly sets NonExistentFile:
+            // https://github.com/microsoft/msbuild/blob/ab9b2f36a5ff7a85f842b205d5529e77fdc9d7ab/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3462-L3470
             { PropertyNames.BuildingInsideVisualStudio, bool.TrueString },
+#endif
 
             { PropertyNames.BuildProjectReferences, bool.FalseString },
             { PropertyNames.BuildingProject, bool.FalseString },

--- a/src/Workspaces/Core/MSBuild/MSBuild/Constants/PropertyNames.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/Constants/PropertyNames.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         public const string LangVersion = nameof(LangVersion);
         public const string ModuleAssemblyName = nameof(ModuleAssemblyName);
         public const string NoCompilerStandardLib = nameof(NoCompilerStandardLib);
+        public const string NonExistentFile = nameof(NonExistentFile);
         public const string NoWarn = nameof(NoWarn);
         public const string _NoWarnings = nameof(_NoWarnings);
         public const string Optimize = nameof(Optimize);


### PR DESCRIPTION
Fixes errors loading projects when run on .NET Core.

Related to microsoft/msbuild#5045