### PR TITLE
Stop Simplifier.ReduceAsync removing empty arg lists from delegates

### DIFF
--- a/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/ExpressionGenerationTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 cs: "E()",
                 csSimple: "E()",
                 vb: "E()",
-                vbSimple: "E");
+                vbSimple: "E()");
         }
 
         [Fact]
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 cs: "E[]",
                 csSimple: "E[]",
                 vb: "E()",
-                vbSimple: "E");
+                vbSimple: "E()");
         }
 
         [Fact]

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -298,6 +298,44 @@ End Class
 
             Await TestAsync(input, expected)
         End Function
+
+        <WorkItem(40442, "https://github.com/dotnet/roslyn/issues/40442")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DontRemoveEmptyArgumentListParenthesesWhenNotInferrable() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Public Class TestClass
+    Private Shared prop As String
+    Public Shared Sub Main()
+        Dim inferred = If(prop, {|SimplifyExtension:Function() As Integer
+                    Return 5
+                End Function()|})
+        System.Console.WriteLine(inferred)
+        System.Console.WriteLine({|SimplifyExtension:inferred.ToString()|})
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Public Class TestClass
+    Private Shared prop As String
+    Public Shared Sub Main()
+        Dim inferred = If(prop, Function() As Integer
+                    Return 5
+                End Function())
+        System.Console.WriteLine(inferred)
+        System.Console.WriteLine(inferred.ToString())
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
 #End Region
 
 #Region "VB Array Literal tests"

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -301,7 +301,7 @@ End Class
 
         <WorkItem(40442, "https://github.com/dotnet/roslyn/issues/40442")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_DoNotRemoveEmptyArgumentListOnLambda() As Task
+        Public Async Function TestVisualBasic_RemoveEmptyArgumentListOnMethodGroup() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -314,18 +314,6 @@ Public Class TestClass
     Public Shared Sub Main()
         Dim inferredMethodGroup = MyIf({|SimplifyExtension:TestClass.GetFour()|})
         System.Console.WriteLine(inferredMethodGroup)
-            
-        Dim inferredInlineFunction = MyIf({|SimplifyExtension:Function()
-                Return 5
-            End Function()|})
-        System.Console.WriteLine(inferredInlineFunction)
-        
-        Dim localDelegate = Function() As Integer
-                Return 6
-            End Function
-
-        Dim inferredLocalDelegate = MyIf({|SimplifyExtension:localDelegate()|})
-        System.Console.WriteLine(inferredLocalDelegate)
     End Sub
     
     Public Shared Function MyIf(y As Integer)
@@ -350,12 +338,104 @@ Public Class TestClass
     Public Shared Sub Main()
         Dim inferredMethodGroup = MyIf(TestClass.GetFour)
         System.Console.WriteLine(inferredMethodGroup)
-            
+    End Sub
+    
+    Public Shared Function MyIf(y As Integer)
+        Return y
+    End Function
+    
+    Public Shared Function MyIf(y As Object)
+        Return y
+    End Function
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(40442, "https://github.com/dotnet/roslyn/issues/40442")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DoNotRemoveEmptyArgumentListOnInlineLambda() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Public Class TestClass
+    Public Shared Sub Main()
+        Dim inferredInlineFunction = MyIf({|SimplifyExtension:Function()
+                Return 5
+            End Function()|})
+        System.Console.WriteLine(inferredInlineFunction)
+    End Sub
+    
+    Public Shared Function MyIf(y As Integer)
+        Return y
+    End Function
+    
+    Public Shared Function MyIf(y As Object)
+        Return y
+    End Function
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Public Class TestClass
+    Public Shared Sub Main()
         Dim inferredInlineFunction = MyIf(Function()
                 Return 5
             End Function())
         System.Console.WriteLine(inferredInlineFunction)
-        
+    End Sub
+    
+    Public Shared Function MyIf(y As Integer)
+        Return y
+    End Function
+    
+    Public Shared Function MyIf(y As Object)
+        Return y
+    End Function
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(40442, "https://github.com/dotnet/roslyn/issues/40442")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DoNotRemoveEmptyArgumentListOnLocalLambda() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Public Class TestClass
+    Public Shared Sub Main()
+        Dim localDelegate = Function() As Integer
+                Return 6
+            End Function
+
+        Dim inferredLocalDelegate = MyIf({|SimplifyExtension:localDelegate()|})
+        System.Console.WriteLine(inferredLocalDelegate)
+    End Sub
+    
+    Public Shared Function MyIf(y As Integer)
+        Return y
+    End Function
+    
+    Public Shared Function MyIf(y As Object)
+        Return y
+    End Function
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Public Class TestClass
+    Public Shared Sub Main()       
         Dim localDelegate = Function() As Integer
                 Return 6
             End Function

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -301,7 +301,7 @@ End Class
 
         <WorkItem(40442, "https://github.com/dotnet/roslyn/issues/40442")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_OnlyRemoveEmptyArgumentLisForMethodGroup() As Task
+        Public Async Function TestVisualBasic_DoNotRemoveEmptyArgumentListOnLambda() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -435,7 +435,7 @@ End Class
             Dim expected =
 <code>
 Public Class TestClass
-    Public Shared Sub Main()       
+    Public Shared Sub Main()
         Dim localDelegate = Function() As Integer
                 Return 6
             End Function

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.DataFlowAnalysis.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.DataFlowAnalysis.vb
@@ -4957,7 +4957,7 @@ Class C
     End Sub
 
     Private Shared Sub NewMethod()
-        Program()
+        Program
     End Sub
 End Class</text>
 
@@ -5169,7 +5169,7 @@ Module Program
     End Sub
 
     Private Sub NewMethod()
-        Console.Write()
+        Console.Write
     End Sub
 End Module</text>
 

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.DataFlowAnalysis.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.DataFlowAnalysis.vb
@@ -4957,7 +4957,7 @@ Class C
     End Sub
 
     Private Shared Sub NewMethod()
-        Program
+        Program()
     End Sub
 End Class</text>
 
@@ -5169,7 +5169,7 @@ Module Program
     End Sub
 
     Private Sub NewMethod()
-        Console.Write
+        Console.Write()
     End Sub
 End Module</text>
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 End If
             End If
 
-            If invocationExpression.IsParentKind(SyntaxKind.CallStatement) Then
+            If invocationExpression.IsParentKind(SyntaxKind.CallStatement) OrElse invocationExpression.IsParentKind(SyntaxKind.ExpressionStatement) Then
                 Return True
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -47,19 +47,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 End If
             End If
 
-            Dim ancestor = invocationExpression.GetAncestor(Of ExecutableStatementSyntax)
-            If ancestor Is Nothing Then Return True ' TODO: Cover cases other than executable statement
-
-            ' Drawbacks:
-            ' * Only covers cases where the invocation is nested within an executable statement
-            ' * Performs abysmally due to creating a whole speculative semantic model for the vast majority of invocations, and additionally using GetOperation which is quite slow in general
-            ' 
-            ' At some point amongst all the code that runs there is presumably a crucial function which has the rules for binding a name-type syntax into an invocation.
-            ' Ideally we'd find a way to call just that function here on invocationExpression.Expression
-            Dim expressionWithoutArgList = ancestor.ReplaceNode(invocationExpression, invocationExpression.Expression)
-            Dim speculativeSemanticModel As SemanticModel = Nothing
-            Return semanticModel.TryGetSpeculativeSemanticModel(invocationExpression.SpanStart, expressionWithoutArgList, speculativeSemanticModel) AndAlso _
-                speculativeSemanticModel.GetOperation(expressionWithoutArgList).Kind = operationkind.Invocation
+            Dim isOrdinaryMethod = semanticModel.GetSymbolInfo(invocationExpression.Expression).Symbol?.IsOrdinaryMethod
+            Return isOrdinaryMethod.HasValue AndAlso isOrdinaryMethod.Value
         End Function
 
         <Extension>

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
         <Extension>
         Public Function CanRemoveEmptyArgumentList(invocationExpression As InvocationExpressionSyntax, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Boolean
-            Return invocationExpression.ArgumentList IsNot Nothing AndAlso invocationExpression.ArgumentList.Arguments.Count = 0 AndAlso _
+            Return invocationExpression.ArgumentList IsNot Nothing AndAlso invocationExpression.ArgumentList.Arguments.Count = 0 AndAlso
                 CanHaveOmittedArgumentList(invocationExpression, semanticModel, cancellationToken)
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 End If
             End If
 
-            If TypeOf invocationExpression.Parent Is CallStatementSyntax
+            If invocationExpression.IsParentKind(SyntaxKind.CallStatement) Then
                 Return True
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -12,14 +12,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
         <Extension>
         Public Function CanRemoveEmptyArgumentList(invocationExpression As InvocationExpressionSyntax, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Boolean
-            If invocationExpression.ArgumentList Is Nothing Then
-                Return False
-            End If
+            Return invocationExpression.ArgumentList IsNot Nothing AndAlso invocationExpression.ArgumentList.Arguments.Count = 0 AndAlso _
+                CanHaveOmittedArgumentList(invocationExpression, semanticModel, cancellationToken)
+        End Function
 
-            If invocationExpression.ArgumentList.Arguments.Count > 0 Then
-                Return False
-            End If
-
+        Private Function CanHaveOmittedArgumentList(invocationExpression As InvocationExpressionSyntax, semanticModel As SemanticModel, cancellationToken As CancellationToken) As Boolean
             Dim nextToken = invocationExpression.GetLastToken().GetNextToken()
 
             If nextToken.IsKindOrHasMatchingText(SyntaxKind.OpenParenToken) Then

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -47,6 +47,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 End If
             End If
 
+            If TypeOf invocationExpression.Parent Is CallStatementSyntax
+                Return True
+            End If
+
             Dim isOrdinaryMethod = semanticModel.GetSymbolInfo(invocationExpression.Expression).Symbol?.IsOrdinaryMethod
             Return isOrdinaryMethod.HasValue AndAlso isOrdinaryMethod.Value
         End Function

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -51,8 +51,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 Return True
             End If
 
-            Dim isOrdinaryMethod = semanticModel.GetSymbolInfo(invocationExpression.Expression).Symbol?.IsOrdinaryMethod
-            Return isOrdinaryMethod.HasValue AndAlso isOrdinaryMethod.Value
+            Dim symbol As ISymbol = semanticModel.GetSymbolInfo(invocationExpression.Expression).Symbol
+            Return symbol IsNot Nothing AndAlso symbol.MatchesKind(SymbolKind.Property, SymbolKind.Method) AndAlso Not symbol.IsAnonymousFunction
         End Function
 
         <Extension>

--- a/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/InvocationExpressionSyntaxExtensions.vb
@@ -47,7 +47,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 End If
             End If
 
-            Return True
+            Dim ancestor = invocationExpression.GetAncestor(Of ExecutableStatementSyntax)
+            If ancestor Is Nothing Then Return True ' TODO: Cover cases other than executable statement
+
+            ' Drawbacks:
+            ' * Only covers cases where the invocation is nested within an executable statement
+            ' * Performs abysmally due to creating a whole speculative semantic model for the vast majority of invocations, and additionally using GetOperation which is quite slow in general
+            ' 
+            ' At some point amongst all the code that runs there is presumably a crucial function which has the rules for binding a name-type syntax into an invocation.
+            ' Ideally we'd find a way to call just that function here on invocationExpression.Expression
+            Dim expressionWithoutArgList = ancestor.ReplaceNode(invocationExpression, invocationExpression.Expression)
+            Dim speculativeSemanticModel As SemanticModel = Nothing
+            Return semanticModel.TryGetSpeculativeSemanticModel(invocationExpression.SpanStart, expressionWithoutArgList, speculativeSemanticModel) AndAlso _
+                speculativeSemanticModel.GetOperation(expressionWithoutArgList).Kind = operationkind.Invocation
         End Function
 
         <Extension>


### PR DESCRIPTION
Fixes #40442

* I suspect the test is in slightly the wrong place, but couldn't find a sensible place.
* I've aimed to err on the side of caution, leaving the brackets where the symbol is unresolvable except in some cases where it couldn't be anything else valid. If you can point at the spec or code that decides whether something without an arg list will be invoked then I'll happily update to use the precise logic if it differs from what I've done.