### PR TITLE
Mark Microsoft.CodeAnalysis.LanguageServer.Protocol as PrivateAssets

### DIFF
--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -67,12 +67,12 @@
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
     <!-- Microsoft.VisualStudio.LanugageServices is intended to only be used by VisualStudio and since 
-         Microsoft.CodeAnalysis.EditorFeatures and Microsoft.CodeAnalysis.EditorFeatures.Wpf are not required to
-         access the public API in this package, they are not published to NuGet, so mark them PrivateAssets="all" -->
+         Microsoft.CodeAnalysis.EditorFeatures, Microsoft.CodeAnalysis.EditorFeatures.Wpf, and Microsoft.CodeAnalysis.LanguageServer.Protocol
+         are not required to access the public API in this package, they are not published to NuGet, so mark them PrivateAssets="all" -->
     <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\..\EditorFeatures\Core.Wpf\Microsoft.CodeAnalysis.EditorFeatures.Wpf.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\..\Features\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\..\..\EditorFeatures\Text\Microsoft.CodeAnalysis.EditorFeatures.Text.csproj" />
-    <ProjectReference Include="..\..\..\Features\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
     <ProjectReference Include="..\..\..\Interactive\Host\Microsoft.CodeAnalysis.InteractiveHost.csproj" PrivateAssets="all" Aliases="InteractiveHost" />


### PR DESCRIPTION
Fix nuget warning.