### PR TITLE
Use a non-localized category string for DiagnosticDescriptors

### DIFF
--- a/src/CodeStyle/Core/Analyzers/CodeStyleResources.Designer.cs
+++ b/src/CodeStyle/Core/Analyzers/CodeStyleResources.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CodeStyleResources {
@@ -130,15 +130,6 @@ namespace Microsoft.CodeAnalysis {
         internal static string Refactoring_Only {
             get {
                 return ResourceManager.GetString("Refactoring_Only", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Style.
-        /// </summary>
-        internal static string Style {
-            get {
-                return ResourceManager.GetString("Style", resourceCulture);
             }
         }
         

--- a/src/CodeStyle/Core/Analyzers/CodeStyleResources.resx
+++ b/src/CodeStyle/Core/Analyzers/CodeStyleResources.resx
@@ -141,9 +141,6 @@
   <data name="Refactoring_Only" xml:space="preserve">
     <value>Refactoring Only</value>
   </data>
-  <data name="Style" xml:space="preserve">
-    <value>Style</value>
-  </data>
   <data name="Suggestion" xml:space="preserve">
     <value>Suggestion</value>
   </data>

--- a/src/CodeStyle/Core/Analyzers/DiagnosticCategory.cs
+++ b/src/CodeStyle/Core/Analyzers/DiagnosticCategory.cs
@@ -4,6 +4,6 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 {
     internal static class DiagnosticCategory
     {
-        public static readonly string Style = CodeStyleResources.Style;
+        public const string Style = nameof(Style);
     }
 }

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.cs.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.cs.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Pouze refaktoring</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Styl</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Návrh</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.de.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.de.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Nur Refactoring</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Stil</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Vorschlag</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.es.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.es.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Solo refactorización</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Estilo</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Sugerencia</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.fr.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.fr.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Refactoring Only</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Style</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Suggestion</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.it.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.it.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Refactoring Only</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Stile</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Suggerimento</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.ja.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.ja.xlf
@@ -42,11 +42,6 @@
         <target state="translated">リファクタリングのみ</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">スタイル</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">提案事項</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.ko.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.ko.xlf
@@ -42,11 +42,6 @@
         <target state="translated">리팩터링만</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">스타일</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">제안</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.pl.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.pl.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Tylko refaktoryzacja</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Styl</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Sugestia</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.pt-BR.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.pt-BR.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Somente Refatoração</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Estilo</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Sugestão</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.ru.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.ru.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Только рефакторинг</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Стиль</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Рекомендация</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.tr.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.tr.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Sadece Yeniden Düzenlenme</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Stil</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">Öneri</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.zh-Hans.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.zh-Hans.xlf
@@ -42,11 +42,6 @@
         <target state="translated">仅重构</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">样式</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">建议</target>

--- a/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.zh-Hant.xlf
+++ b/src/CodeStyle/Core/Analyzers/xlf/CodeStyleResources.zh-Hant.xlf
@@ -42,11 +42,6 @@
         <target state="translated">僅重構</target>
         <note />
       </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">樣式</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Suggestion">
         <source>Suggestion</source>
         <target state="translated">建議</target>

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueDiagnosticDescriptorsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueDiagnosticDescriptorsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
@@ -12,7 +13,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             var d = EditAndContinueDiagnosticDescriptors.GetDescriptor(RudeEditKind.ActiveStatementUpdate);
             Assert.Equal("ENC0001", d.Id);
-            Assert.Equal(FeaturesResources.EditAndContinue, d.Category);
+            Assert.Equal(DiagnosticCategory.EditAndContinue, d.Category);
             Assert.Equal(new[] { "EditAndContinue", "Telemetry", "NotConfigurable" }, d.CustomTags);
             Assert.Equal("", d.Description);
             Assert.Equal("", d.HelpLinkUri);
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             d = EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile);
             Assert.Equal("ENC1001", d.Id);
-            Assert.Equal(FeaturesResources.EditAndContinue, d.Category);
+            Assert.Equal(DiagnosticCategory.EditAndContinue, d.Category);
             Assert.Equal(new[] { "EditAndContinue", "Telemetry", "NotConfigurable" }, d.CustomTags);
             Assert.Equal("", d.Description);
             Assert.Equal("", d.HelpLinkUri);
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             d = EditAndContinueDiagnosticDescriptors.GetModuleDiagnosticDescriptor(12);
             Assert.Equal("ENC2012", d.Id);
-            Assert.Equal(FeaturesResources.EditAndContinue, d.Category);
+            Assert.Equal(DiagnosticCategory.EditAndContinue, d.Category);
             Assert.Equal(new[] { "EditAndContinue", "Telemetry", "NotConfigurable" }, d.CustomTags);
             Assert.Equal("", d.Description);
             Assert.Equal("", d.HelpLinkUri);

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticCategory.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticCategory.cs
@@ -4,9 +4,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal static class DiagnosticCategory
     {
-        public static readonly string Style = FeaturesResources.Style;
-        public static readonly string CodeQuality = FeaturesResources.Code_Quality;
-        public static readonly string EditAndContinue = FeaturesResources.EditAndContinue;
-        public static readonly string Compiler = FeaturesResources.Compiler1;
+        public const string Style = nameof(Style);
+        public const string CodeQuality = nameof(CodeQuality);
+        public const string EditAndContinue = nameof(EditAndContinue);
+        public const string Compiler = nameof(Compiler);
     }
 }

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -975,29 +975,11 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code Quality.
-        /// </summary>
-        internal static string Code_Quality {
-            get {
-                return ResourceManager.GetString("Code_Quality", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Collection initialization can be simplified.
         /// </summary>
         internal static string Collection_initialization_can_be_simplified {
             get {
                 return ResourceManager.GetString("Collection_initialization_can_be_simplified", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Compiler.
-        /// </summary>
-        internal static string Compiler1 {
-            get {
-                return ResourceManager.GetString("Compiler1", resourceCulture);
             }
         }
         
@@ -3815,15 +3797,6 @@ namespace Microsoft.CodeAnalysis {
         internal static string Structures {
             get {
                 return ResourceManager.GetString("Structures", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Style.
-        /// </summary>
-        internal static string Style {
-            get {
-                return ResourceManager.GetString("Style", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -709,12 +709,6 @@ Do you want to continue?</value>
   <data name="Implement_interface_with_Dispose_pattern" xml:space="preserve">
     <value>Implement interface with Dispose pattern</value>
   </data>
-  <data name="Compiler1" xml:space="preserve">
-    <value>Compiler</value>
-  </data>
-  <data name="Style" xml:space="preserve">
-    <value>Style</value>
-  </data>
   <data name="Suppress_0" xml:space="preserve">
     <value>Suppress {0}</value>
   </data>
@@ -1414,9 +1408,6 @@ This version used in: {2}</value>
   </data>
   <data name="Private_property_0_can_be_converted_to_a_method_as_its_get_accessor_is_never_invoked" xml:space="preserve">
     <value>Private property '{0}' can be converted to a method as its get accessor is never invoked.</value>
-  </data>
-  <data name="Code_Quality" xml:space="preserve">
-    <value>Code Quality</value>
   </data>
   <data name="Modifying_source_file_will_prevent_the_debug_session_from_continuing_due_to_internal_error" xml:space="preserve">
     <value>Modifying source file {0} will prevent the debug session from continuing due to internal error: {1}.</value>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Pokud se změní {0} na {1}, relace ladění nebude moct pokračovat, protože dojde ke změně tvaru stavového počítače.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Kvalita kódu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Nakonfigurovat styl kódu {0}</target>
@@ -1676,16 +1671,6 @@ Chcete pokračovat?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Implementovat rozhraní se vzorem Dispose</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Kompilátor</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Styl</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Die Änderung von "{0}" in "{1}" verhindert, dass die Debugsitzung fortgesetzt wird, weil sich dadurch die Form des Zustandsautomaten verändert.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Codequalität</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Codeformat "{0}" konfigurieren</target>
@@ -1676,16 +1671,6 @@ Möchten Sie fortfahren?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Schnittstelle mit Dispose-Muster implementieren</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Compiler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Stil</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Si se cambia "{0}" a "{1}", la sesión de depuración no podrá continuar porque cambia la forma de la máquina de estados.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Calidad del código</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Configurar el estilo de código de {0}</target>
@@ -1676,16 +1671,6 @@ Do you want to continue?</source>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Implementar interfaz con modelo de Dispose</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Compilador</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Estilo</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Le remplacement de '{0}' par '{1}' va empêcher la session de débogage de se poursuivre, car cela change la forme de la machine à états.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Qualité du code</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Configurer le style de code {0}</target>
@@ -1676,16 +1671,6 @@ Voulez-vous continuer ?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Implémenter l'interface avec le modèle Dispose</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Compilateur</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Style</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Se si modifica '{0}' in '{1}', la sessione di debug non potrà continuare perché modifica la forma della macchina a stati.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Qualità del codice</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Configura lo stile del codice di {0}</target>
@@ -1676,16 +1671,6 @@ Continuare?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Implementa l'interfaccia con il criterio Dispose</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Compilatore</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Stile</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -127,11 +127,6 @@
         <target state="translated">'{0}' から '{1}' に変更すると、ステート マシンの形状が変わるため、デバッグ セッションは続行されません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">コードの品質</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">{0} コード スタイルの構成</target>
@@ -1676,16 +1671,6 @@ Do you want to continue?</source>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">破棄パターンを使ってインターフェイスを実装します</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">コンパイラ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">スタイル</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -127,11 +127,6 @@
         <target state="translated">'{0}'을(를) '{1}'(으)로 변경하면 상태 시스템의 셰이프가 변경되므로 디버그 세션을 계속할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">코드 품질</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">{0} 코드 스타일 구성</target>
@@ -1676,16 +1671,6 @@ Do you want to continue?</source>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">인터페이스를 Dispose 패턴으로 구현</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">컴파일러</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">스타일</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Zmiana elementu „{0}” na „{1}” uniemożliwi kontynuowanie sesji debugowania, ponieważ powoduje zmianę kształtu automatu stanów.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Jakość kodu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Konfiguruj styl kodu {0}</target>
@@ -1676,16 +1671,6 @@ Czy chcesz kontynuować?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Implementuj interfejs za pomocą wzorca likwidacji</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Kompilator</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Styl</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Alterar '{0}' para '{1}' impedirá a continuação da sessão de depuração porque altera a forma da máquina de estado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Qualidade do Código</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Configurar estilo de código de {0}</target>
@@ -1676,16 +1671,6 @@ Deseja continuar?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Implementar interface com Padrão de descarte</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Compilador</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Estilo</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -127,11 +127,6 @@
         <target state="translated">Изменение "{0}" на "{1}" сделает продолжение сеанса отладки невозможным, так как меняет форму конечной машины.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Качество кода</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">Настройка стиля кода {0}</target>
@@ -1676,16 +1671,6 @@ Do you want to continue?</source>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Внедрите интерфейс с шаблоном освобождения</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Компилятор</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Стиль</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -127,11 +127,6 @@
         <target state="translated">'{0}' öğesini '{1}' olarak değiştirmek, durum makinesinin şeklini değiştirdiğinden hata ayıklama oturumunun devam etmesini engeller.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">Kod kalite</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">{0} kod stilini yapılandır</target>
@@ -1676,16 +1671,6 @@ Devam etmek istiyor musunuz?</target>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">Ara birimi Dispose düzeniyle uygula</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">Derleyici</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">Stil</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -127,11 +127,6 @@
         <target state="translated">将“{0}”更改为“{1}”会阻止调试会话继续执行，因为它会更改状态机的形状。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">代码质量</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">配置 {0} 代码样式</target>
@@ -1676,16 +1671,6 @@ Do you want to continue?</source>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">通过释放模式实现接口</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">编译器</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">样式</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -127,11 +127,6 @@
         <target state="translated">將 '{0}' 變更為 '{1}' 會變更狀態機器的圖形，進而使偵錯工作階段無法繼續。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Code_Quality">
-        <source>Code Quality</source>
-        <target state="translated">程式碼品質</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Configure_0_code_style">
         <source>Configure {0} code style</source>
         <target state="translated">設定 {0} 程式碼樣式</target>
@@ -1676,16 +1671,6 @@ Do you want to continue?</source>
       <trans-unit id="Implement_interface_with_Dispose_pattern">
         <source>Implement interface with Dispose pattern</source>
         <target state="translated">使用 Dispose 模式實作介面</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Compiler1">
-        <source>Compiler</source>
-        <target state="translated">編譯器</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Style">
-        <source>Style</source>
-        <target state="translated">樣式</target>
         <note />
       </trans-unit>
       <trans-unit id="Re_triage_0_currently_1">


### PR DESCRIPTION
This is not a user facing string, so must not be localized. Additionally, with https://github.com/dotnet/roslyn/pull/38886, we now support bulk severity configuration in editorconfig based on diagnostic category, so the string ought to be a non-localized constant without any spaces.