### PR TITLE
Add /compilerStats option for AnalyzerRunner

### DIFF
--- a/src/Tools/AnalyzerRunner/Options.cs
+++ b/src/Tools/AnalyzerRunner/Options.cs
@@ -19,6 +19,7 @@ namespace AnalyzerRunner
         public readonly bool ReportSuppressedDiagnostics;
         public readonly bool ApplyChanges;
         public readonly bool ShowStats;
+        public readonly bool ShowCompilerDiagnostics;
         public readonly bool UseAll;
         public readonly int Iterations;
         public readonly bool TestDocuments;
@@ -41,6 +42,7 @@ namespace AnalyzerRunner
             bool reportSuppressedDiagnostics,
             bool applyChanges,
             bool showStats,
+            bool showCompilerDiagnostics,
             bool useAll,
             int iterations,
             bool testDocuments,
@@ -60,6 +62,7 @@ namespace AnalyzerRunner
             ReportSuppressedDiagnostics = reportSuppressedDiagnostics;
             ApplyChanges = applyChanges;
             ShowStats = showStats;
+            ShowCompilerDiagnostics = showCompilerDiagnostics;
             UseAll = useAll;
             Iterations = iterations;
             TestDocuments = testDocuments;
@@ -82,6 +85,7 @@ namespace AnalyzerRunner
             bool reportSuppressedDiagnostics = false;
             bool applyChanges = false;
             bool showStats = false;
+            bool showCompilerDiagnostics = false;
             bool useAll = false;
             int iterations = 1;
             bool testDocuments = false;
@@ -106,6 +110,9 @@ namespace AnalyzerRunner
                         break;
                     case "/stats":
                         showStats = true;
+                        break;
+                    case "/compilerStats":
+                        showCompilerDiagnostics = true;
                         break;
                     case "/concurrent":
                         runConcurrent = true;
@@ -189,6 +196,7 @@ namespace AnalyzerRunner
                 reportSuppressedDiagnostics: reportSuppressedDiagnostics,
                 applyChanges: applyChanges,
                 showStats: showStats,
+                showCompilerDiagnostics: showCompilerDiagnostics,
                 useAll: useAll,
                 iterations: iterations,
                 testDocuments: testDocuments,

--- a/src/Tools/AnalyzerRunner/Properties/launchSettings.json
+++ b/src/Tools/AnalyzerRunner/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "IDE Analyzers": {
       "commandName": "Project",
-      "commandLineArgs": "$(OutDir) $(SolutionDir)Roslyn.sln /concurrent /stats"
+      "commandLineArgs": "$(OutDir) $(SolutionDir)Roslyn.sln /concurrent /stats /compilerStats"
     },
     "CSharpEditorFeatures Analyzers": {
       "commandName": "Project",


### PR DESCRIPTION
Prints a table of all compiler diagnostics after solution load.

Example:

```
  Hidden CS8019: 6461 instances (Unnecessary using directive)
  Hidden CS8020: 4 instances (Unused extern alias)
  Hidden BC50001: 4777 instances (Unused import statement)
  Error CS0103: 218 instances (The name '{0}' does not exist in the current context)
  Error CS1061: 59 instances ('{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?))
  Error BC30311: 1 instances (Value of type '{0}' cannot be converted to '{1}'.)
  Error BC30451: 89 instances ('{0}' is not declared. It may be inaccessible due to its protection level.)
  Error BC30057: 1 instances (Too many arguments to '{0}'.)
```