### PR TITLE
Ensure that we don't kick off SolutionCrawler's Reanalyze functionali…

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -164,6 +164,12 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     return;
                 }
 
+                if (!_optionService.GetOption(InternalSolutionCrawlerOptions.SolutionCrawler))
+                {
+                    // Bail out if solution crawler is disabled.
+                    return;
+                }
+
                 ReanalyzeOnOptionChange(sender, e);
             }
 


### PR DESCRIPTION
…ty if solution crawler is turned off with the option `InternalSolutionCrawlerOptions.SolutionCrawler`.

This is needed for our internal RPS performance tests which intend to turn off solution crawler for certain scenarios to reduce noise from it.