### PR TITLE
Improving F12 Decompilation Quality By Passing Fuzzy-Matched References

### DIFF
--- a/src/EditorFeatures/CSharp/CSharpEditorResources.Designer.cs
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.Designer.cs
@@ -61,11 +61,47 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; items in cache.
+        /// </summary>
+        internal static string _0_items_in_cache {
+            get {
+                return ResourceManager.GetString("_0_items_in_cache", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Chosen version: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Chosen_version_0 {
+            get {
+                return ResourceManager.GetString("Chosen_version_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Complete statement on ;.
         /// </summary>
         internal static string Complete_statement_on_semicolon {
             get {
                 return ResourceManager.GetString("Complete_statement_on_semicolon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find by name: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Could_not_find_by_name_0 {
+            get {
+                return ResourceManager.GetString("Could_not_find_by_name_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Decompilation log.
+        /// </summary>
+        internal static string Decompilation_log {
+            get {
+                return ResourceManager.GetString("Decompilation_log", resourceCulture);
             }
         }
         
@@ -79,11 +115,83 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Found &apos;{0}&apos; assemblies for &apos;{1}&apos;:.
+        /// </summary>
+        internal static string Found_0_assemblies_for_1 {
+            get {
+                return ResourceManager.GetString("Found_0_assemblies_for_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found exact match: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Found_exact_match_0 {
+            get {
+                return ResourceManager.GetString("Found_exact_match_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found higher version match: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Found_higher_version_match_0 {
+            get {
+                return ResourceManager.GetString("Found_higher_version_match_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found single assembly: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Found_single_assembly_0 {
+            get {
+                return ResourceManager.GetString("Found_single_assembly_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Load from: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Load_from_0 {
+            get {
+                return ResourceManager.GetString("Load_from_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Module not found!.
+        /// </summary>
+        internal static string Module_not_found {
+            get {
+                return ResourceManager.GetString("Module_not_found", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to      (Press TAB to insert).
         /// </summary>
         internal static string Press_TAB_to_insert {
             get {
                 return ResourceManager.GetString("Press_TAB_to_insert", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resolve: &apos;{0}&apos;.
+        /// </summary>
+        internal static string Resolve_0 {
+            get {
+                return ResourceManager.GetString("Resolve_0", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resolve module: &apos;{0}&apos; of &apos;{1}&apos;.
+        /// </summary>
+        internal static string Resolve_module_0_of_1 {
+            get {
+                return ResourceManager.GetString("Resolve_module_0_of_1", resourceCulture);
             }
         }
         
@@ -102,6 +210,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp {
         internal static string Split_string {
             get {
                 return ResourceManager.GetString("Split_string", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to WARN: Version mismatch. Expected: &apos;{0}&apos;, Got: &apos;{1}&apos;.
+        /// </summary>
+        internal static string WARN_Version_mismatch_Expected_0_Got_1 {
+            get {
+                return ResourceManager.GetString("WARN_Version_mismatch_Expected_0_Got_1", resourceCulture);
             }
         }
     }

--- a/src/EditorFeatures/CSharp/CSharpEditorResources.resx
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.resx
@@ -132,4 +132,43 @@
   <data name="Split_string" xml:space="preserve">
     <value>Split string</value>
   </data>
+  <data name="Chosen_version_0" xml:space="preserve">
+    <value>Chosen version: '{0}'</value>
+  </data>
+  <data name="Could_not_find_by_name_0" xml:space="preserve">
+    <value>Could not find by name: '{0}'</value>
+  </data>
+  <data name="Decompilation_log" xml:space="preserve">
+    <value>Decompilation log</value>
+  </data>
+  <data name="Found_0_assemblies_for_1" xml:space="preserve">
+    <value>Found '{0}' assemblies for '{1}':</value>
+  </data>
+  <data name="Found_exact_match_0" xml:space="preserve">
+    <value>Found exact match: '{0}'</value>
+  </data>
+  <data name="Found_higher_version_match_0" xml:space="preserve">
+    <value>Found higher version match: '{0}'</value>
+  </data>
+  <data name="Found_single_assembly_0" xml:space="preserve">
+    <value>Found single assembly: '{0}'</value>
+  </data>
+  <data name="Load_from_0" xml:space="preserve">
+    <value>Load from: '{0}'</value>
+  </data>
+  <data name="Module_not_found" xml:space="preserve">
+    <value>Module not found!</value>
+  </data>
+  <data name="Resolve_0" xml:space="preserve">
+    <value>Resolve: '{0}'</value>
+  </data>
+  <data name="Resolve_module_0_of_1" xml:space="preserve">
+    <value>Resolve module: '{0}' of '{1}'</value>
+  </data>
+  <data name="WARN_Version_mismatch_Expected_0_Got_1" xml:space="preserve">
+    <value>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</value>
+  </data>
+  <data name="_0_items_in_cache" xml:space="preserve">
+    <value>'{0}' items in cache</value>
+  </data>
 </root>

--- a/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
@@ -12,60 +14,116 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
     internal class AssemblyResolver : IAssemblyResolver
     {
         private readonly Compilation parentCompilation;
-        private static readonly Version zeroVersion = new Version(0, 0, 0, 0);
+        private readonly Dictionary<string, List<IAssemblySymbol>> cache = new Dictionary<string, List<IAssemblySymbol>>();
 
         public AssemblyResolver(Compilation parentCompilation)
         {
             this.parentCompilation = parentCompilation;
+            BuildReferenceCache();
+            Log("{0} items in cache", cache.Count);
         }
 
         public PEFile Resolve(IAssemblyReference name)
         {
-            foreach (var assembly in parentCompilation.GetReferencedAssemblySymbols())
+            Log("------------------");
+            Log("Resolve: {0}", name.FullName);
+
+            // First, find the correct list of assemblies by name
+            if (!cache.TryGetValue(name.Name, out var assemblies))
             {
-                // First, find the correct IAssemblySymbol by name and PublicKeyToken.
-                if (assembly.Identity.Name != name.Name
-                    || !assembly.Identity.PublicKeyToken.SequenceEqual(name.PublicKeyToken ?? Array.Empty<byte>()))
-                {
-                    continue;
-                }
+                Log("Could not find by name: {0}", name.FullName);
+                return null;
+            }
 
-                // Normally we skip versions that do not match, except if the reference is "mscorlib" (see comments below)
-                // or if the name.Version is '0.0.0.0'. This is because we require the metadata of all transitive references
-                // and modules, to achieve best decompilation results.
-                // In the case of .NET Standard projects for example, the 'netstandard' reference contains no references
-                // with actual versions. All versions are '0.0.0.0', therefore we have to ignore those version numbers,
-                // and can just use the references provided by Roslyn instead.
-                if (assembly.Identity.Version != name.Version && name.Version != zeroVersion
-                    && !string.Equals("mscorlib", assembly.Identity.Name, StringComparison.OrdinalIgnoreCase))
+            // If we have only one assembly available, just use it.
+            // This is necessary, because in most cases there is only one assembly,
+            // but still might have a version different from what the decompiler asks for.
+            if (assemblies.Count == 1)
+            {
+                Log("Found single assembly: {0}", assemblies[0]);
+                if (assemblies[0].Identity.Version != name.Version)
                 {
-                    // MSBuild treats mscorlib special for the purpose of assembly resolution/unification, where all
-                    // versions of the assembly are considered equal. The same policy is adopted here.
-                    continue;
+                    Log("WARN: Version mismatch!");
+                    Log("WARN: Expected: {0}, Got: {1}", name.Version, assemblies[0].Identity.Version);
                 }
+                return MakePEFile(assemblies[0]);
+            }
 
+            // There are multiple assemblies
+            Log("Found {0} assemblies for {1}:", assemblies.Count, name.Name);
+
+            // Get an exact match or highest version match from the list
+            IAssemblySymbol highestVersion = null;
+            IAssemblySymbol exactMatch = null;
+
+            var publicKeyTokenOfName = name.PublicKeyToken ?? Array.Empty<byte>();
+
+            foreach (var assembly in assemblies)
+            {
+                Log(assembly.Identity.GetDisplayName());
+                var version = assembly.Identity.Version;
+                var publicKeyToken = assembly.Identity.PublicKey;
+                if (version == name.Version && publicKeyToken.SequenceEqual(publicKeyTokenOfName))
+                {
+                    exactMatch = assembly;
+                    Log("Found exact match: {0}", assembly);
+                }
+                else if (highestVersion == null || highestVersion.Identity.Version < version)
+                {
+                    highestVersion = assembly;
+                    Log("Found higher version match: {0}", assembly);
+                }
+            }
+
+            var chosen = exactMatch ?? highestVersion;
+            Log("Choosing version: {0}", chosen);
+            return MakePEFile(chosen);
+
+            PEFile MakePEFile(IAssemblySymbol assembly)
+            {
                 // reference assemblies should be fine here, we only need the metadata of references.
                 var reference = parentCompilation.GetMetadataReference(assembly);
                 return new PEFile(reference.Display, PEStreamOptions.PrefetchMetadata);
             }
-
-            // not found
-            return null;
         }
 
         public PEFile ResolveModule(PEFile mainModule, string moduleName)
         {
+            Log("-------------");
+            Log("ResolveModule: {0} of {1}", moduleName, mainModule.FullName);
+
             // Primitive implementation to support multi-module assemblies
             // where all modules are located next to the main module.
             var baseDirectory = Path.GetDirectoryName(mainModule.FileName);
             var moduleFileName = Path.Combine(baseDirectory, moduleName);
             if (!File.Exists(moduleFileName))
             {
+                Log("Not found!");
                 return null;
             }
 
+            Log("Found {0}", moduleFileName);
             return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
         }
-    }
 
+        private void BuildReferenceCache()
+        {
+            foreach (var reference in parentCompilation.GetReferencedAssemblySymbols())
+            {
+                if (!cache.TryGetValue(reference.Identity.Name, out var list))
+                {
+                    list = new List<IAssemblySymbol>();
+                    cache.Add(reference.Identity.Name, list);
+                }
+
+                list.Add(reference);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void Log(string format, params object[] args)
+        {
+            File.AppendAllText("C:\\temp\\ICSharpCode.Decompiler.VSAssemblyResolver.log", string.Format(format, args) + Environment.NewLine);
+        }
+    }
 }

--- a/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             _parentCompilation = parentCompilation;
             _logger = logger;
             BuildReferenceCache();
-            Log("'{0}' items in cache", _cache.Count);
+            Log(CSharpEditorResources._0_items_in_cache, _cache.Count);
 
             void BuildReferenceCache()
             {
@@ -42,12 +42,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
         public PEFile Resolve(IAssemblyReference name)
         {
             Log("------------------");
-            Log("Resolve: '{0}'", name.FullName);
+            Log(CSharpEditorResources.Resolve_0, name.FullName);
 
             // First, find the correct list of assemblies by name
             if (!_cache.TryGetValue(name.Name, out var assemblies))
             {
-                Log("Could not find by name: '{0}'", name.FullName);
+                Log(CSharpEditorResources.Could_not_find_by_name_0, name.FullName);
                 return null;
             }
 
@@ -56,16 +56,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             // but still might have a version different from what the decompiler asks for.
             if (assemblies.Count == 1)
             {
-                Log("Found single assembly: '{0}'", assemblies[0]);
+                Log(CSharpEditorResources.Found_single_assembly_0, assemblies[0]);
                 if (assemblies[0].Identity.Version != name.Version)
                 {
-                    Log("WARN: Version mismatch. Expected: '{0}', Got: '{1}'!", name.Version, assemblies[0].Identity.Version);
+                    Log(CSharpEditorResources.WARN_Version_mismatch_Expected_0_Got_1, name.Version, assemblies[0].Identity.Version);
                 }
                 return MakePEFile(assemblies[0]);
             }
 
             // There are multiple assemblies
-            Log("Found '{0}' assemblies for '{1}':", assemblies.Count, name.Name);
+            Log(CSharpEditorResources.Found_0_assemblies_for_1, assemblies.Count, name.Name);
 
             // Get an exact match or highest version match from the list
             IAssemblySymbol highestVersion = null;
@@ -81,24 +81,24 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
                 if (version == name.Version && publicKeyToken.SequenceEqual(publicKeyTokenOfName))
                 {
                     exactMatch = assembly;
-                    Log("Found exact match: '{0}'", assembly);
+                    Log(CSharpEditorResources.Found_exact_match_0, assembly);
                 }
                 else if (highestVersion == null || highestVersion.Identity.Version < version)
                 {
                     highestVersion = assembly;
-                    Log("Found higher version match: '{0}'", assembly);
+                    Log(CSharpEditorResources.Found_higher_version_match_0, assembly);
                 }
             }
 
             var chosen = exactMatch ?? highestVersion;
-            Log("Choosing version: '{0}'", chosen);
+            Log(CSharpEditorResources.Chosen_version_0, chosen);
             return MakePEFile(chosen);
 
             PEFile MakePEFile(IAssemblySymbol assembly)
             {
                 // reference assemblies should be fine here, we only need the metadata of references.
                 var reference = _parentCompilation.GetMetadataReference(assembly);
-                Log("Load from: '{0}'", reference.Display);
+                Log(CSharpEditorResources.Load_from_0, reference.Display);
                 return new PEFile(reference.Display, PEStreamOptions.PrefetchMetadata);
             }
         }
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
         public PEFile ResolveModule(PEFile mainModule, string moduleName)
         {
             Log("-------------");
-            Log("ResolveModule: '{0}' of '{1}'", moduleName, mainModule.FullName);
+            Log(CSharpEditorResources.Resolve_module_0_of_1, moduleName, mainModule.FullName);
 
             // Primitive implementation to support multi-module assemblies
             // where all modules are located next to the main module.
@@ -114,11 +114,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             var moduleFileName = Path.Combine(baseDirectory, moduleName);
             if (!File.Exists(moduleFileName))
             {
-                Log("Not found!");
+                Log(CSharpEditorResources.Module_not_found);
                 return null;
             }
 
-            Log("Found '{0}'", moduleFileName);
+            Log(CSharpEditorResources.Load_from_0, moduleFileName);
             return new PEFile(moduleFileName, PEStreamOptions.PrefetchMetadata);
         }
 

--- a/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/AssemblyResolver.cs
@@ -2,10 +2,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
+using System.Text;
 using ICSharpCode.Decompiler.Metadata;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -15,10 +15,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
     {
         private readonly Compilation parentCompilation;
         private readonly Dictionary<string, List<IAssemblySymbol>> cache = new Dictionary<string, List<IAssemblySymbol>>();
+        private readonly StringBuilder logger;
 
-        public AssemblyResolver(Compilation parentCompilation)
+        public AssemblyResolver(Compilation parentCompilation, StringBuilder logger)
         {
             this.parentCompilation = parentCompilation;
+            this.logger = logger;
             BuildReferenceCache();
             Log("{0} items in cache", cache.Count);
         }
@@ -120,10 +122,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             }
         }
 
-        [Conditional("DEBUG")]
-        private static void Log(string format, params object[] args)
+        private void Log(string format, params object[] args)
         {
-            File.AppendAllText("C:\\temp\\ICSharpCode.Decompiler.VSAssemblyResolver.log", string.Format(format, args) + Environment.NewLine);
+            logger.AppendFormat(format + Environment.NewLine, args);
         }
     }
 }

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
 
             text += "#if false // Decompilation log" + Environment.NewLine;
             text += logger.ToString();
-            text += "#endif";
+            text += "#endif" + Environment.NewLine;
 
             return document.WithText(SourceText.From(text));
         }

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -93,8 +94,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             // Load the assembly.
             var file = new PEFile(assemblyLocation, PEStreamOptions.PrefetchEntireImage);
 
+            var logger = new StringBuilder();
+
             // Initialize a decompiler with default settings.
-            var decompiler = new CSharpDecompiler(file, new AssemblyResolver(compilation), new DecompilerSettings());
+            var decompiler = new CSharpDecompiler(file, new AssemblyResolver(compilation, logger), new DecompilerSettings());
             // Escape invalid identifiers to prevent Roslyn from failing to parse the generated code.
             // (This happens for example, when there is compiler-generated code that is not yet recognized/transformed by the decompiler.)
             decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
@@ -103,6 +106,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
 
             // Try to decompile; if an exception is thrown the caller will handle it
             var text = decompiler.DecompileTypeAsString(fullTypeName);
+
+            text += "#if false // Decompilation log" + Environment.NewLine;
+            text += logger.ToString();
+            text += "#endif";
+
             return document.WithText(SourceText.From(text));
         }
 

--- a/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
+++ b/src/EditorFeatures/CSharp/DecompiledSource/CSharpDecompiledSourceService.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DecompiledSource
             // Try to decompile; if an exception is thrown the caller will handle it
             var text = decompiler.DecompileTypeAsString(fullTypeName);
 
-            text += "#if false // Decompilation log" + Environment.NewLine;
+            text += "#if false // " + CSharpEditorResources.Decompilation_log + Environment.NewLine;
             text += logger.ToString();
             text += "#endif" + Environment.NewLine;
 

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.cs.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Dokončit příkaz středníkem</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Opravit interpolovaný doslovný řetězec</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Pro vložení stiskněte TAB.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Rozdělit řetězec</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.de.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Anweisung abschließen bei ";"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Interpolierte ausführliche Zeichenfolge korrigieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Zum Einfügen TAB-TASTE drücken)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Zeichenfolge teilen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.es.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Completar la instrucción en ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Corregir cadena textual interpolada</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Presione TAB para insertar)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Dividir cadena</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.fr.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Compléter l'instruction avec ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Corriger la chaîne verbatim interpolée</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Appuyez sur TAB pour insérer)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Fractionner la chaîne</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.it.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Completa l'istruzione in corrispondenza di ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Correggi stringa verbatim interpolata</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Premere TAB per inserire)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Dividi stringa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ja.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">ステートメントを ; で完了させてください</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">挿入された逐語的文字列を修正します</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">(Tab キーを押して挿入)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">文字列を分割します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ko.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">;에서 문 완성</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">보간된 축자 문자열 수정</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (삽입하려면 &lt;Tab&gt; 키 누름)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">문자열 분할</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pl.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Zakończ instrukcję przy znaku ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Napraw interpolowany ciąg dosłowny wyrażenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Naciśnij klawisz TAB, aby wstawić)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Rozdziel ciąg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.pt-BR.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Concluir instrução em ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Corrigir cadeia de caracteres verbatim interpolada</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Pressione TAB para inserir)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Dividir cadeia de caracteres</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.ru.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Завершить оператор на ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Исправить интерполированную буквальную строку</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Нажмите клавишу TAB для вставки)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Разделить строку</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.tr.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">Tüm deyimin bulunduğu yer ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">Ara değer olarak eklenmiş tam dizeyi düzelt</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (Eklemek için TAB tuşuna basın)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">Dizeyi böl</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hans.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">完成语句时间;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">修复插值的逐字字符串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">(按 Tab 插入)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">拆分字符串</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>

--- a/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
+++ b/src/EditorFeatures/CSharp/xlf/CSharpEditorResources.zh-Hant.xlf
@@ -2,9 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CSharpEditorResources.resx">
     <body>
+      <trans-unit id="Chosen_version_0">
+        <source>Chosen version: '{0}'</source>
+        <target state="new">Chosen version: '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_statement_on_semicolon">
         <source>Complete statement on ;</source>
         <target state="translated">完成陳述式於 ;</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Could_not_find_by_name_0">
+        <source>Could not find by name: '{0}'</source>
+        <target state="new">Could not find by name: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompilation_log">
+        <source>Decompilation log</source>
+        <target state="new">Decompilation log</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_interpolated_verbatim_string">
@@ -12,9 +27,49 @@
         <target state="translated">修正插入的逐字字串</target>
         <note />
       </trans-unit>
+      <trans-unit id="Found_0_assemblies_for_1">
+        <source>Found '{0}' assemblies for '{1}':</source>
+        <target state="new">Found '{0}' assemblies for '{1}':</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_exact_match_0">
+        <source>Found exact match: '{0}'</source>
+        <target state="new">Found exact match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_higher_version_match_0">
+        <source>Found higher version match: '{0}'</source>
+        <target state="new">Found higher version match: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Found_single_assembly_0">
+        <source>Found single assembly: '{0}'</source>
+        <target state="new">Found single assembly: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Load_from_0">
+        <source>Load from: '{0}'</source>
+        <target state="new">Load from: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Module_not_found">
+        <source>Module not found!</source>
+        <target state="new">Module not found!</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Press_TAB_to_insert">
         <source>     (Press TAB to insert)</source>
         <target state="translated">     (按 TAB 鍵插入)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_0">
+        <source>Resolve: '{0}'</source>
+        <target state="new">Resolve: '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Resolve_module_0_of_1">
+        <source>Resolve module: '{0}' of '{1}'</source>
+        <target state="new">Resolve module: '{0}' of '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="Smart_Indenting">
@@ -25,6 +80,16 @@
       <trans-unit id="Split_string">
         <source>Split string</source>
         <target state="translated">分割字串</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WARN_Version_mismatch_Expected_0_Got_1">
+        <source>WARN: Version mismatch. Expected: '{0}', Got: '{1}'</source>
+        <target state="new">WARN: Version mismatch. Expected: '{0}', Got: '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="_0_items_in_cache">
+        <source>'{0}' items in cache</source>
+        <target state="new">'{0}' items in cache</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
In order to solve the issues with poor decompilation quality in the VS decompiler integration, I have made the following changes to the assembly resolver used by the decompiler:

1) group all references by short assembly name.
2) if there is only one assembly with a given short name, just use that assembly and ignore its version: This is necessary because assembly versions requested by the decompiler almost never match up with what Visual Studio provides, this is a particularly big problem with .NET core / standard.
3) if there are multiple versions of the same assembly, try to find an exact match and the highest version match.
    - if there's an exact match, use it
    - otherwise use the highest version match.

Solution with multiple projects using different target frameworks, all reference the  `Microsoft.Graph` nuget package:
[MultiGraphF12Testing.zip](https://github.com/dotnet/roslyn/files/4071689/MultiGraphF12Testing.zip)

Log files generated by VS with this patch applied:
* [ICSharpCode.Decompiler.VSAssemblyResolver_netcore21.log](https://github.com/dotnet/roslyn/files/4071712/ICSharpCode.Decompiler.VSAssemblyResolver_netcore21.log)
* [ICSharpCode.Decompiler.VSAssemblyResolver_netcore31.log](https://github.com/dotnet/roslyn/files/4071713/ICSharpCode.Decompiler.VSAssemblyResolver_netcore31.log)
* [ICSharpCode.Decompiler.VSAssemblyResolver_netstandard21.log](https://github.com/dotnet/roslyn/files/4071714/ICSharpCode.Decompiler.VSAssemblyResolver_netstandard21.log)
NOTE: in this case, without the patch, the decompiler would not have been able to resolve anything at all, because VS would not pass `netstandard.dll` to the decompiler, which is needed to resolve most of the types built into the framework.
* [ICSharpCode.Decompiler.VSAssemblyResolver_net472.log](https://github.com/dotnet/roslyn/files/4071715/ICSharpCode.Decompiler.VSAssemblyResolver_net472.log)

Example decompilation results with standalone ILSpy 5.0.2: 
[decompresult-ilspy502winstore.cs](https://github.com/dotnet/roslyn/files/4071700/decompresult-ilspy502winstore.cs.txt)
Example decompilation results with VS 16.5 (without the patch): 
[decompresult-vs165.cs](https://github.com/dotnet/roslyn/files/4071706/decompresult-vs165.cs.txt)

Other changes:
* add cache to improve performance
* add logging for debug purposes
  ~~TODO: could you please tell me how to properly implement such logging in the Visual Studio environment? Thank you!~~