### PR TITLE
MethodSymbol and FieldSymbol equality fixes:

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The inferred type at the point of declaration of var locals and parameters.
         /// </summary>
-        private readonly PooledDictionary<Symbol, TypeWithAnnotations> _variableTypes = PooledDictionary<Symbol, TypeWithAnnotations>.GetInstance();
+        private readonly PooledDictionary<Symbol, TypeWithAnnotations> _variableTypes = SpecializedSymbolCollections.GetPooledSymbolDictionaryInstance<Symbol, TypeWithAnnotations>();
 
         /// <summary>
         /// Binder for symbol being analyzed.
@@ -687,6 +687,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray.Create(variableBySlot, start: 0, length: nextVariableSlot),
                 _variableTypes.ToImmutableDictionary(),
                 _symbol);
+
+        //private class SymbolComparer : IEqualityComparer<Symbol>
+        //{
+        //    public bool Equals(Symbol x, Symbol y) => x.Equals(y, TypeCompareKind.ConsiderEverything);
+        //    public int GetHashCode(Symbol obj)
+        //    {
+        //        throw new NotImplementedException();
+        //    }
+        //}
 
         private void TakeIncrementalSnapshot(BoundNode node)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -453,5 +453,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return new PublicModel.FieldSymbol(this);
         }
+
+        public sealed override bool Equals(Symbol other, TypeCompareKind compareKind)
+        {
+            if (object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return (this, other) switch
+            {
+                (SubstitutedFieldSymbol left, FieldSymbol right) => left.Equals(right, compareKind),
+                (FieldSymbol left, SubstitutedFieldSymbol right) => right.Equals(left, compareKind),
+                (TupleFieldSymbol left, TupleFieldSymbol right) => left.Equals(right, compareKind),
+                (TupleErrorFieldSymbol left, TupleErrorFieldSymbol right) => left.Equals(right, compareKind),
+                _ => false
+            };
+        }
+
+        public sealed override int GetHashCode()
+        {
+            var code = this.ContainingType.GetHashCode();
+            code = Hash.Combine(this.Name, code);
+            return code;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1042,5 +1042,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return new PublicModel.MethodSymbol(this);
         }
+
+        public sealed override bool Equals(Symbol obj, TypeCompareKind compareKind)
+        {
+            if (object.ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return (this, obj) switch
+            {
+                (SubstitutedMethodSymbol left, MethodSymbol right) => left.Equals(right, compareKind),
+                (MethodSymbol left, SubstitutedMethodSymbol right) => right.Equals(left, compareKind),
+                (ReducedExtensionMethodSymbol left, ReducedExtensionMethodSymbol right) => left.Equals(right, compareKind),
+                (SynthesizedIntrinsicOperatorSymbol left, SynthesizedIntrinsicOperatorSymbol right) => left.Equals(right, compareKind),
+                (LambdaSymbol left, LambdaSymbol right) => left.Equals(right, compareKind),
+                _ => false
+            };
+        }
+
+        public sealed override int GetHashCode()
+        {
+            var code = this.ContainingType?.GetHashCode() ?? 0;
+            code = Hash.Combine(this.Name, code);
+            return code;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -569,17 +569,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        public override bool Equals(Symbol obj, TypeCompareKind compareKind)
+        internal bool Equals(ReducedExtensionMethodSymbol symbol, TypeCompareKind compareKind)
         {
-            if ((object)this == obj) return true;
-
-            ReducedExtensionMethodSymbol other = obj as ReducedExtensionMethodSymbol;
-            return (object)other != null && _reducedFrom.Equals(other._reducedFrom, compareKind);
-        }
-
-        public override int GetHashCode()
-        {
-            return _reducedFrom.GetHashCode();
+            return _reducedFrom.Equals(symbol._reducedFrom, compareKind);
         }
 
         private sealed class ReducedExtensionMethodParameterSymbol : WrappedParameterSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -377,22 +377,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        public sealed override bool Equals(Symbol symbol, TypeCompareKind compareKind)
+        internal bool Equals(LambdaSymbol lambda, TypeCompareKind compareKind)
         {
-            if ((object)this == symbol) return true;
-
-            return symbol is LambdaSymbol lambda
-                && lambda._syntax == _syntax
+            return lambda._syntax == _syntax
                 && lambda._refKind == _refKind
                 && TypeSymbol.Equals(lambda.ReturnType, this.ReturnType, compareKind)
                 && ParameterTypesWithAnnotations.SequenceEqual(lambda.ParameterTypesWithAnnotations, compareKind,
                                                                (p1, p2, compareKind) => p1.Equals(p2, compareKind))
                 && lambda.ContainingSymbol.Equals(ContainingSymbol, compareKind);
-        }
 
-        public override int GetHashCode()
-        {
-            return _syntax.GetHashCode();
         }
 
         public override bool IsImplicitlyDeclared

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -495,19 +495,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _lazyTypeParameterConstraints;
         }
 
-        public override int GetHashCode()
+        internal bool Equals(LocalFunctionSymbol localFunction, TypeCompareKind compareKind)
         {
-            // this is what lambdas do (do not use hashes of other fields)
-            return _syntax.GetHashCode();
-        }
-
-        public sealed override bool Equals(Symbol symbol, TypeCompareKind compareKind)
-        {
-            if ((object)this == symbol) return true;
-
-            var localFunction = symbol as LocalFunctionSymbol;
-            return (object)localFunction != null
-                && localFunction._syntax == _syntax;
+            return localFunction._syntax == _syntax;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedFieldSymbol.cs
@@ -99,20 +99,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (NamedTypeSymbol)_containingType.TypeSubstitution.SubstituteType(OriginalDefinition.FixedImplementationType(emitModule)).Type;
         }
 
-        public override bool Equals(Symbol obj, TypeCompareKind compareKind)
+        internal bool Equals(FieldSymbol other, TypeCompareKind compareKind)
         {
-            if ((object)this == obj)
-            {
-                return true;
-            }
-
-            var other = obj as SubstitutedFieldSymbol;
-            return (object)other != null && TypeSymbol.Equals(_containingType, other._containingType, compareKind) && OriginalDefinition == other.OriginalDefinition;
-        }
-
-        public override int GetHashCode()
-        {
-            return Hash.Combine(_containingType, OriginalDefinition.GetHashCode());
+            RoslynDebug.Assert(other is object);
+            return TypeSymbol.Equals(_containingType, other.ContainingType, compareKind) && OriginalDefinition == other.OriginalDefinition;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -30,8 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private ImmutableArray<MethodSymbol> _lazyExplicitInterfaceImplementations;
         private OverriddenOrHiddenMembersResult _lazyOverriddenOrHiddenMembers;
 
-        private int _hashCode; // computed on demand
-
         internal SubstitutedMethodSymbol(NamedTypeSymbol containingSymbol, MethodSymbol originalDefinition)
             : this(containingSymbol, containingSymbol.TypeSubstitution, originalDefinition, constructedFrom: null)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -357,40 +357,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        private int ComputeHashCode()
+        internal bool Equals(MethodSymbol other, TypeCompareKind compareKind)
         {
-            int code = this.OriginalDefinition.GetHashCode();
-            code = Hash.Combine(this.ContainingType, code);
-
-            // Unconstructed method may contain alpha-renamed type parameters while
-            // may still be considered equal, we do not want to give different hashcode to such types.
-            //
-            // Example:
-            //   Having original method A<U>.Goo<V>() we create two _unconstructed_ methods
-            //    A<int>.Goo<V'>
-            //    A<int>.Goo<V">     
-            //  Note that V' and V" are type parameters substituted via alpha-renaming of original V
-            //  These are different objects, but represent the same "type parameter at index 1"
-            //
-            //  In short - we are not interested in the type arguments of unconstructed methods.
-            if ((object)ConstructedFrom != (object)this)
-            {
-                foreach (var arg in this.TypeArgumentsWithAnnotations)
-                {
-                    code = Hash.Combine(arg.Type, code);
-                }
-            }
-
-            return code;
-        }
-
-        public sealed override bool Equals(Symbol obj, TypeCompareKind compareKind)
-        {
-            SubstitutedMethodSymbol other = obj as SubstitutedMethodSymbol;
-            if ((object)other == null) return false;
-
             if ((object)this.OriginalDefinition != (object)other.OriginalDefinition &&
-                this.OriginalDefinition != other.OriginalDefinition)
+                !this.OriginalDefinition.Equals(other.OriginalDefinition, compareKind))
             {
                 return false;
             }
@@ -422,25 +392,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        public override int GetHashCode()
-        {
-            int code = _hashCode;
-
-            if (code == 0)
-            {
-                code = ComputeHashCode();
-
-                // 0 means that hashcode is not initialized. 
-                // in a case we really get 0 for the hashcode, tweak it by +1
-                if (code == 0)
-                {
-                    code++;
-                }
-
-                _hashCode = code;
-            }
-
-            return code;
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -413,20 +413,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             throw ExceptionUtilities.Unreachable;
         }
 
-        public override bool Equals(Symbol obj, TypeCompareKind compareKind)
+        internal bool Equals(SynthesizedIntrinsicOperatorSymbol other, TypeCompareKind compareKind)
         {
-            if (obj == (object)this)
-            {
-                return true;
-            }
-
-            var other = obj as SynthesizedIntrinsicOperatorSymbol;
-
-            if ((object)other == null)
-            {
-                return false;
-            }
-
             if (_isCheckedBuiltin == other._isCheckedBuiltin &&
                 _parameters.Length == other._parameters.Length &&
                 string.Equals(_name, other._name, StringComparison.Ordinal) &&
@@ -445,11 +433,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return false;
-        }
-
-        public override int GetHashCode()
-        {
-            return Hash.Combine(_name, Hash.Combine(_containingType, _parameters.Length));
         }
 
         private sealed class SynthesizedOperatorParameterSymbol : SynthesizedParameterSymbolBase

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -152,26 +152,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _useSiteDiagnosticInfo;
         }
 
-        public override sealed int GetHashCode()
+        internal bool Equals(TupleErrorFieldSymbol other, TypeCompareKind compareKind)
         {
-            return Hash.Combine(ContainingType.GetHashCode(), _tupleElementIndex.GetHashCode());
-        }
-
-        public override bool Equals(Symbol obj, TypeCompareKind compareKind)
-        {
-            return Equals(obj as TupleErrorFieldSymbol, compareKind);
-        }
-
-        public bool Equals(TupleErrorFieldSymbol other, TypeCompareKind compareKind)
-        {
-            if ((object)other == this)
-            {
-                return true;
-            }
-
-            return (object)other != null &&
-                _tupleElementIndex == other._tupleElementIndex &&
-                TypeSymbol.Equals(ContainingType, other.ContainingType, compareKind);
+            RoslynDebug.Assert(other is object);
+            return _tupleElementIndex == other._tupleElementIndex
+                && TypeSymbol.Equals(ContainingType, other.ContainingType, compareKind);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -113,26 +113,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _underlyingField.GetUseSiteDiagnostic();
         }
 
-        public override sealed int GetHashCode()
+        internal bool Equals(TupleFieldSymbol other, TypeCompareKind compareKind)
         {
-            return Hash.Combine(_containingTuple.GetHashCode(), _tupleElementIndex.GetHashCode());
-        }
-
-        public override sealed bool Equals(Symbol obj, TypeCompareKind compareKind)
-        {
-            var other = obj as TupleFieldSymbol;
-
-            if ((object?)other == this)
-            {
-                return true;
-            }
+            RoslynDebug.Assert(other is object);
 
             // note we have to compare both index and name because
             // in nameless tuple there could be fields that differ only by index
             // and in named tuples there could be fields that differ only by name
-            return (object?)other != null &&
-                _tupleElementIndex == other._tupleElementIndex &&
-                TypeSymbol.Equals(_containingTuple, other._containingTuple, compareKind);
+            return _tupleElementIndex == other._tupleElementIndex
+                && TypeSymbol.Equals(_containingTuple, other._containingTuple, compareKind);
         }
     }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolEqualityTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
@@ -771,30 +772,202 @@ public class B
                 );
         }
 
-        private void VerifyEquality(ISymbol type1, ISymbol type2, bool expectedDefault, bool expectedIncludeNullability)
+        [Fact]
+        [WorkItem(8195, "https://github.com/dotnet/roslyn/issues/38195")]
+        public void SemanticModel_SubstitutedField_Equality()
+        {
+            var source =
+@"
+#nullable enable
+public class A<T> 
+    where T : class //not neccesary, but makes it easier to reason about the resulting fields
+{
+    public A<T> field = null!;
+    public static void M(A<T> t)
+    {
+        _ = t.field;
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+
+            var member1Syntax = (ClassDeclarationSyntax)root.DescendantNodes().First(sn => sn.Kind() == SyntaxKind.ClassDeclaration);
+            var member2Syntax = (IdentifierNameSyntax)root.DescendantNodes().Last(sn => sn.Kind() == SyntaxKind.IdentifierName);
+
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var field1 = (IFieldSymbol)((INamedTypeSymbol)model.GetDeclaredSymbol(member1Syntax)).GetMembers("field").Single(); // A<T!>! A<T>.field
+            var field2 = (IFieldSymbol)model.GetSymbolInfo(member2Syntax).Symbol;                                               // A<T!>! A<T!>.field
+
+            VerifyEquality(field1, field2,
+                expectedDefault: true,
+                expectedIncludeNullability: false
+                );
+
+            var field1Type = field1.Type; // A<T!>
+            var field2Type = field2.Type; // A<T!>
+
+            VerifyEquality(field1Type, field2Type,
+                expectedDefault: true,
+                expectedIncludeNullability: true
+                );
+
+            var field1ContainingType = field1.ContainingType; //A<T>
+            var field2ContainingType = field2.ContainingType; //A<T!>
+
+            VerifyEquality(field1ContainingType, field2ContainingType,
+                expectedDefault: true,
+                expectedIncludeNullability: false
+                );
+
+        }
+
+        [Fact]
+        [WorkItem(8195, "https://github.com/dotnet/roslyn/issues/38195")]
+        public void SemanticModel_SubstitutedMethod_Equality()
+        {
+            var source =
+@"
+#nullable enable
+public class A<T> 
+    where T : class //not neccesary, but makes it easier to reason about the resulting fields
+{
+    public A<T> M(A<T> t)
+    {
+        t.M(t);
+        return t;
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+
+            var member1Syntax = (ClassDeclarationSyntax)root.DescendantNodes().First(sn => sn.Kind() == SyntaxKind.ClassDeclaration);
+            var member2Syntax = (IdentifierNameSyntax)root.DescendantNodes().Last(sn => sn.Kind() == SyntaxKind.SimpleMemberAccessExpression).DescendantNodes().Last(sn => sn.Kind() == SyntaxKind.IdentifierName);
+
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var method1 = (IMethodSymbol)((INamedTypeSymbol)model.GetDeclaredSymbol(member1Syntax)).GetMembers("M").Single(); // A<T!>! A<T>.M(A<T!>! t)
+            var method2 = (IMethodSymbol)model.GetSymbolInfo(member2Syntax).Symbol;                                           // A<T!>! A<T!>.M(A<T!>! t)
+
+            VerifyEquality(method1, method2,
+                expectedDefault: true,
+                expectedIncludeNullability: false
+                );
+
+            var method1ReturnType = method1.ReturnType; // A<T!>
+            var method2ReturnType = method2.ReturnType; // A<T!>
+
+            VerifyEquality(method1ReturnType, method2ReturnType,
+                expectedDefault: true,
+                expectedIncludeNullability: true
+                );
+
+            var method1ParamType = method1.Parameters.First().Type; // A<T!>
+            var method2ParamType = method2.Parameters.First().Type; // A<T!>
+
+            VerifyEquality(method1ParamType, method2ParamType,
+                expectedDefault: true,
+                expectedIncludeNullability: true
+                );
+
+            var method1ContainingType = method1.ContainingType; //A<T>
+            var method2ContainingType = method2.ContainingType; //A<T!>
+
+            VerifyEquality(method1ContainingType, method2ContainingType,
+                expectedDefault: true,
+                expectedIncludeNullability: false
+                );
+        }
+
+        [Fact]
+        [WorkItem(8195, "https://github.com/dotnet/roslyn/issues/38195")]
+        public void SemanticModel_SubstitutedEvent_Equality()
+        {
+            var source =
+@"
+#nullable enable
+public class A<T> 
+    where T : class //not neccesary, but makes it easier to reason about the resulting fields
+{
+    public event System.EventHandler<T> MyEvent;
+    public static void M(A<T> t)
+    {
+        _  = t.MyEvent;
+    }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (6,41): warning CS8618: Non-nullable event 'MyEvent' is uninitialized. Consider declaring the event as nullable.
+                //     public event System.EventHandler<T> MyEvent;
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "MyEvent").WithArguments("event", "MyEvent").WithLocation(6, 41)
+                );
+
+            var syntaxTree = comp.SyntaxTrees[0];
+            var root = syntaxTree.GetRoot();
+
+            var member1Syntax = (ClassDeclarationSyntax)root.DescendantNodes().First(sn => sn.Kind() == SyntaxKind.ClassDeclaration);
+            var member2Syntax = (IdentifierNameSyntax)root.DescendantNodes().Last(sn => sn.Kind() == SyntaxKind.IdentifierName);
+
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var event1 = (IEventSymbol)((INamedTypeSymbol)model.GetDeclaredSymbol(member1Syntax)).GetMembers("MyEvent").Single(); // System.EventHandler<T!>! A<T>.MyEvent
+            var event2 = (IEventSymbol)model.GetSymbolInfo(member2Syntax).Symbol;                                                 // System.EventHandler<T!>! A<T!>.MyEvent
+
+            VerifyEquality(event1, event2,
+                expectedDefault: true,
+                expectedIncludeNullability: false
+                );
+
+            var event1Type = event1.Type; // System.EventHandler<T!>
+            var event2Type = event2.Type; // System.EventHandler<T!>
+
+            VerifyEquality(event1Type, event2Type,
+                expectedDefault: true,
+                expectedIncludeNullability: true
+                );
+
+            var event1ContainingType = event1.ContainingType; //A<T>
+            var event2ContainingType = event2.ContainingType; //A<T!>
+
+            VerifyEquality(event1ContainingType, event2ContainingType,
+                expectedDefault: true,
+                expectedIncludeNullability: false
+                );
+        }
+
+        private void VerifyEquality(ISymbol symbol1, ISymbol symbol2, bool expectedDefault, bool expectedIncludeNullability)
         {
             // Symbol.Equals
-            Assert.True(type1.Equals(type1));
-            Assert.True(type2.Equals(type2));
-            Assert.Equal(expectedDefault, type1.Equals(type2));
-            Assert.Equal(expectedDefault, type2.Equals(type1));
+            Assert.True(symbol1.Equals(symbol1));
+            Assert.True(symbol2.Equals(symbol2));
+            Assert.Equal(expectedDefault, symbol1.Equals(symbol2));
+            Assert.Equal(expectedDefault, symbol2.Equals(symbol1));
 
             // TypeSymbol.Equals - Default
-            Assert.True(type1.Equals(type1, SymbolEqualityComparer.Default));
-            Assert.True(type2.Equals(type2, SymbolEqualityComparer.Default));
-            Assert.Equal(expectedDefault, type1.Equals(type2, SymbolEqualityComparer.Default));
-            Assert.Equal(expectedDefault, type2.Equals(type1, SymbolEqualityComparer.Default));
+            Assert.True(symbol1.Equals(symbol1, SymbolEqualityComparer.Default));
+            Assert.True(symbol2.Equals(symbol2, SymbolEqualityComparer.Default));
+            Assert.Equal(expectedDefault, symbol1.Equals(symbol2, SymbolEqualityComparer.Default));
+            Assert.Equal(expectedDefault, symbol2.Equals(symbol1, SymbolEqualityComparer.Default));
 
             // TypeSymbol.Equals - IncludeNullability
-            Assert.True(type1.Equals(type1, SymbolEqualityComparer.IncludeNullability));
-            Assert.True(type2.Equals(type2, SymbolEqualityComparer.IncludeNullability));
-            Assert.Equal(expectedIncludeNullability, type1.Equals(type2, SymbolEqualityComparer.IncludeNullability));
-            Assert.Equal(expectedIncludeNullability, type2.Equals(type1, SymbolEqualityComparer.IncludeNullability));
+            Assert.True(symbol1.Equals(symbol1, SymbolEqualityComparer.IncludeNullability));
+            Assert.True(symbol2.Equals(symbol2, SymbolEqualityComparer.IncludeNullability));
+            Assert.Equal(expectedIncludeNullability, symbol1.Equals(symbol2, SymbolEqualityComparer.IncludeNullability));
+            Assert.Equal(expectedIncludeNullability, symbol2.Equals(symbol1, SymbolEqualityComparer.IncludeNullability));
 
             // GetHashCode
-            Assert.Equal(type1.GetHashCode(), type2.GetHashCode());
-            Assert.Equal(SymbolEqualityComparer.Default.GetHashCode(type1), SymbolEqualityComparer.Default.GetHashCode(type2));
-            Assert.Equal(SymbolEqualityComparer.IncludeNullability.GetHashCode(type1), SymbolEqualityComparer.IncludeNullability.GetHashCode(type2));
+            Assert.Equal(symbol1.GetHashCode(), symbol2.GetHashCode());
+            Assert.Equal(SymbolEqualityComparer.Default.GetHashCode(symbol1), SymbolEqualityComparer.Default.GetHashCode(symbol2));
+            Assert.Equal(SymbolEqualityComparer.IncludeNullability.GetHashCode(symbol1), SymbolEqualityComparer.IncludeNullability.GetHashCode(symbol2));
         }
     }
 }

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -20,10 +20,12 @@ namespace Microsoft.CodeAnalysis.PooledObjects
 
         public ImmutableDictionary<K, V> ToImmutableDictionaryAndFree()
         {
-            var result = this.ToImmutableDictionary();
+            var result = this.ToImmutableDictionary(this.Comparer);
             this.Free();
             return result;
         }
+
+        public ImmutableDictionary<K, V> ToImmutableDictionary() => this.ToImmutableDictionary(this.Comparer);
 
         public void Free()
         {


### PR DESCRIPTION
With nullable enabled, it's now valid to compare some method and field symbols across their respective hierarchies. 

This PR makes the equals for method and field symbols sealed, and instead contains an explicit list of valid sub-type comparisons.  This also requires implementing hashcode for the base method and field symbol. This will potentially have a small perf hit, but should be functionally correct. 

