### PR TITLE
Support System.IntPtr and System.UIntPtr from source

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1465,11 +1465,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                                                         HostObjectType.Name,
                                                                                         useCLSCompliantNameArityEncoding: true);
 
-                    symbol = new MissingMetadataTypeSymbol.TopLevelWithCustomErrorInfo(
+                    symbol = new MissingMetadataTypeSymbol.TopLevel(
                         new MissingAssemblySymbol(AssemblyIdentity.FromAssemblyDefinition(HostObjectType.GetTypeInfo().Assembly)).Modules[0],
                         ref mdName,
-                        CreateReflectionTypeNotFoundError(HostObjectType),
-                        SpecialType.None);
+                        SpecialType.None,
+                        CreateReflectionTypeNotFoundError(HostObjectType));
                 }
 
                 Interlocked.CompareExchange(ref _lazyHostObjectTypeSymbol, symbol, null);

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -373,13 +373,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal ErrorTypeSymbol CreateCycleInTypeForwarderErrorTypeSymbol(ref MetadataTypeName emittedName)
         {
             DiagnosticInfo diagnosticInfo = new CSDiagnosticInfo(ErrorCode.ERR_CycleInTypeForwarder, emittedName.FullName, this.Name);
-            return new MissingMetadataTypeSymbol.TopLevelWithCustomErrorInfo(this.Modules[0], ref emittedName, diagnosticInfo);
+            return new MissingMetadataTypeSymbol.TopLevel(this.Modules[0], ref emittedName, diagnosticInfo);
         }
 
         internal ErrorTypeSymbol CreateMultipleForwardingErrorTypeSymbol(ref MetadataTypeName emittedName, ModuleSymbol forwardingModule, AssemblySymbol destination1, AssemblySymbol destination2)
         {
             var diagnosticInfo = new CSDiagnosticInfo(ErrorCode.ERR_TypeForwardedToMultipleAssemblies, forwardingModule, this, emittedName.FullName, destination1, destination2);
-            return new MissingMetadataTypeSymbol.TopLevelWithCustomErrorInfo(forwardingModule, ref emittedName, diagnosticInfo);
+            return new MissingMetadataTypeSymbol.TopLevel(forwardingModule, ref emittedName, diagnosticInfo);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             errorInfo = new CSDiagnosticInfo(ErrorCode.ERR_PredefinedValueTupleTypeAmbiguous3, emittedName.FullName, conflicts.Item1, conflicts.Item2);
                         }
 
-                        result = new MissingMetadataTypeSymbol.TopLevelWithCustomErrorInfo(this.Assembly.Modules[0], ref emittedName, errorInfo, type);
+                        result = new MissingMetadataTypeSymbol.TopLevel(this.Assembly.Modules[0], ref emittedName, type, errorInfo);
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2318,19 +2318,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData)
                 => throw ExceptionUtilities.Unreachable;
 
-            // PROTOTYPE: Temporary approach for AsNativeInt().
-            private PENamedTypeSymbolNonGeneric(PENamedTypeSymbolNonGeneric other, bool isNativeInt) :
-                base(other)
-            {
-                Debug.Assert(isNativeInt != other.IsNativeInt);
-
-                _underlying = other;
-                IsNativeInt = isNativeInt;
-
-                Debug.Assert(this.Equals(other));
-                Debug.Assert(other.Equals(this));
-            }
-
             public override int Arity
             {
                 get

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2356,36 +2356,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
             }
 
-            private readonly PENamedTypeSymbolNonGeneric _underlying;
-            internal override bool IsNativeInt { get; }
-
             internal override NamedTypeSymbol AsNativeInt(bool asNativeInt)
             {
                 Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
 
-                if (IsNativeInt == asNativeInt)
-                {
-                    return this;
-                }
-
-                return asNativeInt ? new PENamedTypeSymbolNonGeneric(this, isNativeInt: true) : _underlying;
+                return asNativeInt ?
+                    (NamedTypeSymbol)new NativeIntegerTypeSymbol(this) :
+                    this;
             }
 
-            // PROTOTYPE: Temporary approach for AsNativeInt().
             internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null)
             {
-                if ((object)t2 == null) return false;
-                if ((object)t2 == this) return true;
-
-                var other = t2 as PENamedTypeSymbolNonGeneric;
-                if ((object)other != null &&
-                    (this.IsNativeInt || other.IsNativeInt) &&
-                    this.SpecialType == other.SpecialType)
-                {
-                    return true;
-                }
-
-                return base.Equals(t2, comparison, isValueTypeOverrideOpt);
+                return t2 is NativeIntegerTypeSymbol nativeInteger ?
+                    nativeInteger.Equals(this, comparison, isValueTypeOverrideOpt) :
+                    base.Equals(t2, comparison, isValueTypeOverrideOpt);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2348,7 +2348,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
 
                 return asNativeInt ?
-                    (NamedTypeSymbol)new NativeIntegerTypeSymbol(this) :
+                    (NamedTypeSymbol)new NativeIntegerTypeSymbol(this) : // PROTOTYPE: Consider caching instance, perhaps on containing assembly.
                     this;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                        isNativeInt: false,
                        errorInfo,
                        containingNamespace: null,
-                       typeId: -1)
+                       typeId)
             {
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1520,8 +1520,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
+        // PROTOTYPE: Should be abstract.
+        /// <summary>
+        /// Returns an instance of a symbol that has <see cref="IsNativeInt"/> set to <paramref name="asNativeInt"/>
+        /// if the underlying symbol represents System.IntPtr or System.UIntPtr.
+        /// For other symbols, throws <see cref="System.InvalidOperationException"/>.
+        /// </summary>
         internal virtual NamedTypeSymbol AsNativeInt(bool asNativeInt) => throw ExceptionUtilities.Unreachable;
 
+        // PROTOTYPE: Should be abstract.
+        /// <summary>
+        /// Returns true if the symbol represents a native integer
+        /// (corresponding to the language tokens nint or nuint).
+        /// </summary>
         internal virtual bool IsNativeInt => false;
 
         protected override ISymbol CreateISymbol()

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1520,10 +1520,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        // PROTOTYPE: Should be abstract.
-        internal virtual NamedTypeSymbol AsNativeInt(bool asNativeInt) => this;
+        internal virtual NamedTypeSymbol AsNativeInt(bool asNativeInt) => throw ExceptionUtilities.Unreachable;
 
-        // PROTOTYPE: Should be abstract.
         internal virtual bool IsNativeInt => false;
 
         protected override ISymbol CreateISymbol()

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class NativeIntegerTypeSymbol : WrappedNamedTypeSymbol
+    {
+        internal NativeIntegerTypeSymbol(NamedTypeSymbol underlying) : base(underlying)
+        {
+            Debug.Assert(!underlying.IsNativeInt);
+            Debug.Assert(underlying.SpecialType == SpecialType.System_IntPtr || underlying.SpecialType == SpecialType.System_UIntPtr);
+            Debug.Assert(this.Equals(underlying));
+            Debug.Assert(underlying.Equals(this));
+        }
+
+        public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
+
+        public override NamedTypeSymbol ConstructedFrom => _underlyingType.ConstructedFrom;
+
+        public override Symbol ContainingSymbol => _underlyingType.ContainingSymbol;
+
+        internal override ImmutableArray<TypeWithAnnotations> TypeArgumentsWithAnnotationsNoUseSiteDiagnostics => ImmutableArray<TypeWithAnnotations>.Empty;
+
+        internal override bool IsComImport => _underlyingType.IsComImport;
+
+        internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics => _underlyingType.BaseTypeNoUseSiteDiagnostics;
+
+        public override SpecialType SpecialType => _underlyingType.SpecialType;
+
+        public override IEnumerable<string> MemberNames => throw new NotImplementedException();
+
+        public override ImmutableArray<Symbol> GetMembers() => _underlyingType.GetMembers();
+
+        public override ImmutableArray<Symbol> GetMembers(string name) => _underlyingType.GetMembers(name);
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => _underlyingType.GetTypeMembers();
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => _underlyingType.GetTypeMembers(name);
+
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity) => _underlyingType.GetTypeMembers(name, arity);
+
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved) => _underlyingType.GetDeclaredBaseType(basesBeingResolved);
+
+        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved) => _underlyingType.GetDeclaredInterfaces(basesBeingResolved);
+
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers() => throw ExceptionUtilities.Unreachable;
+
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name) => throw ExceptionUtilities.Unreachable;
+
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => throw ExceptionUtilities.Unreachable;
+
+        internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => throw ExceptionUtilities.Unreachable;
+
+        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved = null) => _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved);
+
+        internal override bool IsNativeInt => true;
+
+        internal override NamedTypeSymbol AsNativeInt(bool asNativeInt) => asNativeInt ? this : _underlyingType;
+
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null) => _underlyingType.Equals(t2, comparison, isValueTypeOverrideOpt);
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<TypeParameterSymbol> TypeParameters => ImmutableArray<TypeParameterSymbol>.Empty;
 
-        public override NamedTypeSymbol ConstructedFrom => _underlyingType.ConstructedFrom;
+        public override NamedTypeSymbol ConstructedFrom => this;
 
         public override Symbol ContainingSymbol => _underlyingType.ContainingSymbol;
 
@@ -34,17 +34,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override SpecialType SpecialType => _underlyingType.SpecialType;
 
-        public override IEnumerable<string> MemberNames => throw new NotImplementedException();
+        public override IEnumerable<string> MemberNames => Array.Empty<string>();
 
-        public override ImmutableArray<Symbol> GetMembers() => _underlyingType.GetMembers();
+        /// <summary>
+        /// There are no members on <see cref="System.IntPtr"/> that should be exposed directly on nint:
+        /// constructors for nint other than the default parameterless constructor are not supported;
+        /// operators are handled explicitly as built-in operators and conversions;
+        /// 0 should be used instead of Zero;
+        /// sizeof(nint) should be used instead of Size;
+        /// + and - should be used instead of Add() and Subtract();
+        /// ToInt32(), ToInt64(), ToPointer() should be used from System.IntPtr only;
+        /// overridden methods Equals(), GetHashCode(), and ToString() are referenced from System.Object.
+        /// The one remaining member is <see cref="System.IntPtr.ToString(string)"/> which we could expose if needed.
+        /// </summary>
+        public override ImmutableArray<Symbol> GetMembers() => ImmutableArray<Symbol>.Empty;
 
-        public override ImmutableArray<Symbol> GetMembers(string name) => _underlyingType.GetMembers(name);
+        public override ImmutableArray<Symbol> GetMembers(string name) => ImmutableArray<Symbol>.Empty;
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => _underlyingType.GetTypeMembers();
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ImmutableArray<NamedTypeSymbol>.Empty;
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => _underlyingType.GetTypeMembers(name);
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => ImmutableArray<NamedTypeSymbol>.Empty;
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity) => _underlyingType.GetTypeMembers(name, arity);
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity) => ImmutableArray<NamedTypeSymbol>.Empty;
 
         internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved) => _underlyingType.GetDeclaredBaseType(basesBeingResolved);
 
@@ -58,7 +69,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => throw ExceptionUtilities.Unreachable;
 
-        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved = null) => _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved);
+        // PROTOTYPE: Include certain interfaces defined on the underlying type, with substitution
+        // of [U]IntPtr (for instance, IEquatable<nint> rather than IEquatable<IntPtr>).
+        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved = null) => ImmutableArray<NamedTypeSymbol>.Empty;
 
         protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) => throw ExceptionUtilities.Unreachable;
 
@@ -69,5 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override NamedTypeSymbol AsNativeInt(bool asNativeInt) => asNativeInt ? this : _underlyingType;
 
         internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null) => _underlyingType.Equals(t2, comparison, isValueTypeOverrideOpt);
+
+        public override int GetHashCode() => _underlyingType.GetHashCode();
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         internal NativeIntegerTypeSymbol(NamedTypeSymbol underlying) : base(underlying, tupleData: null)
         {
+            Debug.Assert(underlying.TupleData is null);
             Debug.Assert(!underlying.IsNativeInt);
             Debug.Assert(underlying.SpecialType == SpecialType.System_IntPtr || underlying.SpecialType == SpecialType.System_UIntPtr);
             Debug.Assert(this.Equals(underlying));

--- a/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NativeIntegerTypeSymbol.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal sealed class NativeIntegerTypeSymbol : WrappedNamedTypeSymbol
     {
-        internal NativeIntegerTypeSymbol(NamedTypeSymbol underlying) : base(underlying)
+        internal NativeIntegerTypeSymbol(NamedTypeSymbol underlying) : base(underlying, tupleData: null)
         {
             Debug.Assert(!underlying.IsNativeInt);
             Debug.Assert(underlying.SpecialType == SpecialType.System_IntPtr || underlying.SpecialType == SpecialType.System_UIntPtr);
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => throw ExceptionUtilities.Unreachable;
 
         internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<TypeSymbol> basesBeingResolved = null) => _underlyingType.InterfacesNoUseSiteDiagnostics(basesBeingResolved);
+
+        protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) => throw ExceptionUtilities.Unreachable;
+
+        public override bool AreLocalsZeroed => throw ExceptionUtilities.Unreachable;
 
         internal override bool IsNativeInt => true;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -1396,5 +1395,21 @@ next:;
         }
 
         #endregion
+
+        internal override NamedTypeSymbol AsNativeInt(bool asNativeInt)
+        {
+            Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
+
+            return asNativeInt ?
+                (NamedTypeSymbol)new NativeIntegerTypeSymbol(this) :
+                this;
+        }
+
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison, IReadOnlyDictionary<TypeParameterSymbol, bool> isValueTypeOverrideOpt = null)
+        {
+            return t2 is NativeIntegerTypeSymbol nativeInteger ?
+                nativeInteger.Equals(this, comparison, isValueTypeOverrideOpt) :
+                base.Equals(t2, comparison, isValueTypeOverrideOpt);
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1401,7 +1401,7 @@ next:;
             Debug.Assert(this.SpecialType == SpecialType.System_IntPtr || this.SpecialType == SpecialType.System_UIntPtr);
 
             return asNativeInt ?
-                (NamedTypeSymbol)new NativeIntegerTypeSymbol(this) :
+                (NamedTypeSymbol)new NativeIntegerTypeSymbol(this) : // PROTOTYPE: Consider caching instance, perhaps on containing assembly.
                 this;
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -265,6 +265,22 @@ using System.Runtime.CompilerServices;
 
             comp = CreateCompilation(source1, new[] { ref0 }, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics();
+
+            var type = comp.GetTypeByMetadataName("B");
+            Assert.Equal("void B.F1(A<nint, nuint> a)", type.GetMember("F1").ToDisplayString(FormatWithSpecialTypes));
+            Assert.Equal("void B.F2(A<System.IntPtr, System.UIntPtr> a)", type.GetMember("F2").ToDisplayString(FormatWithSpecialTypes));
+            Assert.Equal("void B.F3(A<System.IntPtr, System.UIntPtr> a)", type.GetMember("F3").ToDisplayString(FormatWithSpecialTypes));
+
+            var expected =
+@"B
+    void F1(A<System.IntPtr, System.UIntPtr> a)
+        [NativeInteger({ False, True, True })] A<System.IntPtr, System.UIntPtr> a
+    void F2(A<System.IntPtr, System.UIntPtr> a)
+        [NativeInteger({ False, True })] A<System.IntPtr, System.UIntPtr> a
+    void F3(A<System.IntPtr, System.UIntPtr> a)
+        [NativeInteger({ False, False, True, True })] A<System.IntPtr, System.UIntPtr> a
+";
+            AssertNativeIntegerAttributes(type.ContainingModule, expected);
         }
 
         [Fact]
@@ -897,7 +913,7 @@ class B : A<nint>
         private static void AssertAttributes(MetadataReader reader, CustomAttributeHandleCollection handles, params string[] expectedNames)
         {
             var actualNames = handles.Select(h => GetAttributeConstructorName(reader, h)).ToArray();
-            AssertEx.SetEqual(actualNames, expectedNames);
+            AssertEx.Equal(actualNames, expectedNames);
         }
 
         private static void AssertNoNativeIntegerAttribute(ImmutableArray<CSharpAttributeData> attributes)
@@ -913,7 +929,7 @@ class B : A<nint>
         private static void AssertAttributes(ImmutableArray<CSharpAttributeData> attributes, params string[] expectedNames)
         {
             var actualNames = attributes.Select(a => a.AttributeClass.ToTestDisplayString()).ToArray();
-            AssertEx.SetEqual(actualNames, expectedNames);
+            AssertEx.Equal(actualNames, expectedNames);
         }
 
         private static void AssertNoNativeIntegerAttributes(CSharpCompilation comp)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
@@ -287,6 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
         // - BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol has the comment "dynamic not allowed as an attribute type". Does that apply to "nint"?
         // - BindNonGenericSimpleNamespaceOrTypeOrAliasSymbol checks IsViableType(result)
         // - Use-site diagnostics (basically any use-site diagnostics from IntPtr/UIntPtr)
+        // - Type unification of I<System.IntPtr> and I<nint>
 
         [Fact]
         public void ClassName()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
@@ -153,44 +153,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             VerifyEqualButDistinct(underlyingType, nativeIntegerType);
         }
 
-        private static void VerifyMembers(NamedTypeSymbol type)
-        {
-            var memberNames = type.MemberNames;
-            var allMembers = type.GetMembers();
-
-            foreach (var member in allMembers)
-            {
-                Assert.Contains(member.Name, memberNames);
-                verifyMember(type, member);
-            }
-
-            var unorderedMembers = type.GetMembersUnordered();
-            Assert.Equal(allMembers.Length, unorderedMembers.Length);
-            verifyMembers(type, allMembers, unorderedMembers);
-
-            foreach (var memberName in memberNames)
-            {
-                var members = type.GetMembers(memberName);
-                Assert.False(members.IsDefaultOrEmpty);
-                verifyMembers(type, allMembers, members);
-            }
-
-            static void verifyMembers(NamedTypeSymbol type, ImmutableArray<Symbol> allMembers, ImmutableArray< Symbol> members)
-            {
-                foreach (var member in members)
-                {
-                    Assert.Contains(member, allMembers);
-                    verifyMember(type, member);
-                }
-            }
-
-            static void verifyMember(NamedTypeSymbol type, Symbol member)
-            {
-                Assert.Same(type, member.ContainingSymbol);
-                Assert.Same(type, member.ContainingType);
-            }
-        }
-
         private static void VerifyEqualButDistinct(NamedTypeSymbol type, NamedTypeSymbol other)
         {
             Assert.NotSame(type, other);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 
                 method = model.GetDeclaredSymbol(methodDeclarations[1]);
                 Assert.Equal("void I.F2(System.UIntPtr x, nuint y)", method.ToDisplayString(FormatWithSpecialTypes));
-                verifyTypes(method.Parameters[0].Type.GetSymbol<NamedTypeSymbol>(), method.Parameters[1].Type.GetSymbol<NamedTypeSymbol>(), signed: true);
+                verifyTypes(method.Parameters[0].Type.GetSymbol<NamedTypeSymbol>(), method.Parameters[1].Type.GetSymbol<NamedTypeSymbol>(), signed: false);
             }
 
             static void verifyTypes(NamedTypeSymbol underlyingType, NamedTypeSymbol nativeIntegerType, bool signed)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntTests.cs
@@ -336,13 +336,10 @@ interface I
 
             static void verify(CSharpCompilation comp)
             {
-                var tree = comp.SyntaxTrees[0];
-                var nodes = tree.GetRoot().DescendantNodes().ToArray();
-                var model = comp.GetSemanticModel(tree);
-                var method = model.GetDeclaredSymbol(nodes.OfType<MethodDeclarationSyntax>().Single());
+                var method = comp.GetMember<MethodSymbol>("I.Add");
                 Assert.Equal("System.Int16 I.Add(System.Int16 x, System.UIntPtr y)", method.ToTestDisplayString());
-                var underlyingType0 = method.Parameters[0].Type.GetSymbol<NamedTypeSymbol>();
-                var underlyingType1 = method.Parameters[1].Type.GetSymbol<NamedTypeSymbol>();
+                var underlyingType0 = (NamedTypeSymbol)method.Parameters[0].Type;
+                var underlyingType1 = (NamedTypeSymbol)method.Parameters[1].Type;
                 Assert.Equal(SpecialType.System_Int16, underlyingType0.SpecialType);
                 Assert.False(underlyingType0.IsNativeInt);
                 Assert.Equal(SpecialType.System_UIntPtr, underlyingType1.SpecialType);


### PR DESCRIPTION
Support `nint` and `nuint` when `System.IntPtr` and `System.UIntPtr` are from source.