### PR TITLE
Fix issues in MetadataAsSource XML documentation comment conversion

### DIFF
--- a/src/Features/CSharp/Portable/DocumentationComments/DocCommentConverter.cs
+++ b/src/Features/CSharp/Portable/DocumentationComments/DocCommentConverter.cs
@@ -49,11 +49,16 @@ namespace Microsoft.CodeAnalysis.CSharp.DocumentationComments
                 {
                     if (trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
                     {
-                        newLeadingTrivia.Add(SyntaxFactory.Comment("//"));
-                        newLeadingTrivia.Add(SyntaxFactory.ElasticCarriageReturnLineFeed);
-
                         var structuredTrivia = (DocumentationCommentTriviaSyntax)trivia.GetStructure();
-                        newLeadingTrivia.AddRange(ConvertDocCommentToRegularComment(structuredTrivia));
+                        var commentLines = ConvertDocCommentToRegularComment(structuredTrivia).ToSyntaxTriviaList();
+
+                        if (commentLines.Count > 0)
+                        {
+                            newLeadingTrivia.Add(SyntaxFactory.Comment("//"));
+                            newLeadingTrivia.Add(SyntaxFactory.ElasticCarriageReturnLineFeed);
+
+                            newLeadingTrivia.AddRange(commentLines);
+                        }
                     }
                     else
                     {

--- a/src/Features/Core/Portable/MetadataAsSource/DocumentationCommentUtilities.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DocumentationCommentUtilities.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             using var list = s_pool.GetPooledObject();
             while (reader.ReadLine() is string str)
             {
+                str = str.TrimStart();
                 if (str.StartsWith(docCommentPrefix, StringComparison.Ordinal))
                 {
                     str = str.Substring(docCommentPrefix.Length);


### PR DESCRIPTION
This fixes #39877 

See https://github.com/dotnet/roslyn/issues/39877#issuecomment-575386083 for a detailed description.

TL;DR
1. Only adds a comment above a member, if `DocCommentConverter.ConvertDocCommentToRegularComment` returns anything.
2. Strips leading whitespace before checking whether a line starts with a single-line documentation comment (i.e. `///`).