### PR TITLE
Don't advertise we support hover, handled by liveshare

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Initialize/InitializeHandler.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 DefinitionProvider = true,
                 ImplementationProvider = true,
                 CompletionProvider = new CompletionOptions { ResolveProvider = true, TriggerCharacters = new[] { "." } },
-                HoverProvider = true,
                 SignatureHelpProvider = new SignatureHelpOptions { TriggerCharacters = new[] { "(", "," } },
                 DocumentSymbolProvider = true,
                 WorkspaceSymbolProvider = true,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Initialize/InitializeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Initialize/InitializeTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Initialize
         {
             Assert.True(actual.DefinitionProvider);
             Assert.True(actual.ImplementationProvider);
-            Assert.True(actual.HoverProvider);
             Assert.True(actual.DocumentSymbolProvider);
             Assert.True(actual.WorkspaceSymbolProvider);
             Assert.True(actual.DocumentFormattingProvider);


### PR DESCRIPTION
<details>
**Ask mode template-
Customer and scenario info
Who is impacted by this bug?**
Hover is broken in liveshare.
**What is the workaround?**
None
**How was the bug found?**
Manual testing
**If this fix is for a regression
Overview of the fix?**
We migrated from liveshare to IlanguageClient.  Previously, the hover support in initialize was ignored when running through liveshare, however ILanguageClient supersedes that and runs first.
**What feature areas are impacted by the fix?**
Liveshare
**What is the risk of the code change?**
Very low, at worst hover would not work as it is now.
**Does this change have impact on anything else (e.g., setup, perf, stress, ux, visual freeze, go live, breaking -change, samples)?**
no
**What testing/validation was done on the fix, and what were the results?**
manual testing to confirm that hover works in liveshare.
</details>