### PR TITLE
Reduce amount of allocations related to tracking used assemblies:

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             private readonly RangeVariableMap _rangeVariableMap;
 
             public QueryUnboundLambdaState(Binder binder, RangeVariableMap rangeVariableMap, ImmutableArray<RangeVariableSymbol> parameters, LambdaBodyFactory bodyFactory)
-                : base(binder, unboundLambdaOpt: null)
+                : base(binder)
             {
                 _parameters = parameters;
                 _rangeVariableMap = rangeVariableMap;

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (expr.Kind == BoundKind.MethodGroup && valueKind != BindValueKind.RValueOrMethodGroup)
             {
                 var methodGroup = (BoundMethodGroup)expr;
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, isMethodGroupConversion: false, useSiteInfo: ref useSiteInfo);
                 diagnostics.Add(expr.Syntax, useSiteInfo);
                 Symbol otherSymbol = null;
@@ -270,6 +270,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 LookupResultKind.NotAVariable;
 
             return ToBadExpression(expr, resultKind);
+        }
+
+        public CompoundUseSiteInfo<AssemblySymbol> GetNewCompoundUseSiteInfo(BindingDiagnosticBag futureDestination)
+        {
+            return new CompoundUseSiteInfo<AssemblySymbol>(futureDestination, Compilation.Assembly);
         }
 
         internal static bool IsTypeOrValueExpression(BoundExpression expression)
@@ -981,7 +986,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var accessThroughType = this.GetAccessThroughType(receiver);
                     bool failedThroughTypeCheck;
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     bool isAccessible = this.IsAccessible(setMethod, accessThroughType, out failedThroughTypeCheck, ref useSiteInfo);
                     diagnostics.Add(node, useSiteInfo);
 
@@ -1030,7 +1035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var accessThroughType = this.GetAccessThroughType(receiver);
                     bool failedThroughTypeCheck;
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     bool isAccessible = this.IsAccessible(getMethod, accessThroughType, out failedThroughTypeCheck, ref useSiteInfo);
                     diagnostics.Add(node, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.WithQueryLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.WithQueryLambdaParametersBinder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 LookupResult lookupResult = LookupResult.GetInstance();
                 LookupOptions options = LookupOptions.MustBeInstance;
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 LookupMembersWithFallback(lookupResult, receiver.Type, name, 0, ref useSiteInfo, basesBeingResolved: null, options: options);
                 diagnostics.Add(node, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // its value depends on the values of conditional symbols, which in turn depends on the source file where the attribute is applied.
 
                     Debug.Assert(!attribute.HasErrors);
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
                     bool isConditionallyOmitted = binder.IsAttributeConditionallyOmitted(attribute.AttributeClass, attributeSyntax.SyntaxTree, ref useSiteInfo);
                     diagnostics.Add(attributeSyntax, useSiteInfo);
                     attributesBuilder[i] = attribute.WithOmittedCondition(isConditionallyOmitted);
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder attributeArgumentBinder = this.WithAdditionalFlags(BinderFlags.AttributeArgument);
             AnalyzedAttributeArguments analyzedArguments = attributeArgumentBinder.BindAttributeArguments(argumentListOpt, attributeTypeForBinding, diagnostics);
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             ImmutableArray<int> argsToParamsOpt = default;
             bool expanded = false;
             MethodSymbol attributeConstructor = null;
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     constructorArgsArray, boundAttribute.ConstructorArgumentNamesOpt, (AttributeSyntax)boundAttribute.Syntax, diagnostics, ref hasErrors);
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             bool isConditionallyOmitted = IsAttributeConditionallyOmitted(attributeType, boundAttribute.SyntaxTree, ref useSiteInfo);
             diagnostics.Add(boundAttribute.Syntax, useSiteInfo);
 
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var identifierName = namedArgument.NameEquals.Name;
             var name = identifierName.Identifier.ValueText;
             LookupResult result = LookupResult.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupMembersWithFallback(result, attributeType, name, 0, ref useSiteInfo);
             diagnostics.Add(identifierName, useSiteInfo);
             Symbol resultSymbol = this.ResultSymbol(result, name, 0, identifierName, diagnostics, false, out wasError, qualifierOpt: null);
@@ -762,7 +762,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int line = syntax.SyntaxTree.GetDisplayLineNumber(syntax.Name.Span);
                 kind = TypedConstantKind.Primitive;
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 var conversion = Conversions.GetCallerLineNumberConversion(parameterType, ref useSiteInfo);
                 diagnostics.Add(syntax, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private bool AwaiterImplementsINotifyCompletion(TypeSymbol awaiterType, SyntaxNode node, BindingDiagnosticBag diagnostics)
         {
             var INotifyCompletion = GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_INotifyCompletion, diagnostics, node);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
 
             var conversion = this.Conversions.ClassifyImplicitConversionFromType(awaiterType, INotifyCompletion, ref useSiteInfo);
             if (!conversion.IsImplicit)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeWithAnnotations constraintType,
             BindingDiagnosticBag diagnostics)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, containingSymbol.ContainingAssembly);
             if (!containingSymbol.IsNoMoreVisibleThan(constraintType, ref useSiteInfo))
             {
                 // "Inconsistent accessibility: constraint type '{1}' is less accessible than '{0}'"

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol destination,
             BindingDiagnosticBag diagnostics)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             var conversion = Conversions.ClassifyConversionFromExpression(source, destination, ref useSiteInfo);
 
             diagnostics.Add(source.Syntax, useSiteInfo);
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics: diagnostics);
 
             TypeSymbol conversionParameterType = conversion.BestUserDefinedConversionAnalysis.Operator.GetParameterType(0);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
 
             if (conversion.BestUserDefinedConversionAnalysis.Kind == UserDefinedConversionAnalysisKind.ApplicableInNormalForm &&
                 !TypeSymbol.Equals(conversion.BestUserDefinedConversionAnalysis.FromType, conversionParameterType, TypeCompareKind.ConsiderEverything2))
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var containingType = this.ContainingType;
             if ((object)containingType != null)
             {
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 bool isAccessible = this.IsSymbolAccessibleConditional(memberSymbol.GetTypeOrReturnType().Type, containingType, ref useSiteInfo);
                 diagnostics.Add(node, useSiteInfo);
 
@@ -816,14 +816,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
 
             // If this is an extension method delegate, the caller should have verified the
             // receiver is compatible with the "this" parameter of the extension method.
             Debug.Assert(!isExtensionMethod ||
                 (Conversions.ConvertExtensionMethodThisArg(methodParameters[0].Type, receiverOpt.Type, ref useSiteInfo).Exists && useSiteInfo.Diagnostics.IsNullOrEmpty()));
 
-            useSiteInfo = default;
+            useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(useSiteInfo);
 
             for (int i = 0; i < numParams; i++)
             {
@@ -940,7 +940,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             conversion = Conversions.GetMethodGroupConversion(boundMethodGroup, delegateType, ref useSiteInfo);
             diagnostics.Add(delegateMismatchLocation, useSiteInfo);
             if (!conversion.Exists)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -308,7 +308,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         private ImmutableArray<Symbol> ComputeSortedCrefMembers(CSharpSyntaxNode syntax, NamespaceOrTypeSymbol containerOpt, string memberName, int arity, bool hasParameterList, BindingDiagnosticBag diagnostics)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             var result = ComputeSortedCrefMembers(containerOpt, memberName, arity, hasParameterList, ref useSiteInfo);
             diagnostics.Add(syntax, useSiteInfo);
             return result;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -308,7 +308,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     var single = variable.Single;
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     nestedConversion = this.Conversions.ClassifyConversionFromType(tupleOrDeconstructedTypes[i], single.Type, ref useSiteInfo);
                     diagnostics.Add(single.Syntax, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors = argument.HasAnyErrors;
 
             TypeSymbol typedReferenceType = this.Compilation.GetSpecialType(SpecialType.System_TypedReference);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = this.Conversions.ClassifyConversionFromExpression(argument, typedReferenceType, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
             if (!conversion.IsImplicit || !conversion.IsValid)
@@ -1094,7 +1094,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol typedReferenceType = this.Compilation.GetSpecialType(SpecialType.System_TypedReference);
             TypeSymbol typeType = this.GetWellKnownType(WellKnownType.System_Type, diagnostics, node);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = this.Conversions.ClassifyConversionFromExpression(argument, typedReferenceType, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
             if (!conversion.IsImplicit || !conversion.IsValid)
@@ -1330,7 +1330,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var name = node.Identifier.ValueText;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupSymbolsWithFallback(lookupResult, name, arity: arity, useSiteInfo: ref useSiteInfo, options: options);
             diagnostics.Add(node, useSiteInfo);
 
@@ -1612,7 +1612,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             //
                             FieldSymbol possibleField = null;
                             var lookupResult = LookupResult.GetInstance();
-                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                             this.LookupMembersInType(
                                 lookupResult,
                                 ContainingType,
@@ -1753,9 +1753,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var currentType = this.ContainingType;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
             NamedTypeSymbol declaringType = member.ContainingType;
-            if (currentType.IsEqualToOrDerivedFrom(declaringType, TypeCompareKind.ConsiderEverything, useSiteInfo: ref useSiteInfo) ||
+            if (currentType.IsEqualToOrDerivedFrom(declaringType, TypeCompareKind.ConsiderEverything, useSiteInfo: ref discardedUseSiteInfo) ||
                 (currentType.IsInterface && (declaringType.IsObjectType() || currentType.AllInterfacesNoUseSiteDiagnostics.Contains(declaringType))))
             {
                 bool hasErrors = false;
@@ -1889,7 +1889,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var result = LookupResult.GetInstance();
             string labelName = name.Identifier.ValueText;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupSymbolsWithFallback(result, labelName, arity: 0, useSiteInfo: ref useSiteInfo, options: LookupOptions.LabelsOnly);
             diagnostics.Add(node, useSiteInfo);
 
@@ -2057,7 +2057,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 indexType = nullableType.Construct(indexType);
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = this.Conversions.ClassifyImplicitConversionFromExpression(boundOperand, intType, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 
@@ -2163,7 +2163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 indexType = nullableType.Construct(indexType);
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = this.Conversions.ClassifyImplicitConversionFromExpression(boundOperand, indexType, ref useSiteInfo);
             diagnostics.Add(operand, useSiteInfo);
 
@@ -2178,7 +2178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression BindCastCore(ExpressionSyntax node, BoundExpression operand, TypeWithAnnotations targetTypeWithAnnotations, bool wasCompilerGenerated, BindingDiagnosticBag diagnostics)
         {
             TypeSymbol targetType = targetTypeWithAnnotations.Type;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = this.Conversions.ClassifyConversionFromExpression(operand, targetType, ref useSiteInfo, forCast: true);
             diagnostics.Add(node, useSiteInfo);
 
@@ -3033,7 +3033,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ImmutableArray<BoundExpression> boundInitializerExpressions = BindArrayInitializerExpressions(initializer, diagnostics, dimension: 1, rank: rank);
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 
@@ -3060,7 +3060,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             InitializerExpressionSyntax initializer = node.Initializer;
             ImmutableArray<BoundExpression> boundInitializerExpressions = BindArrayInitializerExpressions(initializer, diagnostics, dimension: 1, rank: 1);
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             TypeSymbol bestType = BestTypeInferrer.InferBestType(boundInitializerExpressions, this.Conversions, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 
@@ -4002,7 +4002,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // We should try to bind it anyway in order for intellisense to work.
 
                     UnboundLambda unboundLambda = (UnboundLambda)argument;
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     var conversion = this.Conversions.ClassifyConversionFromExpression(unboundLambda, type, ref useSiteInfo);
                     diagnostics.Add(node, useSiteInfo);
                     // Attempting to make the conversion caches the diagnostics and the bound state inside
@@ -4067,7 +4067,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         methodGroup.PopulateWithSingleMethod(argument, sourceDelegate.DelegateInvokeMethod);
-                        CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                        CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                         Conversion conv = Conversions.MethodGroupConversion(argument.Syntax, methodGroup, type, ref useSiteInfo);
                         diagnostics.Add(node, useSiteInfo);
                         if (!conv.Exists)
@@ -4640,7 +4640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // NOTE:    its implemented interfaces. However the native compiler checks to see if there is conversion from initializer
                 // NOTE:    type to the predefined System.Collections.IEnumerable type, so we do the same.
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 var result = Conversions.ClassifyImplicitConversionFromType(initializerType, collectionsIEnumerableType, ref useSiteInfo).IsValid;
                 diagnostics.Add(node, useSiteInfo);
                 return result;
@@ -4912,7 +4912,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors = true;
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             BoundObjectInitializerExpressionBase boundInitializerOpt = null;
 
             // If we have a dynamic argument then do overload resolution to see if there are one or more
@@ -4925,7 +4925,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 OverloadResolutionResult<MethodSymbol> overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
                 this.OverloadResolution.ObjectCreationOverloadResolution(GetAccessibleConstructorsForOverloadResolution(type, ref useSiteInfo), analyzedArguments, overloadResolutionResult, ref useSiteInfo);
                 diagnostics.Add(node, useSiteInfo);
-                useSiteInfo = default;
+                useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(useSiteInfo);
 
                 if (overloadResolutionResult.HasAnyApplicableMember)
                 {
@@ -5148,7 +5148,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var classCreation = BindClassCreationExpression(node, coClassType, coClassType.Name, diagnostics, interfaceType);
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 Conversion conversion = this.Conversions.ClassifyConversionFromExpression(classCreation, interfaceType, ref useSiteInfo, forCast: true);
                 diagnostics.Add(node, useSiteInfo);
                 if (!conversion.IsValid)
@@ -5295,7 +5295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Get accessible constructors for performing overload resolution.
             ImmutableArray<MethodSymbol> allInstanceConstructors;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             candidateConstructors = GetAccessibleConstructorsForOverloadResolution(typeContainingConstructors, allowProtectedConstructorsOfBaseType, out allInstanceConstructors, ref useSiteInfo);
 
             OverloadResolutionResult<MethodSymbol> result = OverloadResolutionResult<MethodSymbol>.GetInstance();
@@ -5340,7 +5340,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             diagnostics.Add(errorLocation, useSiteInfo);
-            useSiteInfo = default;
 
             if (succeededIgnoringAccessibility)
             {
@@ -5565,7 +5564,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (left.Kind() == SyntaxKind.IdentifierName)
             {
                 var node = (IdentifierNameSyntax)left;
-                var valueDiagnostics = new BindingDiagnosticBag();
+                var valueDiagnostics = BindingDiagnosticBag.Create(diagnostics);
                 var boundValue = BindIdentifier(node, invoked: false, indexed: false, diagnostics: valueDiagnostics);
 
                 Symbol leftSymbol;
@@ -5595,7 +5594,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var leftName = node.Identifier.ValueText;
                             if (leftType.Name == leftName || IsUsingAliasInScope(leftName))
                             {
-                                var typeDiagnostics = new BindingDiagnosticBag();
+                                var typeDiagnostics = BindingDiagnosticBag.Create(diagnostics);
                                 var boundType = BindNamespaceOrType(node, typeDiagnostics);
                                 if (TypeSymbol.Equals(boundType.Type, leftType, TypeCompareKind.ConsiderEverything2))
                                 {
@@ -5787,7 +5786,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // then the result is that namespace.
 
                             var ns = ((BoundNamespaceExpression)boundLeft).NamespaceSymbol;
-                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                             this.LookupMembersWithFallback(lookupResult, ns, rightName, rightArity, ref useSiteInfo, options: options);
                             diagnostics.Add(right, useSiteInfo);
 
@@ -5855,7 +5854,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
-                                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                                 this.LookupMembersWithFallback(lookupResult, leftType, rightName, rightArity, ref useSiteInfo, basesBeingResolved: null, options: options);
                                 diagnostics.Add(right, useSiteInfo);
                                 if (lookupResult.IsMultiViable)
@@ -5927,7 +5926,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.MethodGroup:
                     {
                         var methodGroup = (BoundMethodGroup)expr;
-                        CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                        CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                         var resolution = this.ResolveMethodGroup(methodGroup, analyzedArguments: null, isMethodGroupConversion: false, useSiteInfo: ref useSiteInfo);
                         diagnostics.Add(expr.Syntax, useSiteInfo);
                         if (!expr.HasAnyErrors)
@@ -5989,7 +5988,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     options |= LookupOptions.UseBaseReferenceAccessibility;
                 }
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 this.LookupMembersWithFallback(lookupResult, leftType, rightName, rightArity, ref useSiteInfo, basesBeingResolved: null, options: options);
                 diagnostics.Add(right, useSiteInfo);
 
@@ -6360,7 +6359,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeWithAnnotations> typeArgumentsWithAnnotations,
             bool isMethodGroupConversion,
             RefKind returnRefKind,
-            TypeSymbol returnType)
+            TypeSymbol returnType,
+            bool withDependencies)
         {
             var firstResult = new MethodGroupResolution();
             AnalyzedArguments actualArguments = null;
@@ -6368,7 +6368,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var scope in new ExtensionMethodScopes(this))
             {
                 var methodGroup = MethodGroup.GetInstance();
-                var diagnostics = BindingDiagnosticBag.GetInstance();
+                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies);
 
                 this.PopulateExtensionMethodsFromSingleBinder(scope, methodGroup, expression, left, methodName, typeArgumentsWithAnnotations, diagnostics);
 
@@ -6409,7 +6409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
                 bool allowRefOmittedArguments = methodGroup.Receiver.IsExpressionOfComImportType();
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 OverloadResolution.MethodInvocationOverloadResolution(
                     methods: methodGroup.Methods,
                     typeArguments: methodGroup.TypeArguments,
@@ -6479,7 +6479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var lookupResult = LookupResult.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupExtensionMethodsInSingleBinder(scope, lookupResult, rightName, arity, options, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 
@@ -6693,7 +6693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             LookupResultKind lookupResult,
             bool hasErrors)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             bool isUsableAsField = eventSymbol.HasAssociatedField && this.IsAccessible(eventSymbol.AssociatedField, ref useSiteInfo, (receiver != null) ? receiver.Type : null);
             diagnostics.Add(node, useSiteInfo);
 
@@ -7111,7 +7111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Give the error that would be given upon conversion to int32.
                 NamedTypeSymbol int32 = GetSpecialType(SpecialType.System_Int32, diagnostics, node);
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 Conversion failedConversion = this.Conversions.ClassifyConversionFromExpression(index, int32, ref useSiteInfo);
                 diagnostics.Add(node, useSiteInfo);
                 GenerateImplicitConversionError(diagnostics, node, failedConversion, index, int32);
@@ -7125,7 +7125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression TryImplicitConversionToArrayIndex(BoundExpression expr, WellKnownType wellKnownType, SyntaxNode node, BindingDiagnosticBag diagnostics)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             TypeSymbol type = GetWellKnownType(wellKnownType, ref useSiteInfo);
 
             if (type.IsErrorType())
@@ -7133,7 +7133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            var attemptDiagnostics = BindingDiagnosticBag.GetInstance();
+            var attemptDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
             var result = TryImplicitConversionToArrayIndex(expr, type, node, attemptDiagnostics);
             if (result is object)
             {
@@ -7146,7 +7146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression TryImplicitConversionToArrayIndex(BoundExpression expr, SpecialType specialType, SyntaxNode node, BindingDiagnosticBag diagnostics)
         {
-            var attemptDiagnostics = BindingDiagnosticBag.GetInstance();
+            var attemptDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
 
             TypeSymbol type = GetSpecialType(specialType, attemptDiagnostics, node);
 
@@ -7166,7 +7166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(expr != null);
             Debug.Assert((object)targetType != null);
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = this.Conversions.ClassifyImplicitConversionFromExpression(expr, targetType, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
             if (!conversion.Exists)
@@ -7255,7 +7255,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             LookupResult lookupResult = LookupResult.GetInstance();
             LookupOptions lookupOptions = expr.Kind == BoundKind.BaseReference ? LookupOptions.UseBaseReferenceAccessibility : LookupOptions.Default;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupMembersWithFallback(lookupResult, expr.Type, WellKnownMemberNames.Indexer, arity: 0, useSiteInfo: ref useSiteInfo, options: lookupOptions);
             diagnostics.Add(node, useSiteInfo);
 
@@ -7411,7 +7411,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             OverloadResolutionResult<PropertySymbol> overloadResolutionResult = OverloadResolutionResult<PropertySymbol>.GetInstance();
             bool allowRefOmittedArguments = receiverOpt.IsExpressionOfComImportType();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.OverloadResolution.PropertyOverloadResolution(propertyGroup, receiverOpt, analyzedArguments, overloadResolutionResult, allowRefOmittedArguments, ref useSiteInfo);
             diagnostics.Add(syntax, useSiteInfo);
             BoundExpression propertyAccess;
@@ -7583,7 +7583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             PropertySymbol lengthOrCountProperty;
 
             var lookupResult = LookupResult.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
 
             // Look for Length first
 
@@ -7608,7 +7608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     LookupOptions.Default,
                     originalBinder: this,
                     diagnose: false,
-                    ref useSiteInfo);
+                    ref discardedUseSiteInfo);
 
                 if (lookupResult.IsMultiViable)
                 {
@@ -7616,7 +7616,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (!candidate.IsStatic &&
                             candidate is PropertySymbol property &&
-                            IsAccessible(property, ref useSiteInfo) &&
+                            IsAccessible(property, ref discardedUseSiteInfo) &&
                             property.OriginalDefinition is { ParameterCount: 1 } original &&
                             isIntNotByRef(original.Parameters[0]))
                         {
@@ -7666,14 +7666,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     LookupOptions.Default,
                     originalBinder: this,
                     diagnose: false,
-                    ref useSiteInfo);
+                    ref discardedUseSiteInfo);
 
                 if (lookupResult.IsMultiViable)
                 {
                     foreach (var candidate in lookupResult.Symbols)
                     {
                         if (!candidate.IsStatic &&
-                            IsAccessible(candidate, ref useSiteInfo) &&
+                            IsAccessible(candidate, ref discardedUseSiteInfo) &&
                             candidate is MethodSymbol method &&
                             method.OriginalDefinition is var original &&
                             original.ParameterCount == 2 &&
@@ -7697,7 +7697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            cleanup(lookupResult, ref useSiteInfo);
+            cleanup(lookupResult);
             if (patternIndexerAccess is null)
             {
                 return false;
@@ -7707,10 +7707,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             checkWellKnown(WellKnownMember.System_Index__GetOffset);
             return true;
 
-            static void cleanup(LookupResult lookupResult, ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
+            static void cleanup(LookupResult lookupResult)
             {
                 lookupResult.Free();
-                useSiteInfo = default;
             }
 
             static bool isIntNotByRef(ParameterSymbol param)
@@ -7736,7 +7735,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     LookupOptions.Default,
                     originalBinder: this,
                     diagnose: false,
-                    useSiteInfo: ref useSiteInfo);
+                    useSiteInfo: ref discardedUseSiteInfo);
 
                 if (lookupResult.IsSingleViable &&
                     lookupResult.Symbols[0] is PropertySymbol property &&
@@ -7744,15 +7743,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     getMethod.ReturnType.SpecialType == SpecialType.System_Int32 &&
                     getMethod.RefKind == RefKind.None &&
                     !getMethod.IsStatic &&
-                    IsAccessible(getMethod, ref useSiteInfo))
+                    IsAccessible(getMethod, ref discardedUseSiteInfo))
                 {
                     lookupResult.Clear();
-                    useSiteInfo = default;
                     valid = property;
                     return true;
                 }
                 lookupResult.Clear();
-                useSiteInfo = default;
                 valid = null;
                 return false;
             }
@@ -7815,7 +7812,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(node.LookupError == null);
 
-                var diagnostics = BindingDiagnosticBag.GetInstance();
+                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, useSiteInfo.AccumulatesDependencies);
                 diagnostics.AddRange(methodResolution.Diagnostics); // Could still have use site warnings.
                 BindMemberAccessReportError(node, diagnostics);
 
@@ -7851,7 +7848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var extensionMethodResolution = BindExtensionMethod(
                 expression, methodName, analyzedArguments, methodGroup.ReceiverOpt, methodGroup.TypeArgumentsOpt, isMethodGroupConversion,
-                returnRefKind: returnRefKind, returnType: returnType);
+                returnRefKind: returnRefKind, returnType: returnType, withDependencies: useSiteInfo.AccumulatesDependencies);
             bool preferExtensionMethodResolution = false;
 
             if (extensionMethodResolution.HasAnyApplicableMethod)
@@ -7920,7 +7917,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var sealedDiagnostics = ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
             if (node.LookupError != null)
             {
-                var diagnostics = BindingDiagnosticBag.GetInstance();
+                var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
                 Error(diagnostics, node.LookupError, node.NameSyntax);
                 sealedDiagnostics = diagnostics.ToReadOnlyAndFree();
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics,
             ref ProcessedFieldInitializers processedInitializers)
         {
-            var diagsForInstanceInitializers = BindingDiagnosticBag.GetInstance();
+            var diagsForInstanceInitializers = BindingDiagnosticBag.GetInstance(withDiagnostics: true, diagnostics.AccumulatesDependencies);
             ImportChain firstImportChain;
             processedInitializers.BoundInitializers = BindFieldInitializers(compilation, scriptInitializerOpt, fieldInitializers, diagsForInstanceInitializers, out firstImportChain);
             processedInitializers.HasErrors = diagsForInstanceInitializers.HasAnyErrors();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var methodGroup = MethodGroup.GetInstance();
             methodGroup.PopulateWithSingleMethod(boundExpression, delegateType.DelegateInvokeMethod);
             var overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             OverloadResolution.MethodInvocationOverloadResolution(
                 methods: methodGroup.Methods,
                 typeArguments: methodGroup.TypeArguments,
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool anyApplicableCandidates)
         {
             BoundExpression result;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             var resolution = this.ResolveMethodGroup(
                 methodGroup, expression, methodName, analyzedArguments, isMethodGroupConversion: false,
                 useSiteInfo: ref useSiteInfo, allowUnexpandedForm: allowUnexpandedForm);
@@ -793,7 +793,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var finalCandidates = ArrayBuilder<TMethodOrPropertySymbol>.GetInstance();
             BindingDiagnosticBag firstFailed = null;
-            var candidateDiagnostics = BindingDiagnosticBag.GetInstance();
+            var candidateDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
 
             for (int i = 0, n = overloadResolutionResult.ResultsBuilder.Count; i < n; i++)
             {
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (firstFailed == null)
                     {
                         firstFailed = candidateDiagnostics;
-                        candidateDiagnostics = BindingDiagnosticBag.GetInstance();
+                        candidateDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
                     }
                     else
                     {
@@ -1557,7 +1557,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void EnsureNameofExpressionSymbols(BoundMethodGroup methodGroup, BindingDiagnosticBag diagnostics)
         {
             // Check that the method group contains something applicable. Otherwise error.
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             var resolution = ResolveMethodGroup(methodGroup, analyzedArguments: null, isMethodGroupConversion: false, useSiteInfo: ref useSiteInfo);
             diagnostics.Add(methodGroup.Syntax, useSiteInfo);
             diagnostics.AddRange(resolution.Diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             namesBuilder.Free();
 
-            return new UnboundLambda(syntax, this, refKinds, types, names, discardsOpt, isAsync);
+            return new UnboundLambda(syntax, this, diagnostics.AccumulatesDependencies, refKinds, types, names, discardsOpt, isAsync);
 
             static ImmutableArray<bool> computeDiscards(SeparatedSyntaxList<ParameterSyntax> parameters, int underscoresCount)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // If the expression does not have a constant value, an error will be reported in the caller
                 if (!hasErrors && expression.ConstantValue is object)
                 {
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     if (expression.ConstantValue == ConstantValue.Null)
                     {
                         if (inputType.IsNonNullableValueType())
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 bool? matchPossible = ExpressionOfTypeMatchesPatternType(
                     Conversions, inputType, patternType, ref useSiteInfo, out Conversion conversion, operandConstantValue: null, operandCouldBeNull: true);
                 diagnostics.Add(typeSyntax, useSiteInfo);
@@ -540,7 +540,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // It is not a tuple type. Seek an appropriate Deconstruct method.
                     var inputPlaceholder = new BoundImplicitReceiver(positionalClause, declType); // A fake receiver expression to permit us to reuse binding logic
-                    var deconstructDiagnostics = BindingDiagnosticBag.GetInstance();
+                    var deconstructDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
                     BoundExpression deconstruct = MakeDeconstructInvocationExpression(
                         positionalClause.Subpatterns.Count, inputPlaceholder, positionalClause,
                         deconstructDiagnostics, outPlaceholders: out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders,
@@ -798,7 +798,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool hasBaseInterface(TypeSymbol type, NamedTypeSymbol possibleBaseInterface)
             {
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 var result = Compilation.Conversions.ClassifyBuiltInConversion(type, possibleBaseInterface, ref useSiteInfo).IsImplicit;
                 diagnostics.Add(node, useSiteInfo);
                 return result;
@@ -900,7 +900,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // It is not a tuple type. Seek an appropriate Deconstruct method.
                             var inputPlaceholder = new BoundImplicitReceiver(node, strippedInputType); // A fake receiver expression to permit us to reuse binding logic
-                            var deconstructDiagnostics = BindingDiagnosticBag.GetInstance();
+                            var deconstructDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
                             BoundExpression deconstruct = MakeDeconstructInvocationExpression(
                                 tupleDesignation.Variables.Count, inputPlaceholder, node, deconstructDiagnostics,
                                 outPlaceholders: out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_QueryErrors.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
 
             if (instanceArgument.Type.IsDynamic())
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool wasError;
                 var plainName = node.Identifier.ValueText;
                 var result = LookupResult.GetInstance();
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 this.LookupSymbolsWithFallback(result, plainName, 0, ref useSiteInfo, null, LookupOptions.NamespaceAliasesOnly);
                 diagnostics.Add(node, useSiteInfo);
 
@@ -643,7 +643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // If the tuple type with names is bound we must have the TupleElementNamesAttribute to emit
                 // it is typically there though, if we have ValueTuple at all
-                var bag = BindingDiagnosticBag.GetInstance();
+                var bag = BindingDiagnosticBag.GetInstance(diagnostics);
                 if (!Compilation.HasTupleNamesAttributes(bag, syntax.Location))
                 {
                     var info = new CSDiagnosticInfo(ErrorCode.ERR_TupleElementNamesAttributeMissing,
@@ -813,7 +813,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = LookupResult.GetInstance();
             LookupOptions options = GetSimpleNameLookupOptions(node, node.Identifier.IsVerbatimIdentifier());
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupSymbolsSimpleName(result, qualifierOpt, identifierValueText, 0, basesBeingResolved, options, diagnose: true, useSiteInfo: ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 
@@ -866,7 +866,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (node.IsTypeInContextWhichNeedsDynamicAttribute())
             {
-                var bag = BindingDiagnosticBag.GetInstance();
+                var bag = BindingDiagnosticBag.GetInstance(diagnostics);
                 if (!Compilation.HasDynamicEmitAttributes(bag, node.Location))
                 {
                     // CONSIDER:    Native compiler reports error CS1980 for each syntax node which binds to dynamic type, we do the same by reporting a diagnostic here.
@@ -1103,7 +1103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var lookupResult = LookupResult.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupSymbolsSimpleName(lookupResult, qualifierOpt, plainName, arity, basesBeingResolved, options, diagnose: true, useSiteInfo: ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_TupleOperators.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Is the operand implicitly convertible to bool?
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             TypeSymbol boolean = GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
             Conversion conversion = this.Conversions.ClassifyImplicitConversionFromType(type, boolean, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!input.Type.Equals(type, TypeCompareKind.AllIgnoreOptions))
             {
                 TypeSymbol inputType = input.Type.StrippedType(); // since a null check has already been done
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(_diagnostics, _compilation.Assembly);
                 Conversion conversion = _conversions.ClassifyBuiltInConversion(inputType, type, ref useSiteInfo);
                 _diagnostics.Add(syntax, useSiteInfo);
                 if (input.Type.IsDynamic() ? type.SpecialType == SpecialType.System_Object : conversion.IsImplicit)
@@ -901,7 +901,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             break;
                         case BoundDagTypeTest t2:
                             {
-                                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(_diagnostics, _compilation.Assembly);
                                 bool? matches = ExpressionOfTypeMatchesPatternTypeForLearningFromSuccessfulTypeTest(t1.Type, t2.Type, ref useSiteInfo);
                                 if (matches == false)
                                 {

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We want to convert from inferredType in the array/string case and builder.ElementType in the enumerator case,
             // but it turns out that these are equivalent (when both are available).
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion elementConversion = this.Conversions.ClassifyConversionFromType(inferredType.Type, iterationVariableType.Type, ref useSiteInfo, forCast: true);
 
             if (!elementConversion.IsValid)
@@ -848,7 +848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // is potentially disposable.
 
             TypeSymbol enumeratorType = builder.GetEnumeratorMethod.ReturnType;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
 
             // For async foreach, we don't do the runtime check
             if ((!enumeratorType.IsSealed && !isAsync) ||
@@ -966,7 +966,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Not using LookupOptions.MustBeInvocableMember because we don't want the corresponding lookup error.
             // We filter out non-methods below.
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             this.LookupMembersInType(
                 lookupResult,
                 patternType,
@@ -1033,7 +1033,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var typeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
             var overloadResolutionResult = OverloadResolutionResult<MethodSymbol>.GetInstance();
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             // We create a dummy receiver of the invocation so MethodInvocationOverloadResolution knows it was invoked from an instance, not a type
             var dummyReceiver = new BoundImplicitReceiver(_syntax.Expression, patternType);
             this.OverloadResolution.MethodInvocationOverloadResolution(
@@ -1127,7 +1127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // wouldn't have to mangle CurrentPropertyName.  However, Dev10 searches for the property and
                 // then extracts the accessor, so we should do the same (in case of accessors with non-standard
                 // names).
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 this.LookupMembersInType(
                     lookupResult,
                     enumeratorType,
@@ -1140,7 +1140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     useSiteInfo: ref useSiteInfo);
 
                 diagnostics.Add(_syntax.Expression, useSiteInfo);
-                useSiteInfo = default;
+                useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(useSiteInfo);
 
                 if (!lookupResult.IsSingleViable)
                 {
@@ -1215,7 +1215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportEnumerableWarning(BindingDiagnosticBag diagnostics, TypeSymbol enumeratorType, Symbol patternMemberCandidate)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             if (this.IsAccessible(patternMemberCandidate, ref useSiteInfo))
             {
                 diagnostics.Add(ErrorCode.WRN_PatternBadSignature, _syntax.Expression.Location, enumeratorType, MessageID.IDS_Collection.Localize(), patternMemberCandidate);
@@ -1259,7 +1259,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics,
             out bool foundMultiple)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             NamedTypeSymbol implementedIEnumerable = GetIEnumerableOfT(type, isAsync, Compilation, ref useSiteInfo, out foundMultiple);
 
             // Prefer generic to non-generic, unless it is inaccessible.
@@ -1366,7 +1366,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     lookupResult.Clear();
 
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     this.LookupMembersInType(
                         lookupResult,
                         patternType,

--- a/src/Compilers/CSharp/Portable/Binder/LockOrUsingBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockOrUsingBinder.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_lazyExpressionAndDiagnostics == null)
             {
                 // Filter out method group in conversion.
-                var expressionDiagnostics = BindingDiagnosticBag.GetInstance();
+                var expressionDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
                 BoundExpression boundExpression = originalBinder.BindValue(TargetExpressionSyntax, expressionDiagnostics, Binder.BindValueKind.RValueOrMethodGroup);
                 if (targetTypeOpt is object)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static bool ReportDelegateMethodGroupDiagnostics(Binder binder, BoundMethodGroup expr, TypeSymbol targetType, BindingDiagnosticBag diagnostics)
         {
             var invokeMethodOpt = GetDelegateInvokeMethodIfAvailable(targetType);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
             var resolution = ResolveDelegateMethodGroup(binder, expr, invokeMethodOpt, ref useSiteInfo);
             diagnostics.Add(expr.Syntax, useSiteInfo);
 
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             !resolution.IsEmpty &&
                             resolution.ResultKind == LookupResultKind.Viable)
                     {
-                        var overloadDiagnostics = BindingDiagnosticBag.GetInstance();
+                        var overloadDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, diagnostics.AccumulatesDependencies);
 
                         result.ReportDiagnostics(
                             binder: binder, location: expr.Syntax.Location, nodeOpt: expr.Syntax, diagnostics: overloadDiagnostics,

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // but there exists an explicit conversion, Dev10 compiler generates a warning "WRN_GotoCaseShouldConvert"
                 // instead of an error. See test "CS0469_NoImplicitConversionWarning".
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                 Conversion conversion = Conversions.ClassifyConversionFromExpression(caseExpression, SwitchGoverningType, ref useSiteInfo);
                 diagnostics.Add(node, useSiteInfo);
                 if (!conversion.IsValid)
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     TypeSymbol resultantGoverningType;
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
                     Conversion conversion = binder.Conversions.ClassifyImplicitUserDefinedConversionForV6SwitchGoverningType(switchGoverningType, out resultantGoverningType, ref useSiteInfo);
                     diagnostics.Add(node, useSiteInfo);
                     if (conversion.IsValid)

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_Patterns.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Bind switch expression and set the switch governing type.
             BoundExpression boundSwitchGoverningExpression = SwitchGoverningExpression;
-            diagnostics.AddRange(SwitchGoverningDiagnostics);
+            diagnostics.AddRange(SwitchGoverningDiagnostics, allowMismatchInDependencyAccumulation: true);
 
             ImmutableArray<BoundSwitchSection> switchSections = BindSwitchSections(originalBinder, diagnostics, out BoundSwitchLabel defaultLabel);
             ImmutableArray<LocalSymbol> locals = GetDeclaredLocalsForScope(node);

--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Bind switch expression and set the switch governing type.
             var boundInputExpression = InputExpression;
-            diagnostics.AddRange(InputExpressionDiagnostics);
+            diagnostics.AddRange(InputExpressionDiagnostics, allowMismatchInDependencyAccumulation: true);
             ImmutableArray<BoundSwitchExpressionArm> switchArms = BindSwitchExpressionArms(node, originalBinder, diagnostics);
             TypeSymbol naturalType = InferResultType(switchArms, diagnostics);
             bool reportedNotExhaustive = CheckSwitchExpressionExhaustive(node, boundInputExpression, switchArms, out BoundDecisionDag decisionDag, out LabelSymbol defaultLabel, diagnostics);
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             seenTypes.Free();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             var commonType = BestTypeInferrer.GetBestType(typesInOrder, Conversions, ref useSiteInfo);
             typesInOrder.Free();
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool populateDisposableConversionOrDisposeMethod(bool fromExpression, out Conversion iDisposableConversion, out MethodSymbol disposeMethodOpt, out TypeSymbol awaitableTypeOpt)
             {
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = originalBinder.GetNewCompoundUseSiteInfo(diagnostics);
                 iDisposableConversion = classifyConversion(fromExpression, disposableInterface, ref useSiteInfo);
                 disposeMethodOpt = null;
                 awaitableTypeOpt = null;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1882,6 +1882,8 @@
     <!-- Type is not significant for this node type; always null -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="always"/>
     <Field Name="Data" Type="UnboundLambdaState" Null="disallow"/>
+    <!-- Track dependencies while binding body, etc. -->
+    <Field Name="WithDependencies" Type="Boolean"/>
   </Node>
 
   <Node Name="BoundQueryClause" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1605,7 +1605,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // These diagnostics (warning only) are added to the compilation only if
                 // there were not any main methods found.
-                var noMainFoundDiagnostics = BindingDiagnosticBag.GetInstance();
+                var noMainFoundDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics);
 
                 bool CheckValid(MethodSymbol candidate, bool isCandidate, BindingDiagnosticBag specificDiagnostics)
                 {
@@ -1629,7 +1629,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 foreach (var candidate in entryPointCandidates)
                 {
-                    var perCandidateBag = BindingDiagnosticBag.GetInstance();
+                    var perCandidateBag = BindingDiagnosticBag.GetInstance(diagnostics);
                     var (IsCandidate, IsTaskLike) = HasEntryPointSignature(candidate, perCandidateBag);
 
                     if (IsTaskLike)
@@ -2453,7 +2453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                builder.AddRange(GetSourceDeclarationDiagnostics(cancellationToken: cancellationToken));
+                builder.AddRange(GetSourceDeclarationDiagnostics(cancellationToken: cancellationToken), allowMismatchInDependencyAccumulation: true);
 
                 if (EventQueue != null && SyntaxTrees.Length == 0)
                 {
@@ -2608,7 +2608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (syntaxTree != null)
             {
-                var builder = BindingDiagnosticBag.GetInstance();
+                var builder = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: false);
                 ClsComplianceChecker.CheckCompliance(this, builder, cancellationToken, syntaxTree, filterSpanWithinTree);
                 return builder.ToReadOnlyAndFree();
             }

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics,
             CancellationToken cancellationToken)
         {
-            Debug.Assert(diagnostics.DependenciesBag is ConcurrentSet<AssemblySymbol>);
+            Debug.Assert(diagnostics.DependenciesBag is null || diagnostics.DependenciesBag is ConcurrentSet<AssemblySymbol>);
 
             _compilation = compilation;
             _filterTree = filterTree;
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="filterSpanWithinTree">If <paramref name="filterTree"/> and <paramref name="filterSpanWithinTree"/> is non-null, report diagnostics within this span in the <paramref name="filterTree"/>.</param>
         public static void CheckCompliance(CSharpCompilation compilation, BindingDiagnosticBag diagnostics, CancellationToken cancellationToken, SyntaxTree filterTree = null, TextSpan? filterSpanWithinTree = null)
         {
-            var queue = new BindingDiagnosticBag(diagnostics.DiagnosticBag, new ConcurrentSet<AssemblySymbol>());
+            var queue = new BindingDiagnosticBag(diagnostics.DiagnosticBag, diagnostics.AccumulatesDependencies ? new ConcurrentSet<AssemblySymbol>() : null);
             var checker = new ClsComplianceChecker(compilation, filterTree, filterSpanWithinTree, queue, cancellationToken);
             checker.Visit(compilation.Assembly);
             checker.WaitForWorkers();

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.IncludeElementExpander.cs
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 Binder binder = BinderFactory.MakeCrefBinder(crefSyntax, memberDeclSyntax, _compilation.GetBinderFactory(memberDeclSyntax.SyntaxTree));
 
-                var crefDiagnostics = BindingDiagnosticBag.GetInstance();
+                var crefDiagnostics = BindingDiagnosticBag.GetInstance(_diagnostics);
                 attribute.Value = GetDocumentationCommentId(crefSyntax, binder, crefDiagnostics); // NOTE: mutation (element must be a copy)
                 RecordBindingDiagnostics(crefDiagnostics, sourceLocation); // Respects DocumentationMode.
                 crefDiagnostics.Free();
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(memberDeclSyntax != null,
                     "Why are we processing a documentation comment that is not attached to a member declaration?");
 
-                var nameDiagnostics = BindingDiagnosticBag.GetInstance();
+                var nameDiagnostics = BindingDiagnosticBag.GetInstance(_diagnostics);
                 Binder binder = MakeNameBinder(isParameter, isTypeParameterRef, _memberSymbol, _compilation);
                 DocumentationCommentCompiler.BindName(attrSyntax, binder, _memberSymbol, ref _documentedParameters, ref _documentedTypeParameters, nameDiagnostics);
                 RecordBindingDiagnostics(nameDiagnostics, sourceLocation); // Respects DocumentationMode.

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
             ImmutableArray<Symbol> referencedSymbols = binder.BindXmlNameAttribute(syntax, ref useSiteInfo);
             diagnostics.Add(syntax, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedEvent.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                         }
                         else
                         {
-                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                            var useSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.DiscardedDependecies;
                             sourceInterface.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
                             diagnostics.Add(syntaxNodeOpt == null ? NoLocation.Singleton : syntaxNodeOpt.Location, useSiteInfo.Diagnostics);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -4326,7 +4326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             UnboundLambda getUnboundLambda(BoundLambda expr, VariableState variableState)
             {
-                return expr.UnboundLambda.WithNullableState(expr.UnboundLambda.Data.Binder, variableState);
+                return expr.UnboundLambda.WithNullableState(variableState);
             }
         }
 
@@ -4347,7 +4347,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 compilation,
                 diagnosticsBuilder,
                 nullabilityBuilder,
-                ref useSiteDiagnosticsBuilder);
+                ref useSiteDiagnosticsBuilder,
+                template: CompoundUseSiteInfo<AssemblySymbol>.Discarded);
             foreach (var pair in nullabilityBuilder)
             {
                 if (pair.UseSiteInfo.DiagnosticInfo is object)

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -6647,36 +6647,40 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class UnboundLambda : BoundExpression
     {
-        public UnboundLambda(SyntaxNode syntax, UnboundLambdaState data, bool hasErrors)
+        public UnboundLambda(SyntaxNode syntax, UnboundLambdaState data, Boolean withDependencies, bool hasErrors)
             : base(BoundKind.UnboundLambda, syntax, null, hasErrors)
         {
 
             Debug.Assert(data is object, "Field 'data' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Data = data;
+            this.WithDependencies = withDependencies;
         }
 
-        public UnboundLambda(SyntaxNode syntax, UnboundLambdaState data)
+        public UnboundLambda(SyntaxNode syntax, UnboundLambdaState data, Boolean withDependencies)
             : base(BoundKind.UnboundLambda, syntax, null)
         {
 
             Debug.Assert(data is object, "Field 'data' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Data = data;
+            this.WithDependencies = withDependencies;
         }
 
 
         public new TypeSymbol Type => base.Type!;
 
         public UnboundLambdaState Data { get; }
+
+        public Boolean WithDependencies { get; }
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitUnboundLambda(this);
 
-        public UnboundLambda Update(UnboundLambdaState data)
+        public UnboundLambda Update(UnboundLambdaState data, Boolean withDependencies)
         {
-            if (data != this.Data)
+            if (data != this.Data || withDependencies != this.WithDependencies)
             {
-                var result = new UnboundLambda(this.Syntax, data, this.HasErrors);
+                var result = new UnboundLambda(this.Syntax, data, withDependencies, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -9987,7 +9991,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitUnboundLambda(UnboundLambda node)
         {
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(node.Data);
+            return node.Update(node.Data, node.WithDependencies);
         }
         public override BoundNode? VisitQueryClause(BoundQueryClause node)
         {
@@ -12095,7 +12099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return node;
             }
 
-            UnboundLambda updatedNode = node.Update(node.Data);
+            UnboundLambda updatedNode = node.Update(node.Data, node.WithDependencies);
             updatedNode.TopLevelNullability = infoAndType.Info;
             return updatedNode;
         }
@@ -13882,6 +13886,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitUnboundLambda(UnboundLambda node, object? arg) => new TreeDumperNode("unboundLambda", null, new TreeDumperNode[]
         {
             new TreeDumperNode("data", node.Data, null),
+            new TreeDumperNode("withDependencies", node.WithDependencies, null),
             new TreeDumperNode("type", node.Type, null),
             new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </returns>
         protected bool VerifyPresenceOfRequiredAPIs()
         {
-            var bag = BindingDiagnosticBag.GetInstance();
+            var bag = BindingDiagnosticBag.GetInstance(withDiagnostics: true, diagnostics.AccumulatesDependencies);
 
             VerifyPresenceOfRequiredAPIs(bag);
 

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </returns>
         protected bool VerifyPresenceOfRequiredAPIs()
         {
-            var bag = BindingDiagnosticBag.GetInstance();
+            var bag = BindingDiagnosticBag.GetInstance(withDiagnostics: true, diagnostics.AccumulatesDependencies);
 
             EnsureSpecialType(SpecialType.System_Int32, bag);
             EnsureSpecialType(SpecialType.System_IDisposable, bag);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -537,7 +537,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression ConvertIndex(BoundExpression expr, TypeSymbol oldType, TypeSymbol newType)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(Diagnostics, _bound.Compilation.Assembly);
             var kind = _bound.Compilation.Conversions.ClassifyConversionFromType(oldType, newType, ref useSiteInfo).Kind;
             Debug.Assert(useSiteInfo.Diagnostics.IsNullOrEmpty());
             Diagnostics.AddDependencies(useSiteInfo);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -673,7 +673,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Use implicit conversion to Boolean if it is defined on the static type of the left operand.
             // If not the type has to implement IsTrue/IsFalse operator - we checked it during binding.
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo();
             var conversion = _compilation.Conversions.ClassifyConversionFromExpression(loweredLeft, boolean, ref useSiteInfo);
             _diagnostics.Add(loweredLeft.Syntax, useSiteInfo);
             if (conversion.IsImplicit)
@@ -696,6 +696,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(leftTruthOperator != null);
             return BoundCall.Synthesized(syntax, null, leftTruthOperator, loweredLeft);
+        }
+
+        private CompoundUseSiteInfo<AssemblySymbol> GetNewCompoundUseSiteInfo()
+        {
+            return new CompoundUseSiteInfo<AssemblySymbol>(_diagnostics, _compilation.Assembly);
         }
 
         private BoundExpression LowerUserDefinedBinaryOperator(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics,
             bool acceptFailingConversion)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, compilation.Assembly);
             Conversion conversion = compilation.Conversions.ClassifyConversionFromType(rewrittenOperand.Type, rewrittenType, ref useSiteInfo);
             diagnostics.Add(rewrittenOperand.Syntax, useSiteInfo);
 
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         private BoundExpression MakeImplicitConversion(BoundExpression rewrittenOperand, TypeSymbol rewrittenType)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo();
             Conversion conversion = _compilation.Conversions.ClassifyConversionFromType(rewrittenOperand.Type, rewrittenType, ref useSiteInfo);
             _diagnostics.Add(rewrittenOperand.Syntax, useSiteInfo);
             if (!conversion.IsImplicit)
@@ -1489,7 +1489,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private Conversion TryMakeConversion(SyntaxNode syntax, TypeSymbol fromType, TypeSymbol toType)
         {
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo();
             var result = TryMakeConversion(syntax, _compilation.Conversions.ClassifyConversionFromType(fromType, toType, ref useSiteInfo), fromType, toType);
             _diagnostics.Add(syntax, useSiteInfo);
             return result;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 idisposableTypeSymbol = disposeMethod.ContainingType;
                 var conversions = new TypeConversions(_factory.CurrentFunction.ContainingAssembly.CorLibrary);
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo();
                 isImplicit = conversions.ClassifyImplicitConversionFromType(enumeratorType, idisposableTypeSymbol, ref useSiteInfo).IsImplicit;
                 _diagnostics.Add(forEachSyntax, useSiteInfo);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             TypeSymbol type = t.Type;
                             var outputTemp = new BoundDagTemp(t.Syntax, type, t);
                             BoundExpression output = _tempAllocator.GetTemp(outputTemp);
-                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = _localRewriter.GetNewCompoundUseSiteInfo();
                             Conversion conversion = _factory.Compilation.Conversions.ClassifyBuiltInConversion(inputType, output.Type, ref useSiteInfo);
                             _localRewriter._diagnostics.Add(t.Syntax, useSiteInfo);
                             BoundExpression evaluated;
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 out BoundExpression sideEffect,
                 out BoundExpression testExpression)
             {
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = _localRewriter.GetNewCompoundUseSiteInfo();
 
                 // case 1: type test followed by cast to that type
                 if (test is BoundDagTypeTest typeDecision &&

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -462,7 +462,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (expression != null)
             {
                 // If necessary, add a conversion on the return expression.
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                var useSiteInfo =
+#if DEBUG
+                    CompoundUseSiteInfo<AssemblySymbol>.DiscardedDependecies;
+#else
+                    CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+#endif 
                 var conversion = Compilation.Conversions.ClassifyConversionFromType(expression.Type, CurrentFunction.ReturnType, ref useSiteInfo);
                 Debug.Assert(useSiteInfo.Diagnostics.IsNullOrEmpty());
                 Debug.Assert(conversion.Kind != ConversionKind.NoConversion);
@@ -1181,7 +1186,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return arg;
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo =
+#if DEBUG
+                    CompoundUseSiteInfo<AssemblySymbol>.DiscardedDependecies;
+#else
+                    CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+#endif 
             Conversion c = Compilation.Conversions.ClassifyConversionFromExpression(arg, type, ref useSiteInfo);
             Debug.Assert(c.Exists);
             Debug.Assert(useSiteInfo.Diagnostics.IsNullOrEmpty());

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -82,6 +82,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         AssemblyIdentity IAssemblySymbolInternal.Identity => Identity;
 
+        IAssemblySymbolInternal IAssemblySymbolInternal.CorLibrary => CorLibrary;
+
         /// <summary>
         /// Assembly version pattern with wildcards represented by <see cref="ushort.MaxValue"/>,
         /// or null if the version string specified in the <see cref="AssemblyVersionAttribute"/> doesn't contain a wildcard.

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -76,7 +76,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var bounds = typeParameter.ResolveBounds(corLibrary, inProgress, constraintTypes, inherited, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
+            var bounds = typeParameter.ResolveBounds(corLibrary, inProgress, constraintTypes, inherited, currentCompilation, diagnosticsBuilder, ref useSiteDiagnosticsBuilder,
+                                                     template: new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, currentCompilation.Assembly));
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -101,7 +102,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             bool inherited,
             CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
-            ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder)
+            ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
+            CompoundUseSiteInfo<AssemblySymbol> template)
         {
             Debug.Assert(currentCompilation == null || typeParameter.IsFromCompilation(currentCompilation));
 
@@ -119,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constraintTypesBuilder = ArrayBuilder<TypeWithAnnotations>.GetInstance();
                 var interfacesBuilder = ArrayBuilder<NamedTypeSymbol>.GetInstance();
                 var conversions = new TypeConversions(corLibrary);
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(template);
 
                 // Resolve base types, determine the effective base class and
                 // interfaces, and filter out any constraint types that cause cycles.
@@ -464,7 +466,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             foreach (var underlyingTuple in underlyingTupleTypeChain)
             {
                 ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-                CheckTypeConstraints(underlyingTuple, conversions, includeNullability, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: nullabilityDiagnosticsBuilder, ref useSiteDiagnosticsBuilder);
+                CheckTypeConstraints(underlyingTuple, conversions, includeNullability, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: nullabilityDiagnosticsBuilder,
+                                     ref useSiteDiagnosticsBuilder, template: new CompoundUseSiteInfo<AssemblySymbol>(diagnosticsOpt, currentCompilation.Assembly));
 
                 if (useSiteDiagnosticsBuilder != null)
                 {
@@ -524,7 +527,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var result = !typeSyntax.HasErrors && CheckTypeConstraints(type, conversions, includeNullability, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
+            var result = !typeSyntax.HasErrors && CheckTypeConstraints(type, conversions, includeNullability, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: diagnosticsBuilder,
+                                                                       ref useSiteDiagnosticsBuilder, template: new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, currentCompilation.Assembly));
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -572,7 +576,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var result = CheckTypeConstraints(type, conversions, includeNullability, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: diagnosticsBuilder, ref useSiteDiagnosticsBuilder);
+            var result = CheckTypeConstraints(type, conversions, includeNullability, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: diagnosticsBuilder,
+                                              ref useSiteDiagnosticsBuilder, template: new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, currentCompilation.Assembly));
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -660,7 +665,8 @@ hasRelatedInterfaces:
 
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var result = CheckMethodConstraints(method, conversions, includeNullability: false, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder);
+            var result = CheckMethodConstraints(method, conversions, includeNullability: false, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null,
+                                                ref useSiteDiagnosticsBuilder, template: new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, currentCompilation.Assembly));
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -691,7 +697,8 @@ hasRelatedInterfaces:
 
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var result = CheckMethodConstraints(method, conversions, includeNullability: false, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder);
+            var result = CheckMethodConstraints(method, conversions, includeNullability: false, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null,
+                                                ref useSiteDiagnosticsBuilder, template: new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, currentCompilation.Assembly));
 
             if (useSiteDiagnosticsBuilder != null)
             {
@@ -714,7 +721,8 @@ hasRelatedInterfaces:
             CSharpCompilation currentCompilation,
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
-            ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder)
+            ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
+            CompoundUseSiteInfo<AssemblySymbol> template)
         {
             return CheckConstraints(
                 type,
@@ -726,7 +734,8 @@ hasRelatedInterfaces:
                 currentCompilation,
                 diagnosticsBuilder,
                 nullabilityDiagnosticsBuilderOpt,
-                ref useSiteDiagnosticsBuilder);
+                ref useSiteDiagnosticsBuilder,
+                template);
         }
 
         public static bool CheckMethodConstraints(
@@ -737,6 +746,7 @@ hasRelatedInterfaces:
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
+            CompoundUseSiteInfo<AssemblySymbol> template,
             BitVector skipParameters = default(BitVector))
         {
             return CheckConstraints(
@@ -750,6 +760,7 @@ hasRelatedInterfaces:
                 diagnosticsBuilder,
                 nullabilityDiagnosticsBuilderOpt,
                 ref useSiteDiagnosticsBuilder,
+                template,
                 skipParameters);
         }
 
@@ -780,6 +791,7 @@ hasRelatedInterfaces:
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
+            CompoundUseSiteInfo<AssemblySymbol> template,
             BitVector skipParameters = default(BitVector),
             HashSet<TypeParameterSymbol> ignoreTypeConstraintsDependentOnTypeParametersOpt = null)
         {
@@ -800,7 +812,8 @@ hasRelatedInterfaces:
                 var typeArgument = typeArguments[i];
                 var typeParameter = typeParameters[i];
 
-                if (!CheckConstraints(containingSymbol, conversions, includeNullability, substitution, typeParameter, typeArgument, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt, ref useSiteDiagnosticsBuilder,
+                if (!CheckConstraints(containingSymbol, conversions, includeNullability, substitution, typeParameter, typeArgument, currentCompilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt,
+                                      ref useSiteDiagnosticsBuilder, template,
                                       ignoreTypeConstraintsDependentOnTypeParametersOpt))
                 {
                     succeeded = false;
@@ -822,6 +835,7 @@ hasRelatedInterfaces:
             ArrayBuilder<TypeParameterDiagnosticInfo> diagnosticsBuilder,
             ArrayBuilder<TypeParameterDiagnosticInfo> nullabilityDiagnosticsBuilderOpt,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder,
+            CompoundUseSiteInfo<AssemblySymbol> template,
             HashSet<TypeParameterSymbol> ignoreTypeConstraintsDependentOnTypeParametersOpt)
         {
             Debug.Assert(substitution != null);
@@ -913,7 +927,7 @@ hasRelatedInterfaces:
             // has constraint "U", not "int". We need to substitute the constraints from the
             // original definition of the type parameters using the map from the constructed symbol.
             var constraintTypes = ArrayBuilder<TypeWithAnnotations>.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(template);
             substitution.SubstituteConstraintTypesDistinctWithoutModifiers(typeParameter, typeParameter.ConstraintTypesWithDefinitionUseSiteDiagnostics(ref useSiteInfo), constraintTypes,
                                                                  ignoreTypeConstraintsDependentOnTypeParametersOpt);
 
@@ -982,12 +996,17 @@ hasRelatedInterfaces:
             TypeParameterSymbol typeParameter,
             ref ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder)
         {
-            if (!useSiteInfo.HasErrors && !useSiteInfo.Dependencies.IsNullOrEmpty())
+            if (!(useSiteInfo.AccumulatesDiagnostics && useSiteInfo.HasErrors) && useSiteInfo.AccumulatesDependencies && !useSiteInfo.Dependencies.IsNullOrEmpty())
             {
                 ensureUseSiteDiagnosticsBuilder(ref useSiteDiagnosticsBuilder).Add(new TypeParameterDiagnosticInfo(typeParameter,
                                                                               useSiteInfo.Dependencies.Count == 1 ?
                                                                                   new UseSiteInfo<AssemblySymbol>(useSiteInfo.Dependencies.Single()) :
                                                                                   new UseSiteInfo<AssemblySymbol>(useSiteInfo.Dependencies.ToImmutableHashSet())));
+            }
+
+            if (!useSiteInfo.AccumulatesDiagnostics)
+            {
+                return false;
             }
 
             var useSiteDiagnostics = useSiteInfo.Diagnostics;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -614,7 +614,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
                 bool inherited = (_containingSymbol.Kind == SymbolKind.Method) && ((MethodSymbol)_containingSymbol).IsOverride;
                 var bounds = this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, inherited, currentCompilation: null,
-                                                diagnosticsBuilder: diagnostics, useSiteDiagnosticsBuilder: ref useSiteDiagnosticsBuilder);
+                                                diagnosticsBuilder: diagnostics, useSiteDiagnosticsBuilder: ref useSiteDiagnosticsBuilder, template: default);
 
                 if (useSiteDiagnosticsBuilder != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(method.ParameterCount > 0);
             Debug.Assert((object)receiverType != null);
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.DiscardedDependecies;
 
             method = InferExtensionMethodTypeArguments(method, receiverType, compilation, ref useSiteInfo);
             if ((object)method == null)
@@ -196,7 +196,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var diagnosticsBuilder = ArrayBuilder<TypeParameterDiagnosticInfo>.GetInstance();
             var substitution = new TypeMap(typeParams, typeArgsForConstraintsCheck);
             ArrayBuilder<TypeParameterDiagnosticInfo> useSiteDiagnosticsBuilder = null;
-            var success = method.CheckConstraints(conversions, includeNullability: false, substitution, typeParams, typeArgsForConstraintsCheck, compilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null, ref useSiteDiagnosticsBuilder,
+            var success = method.CheckConstraints(conversions, includeNullability: false, substitution, typeParams, typeArgsForConstraintsCheck, compilation, diagnosticsBuilder, nullabilityDiagnosticsBuilderOpt: null,
+                                                  ref useSiteDiagnosticsBuilder, template: new CompoundUseSiteInfo<AssemblySymbol>(useSiteInfo),
                                                   ignoreTypeConstraintsDependentOnTypeParametersOpt: notInferredTypeParameters.Count > 0 ? notInferredTypeParameters : null);
             diagnosticsBuilder.Free();
             notInferredTypeParameters.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Make sure implemented member is accessible
             if ((object)implementedMember != null)
             {
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, implementingMember.ContainingAssembly);
 
                 if (!AccessCheck.IsSymbolAccessible(implementedMember, implementingMember.ContainingType, ref useSiteInfo, throughTypeOpt: null))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ComputeReturnType();
 
-            addTo.AddRange(_declarationDiagnostics);
+            addTo.AddRange(_declarationDiagnostics, allowMismatchInDependencyAccumulation: true);
         }
 
         internal override void AddDeclarationDiagnostics(BindingDiagnosticBag diagnostics)
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             SyntaxToken arglistToken;
-            var diagnostics = BindingDiagnosticBag.GetInstance();
+            var diagnostics = BindingDiagnosticBag.GetInstance(_declarationDiagnostics);
 
             var parameters = ParameterHelpers.MakeParameters(
                 _binder,
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            var diagnostics = BindingDiagnosticBag.GetInstance();
+            var diagnostics = BindingDiagnosticBag.GetInstance(_declarationDiagnostics);
             TypeSyntax returnTypeSyntax = _syntax.ReturnType;
             TypeWithAnnotations returnType = _binder.BindType(returnTypeSyntax.SkipRef(), diagnostics);
 
@@ -471,7 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (_lazyTypeParameterConstraints.IsDefault)
             {
-                var diagnostics = BindingDiagnosticBag.GetInstance();
+                var diagnostics = BindingDiagnosticBag.GetInstance(_declarationDiagnostics);
                 var constraints = this.MakeTypeParameterConstraints(
                     _binder,
                     TypeParameters,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // IntelliSense purposes.
 
             TypeSymbol parameterType = parameter.Type;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = binder.Conversions.ClassifyImplicitConversionFromExpression(defaultExpression, parameterType, ref useSiteInfo);
             diagnostics.Add(defaultExpression.Syntax, useSiteInfo);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -809,7 +809,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var compilation = this.DeclaringCompilation;
             var constantValueDiscriminator = ConstantValue.GetDiscriminator(specialType);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnosticsOpt, ContainingAssembly);
             if (constantValueDiscriminator == ConstantValueTypeDiscriminator.Bad)
             {
                 if (arg.Kind != TypedConstantKind.Array && arg.ValueInternal == null)
@@ -892,7 +892,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void ValidateCallerLineNumberAttribute(AttributeSyntax node, BindingDiagnosticBag diagnostics)
         {
             CSharpCompilation compilation = this.DeclaringCompilation;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
             if (!IsValidCallerInfoContext(node))
             {
@@ -920,7 +920,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void ValidateCallerFilePathAttribute(AttributeSyntax node, BindingDiagnosticBag diagnostics)
         {
             CSharpCompilation compilation = this.DeclaringCompilation;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
             if (!IsValidCallerInfoContext(node))
             {
@@ -953,7 +953,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private void ValidateCallerMemberNameAttribute(AttributeSyntax node, BindingDiagnosticBag diagnostics)
         {
             CSharpCompilation compilation = this.DeclaringCompilation;
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
             if (!IsValidCallerInfoContext(node))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, delegateType.ContainingAssembly);
 
             if (!delegateType.IsNoMoreVisibleThan(invoke.ReturnTypeWithAnnotations, ref useSiteInfo))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -494,7 +494,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected void CheckModifiersAndType(BindingDiagnosticBag diagnostics)
         {
             Location location = this.Locations[0];
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
             bool isExplicitInterfaceImplementationInInterface = ContainingType.IsInterface && IsExplicitInterfaceImplementation;
 
             if (this.DeclaredAccessibility == Accessibility.Private && (IsVirtual || (IsAbstract && !isExplicitInterfaceImplementationInInterface) || IsOverride))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -324,7 +324,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private TypeWithAnnotations GetTypeSymbol()
         {
-            var diagnostics = BindingDiagnosticBag.GetInstance();
+            //
+            // Note that we drop the diagnostics on the floor! That is because this code is invoked mainly in
+            // IDE scenarios where we are attempting to use the types of a variable before we have processed
+            // the code which causes the variable's type to be inferred. In batch compilation, on the
+            // other hand, local variables have their type inferred, if necessary, in the course of binding
+            // the statements of a method from top to bottom, and an inferred type is given to a variable
+            // before the variable's type is used by the compiler.
+            //
+            var diagnostics = BindingDiagnosticBag.Discarded;
 
             Binder typeBinder = this.TypeSyntaxBinder;
 
@@ -359,15 +367,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             Debug.Assert(declType.HasType);
 
-            //
-            // Note that we drop the diagnostics on the floor! That is because this code is invoked mainly in
-            // IDE scenarios where we are attempting to use the types of a variable before we have processed
-            // the code which causes the variable's type to be inferred. In batch compilation, on the
-            // other hand, local variables have their type inferred, if necessary, in the course of binding
-            // the statements of a method from top to bottom, and an inferred type is given to a variable
-            // before the variable's type is used by the compiler.
-            //
-            diagnostics.Free();
             return declType;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -671,7 +671,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         continue;
                     }
 
-                    CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                    var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
                     bool isAccessible = AccessCheck.IsSymbolAccessible(hiddenMember, this, ref useSiteInfo);
                     diagnostics.Add(symbolLocation, useSiteInfo);
 
@@ -921,7 +921,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (overridingProperty.IsSealed)
                             {
                                 MethodSymbol ownOrInheritedGetMethod = overridingProperty.GetOwnOrInheritedGetMethod();
-                                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, overridingMember.ContainingAssembly);
                                 if (overridingProperty.GetMethod != ownOrInheritedGetMethod && !AccessCheck.IsSymbolAccessible(ownOrInheritedGetMethod, overridingType, ref useSiteInfo))
                                 {
                                     diagnostics.Add(ErrorCode.ERR_NoGetToOverride, overridingMemberLocation, overridingProperty, overriddenProperty);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_VolatileStruct, this.ErrorLocation, this, type);
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
             if (!this.IsNoMoreVisibleThan(type, ref useSiteInfo))
             {
                 // Inconsistent accessibility: field type '{1}' is less accessible than field '{0}'

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ErrorCode.ERR_BadVisOpReturn :
                 ErrorCode.ERR_BadVisReturnType;
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
             if (!this.IsNoMoreVisibleThan(returnType, ref useSiteInfo))
             {
                 // Inconsistent accessibility: return type '{1}' is less accessible than method '{0}'

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
             if ((object)baseType != null)
             {
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                 }
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
                 if (t.DeclaringCompilation != this.DeclaringCompilation)
                 {
@@ -660,7 +660,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             this.SetKnownToHaveNoDeclaredBaseCycles();
 
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
             NamedTypeSymbol current = declaredBase;
 
             do

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1595,7 +1595,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RefKind refKind;
             var typeSyntax = syntax.Type.SkipRef(out refKind);
             var type = binder.BindType(typeSyntax, diagnostics);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
 
             if (syntax.ExplicitInterfaceSpecifier == null && !this.IsNoMoreVisibleThan(type, ref useSiteInfo))
             {
@@ -1619,7 +1619,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var parameterSyntaxOpt = GetParameterListSyntax(syntax);
             var parameters = MakeParameters(binder, this, parameterSyntaxOpt, diagnostics, addRefReadOnlyModifier: IsVirtual || IsAbstract);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics);
 
             foreach (ParameterSymbol param in parameters)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // "same" is the containing class, so it can't be a type parameter
                 Debug.Assert(!same.IsTypeParameter());
 
-                CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+                var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
                 if (same.IsDerivedFrom(different, TypeCompareKind.IgnoreTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes, useSiteInfo: ref useSiteInfo)) // tomat: ignoreDynamic should be true, but we don't want to introduce breaking change. See bug 605326.
                 {
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // the return type.
 
             var parameterType = this.GetParameterType(0);
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, ContainingAssembly);
 
             if (!parameterType.StrippedType().TupleUnderlyingTypeOrSelf().Equals(this.ContainingType, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -788,7 +788,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private SymbolAndDiagnostics ComputeImplementationAndDiagnosticsForInterfaceMember(Symbol interfaceMember, bool ignoreImplementationInInterfaces, out bool implementationInInterfacesMightChangeResult)
         {
-            var diagnostics = BindingDiagnosticBag.GetInstance();
+            var diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics: true, withDependencies: this.DeclaringCompilation is object);
             var implementingMember = ComputeImplementationForInterfaceMember(interfaceMember, this, diagnostics, ignoreImplementationInInterfaces, out implementationInInterfacesMightChangeResult);
             var implementingMemberAndDiagnostics = new SymbolAndDiagnostics(implementingMember, diagnostics.ToReadOnlyAndFree());
             return implementingMemberAndDiagnostics;
@@ -844,7 +844,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Symbol closestMismatch = null;
             bool canBeImplementedImplicitly = interfaceMember.DeclaredAccessibility == Accessibility.Public && !interfaceMember.IsEventOrPropertyWithImplementableNonPublicAccessor();
             TypeSymbol implementingBaseOpt = null; // Calculated only if canBeImplementedImplicitly == true
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            CSharpCompilation compilation = implementingType.DeclaringCompilation;
+            var useSiteInfo = compilation is object ? new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, compilation.Assembly) : CompoundUseSiteInfo<AssemblySymbol>.DiscardedDependecies;
 
             for (TypeSymbol currType = implementingType; (object)currType != null; currType = currType.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteInfo))
             {

--- a/src/Compilers/Core/Portable/Binding/UseSiteInfo.cs
+++ b/src/Compilers/Core/Portable/Binding/UseSiteInfo.cs
@@ -58,7 +58,8 @@ namespace Microsoft.CodeAnalysis
         public UseSiteInfo(DiagnosticInfo? diagnosticInfo, TAssemblySymbol? primaryDependency, ImmutableHashSet<TAssemblySymbol>? secondaryDependencies)
         {
             Debug.Assert(diagnosticInfo?.Severity != DiagnosticSeverity.Error || (primaryDependency is null && secondaryDependencies?.IsEmpty != false));
-            // PROTOTYPE(UsedAssemblyReferences): Add an assert to verify that a core library is not among the dependencies
+            Debug.Assert(primaryDependency is null || primaryDependency != primaryDependency.CorLibrary);
+            Debug.Assert(secondaryDependencies?.IsEmpty != false || !secondaryDependencies.Any(dependency => dependency == dependency.CorLibrary));
 
             DiagnosticInfo = diagnosticInfo;
             PrimaryDependency = primaryDependency;

--- a/src/Compilers/Core/Portable/Symbols/IAssemblySymbolInternal.cs
+++ b/src/Compilers/Core/Portable/Symbols/IAssemblySymbolInternal.cs
@@ -14,5 +14,7 @@ namespace Microsoft.CodeAnalysis.Symbols
         /// Gets the name of this assembly.
         /// </summary>
         AssemblyIdentity Identity { get; }
+
+        IAssemblySymbolInternal CorLibrary { get; }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Attributes.vb
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Else
                 Dim namedType = DirectCast(symbol, NamedTypeSymbol)
-                Dim localUseSiteInfo = If(useSiteInfo.IsDiscarded, CompoundUseSiteInfo(Of AssemblySymbol).Discarded, Nothing)
+                Dim localUseSiteInfo = If(useSiteInfo.AccumulatesDependencies, New CompoundUseSiteInfo(Of AssemblySymbol)(Compilation.Assembly), CompoundUseSiteInfo(Of AssemblySymbol).DiscardedDependecies)
 
                 ' type cannot be generic
                 If namedType.IsGenericType Then
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If Not attributeTypeForBinding.IsErrorType() Then
 
                 ' Filter out inaccessible constructors 
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                 Dim accessibleConstructors = GetAccessibleConstructors(attributeTypeForBinding, useSiteInfo)
 
                 If accessibleConstructors.Length = 0 Then
@@ -436,7 +436,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As LookupResult = LookupResult.GetInstance()
             Dim identifierName As IdentifierNameSyntax = namedArg.NameColonEquals.Name
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             LookupMember(result, container, identifierName.Identifier.ValueText, 0, LookupOptions.IgnoreExtensionMethods, useSiteInfo)
 
             ' Validating the expression is done when the bound expression is converted to a TypedConstant

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -81,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Classify conversion
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             Dim conv As ConversionKind = Conversions.ClassifyDirectCastConversion(argument, targetType, Me, useSiteInfo)
 
             If diagnostics.Add(node, useSiteInfo) Then
@@ -191,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim conv As ConversionKind
 
             If targetType.IsReferenceType Then
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                 conv = Conversions.ClassifyTryCastConversion(argument, targetType, Me, useSiteInfo)
 
                 If diagnostics.Add(node, useSiteInfo) Then
@@ -350,7 +350,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(Not isOperandOfConditionalBranch OrElse targetType.IsBooleanType())
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
 
             If isOperandOfConditionalBranch AndAlso targetType.IsBooleanType() Then
                 Debug.Assert(Not isExplicit)
@@ -470,7 +470,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' If the conversion from the inferred element type to the source type of the user defined conversion is a narrowing conversion then
                 ' skip to the user defined conversion. Conversion errors on the individual elements will be reported when the array literal is reclassified.
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                 reportArrayLiteralElementNarrowingConversion =
                     Not isExplicit AndAlso
                     Conversions.IsNarrowingConversion(convKind.Key) AndAlso
@@ -655,7 +655,7 @@ DoneWithDiagnostics:
             diagnostics As BindingDiagnosticBag,
             justWarn As Boolean
         ) As Boolean
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             Dim result As Boolean = MakeVarianceConversionSuggestion(convKind, location, sourceType, targetType, diagnostics, useSiteInfo, justWarn)
             diagnostics.AddDependencies(useSiteInfo)
             Return result
@@ -1021,7 +1021,7 @@ DoneWithDiagnostics:
                                                   New BoundRelaxationLambda(tree, boundLambdaOpt, relaxationReceiverPlaceholderOpt).MakeCompilerGenerated()),
                                                targetType)
                 Else
-                    Debug.Assert(diagnostics.DiagnosticBag Is Nothing OrElse diagnostics.HasAnyErrors())
+                    Debug.Assert(Not diagnostics.AccumulatesDiagnostics OrElse diagnostics.HasAnyErrors())
                 End If
             End If
 
@@ -1095,7 +1095,7 @@ DoneWithDiagnostics:
 
             Dim intermediateConv As ConversionKind
             Dim inOutConversionFlags As Byte = 0
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
 
             If argument.Kind = BoundKind.ArrayLiteral Then
                 ' For array literals, report Option Strict diagnostics for each element when reportArrayLiteralElementNarrowingConversion is true.
@@ -1705,7 +1705,7 @@ DoneWithDiagnostics:
                     classType = DirectCast(sourceType, NamedTypeSymbol)
                 End If
 
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
 
                 If classType IsNot Nothing AndAlso
                     interfaceType IsNot Nothing AndAlso

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 hasErrors = True
             End If
 
-            Return New BoundAddressOfOperator(node, Me, group, hasErrors)
+            Return New BoundAddressOfOperator(node, Me, diagnostics.AccumulatesDependencies, group, hasErrors)
         End Function
 
         ''' <summary>
@@ -217,7 +217,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ) As DelegateResolutionResult
             Debug.Assert(targetType IsNot Nothing)
 
-            Dim diagnostics = BindingDiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, addressOfExpression.WithDependencies)
             Dim result As OverloadResolution.OverloadResolutionResult = Nothing
             Dim fromMethod As MethodSymbol = Nothing
 
@@ -367,7 +367,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             diagnostics As BindingDiagnosticBag
         ) As KeyValuePair(Of MethodSymbol, MethodConversionKind)
 
-            Dim argumentDiagnostics = BindingDiagnosticBag.GetInstance
+            Dim argumentDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics)
             Dim couldTryZeroArgumentRelaxation As Boolean = True
 
             Dim matchingMethod As KeyValuePair(Of MethodSymbol, MethodConversionKind) = ResolveMethodForDelegateInvokeFullOrRelaxed(
@@ -381,7 +381,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' If there have been parameters and if there was no ambiguous match before, try zero argument relaxation.
             If matchingMethod.Key Is Nothing AndAlso couldTryZeroArgumentRelaxation Then
 
-                Dim zeroArgumentDiagnostics = BindingDiagnosticBag.GetInstance
+                Dim zeroArgumentDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics)
                 Dim argumentMatchingMethod = matchingMethod
 
                 matchingMethod = ResolveMethodForDelegateInvokeFullOrRelaxed(
@@ -492,7 +492,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(resolutionBinder.OptionStrict = VisualBasic.OptionStrict.Off)
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = addressOfExpression.Binder.GetNewCompoundUseSiteInfo(diagnostics)
             Dim resolutionResult = OverloadResolution.MethodInvocationOverloadResolution(
                 addressOfExpression.MethodGroup,
                 boundArguments,
@@ -632,7 +632,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' determine conversions based on return type
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = addressOfExpression.Binder.GetNewCompoundUseSiteInfo(diagnostics)
             Dim targetMethodSymbol = DirectCast(analysisResult.Candidate.UnderlyingSymbol, MethodSymbol)
 
             If Not ignoreMethodReturnType Then

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Initializers.vb
@@ -485,7 +485,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ) As BoundExpression
             constValue = Nothing
             Dim boundInitValue As BoundExpression = Nothing
-            Dim initValueDiagnostics = BindingDiagnosticBag.GetInstance
+            Dim initValueDiagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, withDependencies:=diagnostics.AccumulatesDependencies)
 
             If equalsValueOrAsNewSyntax.Kind = SyntaxKind.EqualsValue Then
                 Dim equalsValueSyntax As EqualsValueSyntax = DirectCast(equalsValueOrAsNewSyntax, EqualsValueSyntax)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lookup.vb
@@ -1311,7 +1311,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Include "Value" for InternalXmlHelper.Value if necessary.
                 Dim compilation = binder.Compilation
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = CompoundUseSiteInfo(Of AssemblySymbol).DiscardedDependecies
                 If container.IsOrImplementsIEnumerableOfXElement(compilation, useSiteInfo) AndAlso useSiteInfo.Diagnostics.IsNullOrEmpty Then
                     nameSet.AddSymbol(Nothing, StringConstants.ValueProperty, 0)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Operators.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' and the common operand type.
             Dim intrinsicOperatorType As SpecialType = SpecialType.None
             Dim userDefinedOperator As OverloadResolution.OverloadResolutionResult = Nothing
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             Dim operatorKind As BinaryOperatorKind = OverloadResolution.ResolveBinaryOperator(preliminaryOperatorKind, left, right, Me,
                                                                                               True,
                                                                                               intrinsicOperatorType,
@@ -671,7 +671,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Find IsTrue/IsFalse operator
             Dim leftCheckOperator As OverloadResolution.OverloadResolutionResult
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
 
             If opKind = BinaryOperatorKind.AndAlso Then
                 leftCheckOperator = OverloadResolution.ResolveIsFalseOperator(leftPlaceholder, Me, useSiteInfo)
@@ -1121,7 +1121,7 @@ Done:
 
             Dim intrinsicOperatorType As SpecialType = SpecialType.None
             Dim userDefinedOperator As OverloadResolution.OverloadResolutionResult = Nothing
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             Dim operatorKind As UnaryOperatorKind = OverloadResolution.ResolveUnaryOperator(preliminaryOperatorKind, operand, Me, intrinsicOperatorType, userDefinedOperator, useSiteInfo)
 
             If diagnostics.Add(node, useSiteInfo) Then

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Query.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Query.vb
@@ -1986,7 +1986,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         groupByArguments = {keysLambda, itemsLambda, inferenceLambda}
                     End If
 
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                     Dim results As OverloadResolution.OverloadResolutionResult = OverloadResolution.QueryOperatorInvocationOverloadResolution(methodGroup,
                                                                                                                                               groupByArguments.AsImmutableOrNull(), Me,
                                                                                                                                               useSiteInfo)
@@ -2060,7 +2060,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Dim groupJoinArguments() As BoundExpression = {inner, outerKeyLambda, innerKeyLambda, inferenceLambda}
 
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                     Dim results As OverloadResolution.OverloadResolutionResult = OverloadResolution.QueryOperatorInvocationOverloadResolution(methodGroup,
                                                                                                                                               groupJoinArguments.AsImmutableOrNull(), Me,
                                                                                                                                               useSiteInfo)
@@ -2330,7 +2330,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Need to verify result type of the condition and enforce ExprIsOperandOfConditionalBranch for possible future conversions. 
             ' In order to do verification, we simply attempt conversion to boolean in the same manner as BindBooleanExpression.
-            Dim conversionDiagnostic = BindingDiagnosticBag.GetInstance()
+            Dim conversionDiagnostic = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, withDependencies:=diagnostics.AccumulatesDependencies)
 
             Dim boolSymbol As NamedTypeSymbol = GetSpecialType(SpecialType.System_Boolean, condition, diagnostics)
 
@@ -3476,7 +3476,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ' Apply conversion if available.
                     Dim targetType As TypeSymbol = Nothing
                     Dim intrinsicOperatorType As SpecialType = SpecialType.None
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = outerKeyBinder.GetNewCompoundUseSiteInfo(diagnostics)
+
                     Dim operatorKind As BinaryOperatorKind = OverloadResolution.ResolveBinaryOperator(BinaryOperatorKind.Equals,
                                                                                                       outerKey, innerKey,
                                                                                                       innerKeyBinder,
@@ -3492,7 +3493,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(useSiteInfo.Diagnostics.IsNullOrEmpty)
                         diagnostics.AddDependencies(useSiteInfo)
                         targetType = innerKeyBinder.GetSpecialTypeForBinaryOperator(joinCondition, outerKey.Type, innerKey.Type, intrinsicOperatorType,
-                                                                                    (operatorKind And BinaryOperatorKind.Lifted) <> 0, diagnostics)
+                                                                                (operatorKind And BinaryOperatorKind.Lifted) <> 0, diagnostics)
                     Else
                         ' Use dominant type.
                         Dim inferenceCollection = New TypeInferenceCollection()
@@ -4359,7 +4360,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim result As BoundExpression = Nothing
-            Dim additionalDiagnostics = BindingDiagnosticBag.GetInstance()
+            Dim additionalDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics)
 
             ' Does it have Function AsQueryable() As CT returning queryable collection?
             Dim asQueryable As BoundExpression = BindQueryOperatorCall(source.Syntax, source, StringConstants.AsQueryableMethod,
@@ -4434,7 +4435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Look for Select methods available for the source.
             Dim lookupResult As LookupResult = LookupResult.GetInstance()
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             LookupMember(lookupResult, source.Type, StringConstants.SelectMethod, 0, QueryOperatorLookupOptions, useSiteInfo)
 
             If lookupResult.IsGood Then
@@ -4568,7 +4569,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             diagnostics As BindingDiagnosticBag
         ) As BoundMethodGroup
             Dim lookupResult As LookupResult = LookupResult.GetInstance()
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             LookupMember(lookupResult, source.Type, operatorName, 0, QueryOperatorLookupOptions, useSiteInfo)
 
             Dim methodGroup As BoundMethodGroup = Nothing
@@ -4586,6 +4587,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             node,
                             lookupResult,
                             QueryOperatorLookupOptions,
+                            diagnostics.AccumulatesDependencies,
                             source,
                             typeArgumentsOpt,
                             QualificationKind.QualifiedViaValue).MakeCompilerGenerated()
@@ -4653,7 +4655,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim boundCall As BoundExpression = Nothing
 
             If methodGroup IsNot Nothing Then
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                 Dim results As OverloadResolution.OverloadResolutionResult = OverloadResolution.QueryOperatorInvocationOverloadResolution(methodGroup,
                                                                                                                                           arguments, Me,
                                                                                                                                           useSiteInfo)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -173,7 +173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Interface IA(Of T As C) : End Interface
             ' Interface IB(Of T As C) : Inherits IA(Of T) : End Interface
             If checkConstraints AndAlso ShouldCheckConstraints Then
-                constructedType.CheckConstraintsForNonTuple(syntaxArguments, diagnostics)
+                constructedType.CheckConstraintsForNonTuple(syntaxArguments, diagnostics, template:=GetNewCompoundUseSiteInfo(diagnostics))
             End If
 
             constructedType = DirectCast(TupleTypeSymbol.TransformToTupleIfCompatible(constructedType), NamedTypeSymbol)
@@ -300,7 +300,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 binder.AddTypesAssemblyAsDependency(TryCast(typeSymbol, NamedTypeSymbol), diagBag)
                             End If
 
-                            If diagBag.DiagnosticBag IsNot Nothing AndAlso typeSymbol.Kind = SymbolKind.NamedType AndAlso binder.SourceModule.AnyReferencedAssembliesAreLinked Then
+                            If diagBag.AccumulatesDiagnostics AndAlso typeSymbol.Kind = SymbolKind.NamedType AndAlso binder.SourceModule.AnyReferencedAssembliesAreLinked Then
                                 Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(DirectCast(typeSymbol, NamedTypeSymbol), typeSyntax, diagBag.DiagnosticBag)
                             End If
 
@@ -864,7 +864,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     reportedAnError = True
                     Debug.Assert(lookupResult.IsClear)
                 Else
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagBag)
 
                     If SyntaxFacts.IsAttributeName(basicNameSyntax) Then
                         binder.LookupAttributeType(lookupResult, Nothing, idText, LookupOptions.AttributeTypeOnly, useSiteInfo)
@@ -897,7 +897,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim arity As Integer = typeArgumentsSyntax.Arguments.Count
 
                 ' Bind the generic symbol with the current binder.
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagBag)
                 binder.Lookup(lookupResult, idText, arity, LookupOptions.NamespacesOrTypesOnly, useSiteInfo)
 
                 diagBag.Add(genericNameSyntax, useSiteInfo)
@@ -979,7 +979,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 binder.AddTypesAssemblyAsDependency(leftSymbol, diagBag)
 
                 lookupResult.Clear()
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagBag)
 
                 If SyntaxFacts.IsAttributeName(rightIdentSyntax) Then
                     binder.LookupAttributeType(lookupResult,
@@ -1079,7 +1079,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Lookup the generic type.
                 lookupResult.Clear()
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagBag)
                 binder.LookupMember(lookupResult,
                                     leftSymbol,
                                     rightIdentSyntax.ValueText,

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -299,7 +299,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If ShouldCheckConstraints Then
                 Dim diagnosticsBuilder = ArrayBuilder(Of TypeParameterDiagnosticInfo).GetInstance()
                 Dim useSiteDiagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo) = Nothing
-                constructedType.CheckConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder)
+                constructedType.CheckConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder, template:=GetNewCompoundUseSiteInfo(diagBag))
 
                 If useSiteDiagnosticsBuilder IsNot Nothing Then
                     diagnosticsBuilder.AddRange(useSiteDiagnosticsBuilder)
@@ -312,6 +312,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Return constructedType
+        End Function
+
+        Public Function GetNewCompoundUseSiteInfo(futureDestination As BindingDiagnosticBag) As CompoundUseSiteInfo(Of AssemblySymbol)
+            Return New CompoundUseSiteInfo(Of AssemblySymbol)(futureDestination, Compilation.Assembly)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_WithBlock.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_WithBlock.vb
@@ -299,7 +299,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' by EnsureExpressionAndPlaceholder call, note that this call might have
             ' been before in which case the diagnostics were stored in '_withBlockInfo'
             ' See also comment in PrepareBindingOfOmittedLeft(...)
-            diagnostics.AddRange(Me._withBlockInfo.Diagnostics)
+            diagnostics.AddRange(Me._withBlockInfo.Diagnostics, allowMismatchInDependencyAccumulation:=True)
 
             Return New BoundWithStatement(node,
                                           Me._withBlockInfo.OriginalExpression,

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_XmlLiterals.vb
@@ -649,7 +649,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Determine the appropriate overload, allowing
                 ' XElement or IEnumerable(Of XElement) argument.
                 Dim xmlType = GetWellKnownType(WellKnownType.System_Xml_Linq_XElement, syntax, diagnostics)
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
                 If receiverType.IsOrDerivedFrom(xmlType, useSiteInfo) OrElse receiverType.IsCompatibleWithGenericIEnumerableOfType(xmlType, useSiteInfo) Then
                     group = GetXmlMethodOrPropertyGroup(syntax,
                                                             GetInternalXmlHelperType(syntax, diagnostics),
@@ -700,7 +700,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' Determine the appropriate overload, allowing
                 ' XContainer or IEnumerable(Of XContainer) argument.
                 Dim xmlType = GetWellKnownType(WellKnownType.System_Xml_Linq_XContainer, syntax, diagnostics)
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
 
                 If receiverType.IsOrDerivedFrom(xmlType, useSiteInfo) Then
                     group = GetXmlMethodOrPropertyGroup(syntax,
@@ -966,7 +966,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' on this type only, not base types, and ignore extension methods or properties
             ' from the current scope. (Extension methods and properties will be included,
             ' as shared members, if the members are defined on 'type' however.)
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics)
             LookupMember(result,
                          type,
                          memberName,

--- a/src/Compilers/VisualBasic/Portable/Binding/BindingDiagnosticBag.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BindingDiagnosticBag.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
@@ -51,6 +52,44 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Shared Function GetInstance() As BindingDiagnosticBag
             Return New BindingDiagnosticBag(usePool:=True)
+        End Function
+
+        Friend Shared Function GetInstance(withDiagnostics As Boolean, withDependencies As Boolean) As BindingDiagnosticBag
+            If withDependencies Then
+                If withDiagnostics Then
+                    Return GetInstance()
+                End If
+
+                Return New BindingDiagnosticBag(diagnosticBag:=Nothing, PooledHashSet(Of AssemblySymbol).GetInstance())
+
+            ElseIf withDiagnostics Then
+                Return New BindingDiagnosticBag(DiagnosticBag.GetInstance())
+            Else
+                Return Discarded
+            End If
+        End Function
+
+        Friend Shared Function GetInstance(template As BindingDiagnosticBag) As BindingDiagnosticBag
+            Return GetInstance(withDiagnostics:=template.AccumulatesDiagnostics, withDependencies:=template.AccumulatesDependencies)
+        End Function
+
+        Friend Shared Function Create(withDiagnostics As Boolean, withDependencies As Boolean) As BindingDiagnosticBag
+            If withDependencies Then
+                If withDiagnostics Then
+                    Return New BindingDiagnosticBag()
+                End If
+
+                Return New BindingDiagnosticBag(diagnosticBag:=Nothing, New HashSet(Of AssemblySymbol)())
+
+            ElseIf withDiagnostics Then
+                Return New BindingDiagnosticBag(New DiagnosticBag())
+            Else
+                Return Discarded
+            End If
+        End Function
+
+        Friend Shared Function Create(template As BindingDiagnosticBag) As BindingDiagnosticBag
+            Return Create(withDiagnostics:=template.AccumulatesDiagnostics, withDependencies:=template.AccumulatesDependencies)
         End Function
 
         Friend ReadOnly Property IsEmpty As Boolean

--- a/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/DocumentationCommentCrefBinder.vb
@@ -453,7 +453,7 @@ lAgain:
             returnType = Nothing
 
             Dim typeParameterAwareBinder As Binder = Me.GetOrCreateTypeParametersAwareBinder(typeParameters)
-            Dim diagnostic = If(diagnosticBag, BindingDiagnosticBag.GetInstance())
+            Dim diagnostic = If(diagnosticBag, BindingDiagnosticBag.Discarded)
 
             Dim signature As CrefSignatureSyntax = reference.Signature
             Debug.Assert(signature IsNot Nothing)
@@ -472,8 +472,6 @@ lAgain:
             If reference.AsClause IsNot Nothing Then
                 returnType = typeParameterAwareBinder.BindTypeSyntax(reference.AsClause.Type, diagnostic)
             End If
-
-            If diagnosticBag Is Nothing Then diagnostic.Free()
         End Sub
 
         Private Sub CollectCrefNameSymbolsStrict(nameFromCref As TypeSyntax,

--- a/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' Hide the GetAttribute overload which takes a diagnostic bag.
         ' This ensures that diagnostics from the early bound attributes are never preserved.
         Friend Shadows Function GetAttribute(node As AttributeSyntax, boundAttributeType As NamedTypeSymbol, <Out> ByRef generatedDiagnostics As Boolean) As SourceAttributeData
-            Dim diagnostics = BindingDiagnosticBag.GetInstance()
+            Dim diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, withDependencies:=False)
             Dim earlyAttribute = MyBase.GetAttribute(node, boundAttributeType, diagnostics)
             generatedDiagnostics = Not diagnostics.DiagnosticBag.IsEmptyWithoutResolution()
             diagnostics.Free()

--- a/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/SynthesizedStringSwitchHashMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SyntheticBoundTrees/SynthesizedStringSwitchHashMethod.vb
@@ -51,7 +51,7 @@ start:
         ''' This method should be kept consistent with ComputeStringHash
         ''' </remarks>
         Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock
-            Dim F = New SyntheticBoundNodeFactory(Me, Me, Me.Syntax, Nothing, diagnostics)
+            Dim F = New SyntheticBoundNodeFactory(Me, Me, Me.Syntax, compilationState, diagnostics)
             F.CurrentMethod = Me
 
             Dim i As LocalSymbol = F.SynthesizedLocal(Me.ContainingAssembly.GetSpecialType(SpecialType.System_Int32))

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -416,6 +416,8 @@
       <!-- Type is not significant for this node type; always null -->
       <Field Name="Type" Type="TypeSymbol" Override="true" Null="always"/>
       <Field Name="Binder" Type="Binder" Null="disallow"/>
+      <!-- Track dependencies while resolving the delegate -->
+      <Field Name="WithDependencies" Type="Boolean"/>      
       <Field Name="MethodGroup" Type="BoundMethodGroup" Null="disallow"/>      
     </Node>
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
@@ -3,6 +3,7 @@
 Imports System.Collections.Concurrent
 Imports System.Collections.Immutable
 Imports System.Threading
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -130,6 +131,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return delegateType Is info.Item1
         End Function
 
+        Public ReadOnly Property WithDependencies As Boolean
+            Get
+                Return _BindingCache.WithDependencies
+            End Get
+        End Property
+
         Friend Class TargetSignature
             Public ReadOnly ParameterTypes As ImmutableArray(Of TypeSymbol)
             Public ReadOnly ReturnType As TypeSymbol
@@ -217,10 +224,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' outside of the UnboundLambda class.
         ''' </summary>
         Public Class UnboundLambdaBindingCache
+            Public ReadOnly WithDependencies As Boolean
             Public AnonymousDelegate As Tuple(Of NamedTypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol))
             Public ReadOnly InferredReturnType As New ConcurrentDictionary(Of TargetSignature, KeyValuePair(Of TypeSymbol, ImmutableBindingDiagnostic(Of AssemblySymbol)))()
             Public ReadOnly BoundLambdas As New ConcurrentDictionary(Of TargetSignature, BoundLambda)()
             Public ErrorRecoverySignature As TargetSignature
+
+            Public Sub New(withDependencies As Boolean)
+                Me.WithDependencies = withDependencies
+            End Sub
         End Class
     End Class
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Common.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Common.vb
@@ -414,7 +414,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                        ERRID.ERR_None)
 
                         If nameAttribute IsNot Nothing Then
-                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(Me._diagnostics)
                             Dim bindResult As ImmutableArray(Of Symbol) = binder.BindXmlNameAttributeValue(nameAttribute.Reference, useSiteInfo)
 
                             If node.SyntaxTree.ReportDocumentationCommentDiagnostics() Then

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Includes.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Includes.vb
@@ -618,8 +618,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Case SyntaxKind.XmlCrefAttribute
                             Dim binder As binder = Me.GetOrCreateBinder(DocumentationCommentBinder.BinderType.Cref)
                             Dim reference As CrefReferenceSyntax = DirectCast(attr, XmlCrefAttributeSyntax).Reference
-                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
-                            Dim diagnostics = BindingDiagnosticBag.GetInstance()
+                            Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(_diagnostics)
+                            Dim diagnostics = BindingDiagnosticBag.GetInstance(_diagnostics)
                             Dim bindResult As ImmutableArray(Of Symbol) = binder.BindInsideCrefAttributeValue(reference, preserveAliases:=False,
                                                                                                               diagnosticBag:=diagnostics, useSiteInfo:=useSiteInfo)
                             _diagnostics.AddDependencies(diagnostics)
@@ -756,7 +756,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Case SyntaxKind.XmlNameAttribute
                             Dim binder As binder = Me.GetOrCreateBinder(type)
                             Dim identifier As IdentifierNameSyntax = DirectCast(attr, XmlNameAttributeSyntax).Reference
-                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(Me._diagnostics)
                             Dim bindResult As ImmutableArray(Of Symbol) = binder.BindXmlNameAttributeValue(identifier, useSiteInfo)
 
                             Me._diagnostics.AddDependencies(useSiteInfo)

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     diagnostics.Add(ERRID.ERR_DocFileGen, Location.None, ex.Message)
                 End Try
 
-                If diagnostics.DiagnosticBag IsNot Nothing Then
+                If diagnostics.AccumulatesDiagnostics Then
                     If filterTree IsNot Nothing Then
                         MislocatedDocumentationCommentFinder.ReportUnprocessed(filterTree, filterSpanWithinTree, diagnostics.DiagnosticBag, cancellationToken)
                     Else

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentWalker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentWalker.vb
@@ -146,8 +146,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(Not reference.ContainsDiagnostics)
 
                         Dim crefBinder = CreateDocumentationCommentBinderForSymbol(Me.Module, Me._symbol, Me._syntaxTree, DocumentationCommentBinder.BinderType.Cref)
-                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
-                        Dim diagnostics = BindingDiagnosticBag.GetInstance
+                        Dim useSiteInfo = crefBinder.GetNewCompoundUseSiteInfo(_diagnostics)
+                        Dim diagnostics = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, _diagnostics.AccumulatesDependencies)
                         Dim result As ImmutableArray(Of Symbol) = crefBinder.BindInsideCrefAttributeValue(reference, preserveAliases:=False, diagnosticBag:=diagnostics, useSiteInfo:=useSiteInfo)
                         _diagnostics.AddDependencies(diagnostics)
                         _diagnostics.AddDependencies(useSiteInfo)

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedEvent.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                             ' ERRID_SourceInterfaceMustBeInterface/ERR_MissingSourceInterface
                             EmbeddedTypesManager.ReportDiagnostic(diagnostics, ERRID.ERR_SourceInterfaceMustBeInterface, syntaxNodeOpt, underlyingContainingType, UnderlyingEvent)
                         Else
-                            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                            Dim useSiteInfo = CompoundUseSiteInfo(Of AssemblySymbol).DiscardedDependecies
                             sourceInterface.AllInterfacesWithDefinitionUseSiteDiagnostics(useSiteInfo)
                             diagnostics.Add(If(syntaxNodeOpt Is Nothing, NoLocation.Singleton, syntaxNodeOpt.GetLocation()), useSiteInfo.Diagnostics)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -210,7 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         ' STMT:   this.builder.AwaitUnsafeOnCompleted(Of TAwaiter,TSM)((ByRef) $awaiterTemp, (ByRef) Me)
                         '  or
                         ' STMT:   this.builder.AwaitOnCompleted(Of TAwaiter,TSM)((ByRef) $awaiterTemp, (ByRef) Me)
-                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(Me.F.Diagnostics, Me.CompilationState.Compilation.Assembly)
                         Dim useUnsafeOnCompleted As Boolean =
                             Conversions.IsWideningConversion(
                                 Conversions.ClassifyDirectCastConversion(

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
@@ -302,7 +302,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End If
 
-            Dim bag = BindingDiagnosticBag.GetInstance()
+            Dim bag = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, withDependencies:=Me.Diagnostics.AccumulatesDependencies)
 
             EnsureSpecialType(SpecialType.System_Object, bag)
             EnsureSpecialType(SpecialType.System_Void, bag)
@@ -540,7 +540,7 @@ lCaptureRValue:
             Dim group As BoundMethodGroup = Nothing
             Dim result = LookupResult.GetInstance()
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = Me._binder.GetNewCompoundUseSiteInfo(Me.Diagnostics)
             Me._binder.LookupMember(result, type, methodName, arity:=0, options:=_lookupOptions, useSiteInfo:=useSiteInfo)
             Me.Diagnostics.Add(Me.F.Syntax, useSiteInfo)
 
@@ -599,7 +599,7 @@ lCaptureRValue:
             Dim group As BoundPropertyGroup = Nothing
             Dim result = LookupResult.GetInstance()
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = Me._binder.GetNewCompoundUseSiteInfo(Me.Diagnostics)
             Me._binder.LookupMember(result, type, propertyName, arity:=0, options:=_lookupOptions, useSiteInfo:=useSiteInfo)
             Me.Diagnostics.Add(Me.F.Syntax, useSiteInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter.vb
@@ -821,7 +821,7 @@ lSelect:
             Dim group As BoundMethodGroup = Nothing
             Dim result = LookupResult.GetInstance()
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = _binder.GetNewCompoundUseSiteInfo(Me.Diagnostics)
             _binder.LookupMember(result,
                                  Me._expressionType,
                                  methodName,

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
@@ -101,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' the type of the argument of 'conversion' in case 'parameter' is a nullable and the real 
                 ' conversion argument is not
                 Dim parameterType As TypeSymbol = parameter.Type
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = Me._binder.GetNewCompoundUseSiteInfo(Diagnostics)
                 Dim convKind As ConversionKind = Conversions.ClassifyPredefinedConversion(parameterType, conversion.Operand.Type, useSiteInfo)
                 Diagnostics.Add(conversion, useSiteInfo)
 
@@ -194,7 +194,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim realParameterType As TypeSymbol = parameter.Type
             Debug.Assert(TypeSymbol.Equals(expectedParameterType.GetNullableUnderlyingTypeOrSelf, realParameterType.GetNullableUnderlyingTypeOrSelf, TypeCompareKind.ConsiderEverything))
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = _binder.GetNewCompoundUseSiteInfo(Diagnostics)
             Dim innerConversion As ConversionKind = Conversions.ClassifyConversion(realParameterType, expectedParameterType, useSiteInfo).Key
             Diagnostics.Add(conversion, useSiteInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return True
             End If
 
-            Dim bag = BindingDiagnosticBag.GetInstance()
+            Dim bag = BindingDiagnosticBag.GetInstance(withDiagnostics:=True, withDependencies:=Me.Diagnostics.AccumulatesDependencies)
 
             ' NOTE: We don't ensure DebuggerStepThroughAttribute, it is just not emitted if not found
             ' EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Diagnostics_DebuggerStepThroughAttribute__ctor, hasErrors)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -1409,7 +1409,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function OptimizeMethodCallForDelegateInvoke(node As BoundCall) As BoundCall
             Dim method = node.Method
             Dim receiver = node.ReceiverOpt
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(Diagnostics, CompilationState.Compilation.Assembly)
 
             If method.MethodKind = MethodKind.DelegateInvoke AndAlso
                     method.ContainingType.IsAnonymousType AndAlso

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter.vb
@@ -123,7 +123,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             recursionDepth As Integer
         )
             MyBase.New(recursionDepth)
-            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
+            Debug.Assert(diagnostics.AccumulatesDiagnostics)
 
             Me._topMethod = topMethod
             Me._currentMethodOrLambda = currentMethod

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -421,7 +421,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ElseIf operandType.IsStringType Then
                     ' CType(string, T?) ---> new T?(CType(string, T))
                     Dim innerTargetType = resultType.GetNullableUnderlyingType
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                     Dim convKind = Conversions.ClassifyConversion(rewrittenOperand.Type, innerTargetType, useSiteInfo).Key
                     Debug.Assert(Conversions.ConversionExists(convKind))
                     _diagnostics.Add(node, useSiteInfo)
@@ -448,7 +448,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     If HasValue(rewrittenOperand) Then
                         ' DirectCast(operand.GetValueOrDefault, operatorType)
                         Dim unwrappedOperand = NullableValueOrDefault(rewrittenOperand)
-                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                         Dim convKind = Conversions.ClassifyDirectCastConversion(unwrappedOperand.Type, resultType, useSiteInfo)
                         Debug.Assert(Conversions.ConversionExists(convKind))
                         _diagnostics.Add(node, useSiteInfo)
@@ -513,6 +513,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return FinishRewriteNullableConversion(node, resultType, result, operandHasValue, temps, inits)
         End Function
 
+        Private Function GetNewCompoundUseSiteInfo() As CompoundUseSiteInfo(Of AssemblySymbol)
+            Return New CompoundUseSiteInfo(Of AssemblySymbol)(_diagnostics, Me.Compilation.Assembly)
+        End Function
+
         Private Function FinishRewriteNullableConversion(
             node As BoundConversion,
             resultType As TypeSymbol,
@@ -527,7 +531,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' apply unlifted conversion
             If Not operand.Type.IsSameTypeIgnoringAll(unwrappedResultType) Then
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                 Dim convKind = Conversions.ClassifyConversion(operand.Type, unwrappedResultType, useSiteInfo).Key
                 Debug.Assert(Conversions.ConversionExists(convKind))
                 Debug.Assert((convKind And ConversionKind.Tuple) = (node.ConversionKind And ConversionKind.Tuple))
@@ -596,7 +600,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If operandType.IsStringType Then
                 ' CType(string, T?) ---> new T?(CType(string, T))
                 Dim innerTargetType = resultType.GetNullableUnderlyingType
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                 Dim convKind = Conversions.ClassifyConversion(operandType, innerTargetType, useSiteInfo).Key
                 Debug.Assert(Conversions.ConversionExists(convKind))
                 _diagnostics.Add(node, useSiteInfo)
@@ -619,7 +623,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' is not null-propagating
 
                 rewrittenOperand = NullableValue(rewrittenOperand)
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                 Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenOperand.Type, resultType, useSiteInfo)
                 Debug.Assert(Conversions.ConversionExists(convKind))
                 _diagnostics.Add(node, useSiteInfo)
@@ -646,7 +650,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If HasValue(rewrittenOperand) Then
                     ' DirectCast(operand.GetValueOrDefault, operatorType)
                     Dim unwrappedOperand = NullableValueOrDefault(rewrittenOperand)
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                     Dim convKind = Conversions.ClassifyDirectCastConversion(unwrappedOperand.Type, resultType, useSiteInfo)
                     Debug.Assert(Conversions.ConversionExists(convKind))
                     _diagnostics.Add(node, useSiteInfo)
@@ -660,7 +664,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If resultType.IsNullableType Then
                 ' RefType --> T? , this is just an unboxing conversion.
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                 Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenOperand.Type, resultType, useSiteInfo)
                 Debug.Assert(Conversions.ConversionExists(convKind))
                 _diagnostics.Add(node, useSiteInfo)
@@ -885,7 +889,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not operand.Type.IsObjectType() Then
                     Dim objectType As TypeSymbol = memberSymbol.Parameters(0).Type
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                     operand = New BoundDirectCast(operand.Syntax,
                                                   operand,
                                                   Conversions.ClassifyDirectCastConversion(operand.Type, objectType, useSiteInfo),
@@ -960,7 +964,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Debug.Assert(operand.Type.IsReferenceType)
                         Debug.Assert(underlyingTypeTo.IsIntrinsicValueType())
 
-                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                         operand = New BoundDirectCast(operand.Syntax,
                                                       operand,
                                                       Conversions.ClassifyDirectCastConversion(operand.Type, typeFrom, useSiteInfo),

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim binder = node.Binder
 
             Dim lookup = LookupResult.GetInstance()
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo()
 
             binder.LookupMember(lookup, factoryType, factoryMethodName, 0, LookupOptions.MustNotBeInstance Or LookupOptions.MethodsOnly Or LookupOptions.AllMethodsOfAnyArity, useSiteInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateBindingHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LateBindingHelpers.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return MakeNullLiteral(node, objectType)
             Else
                 If Not rewrittenReceiver.Type.IsObjectType Then
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                     Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenReceiver.Type, objectType, useSiteInfo)
                     _diagnostics.Add(node, useSiteInfo)
                     rewrittenReceiver = New BoundDirectCast(node, rewrittenReceiver, convKind, objectType)
@@ -128,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim argument = rewrittenArguments(i)
                 argument = argument.MakeRValue
                 If Not argument.Type.IsObjectType Then
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                     Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteInfo)
                     _diagnostics.Add(node, useSiteInfo)
                     argument = New BoundDirectCast(node, argument, convKind, objectType)
@@ -167,7 +167,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(arrayType.IsSZArray)
             Debug.Assert(objectType.IsObjectType)
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo()
 
             If Not rewrittenValue.Type.IsObjectType Then
                 Dim convKind = Conversions.ClassifyDirectCastConversion(rewrittenValue.Type, objectType, useSiteInfo)
@@ -282,7 +282,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each argument In rewrittenArguments
                     argument = argument.MakeRValue
                     If Not argument.Type.IsObjectType Then
-                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                         Dim convKind = Conversions.ClassifyDirectCastConversion(argument.Type, objectType, useSiteInfo)
                         _diagnostics.Add(argument, useSiteInfo)
                         argument = New BoundDirectCast(node, argument, convKind, objectType)
@@ -383,7 +383,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 End If
 #If DEBUG Then
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(Me.Compilation.Assembly)
 #Else
                 Dim useSiteInfo = CompoundUseSiteInfo(Of AssemblySymbol).Discarded
 #End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.vb
@@ -193,7 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                New BoundMeReference(syntax, _topMethod.ContainingType)),
                                             staticLocalBackingFields.Value, isLValue:=True, type:=staticLocalBackingFields.Value.Type)
 
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo()
             Dim flagAsObject = New BoundDirectCast(syntax,
                                                    flag.MakeRValue(),
                                                    Conversions.ClassifyDirectCastConversion(flag.Type, objectType, useSiteInfo),

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreation.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreation.vb
@@ -37,7 +37,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If node.Type.IsInterfaceType() Then
                     Debug.Assert(result.Type.Equals(DirectCast(node.Type, NamedTypeSymbol).CoClassType))
 
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                     Dim conv As ConversionKind = Conversions.ClassifyDirectCastConversion(result.Type, node.Type, useSiteInfo)
                     Debug.Assert(Conversions.ConversionExists(conv))
                     _diagnostics.Add(result, useSiteInfo)
@@ -84,7 +84,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim createInstance = factory.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Activator__CreateInstance)
             Dim rewrittenObjectCreation As BoundExpression
             If createInstance IsNot Nothing AndAlso Not createInstance.ReturnType.IsErrorType() Then
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = GetNewCompoundUseSiteInfo()
                 Dim conversion = Conversions.ClassifyDirectCastConversion(createInstance.ReturnType, node.Type, useSiteInfo)
                 _diagnostics.Add(node, useSiteInfo)
                 rewrittenObjectCreation = New BoundDirectCast(node.Syntax, factory.Call(Nothing, createInstance, callGetTypeFromCLSID), conversion, node.Type)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_OmittedArgument.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_OmittedArgument.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim fieldAccess = New BoundFieldAccess(node.Syntax, Nothing, missingField, isLValue:=False, type:=missingField.Type)
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo()
             Dim conversion = Conversions.ClassifyDirectCastConversion(fieldAccess.Type, node.Type, useSiteInfo)
             _diagnostics.Add(node, useSiteInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RedimClause.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_RedimClause.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim temporaries As ArrayBuilder(Of SynthesizedLocal) = Nothing
             Dim assignmentTarget = node.Operand
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo()
 
             Dim copyArrayUtilityMethod As MethodSymbol = Nothing
             If node.Preserve AndAlso TryGetWellknownMember(copyArrayUtilityMethod, WellKnownMember.Microsoft_VisualBasic_CompilerServices_Utils__CopyArray, node.Syntax) Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SyncLock.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_SyncLock.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim visitedLockExpression = VisitExpressionNode(node.LockExpression)
 
             Dim objectType = GetSpecialType(SpecialType.System_Object)
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo = GetNewCompoundUseSiteInfo()
             Dim conversionKind = Conversions.ClassifyConversion(visitedLockExpression.Type, objectType, useSiteInfo).Key
             _diagnostics.Add(node, useSiteInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/MethodToClassRewriter/MethodToClassRewriter.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Protected Sub New(slotAllocatorOpt As VariableSlotAllocator, compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag, preserveOriginalLocals As Boolean)
             Debug.Assert(compilationState IsNot Nothing)
-            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
+            Debug.Assert(diagnostics.AccumulatesDiagnostics)
             Me.CompilationState = compilationState
             Me.Diagnostics = diagnostics
             Me.SlotAllocatorOpt = slotAllocatorOpt

--- a/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
@@ -30,14 +30,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Debug.Assert(Not body.HasErrors)
             Debug.Assert(compilationState.ModuleBuilderOpt IsNot Nothing)
-            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
+            Debug.Assert(diagnostics.AccumulatesDiagnostics)
 
             ' performs node-specific lowering.
             Dim sawLambdas As Boolean
             Dim symbolsCapturedWithoutCopyCtor As ISet(Of Symbol) = Nothing
             Dim rewrittenNodes As HashSet(Of BoundNode) = Nothing
             Dim flags = If(allowOmissionOfConditionalCalls, LocalRewriter.RewritingFlags.AllowOmissionOfConditionalCalls, LocalRewriter.RewritingFlags.Default)
-            Dim localDiagnostics = BindingDiagnosticBag.GetInstance()
+            Dim localDiagnostics = BindingDiagnosticBag.GetInstance(diagnostics)
+            Debug.Assert(localDiagnostics.AccumulatesDiagnostics)
             dynamicAnalysisSpans = ImmutableArray(Of SourceSpan).Empty
 
             Try

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(method IsNot Nothing)
             Debug.Assert(compilationState IsNot Nothing)
             Debug.Assert(diagnostics IsNot Nothing)
-            Debug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
+            Debug.Assert(diagnostics.AccumulatesDiagnostics)
             Debug.Assert(stateMachineType IsNot Nothing)
 
             Me.Body = body

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -67,6 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Public Sub New(topLevelMethod As MethodSymbol, currentMethod As MethodSymbol, currentClass As NamedTypeSymbol, node As SyntaxNode, compilationState As TypeCompilationState, diagnostics As BindingDiagnosticBag)
+            Debug.Assert(compilationState IsNot Nothing)
             Me.CompilationState = compilationState
             Me.CurrentMethod = currentMethod
             Me.TopLevelMethod = topLevelMethod
@@ -347,7 +348,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function [Return](Optional expression As BoundExpression = Nothing) As BoundReturnStatement
             If expression IsNot Nothing Then
                 ' If necessary, add a conversion on the return expression.
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(Diagnostics, Me.Compilation.Assembly)
                 Dim conversion = Conversions.ClassifyDirectCastConversion(expression.Type, Me.CurrentMethod.ReturnType, useSiteInfo)
                 Debug.Assert(Conversions.IsWideningConversion(conversion))
                 Diagnostics.Add(expression, useSiteInfo)

--- a/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
@@ -1037,7 +1037,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(base.IsClassType() OrElse base.IsInterfaceType(), "Expected class or interface!!!")
 
             Dim illegalExposure As ArrayBuilder(Of AccessExposure) = Nothing
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, classOrInterface.ContainingAssembly)
 
             VerifyAccessExposure(classOrInterface, base, illegalExposure, useSiteInfo)
 
@@ -1112,7 +1112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             diagBag As BindingDiagnosticBag
         )
             Dim illegalExposure As ArrayBuilder(Of AccessExposure) = Nothing
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, member.ContainingAssembly)
 
             VerifyAccessExposure(member, TypeBehindParam, illegalExposure, useSiteInfo)
 
@@ -1159,7 +1159,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Optional isDelegateFromImplements As Boolean = False
         )
             Dim illegalExposure As ArrayBuilder(Of AccessExposure) = Nothing
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, member.ContainingAssembly)
 
             VerifyAccessExposure(member, typeBehindMember, illegalExposure, useSiteInfo)
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
@@ -2894,7 +2894,7 @@ Bailout:
                 If method.IsGenericMethod Then
                     Dim diagnosticsBuilder = ArrayBuilder(Of TypeParameterDiagnosticInfo).GetInstance()
                     Dim useSiteDiagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo) = Nothing
-                    Dim satisfiedConstraints = method.CheckConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder)
+                    Dim satisfiedConstraints = method.CheckConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder, template:=useSiteInfo)
                     diagnosticsBuilder.Free()
 
                     If useSiteDiagnosticsBuilder IsNot Nothing AndAlso useSiteDiagnosticsBuilder.Count > 0 Then
@@ -4899,7 +4899,7 @@ ContinueCandidatesLoop:
                                 Dim diagnostics = candidate.TypeArgumentInferenceDiagnosticsOpt
 
                                 If diagnostics Is Nothing Then
-                                    diagnostics = New BindingDiagnosticBag()
+                                    diagnostics = BindingDiagnosticBag.Create(withDiagnostics:=True, useSiteInfo.AccumulatesDependencies)
                                     candidate.TypeArgumentInferenceDiagnosticsOpt = diagnostics
                                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -460,7 +460,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        delegateParam.Type.Equals(currentTypedNode.DeclaredTypeParam) Then
 
                                         If Graph.Diagnostic Is Nothing Then
-                                            Graph.Diagnostic = New BindingDiagnosticBag()
+                                            Graph.Diagnostic = BindingDiagnosticBag.Create(withDiagnostics:=True, Graph.UseSiteInfo.AccumulatesDependencies)
                                         End If
 
                                         ' If this was an argument to the unbound Lambda, infer Object.
@@ -2138,7 +2138,7 @@ HandleAsAGeneralExpression:
 
                                 If lambdaReturnType Is Nothing Then
                                     If Me.Diagnostic Is Nothing Then
-                                        Me.Diagnostic = New BindingDiagnosticBag()
+                                        Me.Diagnostic = BindingDiagnosticBag.Create(withDiagnostics:=True, Me.UseSiteInfo.AccumulatesDependencies)
                                     End If
 
                                     Debug.Assert(Me.Diagnostic IsNot Nothing)
@@ -2161,7 +2161,7 @@ HandleAsAGeneralExpression:
 
                                     ' Let's keep return type inference errors
                                     If Me.Diagnostic Is Nothing Then
-                                        Me.Diagnostic = New BindingDiagnosticBag()
+                                        Me.Diagnostic = BindingDiagnosticBag.Create(withDiagnostics:=True, Me.UseSiteInfo.AccumulatesDependencies)
                                     End If
 
                                     Me.Diagnostic.AddRange(returnTypeInfo.Value)
@@ -2181,7 +2181,7 @@ HandleAsAGeneralExpression:
 
                                         ' Let's keep return type inference warnings, if any.
                                         If Me.Diagnostic Is Nothing Then
-                                            Me.Diagnostic = New BindingDiagnosticBag()
+                                            Me.Diagnostic = BindingDiagnosticBag.Create(withDiagnostics:=True, Me.UseSiteInfo.AccumulatesDependencies)
                                         End If
 
                                         Me.Diagnostic.AddRange(returnTypeInfo.Value)
@@ -2192,7 +2192,7 @@ HandleAsAGeneralExpression:
                                         ' Let's preserve diagnostics that caused the failure
                                         If Not boundLambda.Diagnostics.Diagnostics.IsDefaultOrEmpty Then
                                             If Me.Diagnostic Is Nothing Then
-                                                Me.Diagnostic = New BindingDiagnosticBag()
+                                                Me.Diagnostic = BindingDiagnosticBag.Create(withDiagnostics:=True, Me.UseSiteInfo.AccumulatesDependencies)
                                             End If
 
                                             Me.Diagnostic.AddRange(boundLambda.Diagnostics)

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -47,6 +47,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IAssemblySymbolInternal_CorLibrary As IAssemblySymbolInternal Implements IAssemblySymbolInternal.CorLibrary
+            Get
+                Return CorLibrary
+            End Get
+        End Property
+
         ''' <summary>
         ''' A helper method for ReferenceManager to set the system assembly, which provides primitive 
         ''' types like Object, String, etc., e.g. mscorlib.dll. 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Attributes/AttributeData.vb
@@ -233,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Else
                 Dim firstArg As TypedConstant = Me.CommonConstructorArguments.FirstOrDefault()
                 Dim firstArgType = DirectCast(firstArg.TypeInternal, TypeSymbol)
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, compilation.Assembly)
                 If firstArgType IsNot Nothing AndAlso firstArgType.IsOrDerivedFromWellKnownClass(WellKnownType.System_Security_Permissions_SecurityAction, compilation, useSiteInfo) Then
                     Return ValidateSecurityAction(firstArg, targetSymbol, nodeOpt, diagnostics, hasErrors)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
@@ -185,7 +185,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                     ' If delegate is a function method we should already have diagnostics about that
                     If delInvoke IsNot Nothing AndAlso delInvoke.IsSub Then
-                        Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                        Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagnostics)
                         Dim conversion = Conversions.ClassifyMethodConversionForEventRaise(
                                                             delInvoke,
                                                             parameters,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -200,7 +200,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     options = CType(options Or LookupOptions.EventsOnly, LookupOptions)
                 End If
 
-                Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                Dim useSiteInfo = binder.GetNewCompoundUseSiteInfo(diagBag)
                 binder.LookupMember(lookup, interfaceType, implementedMethodName, -1, options, useSiteInfo)
 
                 If lookup.IsAmbiguous Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1142,7 +1142,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Sub GetAllDeclarationErrors(diagnostics As BindingDiagnosticBag, Optional cancellationToken As CancellationToken = Nothing)
             Dim hasExtensionMethods As Boolean = False
             SourceModule.GetAllDeclarationErrors(diagnostics, cancellationToken, hasExtensionMethods)
-            diagnostics.AddRange(GetAssemblyLevelDeclarationErrors(hasExtensionMethods))
+            diagnostics.AddRange(GetAssemblyLevelDeclarationErrors(hasExtensionMethods), allowMismatchInDependencyAccumulation:=True)
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFile.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFile.vb
@@ -348,7 +348,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim type = TryCast(namespaceOrType, TypeSymbol)
             If type IsNot Nothing Then
                 clauseDiagnostics.Clear()
-                type.CheckAllConstraints(location, clauseDiagnostics)
+                type.CheckAllConstraints(location, clauseDiagnostics, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, compilation.Assembly))
                 diagnostics.AddRange(clauseDiagnostics.DiagnosticBag)
 
                 If VisualBasicCompilation.ReportUnusedImportsInTree(location.PossiblyEmbeddedOrMySourceTree) Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2530,7 +2530,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     ByRef instanceInitializers As ArrayBuilder(Of FieldOrPropertyInitializer),
                                     reportAsInvalid As Boolean)
 
-            Debug.Assert(diagBag.DiagnosticBag IsNot Nothing)
+            Debug.Assert(diagBag.AccumulatesDiagnostics)
             ' Partial methods are implemented by a postpass that matches up the declaration with the implementation.
             ' Here we treat them as independent methods.
 
@@ -2856,7 +2856,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     ' Set up a binder.
                                     baseBinder = If(baseBinder, BinderBuilder.CreateBinderForType(m_containingModule, methodStatement.SyntaxTree, Me))
 
-                                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                                    Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, m_containingModule.ContainingAssembly)
                                     eventSym = SourceMemberMethodSymbol.FindEvent(Me.BaseTypeNoUseSiteDiagnostics, baseBinder, eventName, isThroughMyBase:=True, useSiteInfo:=useSiteInfo)
                                     diagBag.Add(handlesClause.EventMember, useSiteInfo)
                                 End If
@@ -3606,7 +3606,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim opInfo As OverloadResolution.OperatorInfo = OverloadResolution.GetOperatorInfo(method.Name)
 
-            If Not OverloadResolution.ValidateOverloadedOperator(method, opInfo, diagnostics) Then
+            If Not OverloadResolution.ValidateOverloadedOperator(method, opInfo, diagnostics, ContainingAssembly) Then
                 ' Malformed operator, but still an operator.
                 Return True
             End If
@@ -3914,7 +3914,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Interface1 and Interface2 have variable ambiguity. Report the warning in the correct location.
         ''' </summary>
         Private Sub ReportVarianceAmbiguityWarning(diagnostics As BindingDiagnosticBag, interface1 As NamedTypeSymbol, interface2 As NamedTypeSymbol)
-            Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, ContainingAssembly)
             Dim hasVarianceAmbiguity As Boolean = VarianceAmbiguity.HasVarianceAmbiguity(Me, interface1, interface2, useSiteInfo)
 
             If hasVarianceAmbiguity OrElse Not useSiteInfo.Diagnostics.IsNullOrEmpty Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberFieldSymbol.vb
@@ -370,7 +370,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                  ByRef instanceInitializers As ArrayBuilder(Of FieldOrPropertyInitializer),
                                  diagBag As BindingDiagnosticBag)
 
-            Debug.Assert(diagBag.DiagnosticBag IsNot Nothing)
+            Debug.Assert(diagBag.AccumulatesDiagnostics)
             ' Decode the flags.
 
             Dim validFlags = SourceMemberFlags.AllAccessibilityModifiers Or

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -2145,7 +2145,7 @@ lReportErrorOnTwoTokens:
                     If param.Locations.Length > 0 Then
                         ' Note: Errors are reported on the parameter name. Ideally, we should
                         ' match Dev10 and report errors on the parameter type syntax instead.
-                        param.Type.CheckAllConstraints(param.Locations(0), diagBag)
+                        param.Type.CheckAllConstraints(param.Locations(0), diagBag, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, sourceModule.ContainingAssembly))
                     End If
                 Next
 
@@ -2153,7 +2153,7 @@ lReportErrorOnTwoTokens:
                     Dim diagnosticsBuilder = ArrayBuilder(Of TypeParameterDiagnosticInfo).GetInstance()
                     Dim useSiteDiagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo) = Nothing
 
-                    retType.CheckAllConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder)
+                    retType.CheckAllConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, sourceModule.ContainingAssembly))
 
                     If useSiteDiagnosticsBuilder IsNot Nothing Then
                         diagnosticsBuilder.AddRange(useSiteDiagnosticsBuilder)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -188,7 +188,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         Dim diagnosticsBuilder = ArrayBuilder(Of TypeParameterDiagnosticInfo).GetInstance()
                         Dim useSiteDiagnosticsBuilder As ArrayBuilder(Of TypeParameterDiagnosticInfo) = Nothing
 
-                        retType.CheckAllConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder)
+                        retType.CheckAllConstraints(diagnosticsBuilder, useSiteDiagnosticsBuilder, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, sourceModule.ContainingAssembly))
 
                         If useSiteDiagnosticsBuilder IsNot Nothing Then
                             diagnosticsBuilder.AddRange(useSiteDiagnosticsBuilder)
@@ -257,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         If param.Locations.Length > 0 Then
                             ' Note: Errors are reported on the parameter name. Ideally, we should
                             ' match Dev10 and report errors on the parameter type syntax instead.
-                            param.Type.CheckAllConstraints(param.Locations(0), diagBag)
+                            param.Type.CheckAllConstraints(param.Locations(0), diagBag, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagBag, sourceModule.ContainingAssembly))
                         End If
                     Next
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceTypeParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceTypeParameterSymbol.vb
@@ -162,18 +162,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' constraints are not checked when binding ConstraintTypes since ConstraintTypes
         ''' has not been set on I(Of T) at that point.
         ''' </summary>
-        Private Shared Sub CheckConstraintTypeConstraints(constraints As ImmutableArray(Of TypeParameterConstraint), diagnostics As BindingDiagnosticBag)
+        Private Sub CheckConstraintTypeConstraints(constraints As ImmutableArray(Of TypeParameterConstraint), diagnostics As BindingDiagnosticBag)
+            Dim containingAssembly As AssemblySymbol = Me.ContainingAssembly
+
             For Each constraint In constraints
                 Dim constraintType = constraint.TypeConstraint
                 If constraintType IsNot Nothing Then
                     Dim location = constraint.LocationOpt
                     Debug.Assert(location IsNot Nothing)
 
-                    Dim useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+                    Dim useSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, containingAssembly)
                     constraintType.AddUseSiteInfo(useSiteInfo)
 
                     If Not diagnostics.Add(location, useSiteInfo) Then
-                        constraintType.CheckAllConstraints(location, diagnostics)
+                        constraintType.CheckAllConstraints(location, diagnostics, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, containingAssembly))
                     End If
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SynthesizedEventAccessorSymbol.vb
@@ -319,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                       type:=parameterSymbol.Type).MakeCompilerGenerated
 
             Dim delegateUpdate As BoundExpression
-            Dim conversionsUseSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol) = Nothing
+            Dim conversionsUseSiteInfo As New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, compilation.Assembly)
             Dim conversionKind1 As ConversionKind
             Dim conversionKind2 As ConversionKind
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -374,7 +374,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Dim constructedType = TupleTypeSymbol.Create(locationOpt, tupleUnderlyingType, elementLocations, elementNames, errorPositions)
             If shouldCheckConstraints Then
-                constructedType.CheckConstraints(syntax, elementLocations, diagnostics)
+                constructedType.CheckConstraints(syntax, elementLocations, diagnostics, template:=New CompoundUseSiteInfo(Of AssemblySymbol)(diagnostics, compilation.Assembly))
             End If
 
             Return constructedType

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -677,7 +677,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             type As TypeSymbol,
             <[In], Out> ByRef useSiteInfo As CompoundUseSiteInfo(Of AssemblySymbol)
         )
-            useSiteInfo.Add(type.GetUseSiteInfo())
+            If useSiteInfo.AccumulatesDiagnostics Then
+                useSiteInfo.Add(type.GetUseSiteInfo())
+            Else
+                Debug.Assert(Not useSiteInfo.AccumulatesDependencies)
+            End If
         End Sub
 
         <Extension()>

--- a/src/Compilers/VisualBasic/Portable/Symbols/UsedAssemblies.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/UsedAssemblies.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 '                                    and we either already encountered errors, or have done all the work 
                 '                                    to record usage.
                 Dim diagnostics = New BindingDiagnosticBag(DiagnosticBag.GetInstance(), New ConcurrentSet(Of AssemblySymbol)())
-                RoslynDebug.Assert(diagnostics.DiagnosticBag IsNot Nothing)
+                RoslynDebug.Assert(diagnostics.AccumulatesDiagnostics)
 
                 GetDiagnosticsWithoutFiltering(CompilationStage.Declare, includeEarlierStages:=True, diagnostics, cancellationToken)
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             // NOTE: This conversion can fail if some of the types involved are from not-yet-loaded modules.
             // For example, if System.Exception hasn't been loaded, then this call will fail for $stowedexception.
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = default;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, compilation.Assembly);
             var conversion = compilation.Conversions.ClassifyConversionFromExpression(expr, type, ref useSiteInfo);
             diagnostics.Add(expr.Syntax, useSiteInfo);
             Debug.Assert(conversion.IsValid || diagnostics.HasAnyErrors());


### PR DESCRIPTION
- Do not track usage of an assembly being built, it is always filtered out at the end.
- Do not track dependencies when consumer is not interested in them. This mostly affects binding and lowering of an executable code.