### PR TITLE
Simplify closure conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 /// </summary>
                 public ClosureEnvironment? DeclaredEnvironment = null;
 
-#nullable disable
+#nullable restore
 
                 public Scope(Scope parent, BoundNode boundNode, Closure containingClosure)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -62,11 +62,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 /// </summary>
                 public readonly Closure ContainingClosureOpt;
 
+#nullable enable
+
                 /// <summary>
-                /// Environments created in this scope to hold <see cref="DeclaredVariables"/>.
+                /// Environment created in this scope to hold <see cref="DeclaredVariables"/>.
+                /// At the moment, all variables declared in the same scope
+                /// always get assigned to the same environment.
                 /// </summary>
-                public readonly ArrayBuilder<ClosureEnvironment> DeclaredEnvironments
-                    = ArrayBuilder<ClosureEnvironment>.GetInstance();
+                public ClosureEnvironment? DeclaredEnvironment = null;
+
+#nullable disable
 
                 public Scope(Scope parent, BoundNode boundNode, Closure containingClosure)
                 {
@@ -96,7 +101,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         closure.Free();
                     }
                     Closures.Free();
-                    DeclaredEnvironments.Free();
                 }
 
                 public override string ToString() => BoundNode.Syntax.GetText().ToString();

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -148,22 +148,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var curScope = scope;
                         while (curScope != null)
                         {
-                            if (capturedEnvs.RemoveAll(curScope.DeclaredEnvironments))
+                            var env = curScope.DeclaredEnvironment;
+                            if (!(env is null) && capturedEnvs.Remove(env) && !env.IsStruct)
                             {
-                                // Right now we only create one environment per scope
-                                Debug.Assert(curScope.DeclaredEnvironments.Count == 1);
-                                var env = curScope.DeclaredEnvironments[0];
-                                if (!env.IsStruct)
-                                {
-                                    closure.ContainingEnvironmentOpt = env;
-                                    break;
-                                }
+                                closure.ContainingEnvironmentOpt = env;
+                                break;
                             }
                             curScope = curScope.Parent;
                         }
 
                         // Now we need to walk up the scopes to find environment captures
-                        var oldEnv = curScope?.DeclaredEnvironments[0];
+                        var oldEnv = curScope?.DeclaredEnvironment;
                         curScope = curScope?.Parent;
                         while (curScope != null)
                         {
@@ -172,17 +167,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 break;
                             }
 
-                            var envs = curScope.DeclaredEnvironments.Where(e => !e.IsStruct);
-                            if (!envs.IsEmpty())
+                            var env = curScope.DeclaredEnvironment;
+                            if (env?.IsStruct == false)
                             {
-                                // Right now we only create one environment per scope
-                                Debug.Assert(envs.IsSingle());
-                                var env = envs.First();
                                 Debug.Assert(!oldEnv.IsStruct);
                                 oldEnv.CapturesParent = true;
                                 oldEnv = env;
                             }
-                            capturedEnvs.RemoveAll(curScope.DeclaredEnvironments);
+                            capturedEnvs.Remove(env);
                             curScope = curScope.Parent;
                         }
 
@@ -213,16 +205,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
-                var topLevelEnvs = ScopeTree.DeclaredEnvironments;
+                var env = ScopeTree.DeclaredEnvironment;
 
                 // If it does exist, 'this' is always in the top-level environment
-                if (topLevelEnvs.Count == 0)
+                if (env is null)
                 {
                     return;
                 }
-
-                Debug.Assert(topLevelEnvs.Count == 1);
-                var env = topLevelEnvs[0];
 
                 // The environment must contain only 'this' to be inlined
                 if (env.CapturedVariables.Count > 1 ||
@@ -272,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 void RemoveEnv()
                 {
-                    topLevelEnvs.RemoveAt(topLevelEnvs.IndexOf(env));
+                    ScopeTree.DeclaredEnvironment = null;
                     VisitClosures(ScopeTree, (scope, closure) =>
                     {
                         var index = closure.CapturedEnvironments.IndexOf(env);
@@ -341,7 +330,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // Next create the environment and add it to the declaration scope
                     var env = new ClosureEnvironment(variablesInEnvironment, isStruct);
-                    scope.DeclaredEnvironments.Add(env);
+                    Debug.Assert(scope.DeclaredEnvironment is null);
+                    scope.DeclaredEnvironment = env;
 
                     _topLevelMethod.TryGetThisParameter(out var thisParam);
                     foreach (var closure in closures)
@@ -369,13 +359,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 VisitScopeTree(ScopeTree, scope =>
                 {
-                    if (scope.DeclaredEnvironments.Count > 0)
+                    if (!(scope.DeclaredEnvironment is null))
                     {
-                        // Right now we only create one environment per scope
-                        Debug.Assert(scope.DeclaredEnvironments.Count == 1);
-
                         closuresCapturingScopeVariables[scope] = PooledHashSet<Closure>.GetInstance();
-                        environmentsToScopes[scope.DeclaredEnvironments[0]] = scope;
+                        environmentsToScopes[scope.DeclaredEnvironment] = scope;
                     }
 
                     foreach (var closure in scope.Closures)
@@ -397,11 +384,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // we update closuresCapturingScopeVariables to reflect this.
                 foreach (var (scope, capturingClosures) in closuresCapturingScopeVariables)
                 {
-                    if (scope.DeclaredEnvironments.Count == 0)
+                    if (scope.DeclaredEnvironment is null)
                         continue;
 
                     var currentScope = scope;
-                    while (currentScope.DeclaredEnvironments.Count == 0 || currentScope.DeclaredEnvironments[0].CapturesParent)
+                    while (currentScope.DeclaredEnvironment is null || currentScope.DeclaredEnvironment.CapturesParent)
                     {
                         currentScope = currentScope.Parent;
 
@@ -410,8 +397,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             throw ExceptionUtilities.Unreachable;
                         }
 
-                        if (currentScope.DeclaredEnvironments.Count == 0 ||
-                            currentScope.DeclaredEnvironments[0].IsStruct)
+                        if (currentScope.DeclaredEnvironment is null ||
+                            currentScope.DeclaredEnvironment.IsStruct)
                         {
                             continue;
                         }
@@ -442,7 +429,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (closuresCapturingScope.Count == 0)
                         continue;
 
-                    var scopeEnv = scope.DeclaredEnvironments[0];
+                    var scopeEnv = scope.DeclaredEnvironment;
 
                     // structs don't allocate, so no point merging them
                     if (scopeEnv.IsStruct)
@@ -462,12 +449,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         var parentScope = currentScope.Parent;
 
-                        // Right now we only create one environment per scope
-                        Debug.Assert(parentScope.DeclaredEnvironments.Count < 2);
-
                         // we skip any scopes which do not have any captured variables, and try to merge into the parent scope instead.
                         // We also skip any struct environments as they don't allocate, so no point merging them
-                        if (parentScope.DeclaredEnvironments.Count == 0 || parentScope.DeclaredEnvironments[0].IsStruct)
+                        var env = parentScope.DeclaredEnvironment;
+                        if (env is null || env.IsStruct)
                         {
                             currentScope = parentScope;
                             continue;
@@ -492,14 +477,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // do the actual work of merging the closure environments
 
-                    var targetEnv = bestScope.DeclaredEnvironments[0];
+                    var targetEnv = bestScope.DeclaredEnvironment;
 
                     foreach (var variable in scopeEnv.CapturedVariables)
                     {
                         targetEnv.CapturedVariables.Add(variable);
                     }
 
-                    scope.DeclaredEnvironments.Clear();
+                    scope.DeclaredEnvironment = null;
 
                     foreach (var closure in closuresCapturingScope)
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -168,13 +168,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
 
                             var env = curScope.DeclaredEnvironment;
-                            if (env?.IsStruct == false)
+                            if (!(env is null))
                             {
-                                Debug.Assert(!oldEnv.IsStruct);
-                                oldEnv.CapturesParent = true;
-                                oldEnv = env;
+                                if (!env.IsStruct)
+                                {
+                                    Debug.Assert(!oldEnv.IsStruct);
+                                    oldEnv.CapturesParent = true;
+                                    oldEnv = env;
+                                }
+                                capturedEnvs.Remove(env);
                             }
-                            capturedEnvs.Remove(env);
                             curScope = curScope.Parent;
                         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -329,14 +329,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Analysis.VisitScopeTree(_analysis.ScopeTree, scope =>
             {
-                if (scope.DeclaredEnvironments.Count > 0)
+                if (scope.DeclaredEnvironment is {} env)
                 {
                     Debug.Assert(!_frames.ContainsKey(scope.BoundNode));
-                    // At the moment, all variables declared in the same
-                    // scope always get assigned to the same environment
-                    Debug.Assert(scope.DeclaredEnvironments.Count == 1);
 
-                    var env = scope.DeclaredEnvironments[0];
                     var frame = MakeFrame(scope, env);
                     env.SynthesizedEnvironment = frame;
 
@@ -1432,7 +1428,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundNode tmpScope = null;
                 Analysis.VisitScopeTree(_analysis.ScopeTree, scope =>
                 {
-                    if (scope.DeclaredEnvironments.Contains(closure.ContainingEnvironmentOpt))
+                    if (scope.DeclaredEnvironment == closure.ContainingEnvironmentOpt)
                     {
                         tmpScope = scope.BoundNode;
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Analysis.VisitScopeTree(_analysis.ScopeTree, scope =>
             {
-                if (scope.DeclaredEnvironment is {} env)
+                if (scope.DeclaredEnvironment is { } env)
                 {
                     Debug.Assert(!_frames.ContainsKey(scope.BoundNode));
 


### PR DESCRIPTION
Moves an ArrayBuilder for DeclaredEnvironments to a single environment.
This means that a scope only declares a single closure environment for its
captured variables.

I left space for us to declare multiple closure environments
in a single scope, but that seems like overengineering at the
moment and it makes a lot of code more complicated. We can
always add it back if it seems like it would be worth it