### PR TITLE
Insert correct `WithNullableContext` binder into the binder chain to …

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -223,14 +222,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool AreNullableAnnotationsEnabled(SyntaxTree syntaxTree, int position)
         {
-            bool? fromTree = ((CSharpSyntaxTree)syntaxTree).GetNullableContextState(position).AnnotationsState;
+            Syntax.NullableContextState context = ((CSharpSyntaxTree)syntaxTree).GetNullableContextState(position);
 
-            if (fromTree != null)
+            if (context.AnnotationsState != null)
             {
-                return fromTree.GetValueOrDefault();
+                return context.AnnotationsState.GetValueOrDefault();
             }
 
-            return AreNullableAnnotationsGloballyEnabled();
+            return AreNullableAnnotationsGloballyEnabled(context.AnnotationsExplicitlyRestored);
         }
 
         internal bool AreNullableAnnotationsEnabled(SyntaxToken token)
@@ -239,10 +238,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return AreNullableAnnotationsEnabled(token.SyntaxTree, token.SpanStart);
         }
 
-        internal virtual bool AreNullableAnnotationsGloballyEnabled()
+        internal virtual bool AreNullableAnnotationsGloballyEnabled(bool annotationsExplicitlyRestored = false)
         {
             RoslynDebug.Assert(Next is object);
-            return Next.AreNullableAnnotationsGloballyEnabled();
+            return Next.AreNullableAnnotationsGloballyEnabled(annotationsExplicitlyRestored);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -157,21 +157,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal override bool AreNullableAnnotationsGloballyEnabled(bool annotationsExplicitlyRestored = false)
+        internal override bool AreNullableAnnotationsGloballyEnabled()
         {
-            switch (Compilation.Options.NullableContextOptions)
-            {
-                case NullableContextOptions.Enable:
-                case NullableContextOptions.Annotations:
-                    return true;
-
-                case NullableContextOptions.Disable:
-                case NullableContextOptions.Warnings:
-                    return false;
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(Compilation.Options.NullableContextOptions);
-            }
+            return GetGlobalAnnotationState();
         }
 
         internal override Binder? GetBinder(SyntaxNode node)

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal override bool AreNullableAnnotationsGloballyEnabled()
+        internal override bool AreNullableAnnotationsGloballyEnabled(bool annotationsExplicitlyRestored = false)
         {
             switch (Compilation.Options.NullableContextOptions)
             {

--- a/src/Compilers/CSharp/Portable/Binder/WithNullableContextBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithNullableContextBinder.cs
@@ -18,9 +18,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             _position = position;
         }
 
-        internal override bool AreNullableAnnotationsGloballyEnabled()
+        internal override bool AreNullableAnnotationsGloballyEnabled(bool annotationsExplicitlyRestored = false)
         {
-            return Next.AreNullableAnnotationsEnabled(_syntaxTree, _position);
+            return annotationsExplicitlyRestored
+                ? Next.AreNullableAnnotationsGloballyEnabled(annotationsExplicitlyRestored)
+                : Next.AreNullableAnnotationsEnabled(_syntaxTree, _position);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/WithNullableContextBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithNullableContextBinder.cs
@@ -18,11 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             _position = position;
         }
 
-        internal override bool AreNullableAnnotationsGloballyEnabled(bool annotationsExplicitlyRestored = false)
+        internal override bool AreNullableAnnotationsGloballyEnabled()
         {
-            return annotationsExplicitlyRestored
-                ? Next.AreNullableAnnotationsGloballyEnabled(annotationsExplicitlyRestored)
-                : Next.AreNullableAnnotationsEnabled(_syntaxTree, _position);
+            return Next.AreNullableAnnotationsEnabled(_syntaxTree, _position);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpDiagnosticFilter.cs
@@ -126,8 +126,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isNullableFlowAnalysisWarning = ErrorFacts.NullableWarnings.Contains(id);
             if (isNullableFlowAnalysisWarning)
             {
-                var nullableWarningsGloballyEnabled = nullableOption == NullableContextOptions.Enable || nullableOption == NullableContextOptions.Warnings;
-                var nullableWarningsEnabled = tree?.GetNullableContextState(position).WarningsState ?? nullableWarningsGloballyEnabled;
+                Syntax.NullableContextState.State? warningsState = tree?.GetNullableContextState(position).WarningsState;
+                var nullableWarningsEnabled = warningsState switch
+                {
+                    Syntax.NullableContextState.State.Enabled => true,
+                    Syntax.NullableContextState.State.Disabled => false,
+                    _ => nullableOption == NullableContextOptions.Enable || nullableOption == NullableContextOptions.Warnings
+                };
+
                 if (!nullableWarningsEnabled)
                 {
                     return ReportDiagnostic.Suppress;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -5084,13 +5084,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return context;
 
-            static NullableContext getFlag(bool? contextState, bool defaultEnableState, NullableContext inheritedFlag, NullableContext enableFlag) =>
+            static NullableContext getFlag(NullableContextState.State contextState, bool defaultEnableState, NullableContext inheritedFlag, NullableContext enableFlag) =>
                 contextState switch
                 {
-                    null when defaultEnableState => (inheritedFlag | enableFlag),
-                    null => inheritedFlag,
-                    true => enableFlag,
-                    false => NullableContext.Disabled
+                    NullableContextState.State.Enabled => enableFlag,
+                    NullableContextState.State.Disabled => NullableContext.Disabled,
+                    _ when defaultEnableState => (inheritedFlag | enableFlag),
+                    _ => inheritedFlag,
                 };
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             crefSymbols = default;
             position = CheckAndAdjustPosition(position);
             expression = SyntaxFactory.GetStandaloneExpression(expression);
-            binder = GetEnclosingBinder(position);
+            binder = GetSpeculativeBinder(position, expression, bindingOption);
             var boundRoot = binder.BindExpression(expression, _ignoredDiagnostics);
             ImmutableDictionary<Symbol, Symbol> ignored = null;
             return (BoundExpression)NullableWalker.AnalyzeAndRewriteSpeculation(position, boundRoot, binder, GetSnapshotManager(), newSnapshots: out _, remappedSymbols: ref ignored);

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -172,8 +172,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(binder != null);
 
-            Binder executablebinder = new ExecutableCodeBinder(body, methodSymbol, binder ?? this.RootBinder);
-            executablebinder = new WithNullableContextBinder(SyntaxTree, position, executablebinder);
+            Binder executablebinder = new WithNullableContextBinder(SyntaxTree, position, binder ?? this.RootBinder);
+            executablebinder = new ExecutableCodeBinder(body, methodSymbol, executablebinder);
             var blockBinder = executablebinder.GetBinder(body).WithAdditionalFlags(GetSemanticModelBinderFlags());
             // We don't pass the snapshot manager along here, because we're speculating about an entirely new body and it should not
             // be influenced by any existing code in the body.

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -172,7 +172,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(binder != null);
 
-            var executablebinder = new ExecutableCodeBinder(body, methodSymbol, binder ?? this.RootBinder);
+            Binder executablebinder = new ExecutableCodeBinder(body, methodSymbol, binder ?? this.RootBinder);
+            executablebinder = new WithNullableContextBinder(SyntaxTree, position, executablebinder);
             var blockBinder = executablebinder.GetBinder(body).WithAdditionalFlags(GetSemanticModelBinderFlags());
             // We don't pass the snapshot manager along here, because we're speculating about an entirely new body and it should not
             // be influenced by any existing code in the body.
@@ -197,6 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var methodSymbol = (MethodSymbol)this.MemberSymbol;
+            binder = new WithNullableContextBinder(SyntaxTree, position, binder);
             binder = new ExecutableCodeBinder(statement, methodSymbol, binder);
             speculativeModel = CreateSpeculative(parentModel, methodSymbol, statement, binder, GetSnapshotManager(), GetRemappedSymbols(), position);
             return true;
@@ -214,6 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var methodSymbol = (MethodSymbol)this.MemberSymbol;
+            binder = new WithNullableContextBinder(SyntaxTree, position, binder);
             binder = new ExecutableCodeBinder(expressionBody, methodSymbol, binder);
 
             speculativeModel = CreateSpeculative(parentModel, methodSymbol, expressionBody, binder, position);
@@ -228,6 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (binder != null)
                 {
                     var methodSymbol = (MethodSymbol)this.MemberSymbol;
+                    binder = new WithNullableContextBinder(SyntaxTree, position, binder);
                     binder = new ExecutableCodeBinder(constructorInitializer, methodSymbol, binder);
                     speculativeModel = CreateSpeculative(parentModel, methodSymbol, constructorInitializer, binder, position);
                     return true;

--- a/src/Compilers/CSharp/Portable/Syntax/NullableContextStateMap.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/NullableContextStateMap.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             AnnotationsState = annotationsState;
         }
 
-        internal enum State
+        internal enum State : byte
         {
             Unknown,
             Disabled,

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -4076,8 +4076,8 @@ class C
             var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
 
             var arrow = SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(@"
-            #nullable disable
-            M(out C c)"));
+#nullable disable
+M(out C c)"));
             Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, arrow, out var speculativeModel));
 
             var type2 = arrow.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/NullablePublicAPITests.cs
@@ -3815,5 +3815,364 @@ class B2 : A<int?>
                 Assert.Equal(expectedState, info.FlowState);
             }
         }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_OutVariableInDifferentContext_01()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var statement = SyntaxFactory.ParseStatement(@"M(out C c);");
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, statement, out var speculativeModel));
+
+            var type2 = statement.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_OutVariableInDifferentContext_02()
+        {
+            var source =
+@"#nullable disable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var statement = SyntaxFactory.ParseStatement(@"M(out C c);");
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, statement, out var speculativeModel));
+
+            var type2 = statement.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.None, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_OutVariableInDifferentContext_03()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var statement = SyntaxFactory.ParseStatement(@"
+#nullable disable
+M(out C c);");
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, statement, out var speculativeModel));
+
+            var type2 = statement.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.None, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_OutVariableInDifferentContext_04()
+        {
+            var source =
+@"#nullable disable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var statement = SyntaxFactory.ParseStatement(@"
+#nullable restore
+M(out C c);");
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, statement, out var speculativeModel));
+
+            var type2 = statement.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_OutVariableInDifferentContext_05()
+        {
+            var source =
+@"#nullable disable annotations
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesTrue());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var statement = SyntaxFactory.ParseStatement(@"
+#nullable restore annotations
+M(out C c);");
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, statement, out var speculativeModel));
+
+            var type2 = statement.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_WholeBody_01()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var methodDeclaration = (MethodDeclarationSyntax)SyntaxFactory.ParseMemberDeclaration(@"
+void M2(out C c2)
+{
+    M(out C c);
+}");
+            Assert.True(model.TryGetSpeculativeSemanticModelForMethodBody(type.SpanStart, methodDeclaration, out var speculativeModel));
+
+            var type2 = methodDeclaration.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_WholeBody_02()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var methodDeclaration = (MethodDeclarationSyntax)SyntaxFactory.ParseMemberDeclaration(@"
+void M2(out C c2)
+{
+#nullable disable
+    M(out C c);
+}");
+            Assert.True(model.TryGetSpeculativeSemanticModelForMethodBody(type.SpanStart, methodDeclaration, out var speculativeModel));
+
+            var type2 = methodDeclaration.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.None, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_ArrowExpression_01()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var arrow = SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(" M(out C c)"));
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, arrow, out var speculativeModel));
+
+            var type2 = arrow.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_ArrowExpression_02()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var type = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+
+            var arrow = SyntaxFactory.ArrowExpressionClause(SyntaxFactory.ParseExpression(@"
+            #nullable disable
+            M(out C c)"));
+            Assert.True(model.TryGetSpeculativeSemanticModel(type.SpanStart, arrow, out var speculativeModel));
+
+            var type2 = arrow.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.None, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_ConstructorInitializer_01()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    C() : this("""") {}
+    C(string s) {}
+    string M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+        return """";
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var initializer = tree.GetRoot().DescendantNodes().OfType<ConstructorInitializerSyntax>().Single();
+
+            var newInitializer = SyntaxFactory.ConstructorInitializer(SyntaxKind.ThisConstructorInitializer, SyntaxFactory.ParseArgumentList(@"(M(out C c))"));
+            Assert.True(model.TryGetSpeculativeSemanticModel(initializer.SpanStart, newInitializer, out var speculativeModel));
+
+            var type2 = newInitializer.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750")]
+        public void SpeculativeSymbolInfo_ConstructorInitializer_02()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    C() : this("""") {}
+    C(string s) {}
+    string M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+        return """";
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var initializer = tree.GetRoot().DescendantNodes().OfType<ConstructorInitializerSyntax>().Single();
+
+            var newInitializer = SyntaxFactory.ConstructorInitializer(SyntaxKind.ThisConstructorInitializer, SyntaxFactory.ParseArgumentList(@"(
+#nullable disable
+M(out C c))"));
+            Assert.True(model.TryGetSpeculativeSemanticModel(initializer.SpanStart, newInitializer, out var speculativeModel));
+
+            var type2 = newInitializer.DescendantNodes().OfType<DeclarationExpressionSyntax>().Single().Type;
+            var symbol2 = speculativeModel.GetSymbolInfo(type2);
+            Assert.Equal(PublicNullableAnnotation.None, ((ITypeSymbol)symbol2.Symbol).NullableAnnotation);
+        }
+
+        [Fact]
+        [WorkItem(40750, "https://github.com/dotnet/roslyn/issues/40750"),
+         WorkItem(39993, "https://github.com/dotnet/roslyn/issues/39993")]
+        public void SpeculativeSymbolInfo_Expression()
+        {
+            var source =
+@"#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out global::C c);
+        c2 = c;
+    }
+}";
+            var comp = CreateCompilation(source, options: WithNonNullTypesFalse());
+            comp.VerifyDiagnostics();
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var initializer = tree.GetRoot().DescendantNodes().OfType<DeclarationExpressionSyntax>().Single();
+
+            var expression = SyntaxFactory.ParseExpression(@"M(out C c)");
+            var symbol2 = (IMethodSymbol)model.GetSpeculativeSymbolInfo(initializer.Position, expression, SpeculativeBindingOption.BindAsExpression).Symbol;
+            Assert.Equal(PublicNullableAnnotation.NotAnnotated, symbol2.Parameters.Single().Type.NullableAnnotation);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -2253,5 +2253,30 @@ class C
     }}
 }}");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task InlineVariable_NullableEnable()
+        {
+            await TestInRegularAndScriptAsync(@"
+#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        [|C|] c;
+        M(out c);
+        c2 = c;
+    }
+}", @"
+#nullable enable
+class C
+{
+    void M(out C c2)
+    {
+        M(out C c);
+        c2 = c;
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -1240,7 +1240,7 @@ class C
 }", safe: true, useSymbolAnnotations);
         }
 
-        [Theory(), InlineData(true), InlineData(false)]
+        [Theory, InlineData(true), InlineData(false)]
         [WorkItem(39641, "https://github.com/dotnet/roslyn/issues/39641")]
         public async Task TestSafeWithMatchingSimpleNameInAllLocations(bool useSymbolAnnotations)
         {

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -1240,7 +1240,7 @@ class C
 }", safe: true, useSymbolAnnotations);
         }
 
-        [Theory(Skip = "https://github.com/dotnet/roslyn/issues/39641"), InlineData(true), InlineData(false)]
+        [Theory(), InlineData(true), InlineData(false)]
         [WorkItem(39641, "https://github.com/dotnet/roslyn/issues/39641")]
         public async Task TestSafeWithMatchingSimpleNameInAllLocations(bool useSymbolAnnotations)
         {


### PR DESCRIPTION
…ensure speculative models return correct information based on speuclation location.

Fixes: https://github.com/dotnet/roslyn/issues/39993
Fixes: https://github.com/dotnet/roslyn/issues/40750

@dotnet/roslyn-compiler @AlekseyTs for review. /cc @jasonmalinowski @ryzngard @y87feng.