### PR TITLE
Stop emitting initobj without address for default expression temp ref local

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2005,7 +2005,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             if (TryEmitAssignmentInPlace(assignmentOperator, useKind != UseKind.Unused))
             {
-                Debug.Assert(!assignmentOperator.IsRef);
                 return;
             }
 
@@ -2072,6 +2071,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         //    i.e. target must not be on the heap and we should not be in a try block.
         private bool TryEmitAssignmentInPlace(BoundAssignmentOperator assignmentOperator, bool used)
         {
+            // If the left hand is itself a ref, then we can't use in-place assignment
+            // because we need to spill the creation. This code can't be written in C#, but
+            // can be produced by lowering.
+            if (assignmentOperator.IsRef)
+            {
+                return false;
+            }
+
             var left = assignmentOperator.Left;
 
             // if result is used, and lives on heap, we must keep RHS value on the stack.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -1698,6 +1698,42 @@ class C
 }");
         }
 
+        [Fact, WorkItem(40776, "https://github.com/dotnet/roslyn/issues/40776")]
+        public void FakeIndexIndexerOnStructConstructor()
+        {
+            var comp = CreateCompilationWithIndexAndRangeAndSpan(@"
+using System;
+
+class C
+{
+    static byte Repro() => new Span<byte>(new byte[] { })[^1];
+}");
+
+            var verifier = CompileAndVerify(comp);
+
+            verifier.VerifyIL("C.Repro", @"
+ {
+    // Code size       31 (0x1f)
+    .maxstack  3
+    .locals init (int V_0,
+                  System.Span<byte> V_1)
+    IL_0000:  ldc.i4.0
+    IL_0001:  newarr     ""byte""
+    IL_0006:  newobj     ""System.Span<byte>..ctor(byte[])""
+    IL_000b:  stloc.1
+    IL_000c:  ldloca.s   V_1
+    IL_000e:  dup
+    IL_000f:  call       ""int System.Span<byte>.Length.get""
+    IL_0014:  ldc.i4.1
+    IL_0015:  sub
+    IL_0016:  stloc.0
+    IL_0017:  ldloc.0
+    IL_0018:  call       ""ref byte System.Span<byte>.this[int].get""
+    IL_001d:  ldind.u1
+    IL_001e:  ret
+}");
+        }
+
         [Fact]
         public void FakeRangeIndexerStringOpenEnd()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -1658,6 +1658,46 @@ class C
 }");
         }
 
+        [Fact, WorkItem(40776, "https://github.com/dotnet/roslyn/issues/40776")]
+        public void FakeIndexIndexerOnDefaultStruct()
+        {
+            var verifier = CompileAndVerifyWithIndexAndRange(@"
+using System;
+
+struct NotASpan
+{
+    public int Length => 1;
+
+    public int this[int index] => 0;
+}
+
+class C
+{
+    static int Repro() => default(NotASpan)[^0];
+
+    static void Main() => Repro();
+}");
+
+            verifier.VerifyIL("C.Repro", @"
+{
+    // Code size       25 (0x19)
+    .maxstack  3
+    .locals init (int V_0,
+                  NotASpan V_1)
+    IL_0000:  ldloca.s   V_1
+    IL_0002:  dup
+    IL_0003:  initobj    ""NotASpan""
+    IL_0009:  dup
+    IL_000a:  call       ""int NotASpan.Length.get""
+    IL_000f:  ldc.i4.0
+    IL_0010:  sub
+    IL_0011:  stloc.0
+    IL_0012:  ldloc.0
+    IL_0013:  call       ""int NotASpan.this[int].get""
+    IL_0018:  ret
+}");
+        }
+
         [Fact]
         public void FakeRangeIndexerStringOpenEnd()
         {


### PR DESCRIPTION
Fixes #40776

⚠ Other options, since I don't know anything about this:

- Only check IsRef inside TryEmitAssignmentInPlace inside `if (right.IsDefaultValue())`

- Change https://github.com/dotnet/roslyn/pull/35004/files#diff-74a82622051b7b258352d8b4f8a95630R214