### PR TITLE
Enforce conditional attributes within method bodies

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -14914,6 +14914,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
+        /// </summary>
+        internal static string WRN_MethodShouldThrow {
+            get {
+                return ResourceManager.GetString("WRN_MethodShouldThrow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
+        /// </summary>
+        internal static string WRN_MethodShouldThrow_Title {
+            get {
+                return ResourceManager.GetString("WRN_MethodShouldThrow_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The annotation for nullable reference types should only be used in code within a &apos;#nullable&apos; annotations context..
         /// </summary>
         internal static string WRN_MissingNonNullTypesContextForAnnotation {
@@ -15850,6 +15868,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string WRN_ObsoleteOverridingNonObsolete_Title {
             get {
                 return ResourceManager.GetString("WRN_ObsoleteOverridingNonObsolete_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; may not have a null value when exiting with &apos;{1}&apos;..
+        /// </summary>
+        internal static string WRN_ParameterConditionallyDisallowsNull {
+            get {
+                return ResourceManager.GetString("WRN_ParameterConditionallyDisallowsNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter may not have a null value when exiting in some condition..
+        /// </summary>
+        internal static string WRN_ParameterConditionallyDisallowsNull_Title {
+            get {
+                return ResourceManager.GetString("WRN_ParameterConditionallyDisallowsNull_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -16117,7 +16117,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
+        ///   Looks up a localized string similar to A method marked [DoesNotReturn] should not return..
         /// </summary>
         internal static string WRN_ShouldNotReturn {
             get {
@@ -16126,7 +16126,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
+        ///   Looks up a localized string similar to A method marked [DoesNotReturn] should not return..
         /// </summary>
         internal static string WRN_ShouldNotReturn_Title {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -14914,24 +14914,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
-        /// </summary>
-        internal static string WRN_MethodShouldThrow {
-            get {
-                return ResourceManager.GetString("WRN_MethodShouldThrow", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
-        /// </summary>
-        internal static string WRN_MethodShouldThrow_Title {
-            get {
-                return ResourceManager.GetString("WRN_MethodShouldThrow_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The annotation for nullable reference types should only be used in code within a &apos;#nullable&apos; annotations context..
         /// </summary>
         internal static string WRN_MissingNonNullTypesContextForAnnotation {
@@ -16131,6 +16113,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string WRN_SequentialOnPartialClass_Title {
             get {
                 return ResourceManager.GetString("WRN_SequentialOnPartialClass_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
+        /// </summary>
+        internal static string WRN_ShouldNotReturn {
+            get {
+                return ResourceManager.GetString("WRN_ShouldNotReturn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method marked with [DoesNotReturn] should throw on all code paths..
+        /// </summary>
+        internal static string WRN_ShouldNotReturn_Title {
+            get {
+                return ResourceManager.GetString("WRN_ShouldNotReturn_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5454,10 +5454,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Parameter may not have a null value when exiting in some condition.</value>
   </data>
   <data name="WRN_ShouldNotReturn" xml:space="preserve">
-    <value>A method marked with [DoesNotReturn] should throw on all code paths.</value>
+    <value>A method marked [DoesNotReturn] should not return.</value>
   </data>
   <data name="WRN_ShouldNotReturn_Title" xml:space="preserve">
-    <value>A method marked with [DoesNotReturn] should throw on all code paths.</value>
+    <value>A method marked [DoesNotReturn] should not return.</value>
   </data>
   <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate" xml:space="preserve">
     <value>Nullability of reference types in return type of '{0}' doesn't match the target delegate '{1}'.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5447,6 +5447,18 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_DisallowNullAttributeForbidsMaybeNullAssignment_Title" xml:space="preserve">
     <value>A possible null value may not be used for a type marked with [NotNull] or [DisallowNull]</value>
   </data>
+  <data name="WRN_ParameterConditionallyDisallowsNull" xml:space="preserve">
+    <value>Parameter '{0}' may not have a null value when exiting with '{1}'.</value>
+  </data>
+  <data name="WRN_ParameterConditionallyDisallowsNull_Title" xml:space="preserve">
+    <value>Parameter may not have a null value when exiting in some condition.</value>
+  </data>
+  <data name="WRN_MethodShouldThrow" xml:space="preserve">
+    <value>A method marked with [DoesNotReturn] should throw on all code paths.</value>
+  </data>
+  <data name="WRN_MethodShouldThrow_Title" xml:space="preserve">
+    <value>A method marked with [DoesNotReturn] should throw on all code paths.</value>
+  </data>
   <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate" xml:space="preserve">
     <value>Nullability of reference types in return type of '{0}' doesn't match the target delegate '{1}'.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5453,10 +5453,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WRN_ParameterConditionallyDisallowsNull_Title" xml:space="preserve">
     <value>Parameter may not have a null value when exiting in some condition.</value>
   </data>
-  <data name="WRN_MethodShouldThrow" xml:space="preserve">
+  <data name="WRN_ShouldNotReturn" xml:space="preserve">
     <value>A method marked with [DoesNotReturn] should throw on all code paths.</value>
   </data>
-  <data name="WRN_MethodShouldThrow_Title" xml:space="preserve">
+  <data name="WRN_ShouldNotReturn_Title" xml:space="preserve">
     <value>A method marked with [DoesNotReturn] should throw on all code paths.</value>
   </data>
   <data name="WRN_NullabilityMismatchInReturnTypeOfTargetDelegate" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1742,7 +1742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExternEventInitializer = 8760,
         ERR_AmbigBinaryOpsOnUnconstrainedDefault = 8761,
         WRN_ParameterConditionallyDisallowsNull = 8762,
-        WRN_MethodShouldThrow = 8763,
+        WRN_ShouldNotReturn = 8763,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1741,6 +1741,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_ExternEventInitializer = 8760,
         ERR_AmbigBinaryOpsOnUnconstrainedDefault = 8761,
+        WRN_ParameterConditionallyDisallowsNull = 8762,
+        WRN_MethodShouldThrow = 8763,
 
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             builder.Add(getId(ErrorCode.WRN_ConvertingNullableToNonNullable));
             builder.Add(getId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
+            builder.Add(getId(ErrorCode.WRN_ParameterConditionallyDisallowsNull));
+            builder.Add(getId(ErrorCode.WRN_MethodShouldThrow));
 
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride));
@@ -421,7 +423,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_UndecoratedCancellationTokenParameter:
                 case ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint:
                 case ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment:
+                case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
                 case ErrorCode.WRN_NullReferenceInitializer:
+                case ErrorCode.WRN_MethodShouldThrow:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             builder.Add(getId(ErrorCode.WRN_ConvertingNullableToNonNullable));
             builder.Add(getId(ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment));
             builder.Add(getId(ErrorCode.WRN_ParameterConditionallyDisallowsNull));
-            builder.Add(getId(ErrorCode.WRN_MethodShouldThrow));
+            builder.Add(getId(ErrorCode.WRN_ShouldNotReturn));
 
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInTypeOnOverride));
             builder.Add(getId(ErrorCode.WRN_NullabilityMismatchInReturnTypeOnOverride));
@@ -425,7 +425,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_DisallowNullAttributeForbidsMaybeNullAssignment:
                 case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
                 case ErrorCode.WRN_NullReferenceInitializer:
-                case ErrorCode.WRN_MethodShouldThrow:
+                case ErrorCode.WRN_ShouldNotReturn:
                     return 1;
                 default:
                     return 0;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1479,8 +1479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 TryGetReturnType(out TypeWithAnnotations returnType, out FlowAnalysisAnnotations returnAnnotations))
             {
                 if (node.RefKind == RefKind.None &&
-                    returnType.Type.SpecialType == SpecialType.System_Boolean &&
-                    isUnconvertedBooleanExpression(expr))
+                    returnType.Type.SpecialType == SpecialType.System_Boolean)
                 {
                     // visit the expression without unsplitting, then check parameters marked with flow analysis attributes
                     Visit(expr);
@@ -1533,12 +1532,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             EnforceDoesNotReturn(node.Syntax);
             return null;
 
-            bool isUnconvertedBooleanExpression(BoundExpression expr)
-            {
-                var (expression, _) = RemoveConversion(expr, includeExplicitConversions: true);
-                return expression.Type?.SpecialType == SpecialType.System_Boolean;
-            }
-
             void checkConditionalParameterState(SyntaxNode syntax, ImmutableArray<ParameterSymbol> parameters, bool sense)
             {
                 LocalState stateWhen = sense ? StateWhenTrue : StateWhenFalse;
@@ -1548,7 +1541,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // Parameter '{name}' may not have a null value when exiting with '{sense}'.
                         ReportDiagnostic(ErrorCode.WRN_ParameterConditionallyDisallowsNull, syntax.Location, parameter.Name, sense ? "true" : "false");
-                        continue;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -226,6 +226,8 @@
                 case ErrorCode.WRN_MissingNonNullTypesContextForAnnotationInGeneratedCode:
                 case ErrorCode.WRN_NullReferenceInitializer:
                 case ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint:
+                case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
+                case ErrorCode.WRN_MethodShouldThrow:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -227,7 +227,7 @@
                 case ErrorCode.WRN_NullReferenceInitializer:
                 case ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint:
                 case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
-                case ErrorCode.WRN_MethodShouldThrow:
+                case ErrorCode.WRN_ShouldNotReturn:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1473,7 +1473,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         && attr.CommonConstructorArguments.Length == 1
                         && attr.CommonConstructorArguments[0].Kind == TypedConstantKind.Type)
                     {
-                        builderArgument = attr.CommonConstructorArguments[0].ValueInternal;
+                        builderArgument = attr.CommonConstructorArguments[0].ValueInternal!;
                         return true;
                     }
                 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">Nepoužívejte „_“ jako odkaz na typ ve výrazu is-type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Poznámka u typů odkazů s možnou hodnotou null by se měla v kódu používat jenom v kontextu poznámek #nullable.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">Nepoužívejte „_“ jako odkaz na typ ve výrazu is-type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Poznámka u typů odkazů s možnou hodnotou null by se měla v kódu používat jenom v kontextu poznámek #nullable.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Typ hodnoty, která připouští hodnotu null, nemůže být null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">Verwenden Sie "_" nicht zum Verweis auf den Typ in einem is-type-Ausdruck.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Die Anmerkung für Nullable-Verweistypen darf nur in Code innerhalb eines #nullable-Anmerkungskontexts verwendet werden.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Ein Werttyp, der NULL zulässt, kann NULL sein.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">Verwenden Sie "_" nicht zum Verweis auf den Typ in einem is-type-Ausdruck.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Die Anmerkung für Nullable-Verweistypen darf nur in Code innerhalb eines #nullable-Anmerkungskontexts verwendet werden.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1440,16 +1440,6 @@
         <target state="translated">No use "_" para hacer referencia al tipo en una expresión is-type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">La anotación para tipos de referencia que aceptan valores NULL solo debe usarse en el código dentro de un contexto de anotaciones "#nullable".</target>
@@ -1768,6 +1758,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1440,6 +1440,16 @@
         <target state="translated">No use "_" para hacer referencia al tipo en una expresión is-type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">La anotación para tipos de referencia que aceptan valores NULL solo debe usarse en el código dentro de un contexto de anotaciones "#nullable".</target>
@@ -1748,6 +1758,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Un tipo que acepta valores NULL puede ser nulo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1761,13 +1761,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">N'utilisez pas '_' pour faire référence au type dans une expression is-type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">N'utilisez pas '_' pour faire référence au type dans une expression is-type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Le type valeur Nullable peut avoir une valeur null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">Non usare '_' per fare riferimento al tipo in un'espressione is-type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">L'annotazione per i tipi riferimento nullable deve essere usata solo nel codice in un contesto di annotations '#nullable'.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Il tipo valore nullable non può essere Null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">Non usare '_' per fare riferimento al tipo in un'espressione is-type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">L'annotazione per i tipi riferimento nullable deve essere usata solo nel codice in un contesto di annotations '#nullable'.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">is 型の式の中で型を参照するために '_' を使用しないでください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">'#nullable' 注釈コンテキスト内のコードでのみ、Null 許容参照型の注釈を使用する必要があります。</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Null 許容値型は Null になる場合があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">is 型の式の中で型を参照するために '_' を使用しないでください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">'#nullable' 注釈コンテキスト内のコードでのみ、Null 許容参照型の注釈を使用する必要があります。</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">'_'을 사용하여 is-type 식의 형식을 참조하지 마세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">nullable 참조 형식에 대한 주석은 코드에서 '#nullable' 주석 컨텍스트 내에만 사용되어야 합니다.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Nullable 값 형식이 null일 수 있습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">'_'을 사용하여 is-type 식의 형식을 참조하지 마세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">nullable 참조 형식에 대한 주석은 코드에서 '#nullable' 주석 컨텍스트 내에만 사용되어야 합니다.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">Nie używaj elementu „_” w celu odwoływania się do typu w wyrażeniu „is” z typem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Adnotacja dla typów referencyjnych dopuszczających wartość null powinna być używana tylko w kodzie z kontekstem adnotacji „#nullable”.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Typ wartości dopuszczający wartość null może być równy null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">Nie używaj elementu „_” w celu odwoływania się do typu w wyrażeniu „is” z typem.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Adnotacja dla typów referencyjnych dopuszczających wartość null powinna być używana tylko w kodzie z kontekstem adnotacji „#nullable”.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">Não use '_' para referir-se ao tipo em uma expressão is-type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">A anotação para tipos de referência anuláveis deve ser usada apenas em código dentro de um contexto de anotações '#nullable'.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">Não use '_' para referir-se ao tipo em uma expressão is-type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">A anotação para tipos de referência anuláveis deve ser usada apenas em código dentro de um contexto de anotações '#nullable'.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">O tipo de valor de nulidade pode ser nulo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">Не используйте "_" для ссылки на тип в выражении is-type.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Аннотацию для ссылочных типов, допускающих значения NULL, следует использовать в коде только в контексте аннотаций "#nullable".</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Тип значения, допускающего NULL, может быть NULL.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">Не используйте "_" для ссылки на тип в выражении is-type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Аннотацию для ссылочных типов, допускающих значения NULL, следует использовать в коде только в контексте аннотаций "#nullable".</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">'_' adını bir is-type ifadesindeki türe başvurmak için kullanmayın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Boş değer atanabilir başvuru türleri için ek açıklama kodda yalnızca bir '#nullable' ek açıklama bağlamı içinde kullanılmalıdır.</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">Boş değer atanabilir değer türü null olabilir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">'_' adını bir is-type ifadesindeki türe başvurmak için kullanmayın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">Boş değer atanabilir başvuru türleri için ek açıklama kodda yalnızca bir '#nullable' ek açıklama bağlamı içinde kullanılmalıdır.</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">请勿使用 "_" 引用 is-type 表达式中的类型。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">只能在 "#nullable" 注释上下文内的代码中使用可为 null 的引用类型的注释。</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">可为 null 的值类型可为 null。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">请勿使用 "_" 引用 is-type 表达式中的类型。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">只能在 "#nullable" 注释上下文内的代码中使用可为 null 的引用类型的注释。</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1439,16 +1439,6 @@
         <target state="translated">請勿使用 '_' 參考 is-type 運算式中的類型。</target>
         <note />
       </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WRN_MethodShouldThrow_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">可為 Null 的參考型別註釋應只用於 '#nullable' 註釋內容中的程式碼。</target>
@@ -1767,6 +1757,16 @@
       <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
         <source>Parameter may not have a null value when exiting in some condition.</source>
         <target state="new">Parameter may not have a null value when exiting in some condition.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ShouldNotReturn_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1760,13 +1760,13 @@
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_ShouldNotReturn_Title">
-        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
-        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <source>A method marked [DoesNotReturn] should not return.</source>
+        <target state="new">A method marked [DoesNotReturn] should not return.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1439,6 +1439,16 @@
         <target state="translated">請勿使用 '_' 參考 is-type 運算式中的類型。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_MethodShouldThrow_Title">
+        <source>A method marked with [DoesNotReturn] should throw on all code paths.</source>
+        <target state="new">A method marked with [DoesNotReturn] should throw on all code paths.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WRN_MissingNonNullTypesContextForAnnotation">
         <source>The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.</source>
         <target state="translated">可為 Null 的參考型別註釋應只用於 '#nullable' 註釋內容中的程式碼。</target>
@@ -1747,6 +1757,16 @@
       <trans-unit id="WRN_NullableValueTypeMayBeNull_Title">
         <source>Nullable value type may be null.</source>
         <target state="translated">可為 Null 的實值型別可為 Null。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull">
+        <source>Parameter '{0}' may not have a null value when exiting with '{1}'.</source>
+        <target state="new">Parameter '{0}' may not have a null value when exiting with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WRN_ParameterConditionallyDisallowsNull_Title">
+        <source>Parameter may not have a null value when exiting in some condition.</source>
+        <target state="new">Parameter may not have a null value when exiting in some condition.</target>
         <note />
       </trans-unit>
       <trans-unit id="WRN_SwitchExpressionNotExhaustive">

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -305,6 +305,8 @@ class X
                         case ErrorCode.WRN_ImplicitCopyInReadOnlyMember:
                         case ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint:
                         case ErrorCode.WRN_NullReferenceInitializer:
+                        case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
+                        case ErrorCode.WRN_MethodShouldThrow:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -306,7 +306,7 @@ class X
                         case ErrorCode.WRN_NullabilityMismatchInTypeParameterNotNullConstraint:
                         case ErrorCode.WRN_NullReferenceInitializer:
                         case ErrorCode.WRN_ParameterConditionallyDisallowsNull:
-                        case ErrorCode.WRN_MethodShouldThrow:
+                        case ErrorCode.WRN_ShouldNotReturn:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:

--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis
 #endif
 
             Environment.FailFast(exception.ToString(), exception);
-            throw null!; // to satisfy [DoesNotReturn]
+            throw ExceptionUtilities.Unreachable; // to satisfy [DoesNotReturn]
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis
 #endif
 
             Environment.FailFast(exception.ToString(), exception);
+            throw null!; // to satisfy [DoesNotReturn]
         }
 
         /// <summary>

--- a/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/SyncNamespace/CSharpChangeNamespaceService.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeNamespace
 
             if (syntaxFacts.IsRightSideOfQualifiedName(nameRef))
             {
+                RoslynDebug.Assert(nameRef.Parent is object);
                 oldNode = nameRef.Parent;
                 var aliasQualifier = GetAliasQualifier(oldNode);
 
@@ -156,6 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeNamespace
             }
             else if (syntaxFacts.IsNameOfMemberAccessExpression(nameRef))
             {
+                RoslynDebug.Assert(nameRef.Parent is object);
                 oldNode = nameRef.Parent;
                 var aliasQualifier = GetAliasQualifier(oldNode);
 

--- a/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
+++ b/src/Features/CSharp/Portable/QuickInfo/CSharpSemanticQuickInfoProvider.cs
@@ -50,7 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp.QuickInfo
             if (token.IsKind(SyntaxKind.CloseBracketToken, SyntaxKind.OpenBracketToken) &&
                 token.Parent?.Parent.IsKind(SyntaxKind.ElementAccessExpression) == true)
             {
-                found = token.Parent.Parent;
+                // Suppression is due to issue https://github.com/dotnet/roslyn/issues/41107
+                found = token.Parent.Parent!;
                 return true;
             }
 

--- a/src/Features/CSharp/Portable/ReverseForStatement/CSharpReverseForStatementCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReverseForStatement/CSharpReverseForStatementCodeRefactoringProvider.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReverseForStatement
                    IsDecrementAfter(variable, after);
         }
 
-        private bool IsIncrementInitializer(VariableDeclaratorSyntax variable, out ExpressionSyntax? start)
+        private bool IsIncrementInitializer(VariableDeclaratorSyntax variable, [NotNullWhen(true)] out ExpressionSyntax? start)
         {
             start = variable.Initializer?.Value;
             return start != null;
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReverseForStatement
 
         private bool IsIncrementCondition(
             VariableDeclaratorSyntax variable, BinaryExpressionSyntax condition,
-            out bool equals, out ExpressionSyntax? end)
+            out bool equals, [NotNullWhen(true)] out ExpressionSyntax? end)
         {
             // i < ...   i <= ...
             if (condition.Kind() == SyntaxKind.LessThanExpression ||
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ReverseForStatement
 
         private bool IsDecrementCondition(
             VariableDeclaratorSyntax variable, BinaryExpressionSyntax condition,
-            out ExpressionSyntax? start)
+            [NotNullWhen(true)] out ExpressionSyntax? start)
         {
             // i >= ...
             if (condition.Kind() == SyntaxKind.GreaterThanOrEqualExpression)


### PR DESCRIPTION
Fixes the second part of https://github.com/dotnet/roslyn/issues/36039 (enforcing nullability attributes in method bodies) by handling conditional attributes.

My previous PR (https://github.com/dotnet/roslyn/pull/40789) handled unconditional attributes and implemented a simple behavior for conditional attributes (ie. treat them unconditionally and leniently).

Note: the `DoesNotReturnIf` attribute won't have any enforcement. I don't think we can do that type of analysis.