### PR TITLE
Use master-vs-deps as ibc source branch as there is no VS branch to i…

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -79,7 +79,8 @@
       "vsix": [ "https://dotnet.myget.org/F/roslyn/vsix/upload" ],
       "channels": [ "dev16.6", "dev16.6p1" ],
       "vsBranch": "master",
-      "vsMajorVersion": 16
+      "vsMajorVersion": 16,
+      "ibcSourceBranch": "master-vs-deps"
     },
     "features/NullableReferenceTypes": {
       "nugetKind": "PerBuildPreRelease",


### PR DESCRIPTION
…nsert into (and therefore the binding redirects have the incorrect roslyn version)