### PR TITLE
Filter identifier name simplification according to aliases and predefined types

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
@@ -4,19 +4,51 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
 {
     internal class TypeSyntaxSimplifierWalker : CSharpSyntaxWalker
     {
+        /// <summary>
+        /// This set contains the full names of types that have equivalent predefined names in the language.
+        /// </summary>
+        private static readonly ImmutableHashSet<string> s_predefinedTypeMetadataNames =
+            ImmutableHashSet.Create(
+                StringComparer.Ordinal,
+                nameof(Boolean),
+                nameof(SByte),
+                nameof(Byte),
+                nameof(Int16),
+                nameof(UInt16),
+                nameof(Int32),
+                nameof(UInt32),
+                nameof(Int64),
+                nameof(UInt64),
+                nameof(Single),
+                nameof(Double),
+                nameof(Decimal),
+                nameof(String),
+                nameof(Char),
+                nameof(Object));
+
         private readonly CSharpSimplifyTypeNamesDiagnosticAnalyzer _analyzer;
         private readonly SemanticModel _semanticModel;
         private readonly OptionSet _optionSet;
         private readonly CancellationToken _cancellationToken;
+
+        /// <summary>
+        /// Set of type and namespace names that have an alias associated with them.  i.e. if the
+        /// user has <c>using X = System.DateTime</c>, then <c>DateTime</c> will be in this set.
+        /// This is used so we can easily tell if we should try to simplify some identifier to an
+        /// alias when we encounter it.
+        /// </summary>
+        private ImmutableHashSet<string> _aliasedNames = ImmutableHashSet.Create<string>(StringComparer.Ordinal);
 
         public List<Diagnostic> Diagnostics { get; } = new List<Diagnostic>();
 
@@ -27,6 +59,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             _semanticModel = semanticModel;
             _optionSet = optionSet;
             _cancellationToken = cancellationToken;
+        }
+
+        public override void VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            if (node.Alias is object)
+            {
+                if (node.Name.GetRightmostName() is IdentifierNameSyntax identifierName)
+                {
+                    var identifierAlias = identifierName.Identifier.ValueText;
+                    if (!RoslynString.IsNullOrEmpty(identifierAlias))
+                    {
+                        ImmutableInterlocked.Update(ref _aliasedNames, (set, alias) => set.Add(alias), identifierAlias);
+                    }
+                }
+            }
+
+            base.VisitUsingDirective(node);
         }
 
         public override void VisitQualifiedName(QualifiedNameSyntax node)
@@ -71,8 +120,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             //
             // In other cases, don't bother looking at the right side of A.B or A::B. We will process those in
             // one of our other top level Visit methods (like VisitQualifiedName).
-            var canTrySimplify = node.Identifier.ValueText!.EndsWith("Attribute", StringComparison.Ordinal)
-                || !node.IsRightSideOfDotOrArrowOrColonColon();
+            var canTrySimplify = node.Identifier.ValueText!.EndsWith("Attribute", StringComparison.Ordinal);
+            if (!canTrySimplify && !node.IsRightSideOfDotOrArrowOrColonColon())
+            {
+                // The only possible simplifications to an unqualified identifier are replacement with an alias or
+                // replacement with a predefined type.
+                canTrySimplify = CanReplaceIdentifierWithAlias(node.Identifier.ValueText!)
+                    || CanReplaceIdentifierWithPredefinedType(node.Identifier.ValueText!);
+            }
 
             if (canTrySimplify && TrySimplify(node))
             {
@@ -82,6 +137,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
 
             // descend further.
             DefaultVisit(node);
+            return;
+
+            // Local functions
+            bool CanReplaceIdentifierWithAlias(string identifier)
+                => _aliasedNames.Contains(identifier);
+
+            static bool CanReplaceIdentifierWithPredefinedType(string identifier)
+                => s_predefinedTypeMetadataNames.Contains(identifier);
         }
 
         public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -8,10 +9,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
     Friend Class TypeSyntaxSimplifierWalker
         Inherits VisualBasicSyntaxWalker
 
+        Private Shared ReadOnly s_predefinedTypeMetadataNames As ImmutableHashSet(Of String) = ImmutableHashSet.Create(
+            CaseInsensitiveComparison.Comparer,
+            NameOf([Boolean]),
+            NameOf([SByte]),
+            NameOf([Byte]),
+            NameOf(Int16),
+            NameOf(UInt16),
+            NameOf(Int32),
+            NameOf(UInt32),
+            NameOf(Int64),
+            NameOf(UInt64),
+            NameOf([Single]),
+            NameOf([Double]),
+            NameOf([Decimal]),
+            NameOf([String]),
+            NameOf([Char]),
+            NameOf(DateTime),
+            NameOf([Object]))
+
         Private ReadOnly _analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer
         Private ReadOnly _semanticModel As SemanticModel
         Private ReadOnly _optionSet As OptionSet
         Private ReadOnly _cancellationToken As CancellationToken
+
+        ''' <summary>
+        ''' Set of type and namespace names that have an alias associated with them.  i.e. if the
+        ''' user has <c>Imports X = System.DateTime</c>, then <c>DateTime</c> will be in this set.
+        ''' This is used so we can easily tell if we should try to simplify some identifier to an
+        ''' alias when we encounter it.
+        ''' </summary>
+        Private _aliasedNames As ImmutableHashSet(Of String) = ImmutableHashSet.Create(Of String)(CaseInsensitiveComparison.Comparer)
 
         Public ReadOnly Property Diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()
 
@@ -22,6 +50,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             _semanticModel = semanticModel
             _optionSet = optionSet
             _cancellationToken = cancellationToken
+
+            For Each aliasSymbol In semanticModel.Compilation.AliasImports()
+                _aliasedNames = _aliasedNames.Add(aliasSymbol.Target.Name)
+            Next
+        End Sub
+
+        Public Overrides Sub VisitSimpleImportsClause(node As SimpleImportsClauseSyntax)
+            If node.Alias IsNot Nothing Then
+                Dim identifierName = TryCast(node.Name.GetRightmostName(), IdentifierNameSyntax)
+                If identifierName IsNot Nothing Then
+                    If Not String.IsNullOrEmpty(identifierName.Identifier.ValueText) Then
+                        ImmutableInterlocked.Update(_aliasedNames, Function(names, identifier) names.Add(identifier), identifierName.Identifier.ValueText)
+                    End If
+                End If
+            End If
+
+            MyBase.VisitSimpleImportsClause(node)
         End Sub
 
         Public Overrides Sub VisitQualifiedName(node As QualifiedNameSyntax)
@@ -45,8 +90,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             '
             ' In other cases, don't bother looking at the right side of A.B or A!B. We will process those in
             ' one of our other top level Visit methods (Like VisitQualifiedName).
-            Dim canTrySimplify = CaseInsensitiveComparison.EndsWith(node.Identifier.ValueText, "Attribute") _
-                OrElse Not node.IsRightSideOfDotOrBang()
+            Dim canTrySimplify = CaseInsensitiveComparison.EndsWith(node.Identifier.ValueText, "Attribute")
+            If Not canTrySimplify AndAlso Not node.IsRightSideOfDotOrBang() Then
+                ' The only possible simplifications to an unqualified identifier are replacement with an alias or
+                ' replacement with a predefined type.
+                canTrySimplify = CanReplaceIdentifierWithAlias(node.Identifier.ValueText) _
+                    OrElse CanReplaceIdentifierWithPredefinedType(node.Identifier.ValueText)
+            End If
 
             If canTrySimplify AndAlso TrySimplify(node) Then
                 Return
@@ -54,6 +104,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 
             MyBase.VisitIdentifierName(node)
         End Sub
+
+        Private Function CanReplaceIdentifierWithAlias(identifier As String) As Boolean
+            Return _aliasedNames.Contains(identifier)
+        End Function
+
+        Private Shared Function CanReplaceIdentifierWithPredefinedType(identifier As String) As Boolean
+            Return s_predefinedTypeMetadataNames.Contains(identifier)
+        End Function
 
         Public Overrides Sub VisitGenericName(node As GenericNameSyntax)
             If node.IsKind(SyntaxKind.GenericName) AndAlso TrySimplify(node) Then

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
@@ -9,6 +9,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
     Friend Class TypeSyntaxSimplifierWalker
         Inherits VisualBasicSyntaxWalker
 
+        Private Shared ReadOnly s_emptyAliasedNames As ImmutableHashSet(Of String) = ImmutableHashSet.Create(Of String)(CaseInsensitiveComparison.Comparer)
+
         Private Shared ReadOnly s_predefinedTypeMetadataNames As ImmutableHashSet(Of String) = ImmutableHashSet.Create(
             CaseInsensitiveComparison.Comparer,
             NameOf([Boolean]),
@@ -39,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         ''' This is used so we can easily tell if we should try to simplify some identifier to an
         ''' alias when we encounter it.
         ''' </summary>
-        Private _aliasedNames As ImmutableHashSet(Of String) = ImmutableHashSet.Create(Of String)(CaseInsensitiveComparison.Comparer)
+        Private ReadOnly _aliasedNames As ImmutableHashSet(Of String)
 
         Public ReadOnly Property Diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()
 
@@ -51,22 +53,43 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             _optionSet = optionSet
             _cancellationToken = cancellationToken
 
+            Dim root = semanticModel.SyntaxTree.GetRoot(cancellationToken)
+            _aliasedNames = GetAliasedNames(TryCast(root, CompilationUnitSyntax))
+
             For Each aliasSymbol In semanticModel.Compilation.AliasImports()
                 _aliasedNames = _aliasedNames.Add(aliasSymbol.Target.Name)
             Next
         End Sub
 
-        Public Overrides Sub VisitSimpleImportsClause(node As SimpleImportsClauseSyntax)
-            If node.Alias IsNot Nothing Then
-                Dim identifierName = TryCast(node.Name.GetRightmostName(), IdentifierNameSyntax)
+        Private Shared Function GetAliasedNames(compilationUnit As CompilationUnitSyntax) As ImmutableHashSet(Of String)
+            Dim aliasedNames = s_emptyAliasedNames
+            If compilationUnit Is Nothing Then
+                Return aliasedNames
+            End If
+
+            For Each importsStatement In compilationUnit.Imports
+                For Each importsClause In importsStatement.ImportsClauses
+                    Dim simpleImportsClause = TryCast(importsClause, SimpleImportsClauseSyntax)
+                    If simpleImportsClause Is Nothing Then
+                        Continue For
+                    End If
+
+                    AddAliasedName(aliasedNames, simpleImportsClause)
+                Next
+            Next
+
+            Return aliasedNames
+        End Function
+
+        Private Shared Sub AddAliasedName(ByRef aliasedNames As ImmutableHashSet(Of String), simpleImportsClause As SimpleImportsClauseSyntax)
+            If simpleImportsClause.Alias IsNot Nothing Then
+                Dim identifierName = TryCast(simpleImportsClause.Name.GetRightmostName(), IdentifierNameSyntax)
                 If identifierName IsNot Nothing Then
                     If Not String.IsNullOrEmpty(identifierName.Identifier.ValueText) Then
-                        ImmutableInterlocked.Update(_aliasedNames, Function(names, identifier) names.Add(identifier), identifierName.Identifier.ValueText)
+                        aliasedNames = aliasedNames.Add(identifierName.Identifier.ValueText)
                     End If
                 End If
             End If
-
-            MyBase.VisitSimpleImportsClause(node)
         End Sub
 
         Public Overrides Sub VisitQualifiedName(node As QualifiedNameSyntax)


### PR DESCRIPTION
Extracted from #40746 and generalized to work with Visual Basic.

Baseline numbers (49a468ca83f5d61e8bcab9341398a86ccbd71690 + #41072):

```text
Found 24193 diagnostics in 97737ms (148431953600 bytes allocated)
Execution times (ms):
CSharpSimplifyTypeNamesDiagnosticAnalyzer:      1552142
  SimpleMemberAccessExpression: 917073ms to try simplifying 1383559 instances
  IdentifierName: 321246ms to try simplifying 2951512 instances
  GenericName: 127254ms to try simplifying 92323 instances
  QualifiedName: 60160ms to try simplifying 158084 instances
  QualifiedCref: 238ms to try simplifying 1245 instances
  AliasQualifiedName: 10ms to try simplifying 30 instances
VisualBasicSimplifyTypeNamesDiagnosticAnalyzer: 1528633
  SimpleMemberAccessExpression: 1098896ms to try simplifying 632418 instances
  IdentifierName: 272517ms to try simplifying 1197747 instances
  GenericName: 51408ms to try simplifying 32776 instances
  QualifiedName: 48384ms to try simplifying 62234 instances
```

Updated numbers (49a468ca83f5d61e8bcab9341398a86ccbd71690 + this pull request):

```text
Found 24202 diagnostics in 93467ms (141284021216 bytes allocated)
Execution times (ms):
CSharpSimplifyTypeNamesDiagnosticAnalyzer:      1601508
  SimpleMemberAccessExpression: 1237560ms to try simplifying 1383578 instances
  GenericName: 169917ms to try simplifying 92326 instances
  QualifiedName: 73563ms to try simplifying 158087 instances
  IdentifierName: 1724ms to try simplifying 10343 instances
  QualifiedCref: 340ms to try simplifying 1245 instances
  AliasQualifiedName: 10ms to try simplifying 30 instances
VisualBasicSimplifyTypeNamesDiagnosticAnalyzer: 1487597
  SimpleMemberAccessExpression: 1300676ms to try simplifying 632444 instances
  QualifiedName: 57909ms to try simplifying 62236 instances
  GenericName: 57496ms to try simplifying 32779 instances
  IdentifierName: 1739ms to try simplifying 4668 instances
```

📝 The increase in diagnostics is due to a bug in Simplify Type Names for the Visual Basic code `NameOf([Object])`. The apparent increase in analyzer execution time is noise caused by contested locks used for measuring the callbacks. The allocation numbers and end-to-end time improvements were consistent.

📝 In combination with #41072, **99.75%** of calls to `TrySimplify` were eliminated as unnecessary for `IdentifierNameSyntax`.