### PR TITLE
Deprecate Workspace.set_Options

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -68,7 +68,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
             Workspace workspace, TestParameters parameters)
         {
             var outOfProcess = (bool)parameters.fixProviderData;
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(
+                workspace.CurrentSolution.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)));
 
             return base.CreateDiagnosticProviderAndFixer(workspace, parameters);
         }

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_NuGet.cs
@@ -32,9 +32,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
         protected override TestWorkspace CreateWorkspaceFromFile(string initialMarkup, TestParameters parameters)
         {
             var workspace = base.CreateWorkspaceFromFile(initialMarkup, parameters);
-            workspace.Options = workspace.Options
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
                 .WithChangedOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.CSharp, true)
-                .WithChangedOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.CSharp, true);
+                .WithChangedOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.CSharp, true)));
             return workspace;
         }
 

--- a/src/EditorFeatures/CSharpTest/BlockCommentEditing/CloseBlockCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/BlockCommentEditing/CloseBlockCommentTests.cs
@@ -279,8 +279,8 @@ a    * /$$
 ";
             Verify(code, expected, workspace =>
             {
-                workspace.Options = workspace.Options.WithChangedOption(
-                    FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp, false);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(
+                    workspace.CurrentSolution.Options.WithChangedOption(FeatureOnOffOptions.AutoInsertBlockCommentStartString, LanguageNames.CSharp, false)));
             });
         }
 

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -881,7 +881,7 @@ partial class Outer
                 code, codeAfterMove, expectedDocumentName, destinationDocumentText,
                 onAfterWorkspaceCreated: w =>
                 {
-                    w.Options = w.Options.WithChangedOption(FormattingOptions.InsertFinalNewLine, true);
+                    w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(FormattingOptions.InsertFinalNewLine, true)));
                 });
         }
 
@@ -922,7 +922,7 @@ partial class Outer
                 code, codeAfterMove, expectedDocumentName, destinationDocumentText,
                 onAfterWorkspaceCreated: w =>
                 {
-                    w.Options = w.Options.WithChangedOption(FormattingOptions.InsertFinalNewLine, false);
+                    w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(FormattingOptions.InsertFinalNewLine, false)));
                 });
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -147,10 +147,11 @@ text;
             var document = workspace.CurrentSolution.GetDocument(documentId);
             var position = hostDocument.CursorPosition.Value;
 
-            workspace.Options = workspace.Options.WithChangedOption(
-                CompletionOptions.EnterKeyBehavior,
-                LanguageNames.CSharp,
-                sendThroughEnterOption);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(
+                    CompletionOptions.EnterKeyBehavior,
+                    LanguageNames.CSharp,
+                    sendThroughEnterOption)));
 
             var service = GetCompletionService(workspace);
             var completionList = await GetCompletionListAsync(service, document, position, RoslynTrigger.Invoke);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1265,11 +1265,11 @@ class C
         public async Task DisabledByOption()
         {
             var workspace = WorkspaceFixture.GetWorkspace();
-            var originalOptions = WorkspaceFixture.GetWorkspace().Options;
+            var originalOptions = workspace.CurrentSolution.Options;
             try
             {
-                workspace.Options = originalOptions.
-                    WithChangedOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp, false);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.
+                    WithChangedOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp, false)));
 
                 var markup = @"
 class Test
@@ -1281,7 +1281,7 @@ class Test
             }
             finally
             {
-                workspace.Options = originalOptions;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
             }
         }
 
@@ -1462,9 +1462,9 @@ public class Class1
 
             try
             {
-                workspace.Options = workspace.Options.WithChangedOption(
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.WithChangedOption(
                     new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp),
-                    NamesEndWithSuffixPreferences());
+                    NamesEndWithSuffixPreferences())));
 
                 var markup = @"
 class Configuration
@@ -1483,7 +1483,7 @@ class Configuration
             }
             finally
             {
-                workspace.Options = originalOptions;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
             }
         }
 
@@ -1495,9 +1495,9 @@ class Configuration
 
             try
             {
-                workspace.Options = workspace.Options.WithChangedOption(
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.WithChangedOption(
                     new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp),
-                    NamesEndWithSuffixPreferences());
+                    NamesEndWithSuffixPreferences())));
 
                 var markup = @"
 class Configuration
@@ -1518,7 +1518,7 @@ class Configuration
             }
             finally
             {
-                workspace.Options = originalOptions;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1265,24 +1265,16 @@ class C
         public async Task DisabledByOption()
         {
             var workspace = WorkspaceFixture.GetWorkspace();
-            var originalOptions = workspace.CurrentSolution.Options;
-            try
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.
-                    WithChangedOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp, false)));
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.
+                WithChangedOption(CompletionOptions.ShowNameSuggestions, LanguageNames.CSharp, false)));
 
-                var markup = @"
+            var markup = @"
 class Test
 {
     Test $$
 }
 ";
-                await VerifyNoItemsExistAsync(markup);
-            }
-            finally
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
-            }
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [WorkItem(23590, "https://github.com/dotnet/roslyn/issues/23590")]
@@ -1458,48 +1450,35 @@ public class Class1
         public async Task CustomNamingStyleInsideClass()
         {
             var workspace = WorkspaceFixture.GetWorkspace();
-            var originalOptions = workspace.Options;
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
+                new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp),
+                NamesEndWithSuffixPreferences())));
 
-            try
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.WithChangedOption(
-                    new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp),
-                    NamesEndWithSuffixPreferences())));
-
-                var markup = @"
+            var markup = @"
 class Configuration
 {
     Configuration $$
 }
 ";
-                await VerifyItemExistsAsync(markup, "ConfigurationField", glyph: (int)Glyph.FieldPublic,
-                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
-                await VerifyItemExistsAsync(markup, "ConfigurationProperty", glyph: (int)Glyph.PropertyPublic,
-                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
-                await VerifyItemExistsAsync(markup, "ConfigurationMethod", glyph: (int)Glyph.MethodPublic,
-                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
-                await VerifyItemIsAbsentAsync(markup, "ConfigurationLocal");
-                await VerifyItemIsAbsentAsync(markup, "ConfigurationLocalFunction");
-            }
-            finally
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
-            }
+            await VerifyItemExistsAsync(markup, "ConfigurationField", glyph: (int)Glyph.FieldPublic,
+                expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+            await VerifyItemExistsAsync(markup, "ConfigurationProperty", glyph: (int)Glyph.PropertyPublic,
+                expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+            await VerifyItemExistsAsync(markup, "ConfigurationMethod", glyph: (int)Glyph.MethodPublic,
+                expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+            await VerifyItemIsAbsentAsync(markup, "ConfigurationLocal");
+            await VerifyItemIsAbsentAsync(markup, "ConfigurationLocalFunction");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CustomNamingStyleInsideMethod()
         {
             var workspace = WorkspaceFixture.GetWorkspace();
-            var originalOptions = workspace.Options;
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
+                new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp),
+                NamesEndWithSuffixPreferences())));
 
-            try
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.WithChangedOption(
-                    new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp),
-                    NamesEndWithSuffixPreferences())));
-
-                var markup = @"
+            var markup = @"
 class Configuration
 {
     void M()
@@ -1508,18 +1487,13 @@ class Configuration
     }
 }
 ";
-                await VerifyItemExistsAsync(markup, "ConfigurationLocal", glyph: (int)Glyph.Local,
-                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
-                await VerifyItemExistsAsync(markup, "ConfigurationLocalFunction", glyph: (int)Glyph.MethodPublic,
-                    expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
-                await VerifyItemIsAbsentAsync(markup, "ConfigurationField");
-                await VerifyItemIsAbsentAsync(markup, "ConfigurationMethod");
-                await VerifyItemIsAbsentAsync(markup, "ConfigurationProperty");
-            }
-            finally
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
-            }
+            await VerifyItemExistsAsync(markup, "ConfigurationLocal", glyph: (int)Glyph.Local,
+                expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+            await VerifyItemExistsAsync(markup, "ConfigurationLocalFunction", glyph: (int)Glyph.MethodPublic,
+                expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
+            await VerifyItemIsAbsentAsync(markup, "ConfigurationField");
+            await VerifyItemIsAbsentAsync(markup, "ConfigurationMethod");
+            await VerifyItemIsAbsentAsync(markup, "ConfigurationProperty");
         }
 
         [WorkItem(31304, "https://github.com/dotnet/roslyn/issues/31304")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
@@ -483,15 +483,11 @@ partial class Bar
         public async Task ExpressionBodyMethod()
         {
             var workspace = WorkspaceFixture.GetWorkspace();
-            var originalOptions = workspace.Options;
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
+                CSharpCodeStyleOptions.PreferExpressionBodiedMethods,
+                new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.Silent))));
 
-            try
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.WithChangedOption(
-                    CSharpCodeStyleOptions.PreferExpressionBodiedMethods,
-                    new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.Silent))));
-
-                var text = @"using System;
+            var text = @"using System;
 partial class Bar
 {
     partial void Foo();
@@ -500,7 +496,7 @@ partial class Bar
 "
 ;
 
-                var expected = @"using System;
+            var expected = @"using System;
 partial class Bar
 {
     partial void Foo();
@@ -509,12 +505,7 @@ partial class Bar
 "
 ;
 
-                await VerifyCustomCommitProviderAsync(text, "Foo()", expected);
-            }
-            finally
-            {
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
-            }
+            await VerifyCustomCommitProviderAsync(text, "Foo()", expected);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
@@ -487,9 +487,9 @@ partial class Bar
 
             try
             {
-                workspace.Options = originalOptions.WithChangedOption(
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions.WithChangedOption(
                     CSharpCodeStyleOptions.PreferExpressionBodiedMethods,
-                    new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.Silent));
+                    new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption.Silent))));
 
                 var text = @"using System;
 partial class Bar
@@ -513,7 +513,7 @@ partial class Bar
             }
             finally
             {
-                workspace.Options = originalOptions;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(originalOptions));
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldTestState.cs
+++ b/src/EditorFeatures/CSharpTest/EncapsulateField/EncapsulateFieldTestState.cs
@@ -50,9 +50,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EncapsulateField
         {
             var exportProvider = s_exportProviderFactory.CreateExportProvider();
             var workspace = TestWorkspace.CreateCSharp(markup, exportProvider: exportProvider);
-            workspace.Options = workspace.Options
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
                 .WithChangedOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CSharpCodeStyleOptions.NeverWithSilentEnforcement)
-                .WithChangedOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.NeverWithSilentEnforcement);
+                .WithChangedOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CSharpCodeStyleOptions.NeverWithSilentEnforcement)));
             return new EncapsulateFieldTestState(workspace);
         }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -256,8 +256,10 @@ namespace M
                 .CreateExportProvider();
 
             using var workspace = TestWorkspace.CreateCSharp(code, exportProvider: exportProvider);
-            workspace.Options = workspace.Options.WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp, systemUsingsFirst);
-            workspace.Options = workspace.Options.WithChangedOption(GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.CSharp, separateUsingGroups);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp, systemUsingsFirst)));
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.CSharp, separateUsingGroups)));
 
             // register this workspace to solution crawler so that analyzer service associate itself with given workspace
             var incrementalAnalyzerProvider = workspace.ExportProvider.GetExportedValue<IDiagnosticAnalyzerService>() as IIncrementalAnalyzerProvider;

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -257,8 +257,7 @@ namespace M
 
             using var workspace = TestWorkspace.CreateCSharp(code, exportProvider: exportProvider);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
-                .WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp, systemUsingsFirst)));
-            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp, systemUsingsFirst)
                 .WithChangedOption(GenerationOptions.SeparateImportDirectiveGroups, LanguageNames.CSharp, separateUsingGroups)));
 
             // register this workspace to solution crawler so that analyzer service associate itself with given workspace

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -131,7 +131,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             {
                 foreach (var option in options)
                 {
-                    workspace.Options = workspace.Options.WithChangedOption(option.option, LanguageNames.CSharp, option.enabled);
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                        .WithChangedOption(option.option, LanguageNames.CSharp, option.enabled)));
                 }
             }
 

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -127,13 +127,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
         protected static void AssertFormatWithView(string expectedWithMarker, string codeWithMarker, params (PerLanguageOption<bool> option, bool enabled)[] options)
         {
             using var workspace = TestWorkspace.CreateCSharp(codeWithMarker);
+
             if (options != null)
             {
+                var optionSet = workspace.Options;
                 foreach (var option in options)
                 {
-                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
-                        .WithChangedOption(option.option, LanguageNames.CSharp, option.enabled)));
+                    optionSet = optionSet.WithChangedOption(option.option, LanguageNames.CSharp, option.enabled);
                 }
+
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(optionSet));
             }
 
             // set up caret position

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -507,7 +507,8 @@ class Program
             using var workspace = TestWorkspace.CreateCSharp(code);
             var subjectDocument = workspace.Documents.Single();
             var spans = subjectDocument.SelectedSpans;
-            workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.AllowDisjointSpanMerging, true);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(FormattingOptions.AllowDisjointSpanMerging, true)));
 
             var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
             var syntaxRoot = await document.GetSyntaxRootAsync();
@@ -2063,7 +2064,7 @@ class MyClass
                     options = options.WithChangedOption(entry.Key, entry.Value);
                 }
 
-                workspace.Options = options;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(options));
             }
 
             var subjectDocument = workspace.Documents.Single();

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
@@ -102,7 +102,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
         {
             // create tree service
             using var workspace = TestWorkspace.CreateCSharp(code);
-            workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs)));
 
             if (baseIndentation.HasValue)
             {

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1364,7 +1364,8 @@ class C
             // create tree service
             using var workspace = TestWorkspace.CreateCSharp(code);
 
-            workspace.Options = workspace.Options.WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs)));
 
             var hostdoc = workspace.Documents.First();
 
@@ -1405,9 +1406,9 @@ class C
         {
             // create tree service
             using var workspace = TestWorkspace.CreateCSharp(code);
-            workspace.Options = workspace.Options
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
                 .WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
-                .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+                .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs)));
             var hostdoc = workspace.Documents.First();
             var buffer = hostdoc.GetTextBuffer();
             var snapshot = buffer.CurrentSnapshot;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2843,8 +2843,9 @@ return;
             {
                 using var workspace = TestWorkspace.CreateCSharp(markup, parseOptions: option);
 
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
-                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs)));
                 var subjectDocument = workspace.Documents.Single();
 
                 var projectedDocument =
@@ -2892,8 +2893,9 @@ return;
             {
                 using var workspace = TestWorkspace.CreateCSharp(code, parseOptions: option);
 
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
-                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs)));
                 TestIndentation(workspace, indentationLine, expectedIndentation);
             }
         }
@@ -2923,8 +2925,9 @@ return;
             {
                 using var workspace = TestWorkspace.CreateCSharp(code, parseOptions: option);
 
-                workspace.Options = workspace.Options.WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
-                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
+                    .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs)));
                 var wpfTextView = workspace.Documents.First().GetTextView();
                 var line = wpfTextView.TextBuffer.CurrentSnapshot.GetLineFromPosition(wpfTextView.Caret.Position.BufferPosition).LineNumber;
                 TestIndentation(workspace, line, expectedIndentation);

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3469,7 +3469,8 @@ class Program{
 
             using var workspace = TestWorkspace.CreateCSharp(markup);
 
-            workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs)));
 
             var subjectDocument = workspace.Documents.Single();
 
@@ -3514,7 +3515,8 @@ class Program{
         {
             using var workspace = TestWorkspace.CreateCSharp(initialMarkup);
 
-            workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs)));
 
             var tuple = GetService(workspace);
             var testDocument = workspace.Documents.Single();

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatTokenTests.cs
@@ -636,7 +636,8 @@ class Program
             // create tree service
             using var workspace = TestWorkspace.CreateCSharp(code);
 
-            workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs)));
 
             var buffer = workspace.Documents.First().GetTextBuffer();
 

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -38,9 +38,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
             bool useTabs = false)
         {
             using var workspace = TestWorkspace.CreateCSharp(inputMarkup);
-            workspace.Options = workspace.Options
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
                 .WithChangedOption(SmartIndent, LanguageNames.CSharp, indentStyle)
-                .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs);
+                .WithChangedOption(UseTabs, LanguageNames.CSharp, useTabs)));
 
             if (useTabs && expectedOutputMarkup != null)
             {

--- a/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/TodoComment/TodoCommentTests.cs
@@ -178,7 +178,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.TodoComment
         private static async Task TestAsync(string codeWithMarker, bool remote)
         {
             using var workspace = TestWorkspace.CreateCSharp(codeWithMarker, openDocuments: false);
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, remote);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(RemoteHostOptions.RemoteHostTest, remote)));
 
             var commentTokens = new TodoCommentTokens();
             var provider = new TodoCommentIncrementalAnalyzerProvider(commentTokens, Array.Empty<Lazy<IEventListener, EventListenerMetadata>>());

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -354,11 +354,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             }
 
             using var context = await TestContext.CreateAsync(initial, expected);
+            var workspace = context.Workspace;
             if (options != null)
             {
                 foreach (var kvp in options)
                 {
-                    context.Workspace.Options = context.Workspace.Options.WithChangedOption(kvp.Key, kvp.Value);
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                        .WithChangedOption(kvp.Key, kvp.Value)));
                 }
             }
 

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -357,11 +357,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             var workspace = context.Workspace;
             if (options != null)
             {
+                var optionSet = workspace.Options;
                 foreach (var kvp in options)
                 {
-                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
-                        .WithChangedOption(kvp.Key, kvp.Value)));
+                    optionSet = optionSet.WithChangedOption(kvp.Key, kvp.Value);
                 }
+
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(optionSet));
             }
 
             var typeSymbol = GetTypeSymbol(type)(context.SemanticModel);

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public async Task TestHasSuccessfullyLoadedBeingFalseFSAOn()
         {
             var workspace = new AdhocWorkspace();
-            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)));
             var document = GetDocumentFromIncompleteProject(workspace);
 
             // open document
@@ -90,7 +91,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public async Task TestHasSuccessfullyLoadedBeingFalseWithCompilerAnalyzerFSAOn()
         {
             var workspace = new AdhocWorkspace();
-            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)));
             var document = GetDocumentFromIncompleteProject(workspace);
 
             await TestAnalyzerAsync(workspace, document, new CSharpCompilerDiagnosticAnalyzer(), CompilerAnalyzerResultSetter, expectedSyntax: true, expectedSemantic: false);
@@ -102,7 +104,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public async Task TestDisabledByDefaultAnalyzerEnabledWithEditorConfig(bool enabledWithEditorconfig)
         {
             using var workspace = new AdhocWorkspace();
-            workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)));
 
             var project = workspace.AddProject(
                 ProjectInfo.Create(

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             workspace.OnSolutionAdded(solutionInfo);
             await WaitWaiterAsync(workspace.ExportProvider);
 
-            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(Analyzer.TestOption, false));
+            var worker = await ExecuteOperation(workspace, w => w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(Analyzer.TestOption, false))));
 
             Assert.Equal(10, worker.SyntaxDocumentIds.Count);
             Assert.Equal(10, worker.DocumentIds.Count);
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.ActiveFile;
-            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
+            var worker = await ExecuteOperation(workspace, w => w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope))));
 
             Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
             Assert.Equal(1, worker.SyntaxDocumentIds.Count);
@@ -441,7 +441,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             Assert.Equal(BackgroundAnalysisScope.Default, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
 
             var newAnalysisScope = BackgroundAnalysisScope.FullSolution;
-            var worker = await ExecuteOperation(workspace, w => w.Options = w.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope));
+            var worker = await ExecuteOperation(workspace, w => w.TryApplyChanges(w.CurrentSolution.WithOptions(w.CurrentSolution.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, newAnalysisScope))));
 
             Assert.Equal(newAnalysisScope, SolutionCrawlerOptions.GetBackgroundAnalysisScope(workspace.Options, LanguageNames.CSharp));
             Assert.Equal(10, worker.SyntaxDocumentIds.Count);
@@ -1063,7 +1063,8 @@ End Class";
             var solution = GetInitialSolutionInfoWithP2P();
 
             using var workspace = new WorkCoordinatorWorkspace(SolutionCrawler);
-            workspace.Options = workspace.Options.WithChangedOption(InternalSolutionCrawlerOptions.DirectDependencyPropagationOnly, false);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(InternalSolutionCrawlerOptions.DirectDependencyPropagationOnly, false)));
 
             workspace.OnSolutionAdded(solution);
             await WaitWaiterAsync(workspace.ExportProvider);
@@ -1083,7 +1084,8 @@ End Class";
             var solution = GetInitialSolutionInfoWithP2P();
 
             using var workspace = new WorkCoordinatorWorkspace(SolutionCrawler);
-            workspace.Options = workspace.Options.WithChangedOption(InternalSolutionCrawlerOptions.DirectDependencyPropagationOnly, true);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(InternalSolutionCrawlerOptions.DirectDependencyPropagationOnly, true)));
 
             workspace.OnSolutionAdded(solution);
             await WaitWaiterAsync(workspace.ExportProvider);
@@ -1378,12 +1380,13 @@ End Class";
         private static void SetOptions(Workspace workspace)
         {
             // override default timespan to make test run faster
-            workspace.Options = workspace.Options.WithChangedOption(InternalSolutionCrawlerOptions.ActiveFileWorkerBackOffTimeSpanInMS, 0)
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.ActiveFileWorkerBackOffTimeSpanInMS, 0)
                                                  .WithChangedOption(InternalSolutionCrawlerOptions.AllFilesWorkerBackOffTimeSpanInMS, 0)
                                                  .WithChangedOption(InternalSolutionCrawlerOptions.PreviewBackOffTimeSpanInMS, 0)
                                                  .WithChangedOption(InternalSolutionCrawlerOptions.ProjectPropagationBackOffTimeSpanInMS, 0)
                                                  .WithChangedOption(InternalSolutionCrawlerOptions.SemanticChangeBackOffTimeSpanInMS, 0)
-                                                 .WithChangedOption(InternalSolutionCrawlerOptions.EntireProjectWorkerBackOffTimeSpanInMS, 100);
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.EntireProjectWorkerBackOffTimeSpanInMS, 100)));
         }
 
         private static void MakeFirstDocumentActive(Project project)
@@ -1421,7 +1424,8 @@ End Class";
             public static WorkCoordinatorWorkspace CreateWithAnalysisScope(BackgroundAnalysisScope analysisScope, string workspaceKind = null, bool disablePartialSolutions = true)
             {
                 var workspace = new WorkCoordinatorWorkspace(workspaceKind, disablePartialSolutions);
-                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, analysisScope);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, analysisScope)));
                 return workspace;
             }
 

--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -41,8 +41,8 @@ namespace MyNamespace
 }";
 
             using var workspace = TestWorkspace.CreateCSharp(code);
-            workspace.Options = workspace.Options.WithChangedOption(
-BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp, true);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.CSharp, true)));
 
             var tags = await GetTagsFromWorkspaceAsync(workspace);
 

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -278,10 +278,10 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
                 ' turn off diagnostic
                 If Not enabled Then
-                    workspace.Options = workspace.Options _
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
                                                   .WithChangedOption(ServiceComponentOnOffOptions.DiagnosticProvider, False) _
                                                   .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.Default) _
-                                                  .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.Default)
+                                                  .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.Default)))
                 End If
 
                 Dim registrationService = workspace.Services.GetService(Of ISolutionCrawlerRegistrationService)()

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -710,7 +710,8 @@ class AnonymousFunctions
                 Dim project = workspace.CurrentSolution.Projects.Single()
 
                 ' turn off heuristic
-                workspace.Options = workspace.Options.WithChangedOption(InternalDiagnosticsOptions.UseCompilationEndCodeFixHeuristic, False)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(InternalDiagnosticsOptions.UseCompilationEndCodeFixHeuristic, False)))
 
                 Dim analyzer = New CompilationEndedAnalyzer
                 Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))
@@ -1984,7 +1985,8 @@ class MyClass
                        </Workspace>
 
             Using workspace = TestWorkspace.CreateWorkspace(test)
-                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)))
 
                 Dim project = workspace.CurrentSolution.Projects.Single()
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -57,7 +57,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
             End If
 
             Using workspace = TestWorkspace.Create(element)
-                workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)))
 
                 Assert.True(workspace.Documents.Any(Function(d) d.CursorPosition.HasValue))
 
@@ -186,7 +187,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
                                        outOfProcess As Boolean) As Task
             options = If(options, FindReferencesSearchOptions.Default)
             Using workspace = TestWorkspace.Create(definition)
-                workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)))
                 workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
 
                 For Each cursorDocument In workspace.Documents.Where(Function(d) d.CursorPosition.HasValue)

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -69,8 +69,9 @@ class C
 
                               </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendTypeChars("repl")
                 state.SendTab()
@@ -303,8 +304,10 @@ class Class1
     }
 }</Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.EnterKeyBehavior, LanguageNames.CSharp, EnterKeyRule.AfterFullyTypedWord)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.EnterKeyBehavior, LanguageNames.CSharp, EnterKeyRule.AfterFullyTypedWord)))
+
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
                 Assert.Equal(<text>
@@ -329,9 +332,9 @@ class Class1
         $$
     }
 }</Document>)
-
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.EnterKeyBehavior, LanguageNames.CSharp, EnterKeyRule.AfterFullyTypedWord)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.EnterKeyBehavior, LanguageNames.CSharp, EnterKeyRule.AfterFullyTypedWord)))
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -660,8 +663,9 @@ class Variable
     }
 }]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 ' This completionImplementation is hard-selected because the suggestion mode never triggers on backspace
@@ -690,8 +694,9 @@ class Variable
     }
 }]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 ' This completionImplementation is hard-selected because the suggestion mode never triggers on backspace
@@ -2800,8 +2805,9 @@ class$$ C
 {
 }]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -2829,8 +2835,9 @@ class Program
     }
 }]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -3467,8 +3474,10 @@ class Program
     }
 }
             ]]></Document>)
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 For Each c In "Offset"
                     state.SendBackspace()
@@ -3494,8 +3503,10 @@ class Program
     }
 }
             ]]></Document>)
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 For Each c In "Offset."
                     state.SendBackspace()
@@ -3611,8 +3622,9 @@ class C
                                   using $$
                               </Document>, {New TaskControlledCompletionProvider(tcs.Task)})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)))
 
                 state.SendTypeChars("Sys.")
                 Await state.AssertNoCompletionSession()
@@ -3629,8 +3641,9 @@ class C
                                   using $$
                               </Document>, {New TaskControlledCompletionProvider(Task.FromResult(True))})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)))
 
                 state.SendTypeChars("Sys")
                 Await state.AssertSelectedCompletionItem(displayText:="System")
@@ -3659,8 +3672,9 @@ class C
                                   using $$
                               </Document>, {provider})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)))
 
                 state.SendTypeChars("Sys")
 
@@ -3733,8 +3747,9 @@ class C
                                   using $$
                               </Document>, {provider})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)))
 
                 state.SendTypeChars("Sys")
                 Dim task1 As Task = Nothing
@@ -3821,8 +3836,9 @@ class C
                 provider.UpdateTask(tcs.Task)
 
                 ' Switch to the non-blocking mode
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, False)))
 
                 ' re-use of TestNoBlockOnCompletionItems1
                 state.SendTypeChars("Sys.")
@@ -3842,8 +3858,8 @@ class C
                 provider.UpdateTask(tcs.Task)
 
                 ' Switch to the blocking mode
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, True)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.BlockForCompletionItems, LanguageNames.CSharp, True)))
 
 #Disable Warning BC42358 ' Because this call is not awaited, execution of the current method continues before the call is completed
                 Task.Run(Function()
@@ -4054,7 +4070,10 @@ class Program
                               </Document>)
 
                 Dim key = New OptionKey(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp)
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(key, True)
+
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(key, True)))
 
                 state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
@@ -4503,8 +4522,9 @@ public class Program
 }
                               </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 state.SendBackspace()
@@ -4527,8 +4547,9 @@ public class Program
 }
                               </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 state.SelectAndMoveCaret(-6)
@@ -4574,8 +4595,9 @@ class C
     }
 }</Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("WriteLine")
@@ -4801,8 +4823,9 @@ class C
 }
                               </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4827,8 +4850,9 @@ class C
 }
                               </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
@@ -4900,8 +4924,9 @@ class C
 }
                               </Document>, {provider})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendBackspace()
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -4991,8 +5016,9 @@ class C
 }
                               </Document>, {provider})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -5036,8 +5062,9 @@ class C
 }
                               </Document>, {provider})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)))
 
                 state.SendTypeChars(".nor")
                 Await state.AssertCompletionItemsContainAll("Normalize", "★ Normalize")
@@ -5090,7 +5117,9 @@ namespace NS2
 }
 ]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)))
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -5156,8 +5185,9 @@ namespace NS2
 }
 ]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -5196,7 +5226,9 @@ namespace NS1
 }
 ]]></Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 ' trigger completion with import completion enabled
                 state.SendInvokeCompletionList()
@@ -5600,8 +5632,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -5671,8 +5704,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -5742,8 +5776,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -5813,8 +5848,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -5885,8 +5921,9 @@ namespace NS2
 }
 "
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)))
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -5933,8 +5970,9 @@ namespace NS
     class ATaAaSaKa { }
 } </Document>, extraExportedTypes:={GetType(TestExperimentationService)}.ToList())
 
-                state.Workspace.Options = state.Workspace.Options _
-                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, False)))
 
                 state.SendTypeChars("task")
                 Await state.WaitForAsynchronousOperationsAsync()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
@@ -670,7 +670,9 @@ class C
                               </Document>)
 
                 ' disable implicit sig help then type a trigger character -> no session should be available
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, "C#", False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, "C#", False)))
                 state.SendTypeChars("(")
                 Await state.AssertNoSignatureHelpSession()
 

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -1806,8 +1806,9 @@ Class Class1
 End Class
 </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.EnterKeyBehavior, LanguageNames.VisualBasic, EnterKeyRule.AfterFullyTypedWord)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.EnterKeyBehavior, LanguageNames.VisualBasic, EnterKeyRule.AfterFullyTypedWord)))
                 state.SendTypeChars("System.TimeSpan.FromMin")
                 state.SendReturn()
                 Assert.Equal(<text>
@@ -1831,8 +1832,9 @@ Class Class1
 End Class
 </Document>)
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
-                    CompletionOptions.EnterKeyBehavior, LanguageNames.VisualBasic, EnterKeyRule.AfterFullyTypedWord)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.EnterKeyBehavior, LanguageNames.VisualBasic, EnterKeyRule.AfterFullyTypedWord)))
 
                 state.SendTypeChars("System.TimeSpan.FromMinutes")
                 state.SendReturn()
@@ -2135,7 +2137,10 @@ Class G
     Public Re$$
 End Class
             ]]></Document>)
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.TriggerOnTyping, LanguageNames.VisualBasic, False)
+
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.TriggerOnTyping, LanguageNames.VisualBasic, False)))
                 state.SendBackspace()
                 Await state.AssertNoCompletionSession()
             End Using
@@ -2624,9 +2629,9 @@ End Class
 }]]></Document>,
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
-                                                                                    LanguageNames.VisualBasic,
-                                                                                    SnippetsRule.AlwaysInclude)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic, SnippetsRule.AlwaysInclude)))
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2647,9 +2652,9 @@ End Class
 }]]></Document>,
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
-                                                                                    LanguageNames.VisualBasic,
-                                                                                    SnippetsRule.AlwaysInclude)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic, SnippetsRule.AlwaysInclude)))
 
                 state.SendTypeChars("Shortcu")
                 Await state.AssertSelectedCompletionItem(displayText:="Shortcut", isHardSelected:=True)
@@ -2671,9 +2676,9 @@ End Class
 }]]></Document>,
                   extraExportedTypes:={GetType(MockSnippetInfoService), GetType(SnippetCompletionProvider), GetType(StubVsEditorAdaptersFactoryService)}.ToList())
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
-                                                                                    LanguageNames.VisualBasic,
-                                                                                    SnippetsRule.AlwaysInclude)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic, SnippetsRule.AlwaysInclude)))
 
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("x", "Shortcut")

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicSignatureHelpCommandHandlerTests.vb
@@ -280,7 +280,9 @@ End Class
                               </Document>)
 
                 ' disable implicit sig help then type a trigger character -> no session should be available
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, LanguageNames.VisualBasic, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, LanguageNames.VisualBasic, False)))
                 state.SendTypeChars("(")
                 Await state.AssertNoSignatureHelpSession()
 

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/AbstractReferenceHighlightingTests.vb
@@ -25,7 +25,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
         Private Async Function VerifyHighlightsAsync(test As XElement, optionIsEnabled As Boolean, outOfProcess As Boolean) As Tasks.Task
             Using workspace = TestWorkspace.Create(test)
                 WpfTestRunner.RequireWpfFact($"{NameOf(AbstractReferenceHighlightingTests)}.{NameOf(Me.VerifyHighlightsAsync)} creates asynchronous taggers")
-                workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)))
 
                 Dim tagProducer = New ReferenceHighlightingViewTaggerProvider(
                     workspace.ExportProvider.GetExportedValue(Of IThreadingContext),
@@ -37,7 +38,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.ReferenceHighlighting
                 Dim caretPosition = hostDocument.CursorPosition.Value
                 Dim snapshot = hostDocument.GetTextBuffer().CurrentSnapshot
 
-                workspace.Options = workspace.Options.WithChangedOption(FeatureOnOffOptions.ReferenceHighlighting, hostDocument.Project.Language, optionIsEnabled)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(FeatureOnOffOptions.ReferenceHighlighting, hostDocument.Project.Language, optionIsEnabled)))
 
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
                 Dim context = New TaggerContext(Of NavigableHighlightTag)(

--- a/src/EditorFeatures/Test2/Rename/DashboardTests.vb
+++ b/src/EditorFeatures/Test2/Rename/DashboardTests.vb
@@ -578,7 +578,7 @@ class D : B
                     Next
                 End If
 
-                workspace.Options = optionSet
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(optionSet))
 
                 Dim sessionInfo = renameService.StartInlineSession(
                     document, document.GetSyntaxTreeAsync().Result.GetRoot().FindToken(cursorPosition).Span, CancellationToken.None)

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -187,7 +187,7 @@ class Deconstructable
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameInStrings, renameInStrings)
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameInComments, renameInComments)
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameFile, renameFile)
-            workspace.Options = optionSet
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(optionSet))
 
             Dim session = StartSession(workspace)
 

--- a/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/TestUtilities/AutomaticCompletion/AbstractAutomaticBraceCompletionTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion
                     options = options.WithChangedOption(entry.Key, entry.Value);
                 }
 
-                workspace.Options = options;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(options));
             }
 
             var document = workspace.Documents.First();

--- a/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                 options = options.WithChangedOption(FeatureOnOffOptions.AutoXmlDocCommentGeneration, testDocument.Project.Language, autoGenerateXmlDocComments);
                 options = options.WithChangedOption(FormattingOptions.NewLine, testDocument.Project.Language, newLine);
 
-                workspace.Options = options;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(options));
 
                 setOptionsOpt?.Invoke(workspace);
 

--- a/src/EditorFeatures/TestUtilities/Extensions/WorkspaceExtensions.cs
+++ b/src/EditorFeatures/TestUtilities/Extensions/WorkspaceExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
                     optionSet = optionSet.WithChangedOption(option.Key, option.Value);
                 }
 
-                workspace.Options = optionSet;
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(optionSet));
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -110,7 +110,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
         {
             using (var workspace = SetupWorkspace(content, createTrackingService))
             {
-                workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)));
                 await body(workspace);
             }
         }

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -344,9 +344,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
             var cursorPosition = testWorkspace.Documents.First(d => d.Name == "SourceDocument").CursorPosition.Value;
             var documentId = testWorkspace.Documents.First(d => d.Name == "SourceDocument").Id;
             var document = testWorkspace.CurrentSolution.GetDocument(documentId);
-            var code = (await document.GetTextAsync()).ToString();
 
-            testWorkspace.Options = testWorkspace.Options.WithChangedOption(CompletionOptions.HideAdvancedMembers, document.Project.Language, hideAdvancedMembers);
+            testWorkspace.TryApplyChanges(testWorkspace.CurrentSolution.WithOptions(testWorkspace.Options
+                .WithChangedOption(CompletionOptions.HideAdvancedMembers, document.Project.Language, hideAdvancedMembers)));
+
+            document = testWorkspace.CurrentSolution.GetDocument(documentId);
+            var code = (await document.GetTextAsync()).ToString();
 
             IList<TextSpan> textSpans = null;
 

--- a/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxStructureProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxStructureProviderTests.cs
@@ -31,9 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Structure
         {
             using (var workspace = TestWorkspace.Create(WorkspaceKind, LanguageName, compilationOptions: null, parseOptions: null, content: markupCode))
             {
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(BlockStructureOptions.MaximumBannerLength, LanguageName, 120)));
                 var hostDocument = workspace.Documents.Single();
-                workspace.Options = workspace.Options.WithChangedOption(
-                    BlockStructureOptions.MaximumBannerLength, LanguageName, 120);
                 Assert.True(hostDocument.CursorPosition.HasValue, "Test must specify a position.");
                 var position = hostDocument.CursorPosition.Value;
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -46,7 +46,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, parameters As TestParameters) As (DiagnosticAnalyzer, CodeFixProvider)
             Dim outOfProcess = DirectCast(parameters.fixProviderData, Boolean)
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                .WithChangedOption(RemoteHostOptions.RemoteHostTest, outOfProcess)))
 
             Return MyBase.CreateDiagnosticProviderAndFixer(workspace, parameters)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -23,9 +23,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
 
         Protected Overrides Function CreateWorkspaceFromFile(initialMarkup As String, parameters As TestParameters) As TestWorkspace
             Dim workspace = MyBase.CreateWorkspaceFromFile(initialMarkup, parameters)
-            workspace.Options = workspace.Options.
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.
                 WithChangedOption(SymbolSearchOptions.SuggestForTypesInNuGetPackages, LanguageNames.VisualBasic, True).
-                WithChangedOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.VisualBasic, True)
+                WithChangedOption(SymbolSearchOptions.SuggestForTypesInReferenceAssemblies, LanguageNames.VisualBasic, True)))
             Return workspace
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
@@ -31,7 +31,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Property
 
         Private Sub DisableLineCommit(workspace As Workspace)
-            workspace.Options = workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                .WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)))
         End Sub
 
         Private Sub VerifyTypedCharApplied(doFunc As Func(Of VisualBasicEndConstructService, ITextView, ITextBuffer, Boolean),

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
@@ -34,7 +34,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent3()
             Using workspace = TestWorkspace.CreateCSharp("")
-                workspace.Options = workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False)))
 
                 Dim document = workspace.Projects.Single().Documents.Single()
                 Dim provider = New SmartIndentProvider()

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -3028,9 +3028,9 @@ end class"
                 useTabs As Boolean,
                 indentStyle As FormattingOptions.IndentStyle)
             Using workspace = TestWorkspace.CreateVisualBasic(code)
-                workspace.Options = workspace.Options _
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
                     .WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle) _
-                    .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.VisualBasic, useTabs)
+                    .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.VisualBasic, useTabs)))
 
                 TestIndentation(workspace, indentationLine, expectedIndentation)
             End Using

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
@@ -176,7 +176,8 @@ End Class
             MarkupTestFile.GetPosition(codeWithMarkup, code, position)
 
             Using workspace = TestWorkspace.CreateVisualBasic(code)
-                workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle)))
 
                 Dim hostdoc = workspace.Documents.First()
                 Dim buffer = hostdoc.GetTextBuffer()

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
@@ -62,7 +62,8 @@ Interface IGoo
 End Interface")
 
                 Dim commandHandler = MoveCaretAndCreateCommandHandler(workspace)
-                workspace.Options = workspace.Options.WithChangedOption(FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic, False)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic, False)))
 
                 Dim nextHandlerCalled = False
                 Dim view = workspace.Documents.Single().GetTextView()

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
@@ -68,7 +68,10 @@ End Class
                     </Project>
                 </Workspace>)
 
-                testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
+                Dim workspace = testData.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)))
+
                 testData.CommandHandler.ExecuteCommand(New PasteCommandArgs(testData.View, testData.Buffer),
                                                        Sub() testData.EditorOperations.InsertText("Class Program" & vbCrLf & "    Sub M(abc As Integer)" & vbCrLf & "        Dim a  = 7" & vbCrLf & "    End Sub" & vbCrLf & "End Class"),
                                                        TestCommandExecutionContext.Create())
@@ -124,7 +127,10 @@ End Class
                                                         </Document>
                                                        </Project>
                                                    </Workspace>)
-                testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
+                Dim workspace = testData.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)))
+
                 testData.Buffer.Insert(57, "    ")
                 testData.CommandHandler.ExecuteCommand(New SaveCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                 Assert.Equal("        Dim a     = 7", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(3).GetText())
@@ -170,7 +176,9 @@ End Module
                                                    </Workspace>)
 
                 ' Turn off pretty listing
-                testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
+                Dim workspace = testData.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)))
                 testData.CommandHandler.ExecuteCommand(New FormatDocumentCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub, TestCommandExecutionContext.Create())
                 Assert.Equal("    Sub Main()", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(1).GetText())
             End Using

--- a/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/TodoComment/TodoCommentTests.vb
@@ -181,7 +181,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.TodoComment
             MarkupTestFile.GetSpans(codeWithMarker.NormalizedValue, code, list)
 
             Using workspace = TestWorkspace.CreateVisualBasic(code, openDocuments:=False)
-                workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, remote)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(RemoteHostOptions.RemoteHostTest, remote)))
 
                 Dim commentTokens = New TodoCommentTokens()
                 Dim provider = New TodoCommentIncrementalAnalyzerProvider(commentTokens, Array.Empty(Of Lazy(Of IEventListener, EventListenerMetadata))())

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/FxCopAnalyzersInstallLogger.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/FxCopAnalyzersInstallLogger.cs
@@ -23,14 +23,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers
             if (!installed && installStatus == FxCopAnalyzersInstallStatus.Installed)
             {
                 // first time after vsix installed
-                workspace.Options = workspace.Options.WithChangedOption(FxCopAnalyzersInstallOptions.VsixInstalled, true);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(FxCopAnalyzersInstallOptions.VsixInstalled, true)));
                 Log("VsixInstalled");
             }
 
             if (installed && installStatus == FxCopAnalyzersInstallStatus.NotInstalled)
             {
                 // first time after vsix is uninstalled
-                workspace.Options = workspace.Options.WithChangedOption(FxCopAnalyzersInstallOptions.VsixInstalled, false);
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(FxCopAnalyzersInstallOptions.VsixInstalled, false)));
                 Log("VsixUninstalled");
             }
         }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             private readonly ImmutableArray<ISymbol> _viableMembers;
             private readonly ImmutableArray<PickMembersOption> _pickMembersOptions;
 
+            private bool? _addNullCheckOptionValue;
+
             public override string Title => FeaturesResources.Generate_constructor;
 
             public GenerateConstructorWithDialogCodeAction(
@@ -65,11 +67,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                     // If we presented the 'Add null check' option, then persist whatever value
                     // the user chose.  That way we'll keep that as the default for the next time
                     // the user opens the dialog.
-                    var workspace = _document.Project.Solution.Workspace;
-                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
-                        GenerateConstructorFromMembersOptions.AddNullChecks,
-                        _document.Project.Language,
-                        addNullChecksOption.Value)));
+                    _addNullCheckOptionValue = addNullChecksOption.Value;
                 }
 
                 var addNullChecks = (addNullChecksOption?.Value).GetValueOrDefault();
@@ -108,6 +106,21 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
 
                     return await codeAction.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
                 }
+            }
+
+            protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+            {
+                var solution = await base.GetChangedSolutionAsync(cancellationToken).ConfigureAwait(false);
+
+                if (_addNullCheckOptionValue.HasValue)
+                {
+                    solution = solution.WithOptions(solution.Options.WithChangedOption(
+                        GenerateConstructorFromMembersOptions.AddNullChecks,
+                        _document.Project.Language,
+                        _addNullCheckOptionValue.Value));
+                }
+
+                return solution;
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.GenerateConstructorWithDialogCodeAction.cs
@@ -66,10 +66,10 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                     // the user chose.  That way we'll keep that as the default for the next time
                     // the user opens the dialog.
                     var workspace = _document.Project.Solution.Workspace;
-                    workspace.Options = workspace.Options.WithChangedOption(
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                         GenerateConstructorFromMembersOptions.AddNullChecks,
                         _document.Project.Language,
-                        addNullChecksOption.Value);
+                        addNullChecksOption.Value)));
                 }
 
                 var addNullChecks = (addNullChecksOption?.Value).GetValueOrDefault();

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
@@ -69,19 +69,19 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 var implementIEqutableOption = result.Options.FirstOrDefault(o => o.Id == ImplementIEquatableId);
                 if (implementIEqutableOption != null)
                 {
-                    workspace.Options = workspace.Options.WithChangedOption(
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                         GenerateEqualsAndGetHashCodeFromMembersOptions.ImplementIEquatable,
                         _document.Project.Language,
-                        implementIEqutableOption.Value);
+                        implementIEqutableOption.Value)));
                 }
 
                 var generateOperatorsOption = result.Options.FirstOrDefault(o => o.Id == GenerateOperatorsId);
                 if (generateOperatorsOption != null)
                 {
-                    workspace.Options = workspace.Options.WithChangedOption(
+                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
                         GenerateEqualsAndGetHashCodeFromMembersOptions.GenerateOperators,
                         _document.Project.Language,
-                        generateOperatorsOption.Value);
+                        generateOperatorsOption.Value)));
                 }
 
                 var implementIEquatable = (implementIEqutableOption?.Value).GetValueOrDefault();

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndHashWithDialogCodeAction.cs
@@ -25,6 +25,9 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             private readonly ImmutableArray<PickMembersOption> _pickMembersOptions;
             private readonly TextSpan _textSpan;
 
+            private bool? _implementIEqutableOptionValue;
+            private bool? _generateOperatorsOptionValue;
+
             public GenerateEqualsAndGetHashCodeWithDialogCodeAction(
                 GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider service,
                 Document document,
@@ -69,19 +72,13 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
                 var implementIEqutableOption = result.Options.FirstOrDefault(o => o.Id == ImplementIEquatableId);
                 if (implementIEqutableOption != null)
                 {
-                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
-                        GenerateEqualsAndGetHashCodeFromMembersOptions.ImplementIEquatable,
-                        _document.Project.Language,
-                        implementIEqutableOption.Value)));
+                    _implementIEqutableOptionValue = implementIEqutableOption.Value;
                 }
 
                 var generateOperatorsOption = result.Options.FirstOrDefault(o => o.Id == GenerateOperatorsId);
                 if (generateOperatorsOption != null)
                 {
-                    workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options.WithChangedOption(
-                        GenerateEqualsAndGetHashCodeFromMembersOptions.GenerateOperators,
-                        _document.Project.Language,
-                        generateOperatorsOption.Value)));
+                    _generateOperatorsOptionValue = generateOperatorsOption.Value;
                 }
 
                 var implementIEquatable = (implementIEqutableOption?.Value).GetValueOrDefault();
@@ -95,6 +92,29 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 
             public override string Title
                 => GenerateEqualsAndGetHashCodeAction.GetTitle(_generateEquals, _generateGetHashCode) + "...";
+
+            protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+            {
+                var solution = await base.GetChangedSolutionAsync(cancellationToken).ConfigureAwait(false);
+
+                if (_implementIEqutableOptionValue.HasValue)
+                {
+                    solution = solution.WithOptions(solution.Options.WithChangedOption(
+                        GenerateEqualsAndGetHashCodeFromMembersOptions.ImplementIEquatable,
+                        _document.Project.Language,
+                        _implementIEqutableOptionValue.Value));
+                }
+
+                if (_generateOperatorsOptionValue.HasValue)
+                {
+                    solution = solution.WithOptions(solution.Options.WithChangedOption(
+                        GenerateEqualsAndGetHashCodeFromMembersOptions.GenerateOperators,
+                        _document.Project.Language,
+                        _generateOperatorsOptionValue.Value));
+                }
+
+                return solution;
+            }
         }
     }
 }

--- a/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
@@ -36,10 +36,10 @@ namespace AnalyzerRunner
                 return;
             }
 
-            workspace.Options = workspace.Options
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
                 .WithChangedOption(StorageOptions.SolutionSizeThreshold, _options.UsePersistentStorage ? 0 : int.MaxValue)
                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, _options.AnalysisScope)
-                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, _options.AnalysisScope);
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, _options.AnalysisScope));
 
             if (!string.IsNullOrEmpty(_options.ProfileRoot))
             {

--- a/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
+++ b/src/Tools/AnalyzerRunner/IncrementalAnalyzerRunner.cs
@@ -39,7 +39,7 @@ namespace AnalyzerRunner
             workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
                 .WithChangedOption(StorageOptions.SolutionSizeThreshold, _options.UsePersistentStorage ? 0 : int.MaxValue)
                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, _options.AnalysisScope)
-                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, _options.AnalysisScope));
+                .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, _options.AnalysisScope)));
 
             if (!string.IsNullOrEmpty(_options.ProfileRoot))
             {

--- a/src/Tools/IdeBenchmarks/SQLitePersistentStorageBenchmark.cs
+++ b/src/Tools/IdeBenchmarks/SQLitePersistentStorageBenchmark.cs
@@ -51,7 +51,8 @@ namespace IdeBenchmarks
 </Workspace>");
 
             // Ensure we always use the storage service, no matter what the size of the solution.
-            _workspace.Options = _workspace.Options.WithChangedOption(StorageOptions.SolutionSizeThreshold, -1);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(
+                _workspace.CurrentSolution.Options.WithChangedOption(StorageOptions.SolutionSizeThreshold, -1)));
 
             _storageService = new SQLitePersistentStorageService(
                 _workspace.Services.GetService<IOptionService>(),

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.ExtractMethod;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.SymbolSearch;
 

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -188,7 +188,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             set
             {
-                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.LabelPositioning, value == 1 ? LabelPositionOptions.LeftMost : LabelPositionOptions.NoIndent);
+                _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                    .WithChangedOption(CSharpFormattingOptions.LabelPositioning, value == 1 ? LabelPositionOptions.LeftMost : LabelPositionOptions.NoIndent)));
             }
         }
 
@@ -201,7 +202,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             set
             {
-                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.LabelPositioning, value);
+                _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                    .WithChangedOption(CSharpFormattingOptions.LabelPositioning, value)));
             }
         }
 
@@ -430,7 +432,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set
             {
                 var option = value == 1 ? BinaryOperatorSpacingOptions.Single : BinaryOperatorSpacingOptions.Ignore;
-                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, option);
+                _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                    .WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, option)));
             }
         }
 
@@ -547,7 +550,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             {
                 try
                 {
-                    _workspace.Options = _workspace.Options.WithChangedOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp, NamingStylePreferences.FromXElement(XElement.Parse(value)));
+                    _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                        .WithChangedOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp, NamingStylePreferences.FromXElement(XElement.Parse(value)))));
                 }
                 catch (Exception)
                 {
@@ -739,7 +743,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             set
             {
-                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, value);
+                _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                    .WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, value)));
             }
         }
 
@@ -778,17 +783,20 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         private void SetBooleanOption(Option<bool> key, int value)
         {
-            _workspace.Options = _workspace.Options.WithChangedOption(key, value != 0);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(key, value != 0)));
         }
 
         private void SetBooleanOption(PerLanguageOption<bool> key, int value)
         {
-            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.CSharp, value != 0);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(key, LanguageNames.CSharp, value != 0)));
         }
 
         private void SetOption<T>(PerLanguageOption<T> key, T value)
         {
-            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.CSharp, value);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(key, LanguageNames.CSharp, value)));
         }
 
         private int GetBooleanOption(PerLanguageOption<bool?> key)
@@ -810,7 +818,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         private void SetBooleanOption(PerLanguageOption<bool?> key, int value)
         {
             var boolValue = (value < 0) ? (bool?)null : (value > 0);
-            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.CSharp, boolValue);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(key, LanguageNames.CSharp, boolValue)));
         }
 
         private string GetXmlOption(PerLanguageOption<CodeStyleOption<bool>> option)
@@ -821,13 +830,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         private void SetXmlOption<T>(Option<CodeStyleOption<T>> option, string value)
         {
             var convertedValue = CodeStyleOption<T>.FromXElement(XElement.Parse(value));
-            _workspace.Options = _workspace.Options.WithChangedOption(option, convertedValue);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(option, convertedValue)));
         }
 
         private void SetXmlOption(PerLanguageOption<CodeStyleOption<bool>> option, string value)
         {
             var convertedValue = CodeStyleOption<bool>.FromXElement(XElement.Parse(value));
-            _workspace.Options = _workspace.Options.WithChangedOption(option, LanguageNames.CSharp, convertedValue);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(option, LanguageNames.CSharp, convertedValue)));
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/DesignerAttribute/DesignerAttributeServiceTests.cs
+++ b/src/VisualStudio/CSharp/Test/DesignerAttribute/DesignerAttributeServiceTests.cs
@@ -42,7 +42,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.DesignerAttri
         private static async Task TestAsync(string codeWithMarker, bool designer, bool remote)
         {
             using var workspace = TestWorkspace.CreateCSharp(codeWithMarker, openDocuments: false);
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, remote);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(RemoteHostOptions.RemoteHostTest, remote)));
 
             var hostDocument = workspace.Documents.First();
             var documentId = hostDocument.Id;

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/FxCopAnalyzersSuggestedActionCallback.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                         FxCopAnalyzersInstallLogger.Log(nameof(FxCopAnalyzersInstallOptions.HasMetCandidacyRequirements));
                     }
 
-                    _workspace.Options = options;
+                    _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(options));
                 }
             }
 
@@ -239,7 +239,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             if (timeSinceLastShown.TotalDays >= 1)
             {
-                _workspace.Options = _workspace.Options.WithChangedOption(FxCopAnalyzersInstallOptions.LastDateTimeInfoBarShown, utcNow.ToBinary());
+                _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                    .WithChangedOption(FxCopAnalyzersInstallOptions.LastDateTimeInfoBarShown, utcNow.ToBinary())));
                 FxCopAnalyzersInstallLogger.Log("InfoBarShown");
 
                 var infoBarService = _workspace.Services.GetRequiredService<IInfoBarService>();
@@ -307,7 +308,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
         private void DoNotShowAgain()
         {
-            _workspace.Options = _workspace.Options.WithChangedOption(FxCopAnalyzersInstallOptions.NeverShowAgain, true);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(FxCopAnalyzersInstallOptions.NeverShowAgain, true)));
             FxCopAnalyzersInstallLogger.Log(nameof(FxCopAnalyzersInstallOptions.NeverShowAgain));
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                     break;
             }
 
-            _workspace.Options = options;
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(options));
             if (options.GetOption(KeybindingResetOptions.NeedsReset))
             {
                 ShowGoldBar();
@@ -352,7 +352,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
 
             KeybindingsResetLogger.Log("KeybindingsReset");
 
-            _workspace.Options = _workspace.Options.WithChangedOption(KeybindingResetOptions.NeedsReset, false);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(KeybindingResetOptions.NeedsReset, false)));
         }
 
         private void OpenExtensionsHyperlink()
@@ -362,13 +363,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             BrowserHelper.StartBrowser(KeybindingsFwLink);
 
             KeybindingsResetLogger.Log("ExtensionsLink");
-            _workspace.Options = _workspace.Options.WithChangedOption(KeybindingResetOptions.NeedsReset, false);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(KeybindingResetOptions.NeedsReset, false)));
         }
 
         private void NeverShowAgain()
         {
-            _workspace.Options = _workspace.Options.WithChangedOption(KeybindingResetOptions.NeverShowAgain, true)
-                                                   .WithChangedOption(KeybindingResetOptions.NeedsReset, false);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(KeybindingResetOptions.NeverShowAgain, true)
+                .WithChangedOption(KeybindingResetOptions.NeedsReset, false)));
             KeybindingsResetLogger.Log("NeverShowAgain");
 
             // The only external references to this object are as callbacks, which are removed by the Shutdown method.

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/StreamingFindUsagesPresenter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/StreamingFindUsagesPresenter.cs
@@ -216,8 +216,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
         private void StoreCurrentGroupingPriority(IFindAllReferencesWindow window)
         {
             var definitionColumn = window.GetDefinitionColumn();
-            _workspace.Options = _workspace.Options.WithChangedOption(
-                FindUsagesOptions.DefinitionGroupingPriority, definitionColumn.GroupingPriority);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(FindUsagesOptions.DefinitionGroupingPriority, definitionColumn.GroupingPriority)));
         }
 
         private void SetDefinitionGroupingPriority(IFindAllReferencesWindow window, int priority)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AnalyzerConfigDocumentAsSolutionItemHandler.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AnalyzerConfigDocumentAsSolutionItemHandler.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // Don't show the InfoBar again link
                 yield return new InfoBarUI(title: ServicesVSResources.Never_show_this_again,
                     kind: InfoBarUI.UIKind.Button,
-                    action: () => _workspace.Options = _workspace.Options.WithChangedOption(NeverShowAgain, true),
+                    action: () => _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options.WithChangedOption(NeverShowAgain, true))),
                     closeAfterAction: true);
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -153,7 +153,8 @@ namespace Microsoft.VisualStudio.LanguageServices
                         () => BrowserHelper.StartBrowser(new Uri(LowVMMoreInfoLink)), closeAfterAction: false));
 
             // Update info bar shown state.
-            _workspace.Options = _workspace.Options.WithChangedOption(RuntimeOptions.BackgroundAnalysisSuspendedInfoBarShown, true);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(RuntimeOptions.BackgroundAnalysisSuspendedInfoBarShown, true)));
         }
 
         private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
@@ -164,7 +165,8 @@ namespace Microsoft.VisualStudio.LanguageServices
             }
 
             // For newly opened solution, reset the info bar state.
-            _workspace.Options = _workspace.Options.WithChangedOption(RuntimeOptions.BackgroundAnalysisSuspendedInfoBarShown, false);
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options
+                .WithChangedOption(RuntimeOptions.BackgroundAnalysisSuspendedInfoBarShown, false)));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioSymbolNavigationService.cs
@@ -126,7 +126,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     allowDecompilation = notificationService.ConfirmMessageBox(ServicesVSResources.Decompiler_Legal_Notice_Message, ServicesVSResources.Decompiler_Legal_Notice_Title, NotificationSeverity.Warning);
                     if (allowDecompilation)
                     {
-                        project.Solution.Workspace.Options = project.Solution.Workspace.Options.WithChangedOption(FeatureOnOffOptions.AcceptedDecompilerDisclaimer, true);
+                        var workspace = project.Solution.Workspace;
+                        workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                            .WithChangedOption(FeatureOnOffOptions.AcceptedDecompilerDisclaimer, true)));
                     }
                 }
             }

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -119,7 +119,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var exportProvider = TestHostServices.CreateMinimalExportProvider();
 
             var workspace = new AdhocWorkspace(TestHostServices.CreateHostServices(exportProvider));
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS, 1);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS, 1)));
 
             var listenerProvider = exportProvider.GetExportedValue<AsynchronousOperationListenerProvider>();
             var analyzerReference = new AnalyzerFileReference(typeof(object).Assembly.Location, new NullAssemblyAnalyzerLoader());
@@ -234,9 +235,10 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             IAsynchronousOperationListenerProvider listenerProvider = null)
         {
             workspace = workspace ?? new AdhocWorkspace(TestHostServices.CreateHostServices());
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                                                 .WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
                                                  .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
-                                                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.FullSolution);
+                                                 .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.FullSolution)));
 
             var analyzerService = GetDiagnosticAnalyzerService(hostAnalyzerReferences ?? SpecializedCollections.EmptyEnumerable<AnalyzerReference>());
 

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -53,7 +53,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 Assert.Equal(DiagnosticSeverity.Hidden, diagnostics[0].Severity);
 
                 // set option
-                workspace.Options = workspace.Options.WithChangedOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, new CodeStyleOption<bool>(false, NotificationOption.Suggestion));
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, new CodeStyleOption<bool>(false, NotificationOption.Suggestion))));
                 analyzerResult = await AnalyzeAsync(workspace, workspace.CurrentSolution.ProjectIds.First(), analyzerType);
 
                 diagnostics = analyzerResult.GetDocumentDiagnostics(analyzerResult.DocumentIds.First(), AnalysisKind.Semantic);
@@ -75,7 +76,8 @@ End Class";
             using (var workspace = CreateWorkspace(LanguageNames.VisualBasic, code))
             {
                 // set option
-                workspace.Options = workspace.Options.WithChangedOption(CodeStyleOptions.PreferNullPropagation, LanguageNames.VisualBasic, new CodeStyleOption<bool>(false, NotificationOption.Silent));
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(CodeStyleOptions.PreferNullPropagation, LanguageNames.VisualBasic, new CodeStyleOption<bool>(false, NotificationOption.Silent))));
 
                 var analyzerType = typeof(VisualBasicUseNullPropagationDiagnosticAnalyzer);
                 var analyzerResult = await AnalyzeAsync(workspace, workspace.CurrentSolution.ProjectIds.First(), analyzerType);
@@ -83,7 +85,8 @@ End Class";
                 Assert.True(analyzerResult.IsEmpty);
 
                 // set option
-                workspace.Options = workspace.Options.WithChangedOption(CodeStyleOptions.PreferNullPropagation, LanguageNames.VisualBasic, new CodeStyleOption<bool>(true, NotificationOption.Error));
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(CodeStyleOptions.PreferNullPropagation, LanguageNames.VisualBasic, new CodeStyleOption<bool>(true, NotificationOption.Error))));
                 analyzerResult = await AnalyzeAsync(workspace, workspace.CurrentSolution.ProjectIds.First(), analyzerType);
 
                 var diagnostics = analyzerResult.GetDocumentDiagnostics(analyzerResult.DocumentIds.First(), AnalysisKind.Semantic);
@@ -182,7 +185,8 @@ End Class";
                     CancellationToken.None));
 
                 // set option
-                workspace.Options = workspace.Options.WithChangedOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, new CodeStyleOption<bool>(false, NotificationOption.Suggestion));
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                    .WithChangedOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, new CodeStyleOption<bool>(false, NotificationOption.Suggestion))));
 
                 // run analysis
                 var project = workspace.CurrentSolution.Projects.First();
@@ -277,9 +281,10 @@ End Class";
                 TestWorkspace.CreateCSharp(code, parseOptions: options, exportProvider: TestHostServices.CreateExportProvider()) :
                 TestWorkspace.CreateVisualBasic(code, parseOptions: options, exportProvider: TestHostServices.CreateExportProvider());
 
-            workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                                     .WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
                                      .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
-                                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.FullSolution);
+                                     .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.VisualBasic, BackgroundAnalysisScope.FullSolution)));
 
             return workspace;
         }

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -53,9 +53,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                 code As XElement, expectedCode As XElement, updater As Action(Of TCodeElement),
                 Optional options As IDictionary(Of OptionKey, Object) = Nothing) As Task
             Using state = CreateCodeModelTestState(GetWorkspaceDefinition(code))
+                Dim workspace = state.Workspace
                 If options IsNot Nothing Then
                     For Each kvp In options
-                        state.Workspace.Options = state.Workspace.Options.WithChangedOption(kvp.Key, kvp.Value)
+                        workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                            .WithChangedOption(kvp.Key, kvp.Value)))
                     Next
                 End If
 

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -116,7 +116,9 @@ class C
                 Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
                 testSnippetInfoService.SetSnippetShortcuts({"for"})
 
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, False)
+                Dim workspace = state.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(InternalFeatureOnOffOptions.Snippets, False)))
 
                 state.SendTypeChars("for")
                 Await state.AssertCompletionSession()

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -253,7 +253,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim waiter = New AsynchronousOperationListener()
 
                 ' turn on FSA
-                workspace.Options = workspace.Options.WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(SolutionCrawlerOptions.BackgroundAnalysisScopeOption, LanguageNames.CSharp, BackgroundAnalysisScope.FullSolution)))
 
                 Dim project = workspace.CurrentSolution.Projects.First()
 

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -301,10 +301,10 @@ using G=   H.I;
             Using workspace = TestWorkspace.Create(workspaceXml, openDocuments:=False)
                 Dim document = workspace.Documents.Single()
 
-                workspace.Options = workspace.Options _
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
                     .WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True) _
                     .WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize) _
-                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
+                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)))
 
                 Dim snippetExpansionClient = New SnippetExpansionClient(
                     workspace.ExportProvider.GetExportedValue(Of IThreadingContext),

--- a/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetCompletionProviderTests.vb
@@ -78,8 +78,9 @@ End Class</File>.Value
 
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
-                testState.Workspace.Options = testState.Workspace.Options.WithChangedOption(
-                    New Options.OptionKey(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                Dim workspace = testState.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(New Options.OptionKey(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)))
                 testState.SendTypeChars("'T")
                 Await testState.AssertNoCompletionSession()
             End Using
@@ -95,8 +96,9 @@ End Class</File>.Value
 
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
-                testState.Workspace.Options = testState.Workspace.Options.WithChangedOption(
-                    New Options.OptionKey(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                Dim workspace = testState.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(New Options.OptionKey(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)))
                 testState.SendTypeChars("'''T")
                 Await testState.AssertNoCompletionSession()
             End Using
@@ -111,8 +113,9 @@ End Class</File>.Value
 
             Dim testState = SnippetTestState.CreateTestState(markup, LanguageNames.VisualBasic, extraParts:={GetType(MockSnippetInfoService)})
             Using testState
-                testState.Workspace.Options = testState.Workspace.Options.WithChangedOption(
-                    New Options.OptionKey(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)
+                Dim workspace = testState.Workspace
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                    .WithChangedOption(New Options.OptionKey(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic), SnippetsRule.AlwaysInclude)))
                 testState.SendTypeChars("Shortcut")
                 Await testState.AssertSelectedCompletionItem(displayText:="Shortcut")
             End Using

--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -33,7 +33,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
                        excludedTypes:={GetType(IIntelliSensePresenter(Of ISignatureHelpPresenterSession, ISignatureHelpSession)), GetType(FormatCommandHandler)}.Concat(If(excludedTypes, {})).ToList(),
                        includeFormatCommandHandler:=False)
 
-            Workspace.Options = Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, True)
+            Workspace.TryApplyChanges(Workspace.CurrentSolution.WithOptions(Workspace.Options _
+                    .WithChangedOption(InternalFeatureOnOffOptions.Snippets, True)))
 
             Dim mockEditorAdaptersFactoryService = New Mock(Of IVsEditorAdaptersFactoryService)
             Dim mockSVsServiceProvider = New Mock(Of SVsServiceProvider)
@@ -77,7 +78,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
                                </Workspace>
 
             Dim state = New SnippetTestState(workspaceXml, languageName, startActiveSession, extraParts, excludedTypes:=Enumerable.Empty(Of Type), WorkspaceKind.Interactive)
-            state.Workspace.Options = state.Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, False)
+            Dim workspace = state.Workspace
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
+                .WithChangedOption(InternalFeatureOnOffOptions.Snippets, False)))
             Return state
         End Function
 

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
@@ -343,10 +343,10 @@ End Class</Test>
             Using workspace = TestWorkspace.Create(workspaceXml, openDocuments:=False)
                 Dim document = workspace.Documents.Single()
 
-                workspace.Options = workspace.Options _
+                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
                     .WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True) _
                     .WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize) _
-                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
+                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)))
 
                 Dim snippetExpansionClient = New SnippetExpansionClient(
                     workspace.ExportProvider.GetExportedValue(Of IThreadingContext),

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -310,7 +310,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         End Function
 
         Private Sub SetBooleanOption(key As [PerLanguageOption](Of Boolean), value As Boolean)
-            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.VisualBasic, value)
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options _
+                .WithChangedOption(key, LanguageNames.VisualBasic, value)))
         End Sub
 
         Private Function GetBooleanOption(key As PerLanguageOption(Of Boolean?)) As Integer
@@ -324,12 +325,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Private Sub SetBooleanOption(key As PerLanguageOption(Of Boolean?), value As Integer)
             Dim boolValue As Boolean? = If(value < 0, Nothing, value > 0)
-            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.VisualBasic, boolValue)
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options _
+                .WithChangedOption(key, LanguageNames.VisualBasic, boolValue)))
         End Sub
 
         Private Sub SetXmlOption(key As PerLanguageOption(Of CodeStyleOption(Of Boolean)), value As String)
             Dim convertedValue = CodeStyleOption(Of Boolean).FromXElement(XElement.Parse(value))
-            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.VisualBasic, convertedValue)
+            _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(_workspace.Options _
+                .WithChangedOption(key, LanguageNames.VisualBasic, convertedValue)))
         End Sub
 
     End Class

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticProvider.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis
         {
             var service = workspace.Services.GetService<ISolutionCrawlerRegistrationService>();
 
-            workspace.Options = GetOptions(workspace, options);
+            var newOptions = GetOptions(workspace, options);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(newOptions));
             service.Register(workspace);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -200,8 +200,8 @@ namespace Microsoft.CodeAnalysis
             {
                 return this.CurrentSolution.Options;
             }
-            // TODO: mark the setter as deprecated, add a new API that clearly indicates to the caller that underlying CurrentSolution changed,
-            //       and migrate all the callsites of this setter to the new API.
+
+            [Obsolete(@"Workspace options should be set by invoking 'workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(newOptionSet))'")]
             set
             {
                 SetOptions(value);

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                                                  .WithChangedOption(CodeStyleOptions.QualifyFieldAccess, LanguageNames.CSharp, newQualifyFieldAccessValue)
                                                  .WithChangedOption(CodeStyleOptions.QualifyMethodAccess, LanguageNames.VisualBasic, newQualifyMethodAccessValue)
                                                  .WithChangedOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, newVarWhenTypeIsApparentValue)
-                                                 .WithChangedOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, LanguageNames.VisualBasic, newPreferIntrinsicPredefinedTypeKeywordInMemberAccessValue);
+                                                 .WithChangedOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, LanguageNames.VisualBasic, newPreferIntrinsicPredefinedTypeKeywordInMemberAccessValue)));
 
             await VerifyOptionSetsAsync(workspace, VerifyOptions).ConfigureAwait(false);
 

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -322,7 +322,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var newVarWhenTypeIsApparentValue = new CodeStyleOption<bool>(false, NotificationOption.Suggestion);
             var newPreferIntrinsicPredefinedTypeKeywordInMemberAccessValue = new CodeStyleOption<bool>(true, NotificationOption.Silent);
 
-            workspace.Options = workspace.Options.WithChangedOption(CodeStyleOptions.QualifyFieldAccess, LanguageNames.CSharp, newQualifyFieldAccessValue)
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                                                 .WithChangedOption(CodeStyleOptions.QualifyFieldAccess, LanguageNames.CSharp, newQualifyFieldAccessValue)
                                                  .WithChangedOption(CodeStyleOptions.QualifyMethodAccess, LanguageNames.VisualBasic, newQualifyMethodAccessValue)
                                                  .WithChangedOption(CSharpCodeStyleOptions.VarWhenTypeIsApparent, newVarWhenTypeIsApparentValue)
                                                  .WithChangedOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, LanguageNames.VisualBasic, newPreferIntrinsicPredefinedTypeKeywordInMemberAccessValue);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -726,7 +726,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         private Solution CreateNotKeptAliveSolution()
         {
             var workspace = new AdhocWorkspace(MefHostServices.Create(TestHost.Assemblies), "NotKeptAlive");
-            workspace.Options = workspace.Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0)));
             return workspace.CurrentSolution;
         }
 
@@ -1486,7 +1487,8 @@ public class C : A {
             // set max file length to 1 bytes
             var maxLength = 1;
             var workspace = new AdhocWorkspace(MefHostServices.Create(TestHost.Assemblies), ServiceLayer.Host);
-            workspace.Options = workspace.Options.WithChangedOption(FileTextLoaderOptions.FileLengthThreshold, maxLength);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(FileTextLoaderOptions.FileLengthThreshold, maxLength)));
 
             using var root = new TempRoot();
             var file = root.CreateFile(prefix: "massiveFile", extension: ".cs").WriteAllText("hello");

--- a/src/Workspaces/CoreTest/SyntaxReferenceTests.cs
+++ b/src/Workspaces/CoreTest/SyntaxReferenceTests.cs
@@ -38,7 +38,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         private static Solution CreateEmptySolutionUsingRecoverableSyntaxTrees()
         {
             var workspace = new AdhocWorkspace(MefHostServices.Create(TestHost.Assemblies), workspaceKind: "NotKeptAlive");
-            workspace.Options = workspace.Options.WithChangedOption(Host.CacheOptions.RecoverableTreeLengthThreshold, 0);
+            workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options
+                .WithChangedOption(Host.CacheOptions.RecoverableTreeLengthThreshold, 0)));
             return workspace.CurrentSolution;
         }
 

--- a/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/AdhocWorkspaceTests.cs
@@ -393,7 +393,8 @@ language: LanguageNames.CSharp);
         private AdhocWorkspace CreateWorkspaceWithRecoverableTrees(HostServices hostServices)
         {
             var ws = new AdhocWorkspace(hostServices, workspaceKind: "NotKeptAlive");
-            ws.Options = ws.Options.WithChangedOption(Host.CacheOptions.RecoverableTreeLengthThreshold, 0);
+            ws.TryApplyChanges(ws.CurrentSolution.WithOptions(ws.CurrentSolution.Options
+                .WithChangedOption(Host.CacheOptions.RecoverableTreeLengthThreshold, 0)));
             return ws;
         }
 

--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
             RegisterDocumentOptionProviders(exportProvider.GetExports<IDocumentOptionsProviderFactory, OrderableMetadata>());
 
-            Options = Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0);
+            SetOptions(Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0));
 
             _registrationService = Services.GetService<ISolutionCrawlerRegistrationService>();
             _registrationService?.Register(this);

--- a/src/Workspaces/Remote/Core/Services/TemporaryWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/TemporaryWorkspace.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private TemporaryWorkspace()
             : base(RoslynServices.HostServices, workspaceKind: WorkspaceKind.RemoteTemporaryWorkspace)
         {
-            Options = Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0);
+            SetOptions(Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0));
 
             var documentOptionsProviderFactories = ((IMefHostExportProvider)Services.HostServices).GetExports<IDocumentOptionsProviderFactory, OrderableMetadata>();
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/roslyn/pull/40289

Workspace options should now be set with `Workspace.TryApplyChanges(Workspace.CurrentSolution.WithOptions(newOptions))`