### PR TITLE
Rewrite simplify type names using SemanticModel action and a tree walker

### DIFF
--- a/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -2613,7 +2613,7 @@ class A
 
         [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
-        public async Task TestNullableSimplificationInsideCref()
+        public async Task TestNullableSimplificationInsideCref_Indirect()
         {
             await TestInRegularAndScriptAsync(
 @"/// <summary>
@@ -2627,6 +2627,31 @@ struct A
 }",
 @"/// <summary>
 /// <see cref=""A.M(A?)""/>
+/// </summary>
+struct A
+{
+    public void M(A? x)
+    {
+    }
+}");
+        }
+
+        [WorkItem(29, "https://github.com/dotnet/roslyn/issues/29")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestNullableSimplificationInsideCref_Direct()
+        {
+            await TestInRegularAndScriptAsync(
+@"/// <summary>
+/// <see cref=""M([|System.Nullable{A}|])""/>
+/// </summary>
+struct A
+{
+    public void M(A? x)
+    {
+    }
+}",
+@"/// <summary>
+/// <see cref=""M(A?)""/>
 /// </summary>
 struct A
 {
@@ -2890,6 +2915,68 @@ class Program
     class Program
     {
         public Goo Goo;
+    }
+}");
+        }
+
+        [WorkItem(40632, "https://github.com/dotnet/roslyn/issues/40632")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestColorColorCase5()
+        {
+            await TestMissingAsync(
+@"using A;
+
+namespace A
+{
+    public struct Goo { }
+}
+
+namespace N
+{
+    /// <summary><see cref=""[|A|].Goo""/></summary
+    class Color
+    {
+        public Goo Goo;
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestColorColorCase6()
+        {
+            await TestMissingAsync(
+@"using System.Reflection.Metadata;
+using Microsoft.Cci;
+
+namespace System.Reflection.Metadata
+{
+    public enum PrimitiveTypeCode
+    {
+        Void = 1,
+    }
+}
+
+namespace Microsoft.Cci
+{
+    internal enum PrimitiveTypeCode
+    {
+        NotPrimitive,
+        Pointer,
+    }
+}
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal class TypeSymbol
+    {
+        internal Cci.PrimitiveTypeCode PrimitiveTypeCode => Cci.PrimitiveTypeCode.Pointer;
+    }
+
+    internal partial class NamedTypeSymbol : TypeSymbol
+    {
+        Cci.PrimitiveTypeCode TypeCode
+            => [|Cci|].PrimitiveTypeCode.NotPrimitive;
     }
 }");
         }
@@ -3813,7 +3900,7 @@ options: PreferIntrinsicTypeInMemberAccess);
 
         [WorkItem(954536, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/954536")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
-        public async Task TestIntrinsicTypesInsideCref_NonDefault_6()
+        public async Task TestIntrinsicTypesInsideCref_NonDefault_6_PreferMemberAccess()
         {
             await TestInRegularAndScriptAsync(
 @"class C
@@ -3831,6 +3918,20 @@ options: PreferIntrinsicTypeInMemberAccess);
     }
 }",
 options: PreferIntrinsicTypeInMemberAccess);
+        }
+
+        [WorkItem(954536, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/954536")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestIntrinsicTypesInsideCref_NonDefault_6_PreferDeclaration()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    /// <see cref=""System.Collections.Generic.List{T}.CopyTo([|System.Int32|], T[], int, int)""/>
+    public void z()
+    {
+    }
+}", new TestParameters(options: PreferIntrinsicTypeInDeclaration));
         }
 
         [WorkItem(942568, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/942568")]
@@ -4837,6 +4938,859 @@ namespace N
 {{
     using My{typeName} = [|System.{typeName}|];
 }}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyMemberAccessOffOfObjectKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    bool Goo()
+    {
+        return [|object|].Equals(null, null);
+    }
+}",
+@"using System;
+
+class C
+{
+    bool Goo()
+    {
+        return Equals(null, null);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoNotSimplifyBaseCallToVirtualInNonSealedClass()
+        {
+            await TestMissingAsync(
+@"using System;
+
+class C
+{
+    void Goo()
+    {
+        var v = [|base|].GetHashCode();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoSimplifyBaseCallToVirtualInSealedClass()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+sealed class C
+{
+    void Goo()
+    {
+        var v = [|base|].GetHashCode();
+    }
+}",
+@"using System;
+
+sealed class C
+{
+    void Goo()
+    {
+        var v = GetHashCode();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoSimplifyBaseCallToVirtualInStruct()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+struct C
+{
+    void Goo()
+    {
+        var v = [|base|].GetHashCode();
+    }
+}",
+@"using System;
+
+struct C
+{
+    void Goo()
+    {
+        var v = GetHashCode();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoNotSimplifyBaseCallToVirtualWithOverride()
+        {
+            await TestMissingAsync(
+@"using System;
+
+class C
+{
+    void Goo()
+    {
+        var v = [|base|].GetHashCode();
+    }
+
+    public override int GetHashCode() => 0;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoSimplifyBaseCallToNonVirtual()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class Base
+{
+    public int Baz() => 0;
+}
+
+class C : Base
+{
+    void Goo()
+    {
+        var v = [|base|].Baz();
+    }
+}",
+@"using System;
+
+class Base
+{
+    public int Baz() => 0;
+}
+
+class C : Base
+{
+    void Goo()
+    {
+        var v = Baz();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoNotSimplifyBaseCallIfOverloadChanges()
+        {
+            await TestMissingAsync(
+@"using System;
+
+class Base
+{
+    public int Baz(object o) => 0;
+}
+
+class C : Base
+{
+    void Goo()
+    {
+        var v = [|base|].Baz(0);
+    }
+
+    public int Baz(int o) => 0;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoNotSimplifyInsideNameof()
+        {
+            await TestMissingAsync(
+@"using System;
+
+class Base
+{
+    public int Baz(string type)
+        => type switch
+        {
+            nameof([|Int32|]) => 0,
+        };
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoSimplifyInferrableTypeArgumentList()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class Base
+{
+    public void Goo() => Bar[|<int>|](0);
+    public void Bar<T>(T t) => default;
+}
+",
+@"using System;
+
+class Base
+{
+    public void Goo() => Bar(0);
+    public void Bar<T>(T t) => default;
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task DoNotSimplifyNonInferrableTypeArgumentList()
+        {
+            await TestMissingAsync(
+@"using System;
+
+class Base
+{
+    public void Goo() => Bar[|<int>|](0);
+    public void Bar<T>() => default;
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyEnumMemberReferenceInsideEnum()
+        {
+            await TestInRegularAndScript1Async(
+@"
+enum E
+{
+    Goo = 1,
+    Bar = [|E|].Goo,
+}",
+@"
+enum E
+{
+    Goo = 1,
+    Bar = Goo,
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyEnumMemberReferenceInsideEnumDocComment()
+        {
+            await TestInRegularAndScript1Async(
+@"
+/// <summary>
+/// <see cref=""[|E|].Goo""/>
+/// </summary>
+enum E
+{
+    Goo = 1,
+}",
+@"
+/// <summary>
+/// <see cref=""Goo""/>
+/// </summary>
+enum E
+{
+    Goo = 1,
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestInstanceMemberReferenceInCref1()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    /// <see cref=""[|C.z|]""/>
+    public void z()
+    {
+    }
+}", @"
+class C
+{
+    /// <see cref=""z""/>
+    public void z()
+    {
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyAttributeReference1()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class GooAttribute : Attribute
+{
+}
+
+[Goo[|Attribute|]]
+class Bar
+{
+}
+",
+@"using System;
+
+class GooAttribute : Attribute
+{
+}
+
+[Goo]
+class Bar
+{
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyAttributeReference2()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+class GooAttribute : Attribute
+{
+}
+
+[Goo[|Attribute|]()]
+class Bar
+{
+}
+",
+@"using System;
+
+class GooAttribute : Attribute
+{
+}
+
+[Goo()]
+class Bar
+{
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyAttributeReference3()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+namespace N
+{
+    class GooAttribute : Attribute
+    {
+    }
+}
+
+[N.Goo[|Attribute|]()]
+class Bar
+{
+}
+",
+@"using System;
+
+namespace N
+{
+    class GooAttribute : Attribute
+    {
+    }
+}
+
+[N.Goo()]
+class Bar
+{
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyAttributeReference4()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+
+namespace N
+{
+    class GooAttribute : Attribute
+    {
+    }
+}
+
+[N.GooAttribute([|typeof(System.Int32)|])]
+class Bar
+{
+}
+",
+@"using System;
+
+namespace N
+{
+    class GooAttribute : Attribute
+    {
+    }
+}
+
+[N.GooAttribute(typeof(int))]
+class Bar
+{
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifySystemAttribute()
+        {
+            await TestInRegularAndScript1Async(
+@"using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft
+{
+    [[|System|].Serializable]
+    public struct ClassifiedToken
+    {
+    }
+}",
+@"using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft
+{
+    [Serializable]
+    public struct ClassifiedToken
+    {
+    }
+}");
+        }
+
+        [WorkItem(40633, "https://github.com/dotnet/roslyn/issues/40633")]
+        [WorkItem(542100, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542100")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestAllowSimplificationThatWouldNotCauseConflict1()
+        {
+            await TestInRegularAndScriptAsync(
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main()
+        {
+            [|N.Program|].Goo.Bar();
+            {
+                int Goo;
+            }
+        }
+    }
+}",
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main()
+        {
+            Goo.Bar();
+            {
+                int Goo;
+            }
+        }
+    }
+}");
+        }
+
+        [WorkItem(542100, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542100")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestAllowSimplificationThatWouldNotCauseConflict2()
+        {
+            await TestInRegularAndScriptAsync(
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main()
+        {
+            [|Program|].Goo.Bar();
+            {
+                int Goo;
+            }
+        }
+    }
+}",
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main()
+        {
+            Goo.Bar();
+            {
+                int Goo;
+            }
+        }
+    }
+}");
+        }
+
+        [WorkItem(542100, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542100")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestPreventSimplificationThatWouldCauseConflict1()
+        {
+            await TestInRegularAndScript1Async(
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main()
+        {
+            [|N|].Program.Goo.Bar();
+            int Goo;
+        }
+    }
+}",
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main()
+        {
+            Program.Goo.Bar();
+            int Goo;
+        }
+    }
+}");
+        }
+
+        [WorkItem(542100, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542100")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestPreventSimplificationThatWouldCauseConflict2()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"namespace N
+{
+    class Program
+    {
+        class Goo
+        {
+            public static void Bar()
+            {
+            }
+        }
+
+        static void Main(int[] args)
+        {
+            [|Program|].Goo.Bar();
+            int Goo;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestSimplifyPredefinedTypeMemberAccessThatIsInScope()
+        {
+            await TestInRegularAndScript1Async(
+@"using static System.Int32;
+
+class Goo
+{
+    public void Bar(string a)
+    {
+        var v = [|int|].Parse(a);
+    }
+}",
+@"using static System.Int32;
+
+class Goo
+{
+    public void Bar(string a)
+    {
+        var v = Parse(a);
+    }
+}");
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [InlineData("Boolean")]
+        [InlineData("Char")]
+        [InlineData("String")]
+        [InlineData("Int16")]
+        [InlineData("UInt16")]
+        [InlineData("Int32")]
+        [InlineData("UInt32")]
+        [InlineData("Int64")]
+        [InlineData("UInt64")]
+        public async Task TestDoesNotSimplifyUsingAliasDirectiveToBuiltInType(string typeName)
+        {
+            await TestInRegularAndScript1Async(
+$@"using System;
+namespace N
+{{
+    using My{typeName} = [|System.{typeName}|];
+}}",
+$@"using System;
+namespace N
+{{
+    using My{typeName} = {typeName};
+}}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestDoNotSimplifyIfItWouldIntroduceAmbiguity()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using A;
+using B;
+
+namespace A
+{
+    class Goo { }
+}
+
+namespace B
+{
+    class Goo { }
+}
+
+class C
+{
+    void Bar(object o)
+    {
+        var x = ([|A|].Goo)o;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestDoNotSimplifyIfItWouldIntroduceAmbiguity2()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"using A;
+
+namespace A
+{
+    class Goo { }
+}
+
+namespace B
+{
+    class Goo { }
+}
+
+namespace N
+{
+    using B;
+
+    class C
+    {
+        void Bar(object o)
+        {
+            var x = ([|A|].Goo)o;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestAllowSimplificationWithoutAmbiguity2()
+        {
+            await TestInRegularAndScript1Async(
+@"using A;
+
+namespace A
+{
+    class Goo { }
+}
+
+namespace B
+{
+    class Goo { }
+}
+
+namespace N
+{
+    using A;
+
+    class C
+    {
+        void Bar(object o)
+        {
+            var x = ([|A|].Goo)o;
+        }
+    }
+}",
+@"using A;
+
+namespace A
+{
+    class Goo { }
+}
+
+namespace B
+{
+    class Goo { }
+}
+
+namespace N
+{
+    using A;
+
+    class C
+    {
+        void Bar(object o)
+        {
+            var x = (Goo)o;
+        }
+    }
+}");
+        }
+
+        [WorkItem(995168, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/995168")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task SimplifyCrefAliasPredefinedType_OnClass()
+        {
+            await TestInRegularAndScriptAsync(
+@"namespace N1
+{
+    /// <see cref=""[|System.Int32|]""/>
+    public class C1
+    {
+        public C1()
+        {
+        }
+    }
+}",
+@"namespace N1
+{
+    /// <see cref=""int""/>
+    public class C1
+    {
+        public C1()
+        {
+        }
+    }
+}", options: PreferIntrinsicTypeEverywhere);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestMissingOnInstanceMemberAccessOfOtherValue()
+        {
+            var content =
+@"
+using System;
+
+internal struct BitVector : IEquatable<BitVector>
+{
+    public bool Equals(BitVector other)
+    {
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is BitVector other && Equals(other);
+    }
+
+    public static bool operator ==(BitVector left, BitVector right)
+    {
+        return [|left|].Equals(right);
+    }
+}";
+
+            await TestMissingInRegularAndScriptAsync(content);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestSimplifyStaticMemberAccessThroughDerivedType()
+        {
+            var source =
+@"class Base
+{
+    public static int Y;
+}
+
+class Derived : Base
+{
+}
+
+static class M
+{
+    public static void Main()
+    {
+        int k = [|Derived|].Y;
+    }
+}";
+            await TestInRegularAndScriptAsync(source,
+@"class Base
+{
+    public static int Y;
+}
+
+class Derived : Base
+{
+}
+
+static class M
+{
+    public static void Main()
+    {
+        int k = Base.Y;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        public async Task TestNameofReportsSimplifyMemberAccess()
+        {
+            await TestDiagnosticInfoAsync(
+@"using System;
+
+class Base
+{
+    void Goo()
+    {
+        var v = nameof([|System|].Int32);
+    }
+}", OptionsSet(), IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId, DiagnosticSeverity.Hidden);
         }
 
         private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
+{
+    internal class TypeSyntaxSimplifierWalker : CSharpSyntaxWalker
+    {
+        private readonly CSharpSimplifyTypeNamesDiagnosticAnalyzer _analyzer;
+        private readonly SemanticModel _semanticModel;
+        private readonly OptionSet _optionSet;
+        private readonly CancellationToken _cancellationToken;
+
+        public List<Diagnostic> Diagnostics { get; } = new List<Diagnostic>();
+
+        public TypeSyntaxSimplifierWalker(CSharpSimplifyTypeNamesDiagnosticAnalyzer analyzer, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
+            : base(SyntaxWalkerDepth.StructuredTrivia)
+        {
+            _analyzer = analyzer;
+            _semanticModel = semanticModel;
+            _optionSet = optionSet;
+            _cancellationToken = cancellationToken;
+        }
+
+        public override void VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.QualifiedName) && TrySimplify(node))
+            {
+                // found a match. report it and stop processing.
+                return;
+            }
+
+            // descend further.
+            DefaultVisit(node);
+        }
+
+        public override void VisitAliasQualifiedName(AliasQualifiedNameSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.AliasQualifiedName) && TrySimplify(node))
+            {
+                // found a match. report it and stop processing.
+                return;
+            }
+
+            // descend further.
+            DefaultVisit(node);
+        }
+
+        public override void VisitGenericName(GenericNameSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.GenericName) && TrySimplify(node))
+            {
+                // found a match. report it and stop processing.
+                return;
+            }
+
+            // descend further.
+            DefaultVisit(node);
+        }
+
+        public override void VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.IdentifierName) && TrySimplify(node))
+            {
+                // found a match. report it and stop processing.
+                return;
+            }
+
+            // descend further.
+            DefaultVisit(node);
+        }
+
+        public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.SimpleMemberAccessExpression) && TrySimplify(node))
+            {
+                // found a match. report it and stop processing.
+                return;
+            }
+
+            // descend further.
+            DefaultVisit(node);
+        }
+
+        public override void VisitQualifiedCref(QualifiedCrefSyntax node)
+        {
+            // First, just try to simplify the top-most qualified-cref alone. If we're able to do
+            // this, then there's no need to process it's container.  i.e.
+            //
+            // if we have <see cref="A.B.C"/> and we simplify that to <see cref="C"/> there's no
+            // point looking at `A.B`.
+            if (node.IsKind(SyntaxKind.QualifiedCref) && TrySimplify(node))
+            {
+                // found a match on the qualified cref itself. report it and keep processing.
+            }
+            else
+            {
+                // couldn't simplify the qualified cref itself.  descend into the container portion
+                // as that might have portions that can be simplified.
+                Visit(node.Container);
+            }
+
+            // unilaterally process the member portion of the qualified cref.  These may have things
+            // like parameters that could be simplified.  i.e. if we have:
+            //
+            //      <see cref="A.B.C(X.Y)"/>
+            //
+            // We can simplify both the qualified portion to just `C` and we can simplify the
+            // parameter to just `Y`.
+            Visit(node.Member);
+        }
+
+        /// <summary>
+        /// This is the root helper that all other TrySimplify methods in this type must call
+        /// through once they think there is a good chance something is simplifiable.  It does the
+        /// work of actually going through the real simplification system to validate that the
+        /// simplification is legal and does not affect semantics.
+        /// </summary>
+        private bool TrySimplify(SyntaxNode node)
+        {
+            if (!_analyzer.TrySimplify(_semanticModel, node, out var diagnostic, _optionSet, _cancellationToken))
+                return false;
+
+            Diagnostics.Add(diagnostic);
+            return true;
+        }
+    }
+}

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
@@ -1,0 +1,69 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
+    Friend Class TypeSyntaxSimplifierWalker
+        Inherits VisualBasicSyntaxWalker
+
+        Private ReadOnly _analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer
+        Private ReadOnly _semanticModel As SemanticModel
+        Private ReadOnly _optionSet As OptionSet
+        Private ReadOnly _cancellationToken As CancellationToken
+
+        Public ReadOnly Property Diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()
+
+        Public Sub New(analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer, semanticModel As SemanticModel, optionSet As OptionSet, cancellationToken As CancellationToken)
+            MyBase.New(SyntaxWalkerDepth.StructuredTrivia)
+
+            _analyzer = analyzer
+            _semanticModel = semanticModel
+            _optionSet = optionSet
+            _cancellationToken = cancellationToken
+        End Sub
+
+        Public Overrides Sub VisitQualifiedName(node As QualifiedNameSyntax)
+            If node.IsKind(SyntaxKind.QualifiedName) AndAlso TrySimplify(node) Then
+                Return
+            End If
+
+            MyBase.VisitQualifiedName(node)
+        End Sub
+
+        Public Overrides Sub VisitMemberAccessExpression(node As MemberAccessExpressionSyntax)
+            If node.IsKind(SyntaxKind.SimpleMemberAccessExpression) AndAlso TrySimplify(node) Then
+                Return
+            End If
+
+            MyBase.VisitMemberAccessExpression(node)
+        End Sub
+
+        Public Overrides Sub VisitIdentifierName(node As IdentifierNameSyntax)
+            If node.IsKind(SyntaxKind.IdentifierName) AndAlso TrySimplify(node) Then
+                Return
+            End If
+
+            MyBase.VisitIdentifierName(node)
+        End Sub
+
+        Public Overrides Sub VisitGenericName(node As GenericNameSyntax)
+            If node.IsKind(SyntaxKind.GenericName) AndAlso TrySimplify(node) Then
+                Return
+            End If
+
+            MyBase.VisitGenericName(node)
+        End Sub
+
+        Private Function TrySimplify(node As SyntaxNode) As Boolean
+            Dim diagnostic As Diagnostic = Nothing
+            If Not _analyzer.TrySimplify(_semanticModel, node, diagnostic, _optionSet, _cancellationToken) Then
+                Return False
+            End If
+
+            Diagnostics.Add(diagnostic)
+            Return True
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -21,31 +21,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             SyntaxKind.IdentifierName,
             SyntaxKind.GenericName)
 
-        Public Sub New()
-            MyBase.New(s_kindsOfInterest)
-        End Sub
+        Protected Overrides Sub AnalyzeSemanticModel(context As SemanticModelAnalysisContext)
+            Dim semanticModel = context.SemanticModel
+            Dim cancellationToken = context.CancellationToken
 
-        Protected Overrides Sub AnalyzeNode(context As SyntaxNodeAnalysisContext)
-            If context.Node.Ancestors(ascendOutOfTrivia:=False).Any(AddressOf IsNodeKindInteresting) Then
-                ' Already simplified an ancestor of this node.
-                Return
-            End If
+            Dim syntaxTree = semanticModel.SyntaxTree
+            Dim options = context.Options
+            Dim optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult()
+            Dim root = syntaxTree.GetRoot(cancellationToken)
 
-            Dim descendIntoChildren As Func(Of SyntaxNode, Boolean) =
-                Function(n)
-                    Dim diagnostic As Diagnostic = Nothing
+            Dim simplifier As New TypeSyntaxSimplifierWalker(Me, semanticModel, optionSet, cancellationToken)
+            simplifier.Visit(root)
 
-                    If Not IsCandidate(n) OrElse
-                       Not TrySimplifyTypeNameExpression(context.SemanticModel, n, context.Options, diagnostic, context.CancellationToken) Then
-                        Return True
-                    End If
-
-                    context.ReportDiagnostic(diagnostic)
-                    Return False
-                End Function
-
-            For Each candidate In context.Node.DescendantNodesAndSelf(descendIntoChildren, descendIntoTrivia:=True)
-                context.CancellationToken.ThrowIfCancellationRequested()
+            For Each diagnostic In simplifier.Diagnostics
+                context.ReportDiagnostic(diagnostic)
             Next
         End Sub
 


### PR DESCRIPTION
This is a structural reorganization which allows future improvements to be implemented with less code churn. Extracted from #40746.