### PR TITLE
Add Namespace grouping to API

### DIFF
--- a/src/Workspaces/Remote/Core/Telemetry/ApiUsageIncrementalAnalyzerProvider.cs
+++ b/src/Workspaces/Remote/Core/Telemetry/ApiUsageIncrementalAnalyzerProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
                     Namespaces = assemblyGroup.GroupBy(symbol => symbol.ContainingNamespace)
                         .Select(namespaceGroup =>
                         {
-                            var namespaceName = namespaceGroup.Key.ToString();
+                            var namespaceName = namespaceGroup.Key?.ToString() ?? string.Empty;
 
                             return new
                             {


### PR DESCRIPTION
Enhance the data returned (from https://github.com/dotnet/roslyn/pull/37917) by grouping symbols by namespace.

The current shape of the api data:
```
{
     “AssemblyName”: {Hash of Assembly Name},
     “AssemblyVersion”: {Unhashed Assembly Version},
     “Symbols”: [{Hash of Symbol’s Documentation Comment Id},…]
}
```
The shape after adding a grouping on namespace:
```
{
    “AssemblyName”: {Hash of Assembly Name},
    “AssemblyVersion”: {Unhashed Assembly Version},
    “Namespaces”:
    [
        {
           “Namespace”: {Hash of Namespace} ,
            “Symbols”: [{Hash of Symbol’s Documentation Comment Id},…]
        },
        {…}
    ]
}
```