### PR TITLE
Fix special handling of Winforms Reset method in IDE0051 (RemoveUnuse…

### DIFF
--- a/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -2084,22 +2084,36 @@ $@"class C
 }}");
         }
 
-        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
-        [InlineData("ShouldSerialize")]
-        [InlineData("Reset")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
         [WorkItem(30887, "https://github.com/dotnet/roslyn/issues/30887")]
-        public async Task ShouldSerializeOrResetPropertyMethod(string prefix)
+        public async Task ShouldSerializePropertyMethod()
         {
             await TestDiagnosticMissingAsync(
-$@"class C
-{{
-    private bool [|{prefix}Data|]()
-    {{
+@"class C
+{
+    private bool [|ShouldSerializeData|]()
+    {
         return true;
-    }}
+    }
 
-    public int Data {{ get; private set; }}
-}}");
+    public int Data { get; private set; }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]
+        [WorkItem(38491, "https://github.com/dotnet/roslyn/issues/38491")]
+        public async Task ResetPropertyMethod()
+        {
+            await TestDiagnosticMissingAsync(
+@"class C
+{
+    private void [|ResetData|]()
+    {
+        return;
+    }
+
+    public int Data { get; private set; }
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedMembers)]

--- a/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -699,15 +699,14 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
 
             private bool IsShouldSerializeOrResetPropertyMethod(IMethodSymbol methodSymbol)
             {
-                // ShouldSerializeXXX and ResetXXX are ok if there is a matching
+                // "bool ShouldSerializeXXX()" and "void ResetXXX()" are ok if there is a matching
                 // property XXX as they are used by the windows designer property grid
                 // Note that we do a case sensitive compare for compatibility with legacy FxCop
                 // implementation of this rule.
 
-                return methodSymbol.ReturnType.SpecialType == SpecialType.System_Boolean &&
-                    methodSymbol.Parameters.IsEmpty &&
-                    (IsSpecialMethodWithMatchingProperty("ShouldSerialize") ||
-                     IsSpecialMethodWithMatchingProperty("Reset"));
+                return methodSymbol.Parameters.IsEmpty &&
+                    (IsSpecialMethodWithMatchingProperty("ShouldSerialize") && methodSymbol.ReturnType.SpecialType == SpecialType.System_Boolean ||
+                     IsSpecialMethodWithMatchingProperty("Reset") && methodSymbol.ReturnsVoid);
 
                 // Local functions.
                 bool IsSpecialMethodWithMatchingProperty(string prefix)


### PR DESCRIPTION
…dMembers)

My previous fix to #30887 added special handling for special Winforms  method with prefix "ShouldSerialize" or "Reset". However, I incorrectly required both these methods to have boolean return type, while only the former should have boolean return. Reset methods needs to be void returning. This change fixes this case.

Fixes #38491 reported on developer community for this bug.