### PR TITLE
Fix VisualBasicSyntaxFactsService.IsLeftSideOfCompoundAssignment

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -797,9 +797,49 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         <Extension>
-        Public Function IsLeftSideOfAnyAssignStatement(node As SyntaxNode) As Boolean
+        Public Function IsLeftSideOfSimpleAssignmentStatement(node As SyntaxNode) As Boolean
             Return node.IsParentKind(SyntaxKind.SimpleAssignmentStatement) AndAlso
                 DirectCast(node.Parent, AssignmentStatementSyntax).Left Is node
+        End Function
+
+        <Extension>
+        Public Function IsLeftSideOfAnyAssignmentStatement(node As SyntaxNode) As Boolean
+            Return node IsNot Nothing AndAlso
+                node.Parent.IsAnyAssignmentStatement() AndAlso
+                DirectCast(node.Parent, AssignmentStatementSyntax).Left Is node
+        End Function
+
+        <Extension>
+        Public Function IsAnyAssignmentStatement(node As SyntaxNode) As Boolean
+            Return node IsNot Nothing AndAlso
+                SyntaxFacts.IsAssignmentStatement(node.Kind)
+        End Function
+
+        <Extension>
+        Public Function IsLeftSideOfCompoundAssignmentStatement(node As SyntaxNode) As Boolean
+            Return node IsNot Nothing AndAlso
+                node.Parent.IsCompoundAssignmentStatement() AndAlso
+                DirectCast(node.Parent, AssignmentStatementSyntax).Left Is node
+        End Function
+
+        <Extension>
+        Public Function IsCompoundAssignmentStatement(node As SyntaxNode) As Boolean
+            If node IsNot Nothing Then
+                Select Case node.Kind
+                    Case SyntaxKind.AddAssignmentStatement,
+                         SyntaxKind.SubtractAssignmentStatement,
+                         SyntaxKind.MultiplyAssignmentStatement,
+                         SyntaxKind.DivideAssignmentStatement,
+                         SyntaxKind.IntegerDivideAssignmentStatement,
+                         SyntaxKind.ExponentiateAssignmentStatement,
+                         SyntaxKind.LeftShiftAssignmentStatement,
+                         SyntaxKind.RightShiftAssignmentStatement,
+                         SyntaxKind.ConcatenateAssignmentStatement
+                        Return True
+                End Select
+            End If
+
+            Return False
         End Function
 
         <Extension>

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1326,16 +1326,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Function IsLeftSideOfAssignment(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsLeftSideOfAssignment
-            Return TryCast(node, ExpressionSyntax).IsLeftSideOfAnyAssignStatement
+            Return TryCast(node, ExpressionSyntax).IsLeftSideOfSimpleAssignmentStatement
         End Function
 
         Public Function IsLeftSideOfAnyAssignment(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsLeftSideOfAnyAssignment
-            Return TryCast(node, ExpressionSyntax).IsLeftSideOfAnyAssignStatement
+            Return TryCast(node, ExpressionSyntax).IsLeftSideOfAnyAssignmentStatement
         End Function
 
         Public Function IsLeftSideOfCompoundAssignment(node As SyntaxNode) As Boolean Implements ISyntaxFactsService.IsLeftSideOfCompoundAssignment
-            ' VB does not support compound assignments.
-            Return False
+            Return TryCast(node, ExpressionSyntax).IsLeftSideOfCompoundAssignmentStatement
         End Function
 
         Public Function GetRightHandSideOfAssignment(node As SyntaxNode) As SyntaxNode Implements ISyntaxFactsService.GetRightHandSideOfAssignment

--- a/src/Workspaces/VisualBasicTest/VisualBasicSyntaxFactsServiceTests.vb
+++ b/src/Workspaces/VisualBasicTest/VisualBasicSyntaxFactsServiceTests.vb
@@ -530,6 +530,24 @@ End Class"
 
             Return service.IsQueryKeyword(token)
         End Function
+
+        <Fact, WorkItem(40917, "https://github.com/dotnet/roslyn/issues/40917")>
+        Public Sub IsLeftSideOfCompoundAssignment()
+            Assert.True(IsLeftSideOfCompoundAssignment(WrapInMethod("
+Dim index As Integer = 0
+$$index += 1")))
+        End Sub
+
+        Private Function IsLeftSideOfCompoundAssignment(markup As String) As Boolean
+            Dim code As String = Nothing
+            Dim position As Integer
+            MarkupTestFile.GetPosition(markup, code, position)
+            Dim tree = SyntaxFactory.ParseSyntaxTree(code)
+            Dim node = tree.GetRoot().FindToken(position).Parent
+            Dim service = VisualBasicSyntaxFactsService.Instance
+
+            Return service.IsLeftSideOfCompoundAssignment(node)
+        End Function
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #40917

Addresses feedback from https://github.com/dotnet/roslyn/pull/40896#discussion_r365505109