### PR TITLE
Fix type expression nullability to be the declared nullability, and c…

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2185,6 +2185,18 @@ done:
                 }
             }
 
+            switch (node.Kind())
+            {
+                case SyntaxKind.AliasQualifiedName:
+                case SyntaxKind.QualifiedName:
+                case SyntaxKind.IdentifierName:
+                    if (node.Parent.IsKind(SyntaxKind.NullableType))
+                    {
+                        node = node.Parent;
+                    }
+                    break;
+            }
+
             return node;
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2185,18 +2185,6 @@ done:
                 }
             }
 
-            switch (node.Kind())
-            {
-                case SyntaxKind.AliasQualifiedName:
-                case SyntaxKind.QualifiedName:
-                case SyntaxKind.IdentifierName:
-                    if (node.Parent.IsKind(SyntaxKind.NullableType))
-                    {
-                        node = node.Parent;
-                    }
-                    break;
-            }
-
             return node;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7105,6 +7105,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         TypeWithAnnotations destinationType = iterationVariable.TypeWithAnnotations;
                         TypeWithState result = sourceState;
+                        var isVar = node.Syntax is ForEachStatementSyntax { Type: { IsVar: true } };
                         if (iterationVariable.IsRef)
                         {
                             // foreach (ref DestinationType variable in collection)
@@ -7114,7 +7115,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 ReportNullabilityMismatchInAssignment(foreachSyntax.Type, sourceType, destinationType);
                             }
                         }
-                        else if (node.Syntax is ForEachStatementSyntax { Type: { IsVar: true } })
+                        else if (isVar)
                         {
                             // foreach (var variable in collection)
                             _variableTypes[iterationVariable] = sourceState.ToTypeWithAnnotations();
@@ -7143,7 +7144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         // In non-error cases we'll only run this loop a single time. In error cases we'll set the nullability of the VariableType multiple times, but at least end up with something
-                        SetAnalyzedNullability(node.IterationVariableType, new VisitResult(result, destinationType), isLvalue: true);
+                        SetAnalyzedNullability(node.IterationVariableType, new VisitResult(isVar ? result : destinationType.ToTypeWithState(), destinationType), isLvalue: true);
                         state = result.State;
                     }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -7193,7 +7193,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitTypeExpression(node.BoundContainingTypeOpt);
             }
 
-            SetNotNullResult(node);
+            SetResult(node, node.TypeWithAnnotations.ToTypeWithState(), node.TypeWithAnnotations);
             return result;
         }
 


### PR DESCRIPTION
…ompensate for when passed an indentifier that is parented by a NullableSyntax.

Fixes https://github.com/dotnet/roslyn/issues/40925.

@jcouv, this fixes the bug you showed, but I'm not convinced it's the cause of the simplification issues. Further, I'm not convinced by the arguments you made in the bug: the IDE needs to understand that it should not be calling `GetTypeInfo` on the underlying syntax node, and should instead be calling it on the containing syntax. If calling it on the syntax underlying a `NullableTypeSyntax` is core to how the IDE simplifier works here, the design is busted.