### PR TITLE
Avoid trying to simplify descendant identifier names

### DIFF
--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
@@ -41,7 +41,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         End Sub
 
         Public Overrides Sub VisitIdentifierName(node As IdentifierNameSyntax)
-            If node.IsKind(SyntaxKind.IdentifierName) AndAlso TrySimplify(node) Then
+            ' Always try to simplify identifiers with an 'Attribute' suffix.
+            '
+            ' In other cases, don't bother looking at the right side of A.B or A!B. We will process those in
+            ' one of our other top level Visit methods (Like VisitQualifiedName).
+            Dim canTrySimplify = CaseInsensitiveComparison.EndsWith(node.Identifier.ValueText, "Attribute") _
+                OrElse Not node.IsRightSideOfDotOrBang()
+
+            If canTrySimplify AndAlso TrySimplify(node) Then
                 Return
             End If
 


### PR DESCRIPTION
These identifiers are already simplified as part of nodes further up the tree.

Extracted from #40746.

Baseline numbers (49a468ca83f5d61e8bcab9341398a86ccbd71690):

```text
Found 24193 diagnostics in 102883ms (150147571248 bytes allocated)
Execution times (ms):
CSharpSimplifyTypeNamesDiagnosticAnalyzer:      2190940
  SimpleMemberAccessExpression: 1170342ms to try simplifying 1383556 instances
  IdentifierName: 605398ms to try simplifying 4466446 instances
  GenericName: 146827ms to try simplifying 92323 instances
  QualifiedName: 68286ms to try simplifying 158081 instances
  QualifiedCref: 434ms to try simplifying 1245 instances
  AliasQualifiedName: 10ms to try simplifying 30 instances
VisualBasicSimplifyTypeNamesDiagnosticAnalyzer: 1764312
  SimpleMemberAccessExpression: 1236160ms to try simplifying 632416 instances
  IdentifierName: 353337ms to try simplifying 1860769 instances
  GenericName: 64360ms to try simplifying 32776 instances
  QualifiedName: 55078ms to try simplifying 62234 instances
```

Updated numbers (49a468ca83f5d61e8bcab9341398a86ccbd71690 + this pull request):

```text
Found 24193 diagnostics in 97737ms (148431953600 bytes allocated)
Execution times (ms):
CSharpSimplifyTypeNamesDiagnosticAnalyzer:      1552142
  SimpleMemberAccessExpression: 917073ms to try simplifying 1383559 instances
  IdentifierName: 321246ms to try simplifying 2951512 instances
  GenericName: 127254ms to try simplifying 92323 instances
  QualifiedName: 60160ms to try simplifying 158084 instances
  QualifiedCref: 238ms to try simplifying 1245 instances
  AliasQualifiedName: 10ms to try simplifying 30 instances
VisualBasicSimplifyTypeNamesDiagnosticAnalyzer: 1528633
  SimpleMemberAccessExpression: 1098896ms to try simplifying 632418 instances
  IdentifierName: 272517ms to try simplifying 1197747 instances
  GenericName: 51408ms to try simplifying 32776 instances
  QualifiedName: 48384ms to try simplifying 62234 instances
```