### PR TITLE
Emit NativeIntegerAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -566,6 +566,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (returnType.HasType)
             {
+                if (returnType.Type.ContainsNativeInteger())
+                {
+                    compilation.EnsureNativeIntegerAttributeExists(diagnostics, lambdaSymbol.DiagnosticLocation, modifyCompilation: false);
+                }
+
                 if (compilation.ShouldEmitNullableAttributes(lambdaSymbol) &&
                     returnType.NeedsNullableAttribute())
                 {

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -579,6 +579,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, lambdaSymbol, lambdaParameters, diagnostics, modifyCompilation: false);
             // Note: we don't need to warn on annotations used in #nullable disable context for lambdas, as this is handled in binding already
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1607,5 +1607,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.NullableAttribute);
         }
+
+        internal void EnsureNativeIntegerAttributeExists()
+        {
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.NativeIntegerAttribute);
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -265,7 +265,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     moduleBuilder.EnsureIsUnmanagedAttributeExists();
                 }
 
-                if (hasReturnTypeOrParameter(localFunction, t => t.Type?.ContainsNativeInteger() == true))
+                if (hasReturnTypeOrParameter(localFunction, t => t.ContainsNativeInteger()) ||
+                    typeParameters.Any(t => t.ConstraintTypesNoUseSiteDiagnostics.Any(t => t.ContainsNativeInteger())))
                 {
                     moduleBuilder.EnsureNativeIntegerAttributeExists();
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -522,6 +522,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.NullableContextAttribute, diagnostics, location, modifyCompilation);
         }
 
+        internal void EnsureNativeIntegerAttributeExists(DiagnosticBag? diagnostics, Location location, bool modifyCompilation)
+        {
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.NativeIntegerAttribute, diagnostics, location, modifyCompilation);
+        }
+
         internal bool CheckIfAttributeShouldBeEmbedded(EmbeddableAttributes attribute, DiagnosticBag? diagnosticsOpt, Location locationOpt)
         {
             switch (attribute)
@@ -548,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor);
 
                 case EmbeddableAttributes.NullableAttribute:
-                    // Note: if the type exists, we'll check both constructors, regardless of which one(s) we'll eventually need
+                    // If the type exists, we'll check both constructors, regardless of which one(s) we'll eventually need.
                     return CheckIfAttributeShouldBeEmbedded(
                         diagnosticsOpt,
                         locationOpt,
@@ -569,6 +574,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                         locationOpt,
                         WellKnownType.System_Runtime_CompilerServices_NullablePublicOnlyAttribute,
                         WellKnownMember.System_Runtime_CompilerServices_NullablePublicOnlyAttribute__ctor);
+
+                case EmbeddableAttributes.NativeIntegerAttribute:
+                    // If the type exists, we'll check both constructors, regardless of which one(s) we'll eventually need.
+                    return CheckIfAttributeShouldBeEmbedded(
+                        diagnosticsOpt,
+                        locationOpt,
+                        WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute,
+                        WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
+                        WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(attribute);
@@ -699,7 +713,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 RoslynDebug.Assert((object)booleanType != null);
                 var transformFlags = DynamicTransformsEncoder.Encode(type, refKindOpt, customModifiersCount, booleanType);
                 var boolArray = ArrayTypeSymbol.CreateSZArray(booleanType.ContainingAssembly, TypeWithAnnotations.Create(booleanType));
-                var arguments = ImmutableArray.Create<TypedConstant>(new TypedConstant(boolArray, transformFlags));
+                var arguments = ImmutableArray.Create(new TypedConstant(boolArray, transformFlags));
                 return TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_DynamicAttribute__ctorTransformFlags, arguments);
             }
         }
@@ -896,11 +910,45 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private static void HandleCustomModifiers(int customModifiersCount, ArrayBuilder<bool> transformFlagsBuilder)
             {
-                for (int i = 0; i < customModifiersCount; i++)
+                // Native compiler encodes an extra transforms flag, always false, for each custom modifier.
+                transformFlagsBuilder.AddMany(false, customModifiersCount);
+            }
+        }
+
+        internal static class NativeIntegerTransformsEncoder
+        {
+            internal static ImmutableArray<TypedConstant> Encode(TypeSymbol type, TypeSymbol booleanType)
+            {
+                var builder = ArrayBuilder<bool>.GetInstance();
+                type.VisitType((typeSymbol, builder, isNested) => AddFlags(typeSymbol, builder, isNested), builder);
+                Debug.Assert(builder.Any());
+                Debug.Assert(builder.Contains(true));
+
+                var result = builder.SelectAsArray((flag, constantType) => new TypedConstant(constantType, TypedConstantKind.Primitive, flag), booleanType);
+                builder.Free();
+                return result;
+            }
+
+            private static bool AddFlags(TypeSymbol type, ArrayBuilder<bool> builder, bool isNestedNamedType)
+            {
+                switch (type.TypeKind)
                 {
-                    // Native compiler encodes an extra transforms flag, always false, for each custom modifier.
-                    transformFlagsBuilder.Add(false);
+                    case TypeKind.Array:
+                    case TypeKind.Pointer:
+                        builder.Add(false);
+                        break;
+
+                    default:
+                        // For nested named types, a single false is encoded for the entire type name, followed by flags for all of the type arguments.
+                        if (!isNestedNamedType)
+                        {
+                            builder.Add((type as NamedTypeSymbol)?.IsNativeInt == true);
+                        }
+                        break;
                 }
+
+                // Continue walking types
+                return false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -935,15 +935,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case TypeKind.Array:
                     case TypeKind.Pointer:
+                    case TypeKind.TypeParameter:
+                    case TypeKind.Dynamic:
                         builder.Add(false);
                         break;
 
-                    default:
+                    case TypeKind.Class:
+                    case TypeKind.Struct:
+                    case TypeKind.Interface:
+                    case TypeKind.Delegate:
+                    case TypeKind.Enum:
+                    case TypeKind.Error:
                         // For nested named types, a single false is encoded for the entire type name, followed by flags for all of the type arguments.
                         if (!isNestedNamedType)
                         {
-                            builder.Add((type as NamedTypeSymbol)?.IsNativeInt == true);
+                            builder.Add(((NamedTypeSymbol)type).IsNativeInt);
                         }
+                        break;
+
+                    default:
+                        Debug.Assert(false);
                         break;
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -939,7 +939,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case TypeKind.Dynamic:
                         builder.Add(false);
                         break;
-
                     case TypeKind.Class:
                     case TypeKind.Struct:
                     case TypeKind.Interface:
@@ -952,10 +951,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             builder.Add(((NamedTypeSymbol)type).IsNativeInt);
                         }
                         break;
-
                     default:
-                        Debug.Assert(false);
-                        break;
+                        throw ExceptionUtilities.UnexpectedValue(type.TypeKind);
                 }
 
                 // Continue walking types

--- a/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
@@ -15,5 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         NullableAttribute = 0x08,
         NullableContextAttribute = 0x10,
         NullablePublicOnlyAttribute = 0x20,
+        NativeIntegerAttribute = 0x40,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             if (!type.IsGenericType)
             {
-                return _transformFlags[index] ? type.AsNativeInt(true) : type;
+                return _transformFlags[index] ? TransformTypeDefinition(type) : type;
             }
 
             var allTypeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
@@ -107,6 +107,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return _index++;
             }
             throw new ArgumentException();
+        }
+
+        private static NamedTypeSymbol TransformTypeDefinition(NamedTypeSymbol type)
+        {
+            switch (type.SpecialType)
+            {
+                case SpecialType.System_IntPtr:
+                case SpecialType.System_UIntPtr:
+                    return type.AsNativeInt(true);
+                default:
+                    throw new ArgumentException();
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -16,20 +16,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
     {
         internal static TypeSymbol TransformType(TypeSymbol type, EntityHandle handle, PEModuleSymbol containingModule)
         {
-            try
+            if (containingModule.Module.HasNativeIntegerAttribute(handle, out var transformFlags))
             {
-                if (containingModule.Module.HasNativeIntegerAttribute(handle, out var transformFlags))
+                var decoder = new NativeIntegerTypeDecoder(transformFlags);
+                try
                 {
-                    var decoder = new NativeIntegerTypeDecoder(transformFlags);
                     var result = decoder.TransformType(type);
                     if (decoder._index == transformFlags.Length)
                     {
                         return result;
                     }
                 }
-            }
-            catch (ArgumentException)
-            {
+                catch (ArgumentException)
+                {
+                }
             }
             return type;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return type;
         }
 
-
         private readonly ImmutableArray<bool> _transformFlags;
         private int _index;
 
@@ -60,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 NamedTypeSymbol namedType => TransformNamedType(namedType),
                 ArrayTypeSymbol arrayType => TransformArrayType(arrayType),
                 PointerTypeSymbol pointerType => TransformPointerType(pointerType),
-                _ => throw ExceptionUtilities.UnexpectedValue(type)
+                _ => type,
             };
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -57,7 +57,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             switch (type.TypeKind)
             {
                 case TypeKind.Array:
+                    return TransformArrayType((ArrayTypeSymbol)type);
                 case TypeKind.Pointer:
+                    return TransformPointerType((PointerTypeSymbol)type);
                 case TypeKind.TypeParameter:
                 case TypeKind.Dynamic:
                     return type;
@@ -67,7 +69,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 case TypeKind.Delegate:
                 case TypeKind.Enum:
                     return TransformNamedType((NamedTypeSymbol)type);
-                case TypeKind.Error:
                 default:
                     Debug.Assert(type.TypeKind == TypeKind.Error);
                     throw new ArgumentException();

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -6,9 +6,9 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
@@ -54,13 +54,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private TypeSymbol TransformType(TypeSymbol type)
         {
-            return type switch
+            switch (type.TypeKind)
             {
-                NamedTypeSymbol namedType => TransformNamedType(namedType),
-                ArrayTypeSymbol arrayType => TransformArrayType(arrayType),
-                PointerTypeSymbol pointerType => TransformPointerType(pointerType),
-                _ => type,
-            };
+                case TypeKind.Array:
+                case TypeKind.Pointer:
+                case TypeKind.TypeParameter:
+                case TypeKind.Dynamic:
+                    return type;
+                case TypeKind.Class:
+                case TypeKind.Struct:
+                case TypeKind.Interface:
+                case TypeKind.Delegate:
+                case TypeKind.Enum:
+                    return TransformNamedType((NamedTypeSymbol)type);
+                case TypeKind.Error:
+                default:
+                    Debug.Assert(type.TypeKind == TypeKind.Error);
+                    throw new ArgumentException();
+            }
         }
 
         private NamedTypeSymbol TransformNamedType(NamedTypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/NativeIntegerTypeDecoder.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
+{
+    internal static class NativeIntegerTypeDecoder
+    {
+        internal static TypeSymbol TransformType(TypeSymbol type, EntityHandle handle, PEModuleSymbol containingModule)
+        {
+            if (containingModule.Module.HasNativeIntegerAttribute(handle, out var transformFlags))
+            {
+                var state = (transformFlags, 0);
+                // PROTOTYPE: Test too few and too many bools.
+                return TransformType(type, ref state);
+            }
+
+            return type;
+        }
+
+        private static TypeWithAnnotations TransformTypeWithAnnotations(TypeWithAnnotations type, ref (ImmutableArray<bool>, int) arg)
+        {
+            return type.WithTypeAndModifiers(TransformType(type.Type, ref arg), type.CustomModifiers);
+        }
+
+        private static TypeSymbol TransformType(TypeSymbol type, ref (ImmutableArray<bool>, int) arg)
+        {
+            return type switch
+            {
+                NamedTypeSymbol namedType => TransformNamedType(namedType, ref arg),
+                ArrayTypeSymbol arrayType => TransformArrayType(arrayType, ref arg),
+                PointerTypeSymbol pointerType => TransformPointerType(pointerType, ref arg),
+                _ => throw ExceptionUtilities.UnexpectedValue(type)
+            };
+        }
+
+        private static NamedTypeSymbol TransformNamedType(NamedTypeSymbol type, ref (ImmutableArray<bool>, int) arg)
+        {
+            if (!type.IsGenericType)
+            {
+                return arg.Item1[arg.Item2++] ? type.AsNativeInt(true) : type;
+            }
+
+            arg.Item2++;
+
+            var allTypeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
+            type.GetAllTypeArgumentsNoUseSiteDiagnostics(allTypeArguments);
+
+            bool haveChanges = false;
+            for (int i = 0; i < allTypeArguments.Count; i++)
+            {
+                TypeWithAnnotations oldTypeArgument = allTypeArguments[i];
+                TypeWithAnnotations newTypeArgument = TransformTypeWithAnnotations(oldTypeArgument, ref arg);
+                if (!oldTypeArgument.IsSameAs(newTypeArgument))
+                {
+                    allTypeArguments[i] = newTypeArgument;
+                    haveChanges = true;
+                }
+            }
+
+            NamedTypeSymbol result = haveChanges ? type.WithTypeArguments(allTypeArguments.ToImmutable()) : type;
+            allTypeArguments.Free();
+            return result;
+        }
+
+        private static ArrayTypeSymbol TransformArrayType(ArrayTypeSymbol type, ref (ImmutableArray<bool>, int) arg)
+        {
+            arg.Item2++;
+            return type.WithElementType(TransformTypeWithAnnotations(type.ElementTypeWithAnnotations, ref arg));
+        }
+
+        private static PointerTypeSymbol TransformPointerType(PointerTypeSymbol type, ref (ImmutableArray<bool>, int) arg)
+        {
+            arg.Item2++;
+            return type.WithPointedAtType(TransformTypeWithAnnotations(type.PointedAtTypeWithAnnotations, ref arg));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEEventSymbol.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
+using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System;
@@ -13,7 +14,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
@@ -98,6 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 const int targetSymbolCustomModifierCount = 0;
                 var typeSymbol = DynamicTypeDecoder.TransformType(originalEventType, targetSymbolCustomModifierCount, handle, moduleSymbol);
+                typeSymbol = NativeIntegerTypeDecoder.TransformType(typeSymbol, handle, moduleSymbol);
 
                 // We start without annotation (they will be decoded below)
                 var type = TypeWithAnnotations.Create(typeSymbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -258,6 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ImmutableArray<CustomModifier> customModifiersArray = CSharpCustomModifier.Convert(customModifiers);
 
                 typeSymbol = DynamicTypeDecoder.TransformType(typeSymbol, customModifiersArray.Length, _handle, moduleSymbol);
+                typeSymbol = NativeIntegerTypeDecoder.TransformType(typeSymbol, _handle, moduleSymbol);
 
                 // We start without annotations
                 var type = TypeWithAnnotations.Create(typeSymbol, customModifiers: customModifiersArray);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -531,8 +531,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         EntityHandle interfaceHandle = moduleSymbol.Module.MetadataReader.GetInterfaceImplementation(interfaceImpl).Interface;
                         TypeSymbol typeSymbol = tokenDecoder.GetTypeOfToken(interfaceHandle);
 
-                        typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, interfaceImpl, moduleSymbol);
                         typeSymbol = NativeIntegerTypeDecoder.TransformType(typeSymbol, interfaceImpl, moduleSymbol);
+                        typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, interfaceImpl, moduleSymbol);
                         typeSymbol = NullableTypeDecoder.TransformType(TypeWithAnnotations.Create(typeSymbol), interfaceImpl, moduleSymbol, accessSymbol: this, nullableContext: this).Type;
 
                         var namedTypeSymbol = typeSymbol as NamedTypeSymbol ?? new UnsupportedMetadataTypeSymbol(); // interface list contains a bad type

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -471,6 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                     var moduleSymbol = ContainingPEModule;
                     TypeSymbol decodedType = DynamicTypeDecoder.TransformType(baseType, 0, _handle, moduleSymbol);
+                    decodedType = NativeIntegerTypeDecoder.TransformType(decodedType, _handle, moduleSymbol);
                     decodedType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(decodedType, _handle, moduleSymbol);
                     baseType = (NamedTypeSymbol)NullableTypeDecoder.TransformType(TypeWithAnnotations.Create(decodedType), _handle, moduleSymbol, accessSymbol: this, nullableContext: this).Type;
                 }
@@ -531,6 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         TypeSymbol typeSymbol = tokenDecoder.GetTypeOfToken(interfaceHandle);
 
                         typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, interfaceImpl, moduleSymbol);
+                        typeSymbol = NativeIntegerTypeDecoder.TransformType(typeSymbol, interfaceImpl, moduleSymbol);
                         typeSymbol = NullableTypeDecoder.TransformType(TypeWithAnnotations.Create(typeSymbol), interfaceImpl, moduleSymbol, accessSymbol: this, nullableContext: this).Type;
 
                         var namedTypeSymbol = typeSymbol as NamedTypeSymbol ?? new UnsupportedMetadataTypeSymbol(); // interface list contains a bad type

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -259,6 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
 
                 var typeSymbol = DynamicTypeDecoder.TransformType(typeWithAnnotations.Type, countOfCustomModifiers, handle, moduleSymbol, refKind);
+                typeSymbol = NativeIntegerTypeDecoder.TransformType(typeSymbol, handle, moduleSymbol);
                 typeWithAnnotations = typeWithAnnotations.WithTypeAndModifiers(typeSymbol, typeWithAnnotations.CustomModifiers);
                 // Decode nullable before tuple types to avoid converting between
                 // NamedTypeSymbol and TupleTypeSymbol unnecessarily.

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -7,14 +7,12 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 {
@@ -165,6 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             TypeSymbol originalPropertyType = returnInfo.Type;
 
             originalPropertyType = DynamicTypeDecoder.TransformType(originalPropertyType, typeCustomModifiers.Length, handle, moduleSymbol, _refKind);
+            originalPropertyType = NativeIntegerTypeDecoder.TransformType(originalPropertyType, handle, moduleSymbol);
 
             // Dynamify object type if necessary
             originalPropertyType = originalPropertyType.AsDynamicIfNoPia(_containingType);

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1026,7 +1026,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-
         /// <summary>
         /// Returns true if locals are to be initialized
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1010,6 +1010,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length + this.RefCustomModifiers.Length, this.RefKind));
             }
 
+            if (type.Type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
+            }
+
             if (type.Type.ContainsTupleNames() && compilation.HasTupleNamesAttributes)
             {
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeTupleNamesAttribute(type.Type));

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -854,7 +854,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var allTypeArguments = ArrayBuilder<TypeWithAnnotations>.GetInstance();
             bool haveChanges = MergeEquivalentTypeArguments(this, (NamedTypeSymbol)other, variance, allTypeParameters, allTypeArguments);
 
-            NamedTypeSymbol result = haveChanges ? this.WithTypeArguments(allTypeArguments.ToImmutable()) : this;
+            NamedTypeSymbol result;
+            if (haveChanges)
+            {
+                TypeMap substitution = new TypeMap(allTypeParameters.ToImmutable(), allTypeArguments.ToImmutable());
+                result = substitution.SubstituteNamedType(this.OriginalDefinition);
+            }
+            else
+            {
+                result = this;
+            }
 
             allTypeArguments.Free();
             allTypeParameters.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return WithPointedAtType(pointedAtType);
         }
 
-        private PointerTypeSymbol WithPointedAtType(TypeWithAnnotations newPointedAtType)
+        internal PointerTypeSymbol WithPointedAtType(TypeWithAnnotations newPointedAtType)
         {
             return PointedAtTypeWithAnnotations.IsSameAs(newPointedAtType) ? this : new PointerTypeSymbol(newPointedAtType);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.PooledObjects;
 using System.Collections.Immutable;
@@ -76,6 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // NOTE: ref is irrelevant here since we are just encoding/decoding the type out of the signature context
             ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
             TypeSymbol typeWithDynamic = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
+            // PROTOTYPE: Should we use NativeIntegerTypeDecoder here?
 
             TypeSymbol resultType;
             if (destinationType.ContainsTuple() && !sourceType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes | TypeCompareKind.IgnoreDynamic))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -197,25 +197,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 MarshalAsAttributeDecoder<FieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
             {
-                // DynamicAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
-            {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
-            {
-                // IsUnmanagedAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))
             {
@@ -224,15 +208,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DecimalConstantAttribute))
             {
                 VerifyConstantValueMatches(attribute.DecodeDecimalConstantValue(), ref arguments);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
-            {
-                // NullableAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
             {
@@ -406,7 +381,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (type.Type.ContainsDynamic())
             {
                 AddSynthesizedAttribute(ref attributes,
-                    compilation.SynthesizeDynamicAttribute(type.Type, TypeWithAnnotations.CustomModifiers.Length));
+                    compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length));
+            }
+
+            if (type.Type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
             }
 
             if (type.Type.ContainsTupleNames())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 MarshalAsAttributeDecoder<FieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
             }
             else if (ReportExplicitUseOfReservedAttributes(ref arguments,
-                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DateTimeConstantAttribute))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/FieldSymbolWithAttributesAndModifiers.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 MarshalAsAttributeDecoder<FieldWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.Field, MessageProvider.Instance);
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -171,6 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var compilation = DeclaringCompilation;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
+            ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, this, parameters, diagnostics, modifyCompilation: false);
             // Note: we don't need to warn on annotations used in #nullable disable context for local functions, as this is handled in binding already
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -251,6 +251,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     compilation.EnsureIsReadOnlyAttributeExists(diagnostics, location, modifyCompilation: false);
                 }
 
+                if (returnType.Type.ContainsNativeInteger())
+                {
+                    compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: false);
+                }
+
                 if (compilation.ShouldEmitNullableAttributes(this) &&
                     returnType.NeedsNullableAttribute())
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -155,10 +155,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 foreach (var parameter in parameters)
                 {
+                    var type = parameter.TypeWithAnnotations;
+                    if (!type.HasType)
+                    {
+                        continue;
+                    }
+                    if (type.Type.ContainsNativeInteger())
+                    {
+                        compilation.EnsureNativeIntegerAttributeExists(diagnostics, getLocation(parameter), modifyCompilation);
+                    }
                     if (parameter.TypeWithAnnotations.NeedsNullableAttribute())
                     {
-                        compilation.EnsureNullableAttributeExists(diagnostics, parameter.GetNonNullSyntaxNode().Location, modifyCompilation);
+                        compilation.EnsureNullableAttributeExists(diagnostics, getLocation(parameter), modifyCompilation);
                     }
+                    static Location getLocation(ParameterSymbol parameter) => parameter.GetNonNullSyntaxNode().Location;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -646,7 +646,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ValidateCallerMemberNameAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics);
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -646,34 +646,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 ValidateCallerMemberNameAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
             {
-                // DynamicAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
-            {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
-            {
-                // IsUnmanagedAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
-            {
-                // NullableAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -647,7 +647,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ValidateCallerMemberNameAttribute(arguments.AttributeSyntaxOpt, arguments.Diagnostics);
             }
             else if (ReportExplicitUseOfReservedAttributes(ref arguments,
-                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.AllowNullAttribute))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -130,6 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var compilation = DeclaringCompilation;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, this, Parameters, diagnostics, modifyCompilation: true);
 
             foreach (var parameter in this.Parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -321,6 +321,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
                 }
 
+                ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+
                 if (compilation.ShouldEmitNullableAttributes(this) &&
                     ReturnTypeWithAnnotations.NeedsNullableAttribute())
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -2,16 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.Collections.Generic;
-using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -319,6 +315,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+
+                if (ReturnType.ContainsNativeInteger())
+                {
+                    compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
+                }
 
                 if (compilation.ShouldEmitNullableAttributes(this) &&
                     ReturnTypeWithAnnotations.NeedsNullableAttribute())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.TupleElementNamesAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute | ReservedAttributes.TupleElementNamesAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -291,7 +291,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute | ReservedAttributes.TupleElementNamesAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(in arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute | ReservedAttributes.TupleElementNamesAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -291,18 +291,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments, ReservedAttributes.NullableAttribute | ReservedAttributes.TupleElementNamesAttribute))
             {
-                // NullableAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
             {
@@ -320,6 +314,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (type.Type.ContainsDynamic())
             {
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length));
+            }
+
+            if (type.Type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
             }
 
             if (type.Type.ContainsTupleNames())
@@ -733,6 +732,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             this.CheckModifiersAndType(diagnostics);
             this.Type.CheckAllConstraints(compilation, conversions, location, diagnostics);
+
+            if (Type.ContainsNativeInteger())
+            {
+                compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
+            }
 
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 TypeWithAnnotations.NeedsNullableAttribute())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -132,6 +132,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = DeclaringCompilation;
             var location = ErrorLocation;
 
+            if (Type.ContainsNativeInteger())
+            {
+                compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
+            }
+
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 TypeWithAnnotations.NeedsNullableAttribute())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1434,6 +1434,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureIsReadOnlyAttributeExists(diagnostics, location, modifyCompilation: true);
             }
 
+            if (hasBaseTypeOrInterface(t => t.ContainsNativeInteger()))
+            {
+                compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
+            }
+
             if (compilation.ShouldEmitNullableAttributes(this))
             {
                 if (ShouldEmitNullableContextValue(out _))
@@ -1441,24 +1446,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     compilation.EnsureNullableContextAttributeExists(diagnostics, location, modifyCompilation: true);
                 }
 
-                // https://github.com/dotnet/roslyn/issues/30080: Report diagnostics for base type and interfaces at more specific locations.
-
-                if (hasBaseTypeOrInterface(t => t.ContainsNativeInteger()))
-                {
-                    compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
-                }
-
                 if (hasBaseTypeOrInterface(t => t.NeedsNullableAttribute()))
                 {
                     compilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);
                 }
+            }
 
-                bool hasBaseTypeOrInterface(Func<NamedTypeSymbol, bool> predicate)
-                {
-                    var baseType = BaseTypeNoUseSiteDiagnostics;
-                    return ((object)baseType != null && predicate(baseType)) ||
-                        InterfacesNoUseSiteDiagnostics().Any(predicate);
-                }
+            // https://github.com/dotnet/roslyn/issues/30080: Report diagnostics for base type and interfaces at more specific locations.
+            bool hasBaseTypeOrInterface(Func<NamedTypeSymbol, bool> predicate)
+            {
+                var baseType = BaseTypeNoUseSiteDiagnostics;
+                return ((object)baseType != null && predicate(baseType)) ||
+                    InterfacesNoUseSiteDiagnostics().Any(predicate);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1434,6 +1434,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureIsReadOnlyAttributeExists(diagnostics, location, modifyCompilation: true);
             }
 
+            // https://github.com/dotnet/roslyn/issues/30080: Report diagnostics for base type and interfaces at more specific locations.
             if (hasBaseTypeOrInterface(t => t.ContainsNativeInteger()))
             {
                 compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
@@ -1452,7 +1453,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            // https://github.com/dotnet/roslyn/issues/30080: Report diagnostics for base type and interfaces at more specific locations.
             bool hasBaseTypeOrInterface(Func<NamedTypeSymbol, bool> predicate)
             {
                 var baseType = BaseTypeNoUseSiteDiagnostics;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -12,7 +12,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1220,29 +1220,14 @@ done:
             else if (VerifyObsoleteAttributeAppliedToMethod(ref arguments, AttributeDescription.DeprecatedAttribute))
             {
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.NullableContextAttribute))
             {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
-            {
-                // IsUnmanagedAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.CaseSensitiveExtensionAttribute))
             {
                 // [Extension] attribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableContextAttribute))
-            {
-                ReportExplicitUseOfNullabilityAttribute(in arguments, AttributeDescription.NullableContextAttribute);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SecurityCriticalAttribute)
                 || attribute.IsTargetAttribute(this, AttributeDescription.SecuritySafeCriticalAttribute))
@@ -1380,34 +1365,9 @@ done:
                 // MarshalAs applied to the return value:
                 MarshalAsAttributeDecoder<ReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
             {
-                // DynamicAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
-            {
-                // IsUnmanagedAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
-            {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
-            {
-                // NullableAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1220,7 +1220,7 @@ done:
             else if (VerifyObsoleteAttributeAppliedToMethod(ref arguments, AttributeDescription.DeprecatedAttribute))
             {
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.NullableContextAttribute))
             {
             }
@@ -1365,7 +1365,7 @@ done:
                 // MarshalAs applied to the return value:
                 MarshalAsAttributeDecoder<ReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -1366,7 +1366,7 @@ done:
                 MarshalAsAttributeDecoder<ReturnTypeWellKnownAttributeData, AttributeSyntax, CSharpAttributeData, AttributeLocation>.Decode(ref arguments, AttributeTargets.ReturnValue, MessageProvider.Instance);
             }
             else if (ReportExplicitUseOfReservedAttributes(ref arguments,
-                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.MaybeNullAttribute))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -513,7 +513,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     arguments.GetOrCreateData<ModuleWellKnownAttributeData>().DefaultCharacterSet = charSet;
                 }
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.NullableContextAttribute | ReservedAttributes.NullablePublicOnlyAttribute))
             {
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -513,13 +513,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     arguments.GetOrCreateData<ModuleWellKnownAttributeData>().DefaultCharacterSet = charSet;
                 }
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableContextAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.NullableContextAttribute | ReservedAttributes.NullablePublicOnlyAttribute))
             {
-                ReportExplicitUseOfNullabilityAttribute(in arguments, AttributeDescription.NullableContextAttribute);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullablePublicOnlyAttribute))
-            {
-                ReportExplicitUseOfNullabilityAttribute(in arguments, AttributeDescription.NullablePublicOnlyAttribute);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -889,29 +889,9 @@ next:;
                 // ExtensionAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NullableContextAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
-                // DynamicAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
-            {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
-            {
-                // IsUnmanagedAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SecurityCriticalAttribute)
                 || attribute.IsTargetAttribute(this, AttributeDescription.SecuritySafeCriticalAttribute))
@@ -925,15 +905,6 @@ next:;
             else if (_lazyIsExplicitDefinitionOfNoPiaLocalType == ThreeState.Unknown && attribute.IsTargetAttribute(this, AttributeDescription.TypeIdentifierAttribute))
             {
                 _lazyIsExplicitDefinitionOfNoPiaLocalType = ThreeState.True;
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
-            {
-                // NullableAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableContextAttribute))
-            {
-                ReportExplicitUseOfNullabilityAttribute(in arguments, AttributeDescription.NullableContextAttribute);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -889,7 +889,7 @@ next:;
                 // ExtensionAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitExtension, arguments.AttributeSyntaxOpt.Location);
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NullableContextAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1169,6 +1169,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
+            if (ReturnType.ContainsNativeInteger())
+            {
+                compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
+            }
+
             if (compilation.ShouldEmitNullableAttributes(this) && ReturnTypeWithAnnotations.NeedsNullableAttribute())
             {
                 compilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -1174,6 +1174,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
             }
 
+            ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+
             if (compilation.ShouldEmitNullableAttributes(this) && ReturnTypeWithAnnotations.NeedsNullableAttribute())
             {
                 compilation.EnsureNullableAttributeExists(diagnostics, location, modifyCompilation: true);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -87,6 +87,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length + this.RefCustomModifiers.Length, this.RefKind));
             }
 
+            if (type.Type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
+            }
+
             if (type.Type.ContainsTupleNames())
             {
                 AddSynthesizedAttribute(ref attributes,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1389,7 +1389,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
             }
             else if (ReportExplicitUseOfReservedAttributes(ref arguments,
-                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -823,6 +823,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
+            if (Type.ContainsNativeInteger())
+            {
+                compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
+            }
+
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 this.TypeWithAnnotations.NeedsNullableAttribute())
             {
@@ -1257,6 +1262,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length + RefCustomModifiers.Length, _refKind));
             }
 
+            if (type.Type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
+            }
+
             if (type.Type.ContainsTupleNames())
             {
                 AddSynthesizedAttribute(ref attributes,
@@ -1378,29 +1388,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // DynamicAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
             }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsReadOnlyAttribute))
+            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+                ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute))
             {
-                // IsReadOnlyAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsReadOnlyAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsUnmanagedAttribute))
-            {
-                // IsUnmanagedAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsUnmanagedAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.IsByRefLikeAttribute))
-            {
-                // IsByRefLikeAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, AttributeDescription.IsByRefLikeAttribute.FullName);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
-            {
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
-            }
-            else if (attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
-            {
-                // NullableAttribute should not be set explicitly.
-                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DisallowNullAttribute))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -828,6 +828,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureNativeIntegerAttributeExists(diagnostics, location, modifyCompilation: true);
             }
 
+            ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 this.TypeWithAnnotations.NeedsNullableAttribute())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1390,7 +1390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // DynamicAttribute should not be set explicitly.
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
             }
-            else if (ReportExplicitUseOfReservedAttributes(ref arguments,
+            else if (ReportExplicitUseOfReservedAttributes(in arguments,
                 ReservedAttributes.DynamicAttribute | ReservedAttributes.IsReadOnlyAttribute | ReservedAttributes.IsUnmanagedAttribute | ReservedAttributes.IsByRefLikeAttribute | ReservedAttributes.TupleElementNamesAttribute | ReservedAttributes.NullableAttribute | ReservedAttributes.NativeIntegerAttribute))
             {
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void EnsureAttributesFromConstraints(DiagnosticBag diagnostics)
         {
-            if (ConstraintTypesNoUseSiteDiagnostics.Any(t => t.Type?.ContainsNativeInteger() == true))
+            if (ConstraintTypesNoUseSiteDiagnostics.Any(t => t.ContainsNativeInteger()))
             {
                 DeclaringCompilation.EnsureNativeIntegerAttributeExists(diagnostics, getLocation(), ModifyCompilationForAttributeEmbedding());
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     this.CheckConstraintTypeConstraints(diagnostics);
                     this.CheckUnmanagedConstraint(diagnostics);
-                    this.CheckNullableAnnotationsInConstraints(diagnostics);
+                    this.EnsureAttributesFromConstraints(diagnostics);
                     this.AddDeclarationDiagnostics(diagnostics);
                     _state.NotePartComplete(CompletionPart.TypeParameterConstraints);
                 }
@@ -300,12 +300,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return modifyCompilation;
         }
 
-        private void CheckNullableAnnotationsInConstraints(DiagnosticBag diagnostics)
+        private void EnsureAttributesFromConstraints(DiagnosticBag diagnostics)
         {
+            if (ConstraintTypesNoUseSiteDiagnostics.Any(t => t.Type?.ContainsNativeInteger() == true))
+            {
+                DeclaringCompilation.EnsureNativeIntegerAttributeExists(diagnostics, getLocation(), ModifyCompilationForAttributeEmbedding());
+            }
             if (ConstraintsNeedNullableAttribute())
             {
-                DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, this.GetNonNullSyntaxNode().Location, ModifyCompilationForAttributeEmbedding());
+                DeclaringCompilation.EnsureNullableAttributeExists(diagnostics, getLocation(), ModifyCompilationForAttributeEmbedding());
             }
+            Location getLocation() => this.GetNonNullSyntaxNode().Location;
         }
 
         // See https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -671,6 +671,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.EnsureNativeIntegerAttributeExists(diagnostics, ReturnTypeSyntax.Location, modifyCompilation: true);
             }
 
+            ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 ReturnTypeWithAnnotations.NeedsNullableAttribute())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -666,6 +666,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
+            if (ReturnType.ContainsNativeInteger())
+            {
+                compilation.EnsureNativeIntegerAttributeExists(diagnostics, ReturnTypeSyntax.Location, modifyCompilation: true);
+            }
+
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 ReturnTypeWithAnnotations.NeedsNullableAttribute())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1220,7 +1220,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NativeIntegerAttribute = 1 << 9,
         }
 
-        internal bool ReportExplicitUseOfReservedAttributes(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, ReservedAttributes reserved)
+        internal bool ReportExplicitUseOfReservedAttributes(in DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, ReservedAttributes reserved)
         {
             var attribute = arguments.Attribute;
             if ((reserved & ReservedAttributes.DynamicAttribute) != 0 &&

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1129,7 +1129,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-
         /// <summary>
         /// Returns data decoded from <see cref="ObsoleteAttribute"/> attribute or null if there is no <see cref="ObsoleteAttribute"/> attribute.
         /// This property returns <see cref="Microsoft.CodeAnalysis.ObsoleteAttributeData.Uninitialized"/> if attribute arguments haven't been decoded yet.
@@ -1207,10 +1206,80 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal void ReportExplicitUseOfNullabilityAttribute(in DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, AttributeDescription attributeDescription)
+        [Flags]
+        internal enum ReservedAttributes
         {
-            // Attribute should not be set explicitly.
-            arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, attributeDescription.FullName);
+            DynamicAttribute = 1 << 1,
+            IsReadOnlyAttribute = 1 << 2,
+            IsUnmanagedAttribute = 1 << 3,
+            IsByRefLikeAttribute = 1 << 4,
+            TupleElementNamesAttribute = 1 << 5,
+            NullableAttribute = 1 << 6,
+            NullableContextAttribute = 1 << 7,
+            NullablePublicOnlyAttribute = 1 << 8,
+            NativeIntegerAttribute = 1 << 9,
+        }
+
+        internal bool ReportExplicitUseOfReservedAttributes(ref DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, ReservedAttributes reserved)
+        {
+            var attribute = arguments.Attribute;
+            if ((reserved & ReservedAttributes.DynamicAttribute) != 0 &&
+                attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
+            {
+                // DynamicAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitDynamicAttr, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if ((reserved & ReservedAttributes.IsReadOnlyAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.IsReadOnlyAttribute))
+            {
+            }
+            else if ((reserved & ReservedAttributes.IsUnmanagedAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.IsUnmanagedAttribute))
+            {
+            }
+            else if ((reserved & ReservedAttributes.IsByRefLikeAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.IsByRefLikeAttribute))
+            {
+            }
+            else if ((reserved & ReservedAttributes.TupleElementNamesAttribute) != 0 &&
+                attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
+            {
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if ((reserved & ReservedAttributes.NullableAttribute) != 0 &&
+                attribute.IsTargetAttribute(this, AttributeDescription.NullableAttribute))
+            {
+                // NullableAttribute should not be set explicitly.
+                arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitNullableAttribute, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if ((reserved & ReservedAttributes.NullableContextAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.NullableContextAttribute))
+            {
+            }
+            else if ((reserved & ReservedAttributes.NullablePublicOnlyAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.NullablePublicOnlyAttribute))
+            {
+            }
+            else if ((reserved & ReservedAttributes.NativeIntegerAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.NativeIntegerAttribute))
+            {
+            }
+            else
+            {
+                return false;
+            }
+            return true;
+
+            bool reportExplicitUseOfReservedAttribute(CSharpAttributeData attribute, in DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, in AttributeDescription attributeDescription)
+            {
+                if (attribute.IsTargetAttribute(this, attributeDescription))
+                {
+                    // Do not use '{FullName}'. This is reserved for compiler usage.
+                    arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitReservedAttr, arguments.AttributeSyntaxOpt.Location, attributeDescription.FullName);
+                    return true;
+                }
+                return false;
+            }
         }
 
         internal virtual byte? GetNullableContextValue()

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNativeIntegerAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedNativeIntegerAttributeSymbol.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SynthesizedEmbeddedNativeIntegerAttributeSymbol : SynthesizedEmbeddedAttributeSymbolBase
+    {
+        private readonly ImmutableArray<FieldSymbol> _fields;
+        private readonly ImmutableArray<MethodSymbol> _constructors;
+        private readonly TypeSymbol _boolType;
+
+        private const string FieldName = "TransformFlags";
+
+        public SynthesizedEmbeddedNativeIntegerAttributeSymbol(
+            string name,
+            NamespaceSymbol containingNamespace,
+            ModuleSymbol containingModule,
+            NamedTypeSymbol systemAttributeType,
+            TypeSymbol boolType)
+            : base(name, containingNamespace, containingModule, baseType: systemAttributeType)
+        {
+            _boolType = boolType;
+
+            var boolArrayType = TypeWithAnnotations.Create(
+                ArrayTypeSymbol.CreateSZArray(
+                    boolType.ContainingAssembly,
+                    TypeWithAnnotations.Create(boolType)));
+
+            _fields = ImmutableArray.Create<FieldSymbol>(
+                new SynthesizedFieldSymbol(
+                    this,
+                    boolArrayType.Type,
+                    FieldName,
+                    isPublic: true,
+                    isReadOnly: true,
+                    isStatic: false));
+
+            _constructors = ImmutableArray.Create<MethodSymbol>(
+                new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(
+                    this,
+                    m => ImmutableArray<ParameterSymbol>.Empty,
+                    (f, s, p) => GenerateParameterlessConstructorBody(f, s)),
+                new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(
+                    this,
+                    m => ImmutableArray.Create(SynthesizedParameterSymbol.Create(m, boolArrayType, 0, RefKind.None)),
+                    (f, s, p) => GenerateBoolArrayConstructorBody(f, s, p)));
+
+            // Ensure we never get out of sync with the description
+            Debug.Assert(_constructors.Length == AttributeDescription.NativeIntegerAttribute.Signatures.Length);
+        }
+
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => _fields;
+
+        public override ImmutableArray<MethodSymbol> Constructors => _constructors;
+
+        internal override AttributeUsageInfo GetAttributeUsageInfo()
+        {
+            return new AttributeUsageInfo(
+                AttributeTargets.Class | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.GenericParameter | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue,
+                allowMultiple: false,
+                inherited: false);
+        }
+
+        private void GenerateParameterlessConstructorBody(SyntheticBoundNodeFactory factory, ArrayBuilder<BoundStatement> statements)
+        {
+            statements.Add(
+                factory.ExpressionStatement(
+                    factory.AssignmentExpression(
+                        factory.Field(
+                            factory.This(),
+                            _fields.Single()),
+                        factory.Array(
+                            _boolType,
+                            ImmutableArray.Create<BoundExpression>(factory.Literal(true))
+                        )
+                    )
+                )
+            );
+        }
+
+        private void GenerateBoolArrayConstructorBody(SyntheticBoundNodeFactory factory, ArrayBuilder<BoundStatement> statements, ImmutableArray<ParameterSymbol> parameters)
+        {
+            statements.Add(
+                factory.ExpressionStatement(
+                    factory.AssignmentExpression(
+                        factory.Field(
+                            factory.This(),
+                            _fields.Single()),
+                        factory.Parameter(parameters.Single())
+                    )
+                )
+            );
+        }
+    }
+}
+

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldSymbolBase.cs
@@ -63,6 +63,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type, typeWithAnnotations.CustomModifiers.Length));
             }
 
+            if (type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type));
+            }
+
             if (type.ContainsTupleNames() &&
                 compilation.HasTupleNamesAttributes &&
                 compilation.CanEmitSpecialType(SpecialType.System_String))

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -152,6 +152,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, compilation.SynthesizeDynamicAttribute(type.Type, type.CustomModifiers.Length + this.RefCustomModifiers.Length, this.RefKind));
             }
 
+            if (type.Type.ContainsNativeInteger())
+            {
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
+            }
+
             if (type.Type.ContainsTupleNames() &&
                 compilation.HasTupleNamesAttributes &&
                 compilation.CanEmitSpecialType(SpecialType.System_String))

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -902,6 +902,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private static readonly Func<TypeSymbol, object?, bool, bool> s_containsDynamicPredicate = (type, unused1, unused2) => type.TypeKind == TypeKind.Dynamic;
 
+        internal static bool ContainsNativeInteger(this TypeSymbol type)
+        {
+            var result = type.VisitType((type, unused1, unused2) => (type as NamedTypeSymbol)?.IsNativeInt == true, (object?)null, canDigThroughNullable: true);
+            return result is object;
+        }
+
         /// <summary>
         /// Return true if the type contains any tuples.
         /// </summary>
@@ -1630,16 +1636,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (type.Type.ContainsTupleNames())
                 {
-                    SynthesizedAttributeData? attr = compilation.SynthesizeTupleNamesAttribute(type.Type);
-                    if (attr != null)
-                    {
-                        builder.Add(attr);
-                    }
+                    addIfNotNull(builder, compilation.SynthesizeTupleNamesAttribute(type.Type));
                 }
-
+                if (type.Type.ContainsNativeInteger())
+                {
+                    addIfNotNull(builder, moduleBuilder.SynthesizeNativeIntegerAttribute(declaringSymbol, type.Type));
+                }
                 if (compilation.ShouldEmitNullableAttributes(declaringSymbol))
                 {
-                    SynthesizedAttributeData? attr = moduleBuilder.SynthesizeNullableAttributeIfNecessary(declaringSymbol, declaringSymbol.GetNullableContextValue(), type);
+                    addIfNotNull(builder, moduleBuilder.SynthesizeNullableAttributeIfNecessary(declaringSymbol, declaringSymbol.GetNullableContextValue(), type));
+                }
+
+                static void addIfNotNull(ArrayBuilder<Cci.ICustomAttribute> builder, SynthesizedAttributeData? attr)
+                {
                     if (attr != null)
                     {
                         builder.Add(attr);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -908,6 +908,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result is object;
         }
 
+        internal static bool ContainsNativeInteger(this TypeWithAnnotations type)
+        {
+            return type.Type?.ContainsNativeInteger() == true;
+        }
+
         /// <summary>
         /// Return true if the type contains any tuples.
         /// </summary>

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -1,0 +1,654 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class AttributeTests_NativeInteger : CSharpTestBase
+    {
+        private static readonly SymbolDisplayFormat FormatWithSpecialTypes = SymbolDisplayFormat.TestFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+        [Fact]
+        public void EmptyProject()
+        {
+            var source = @"";
+            var comp = CreateCompilation(source);
+            var expected =
+@"";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void ExplicitAttribute_FromSource()
+        {
+            var source =
+@"public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+}";
+            var comp = CreateCompilation(new[] { NativeIntegerAttributeDefinition, source }, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    [NativeInteger] System.IntPtr F1
+    [NativeInteger({ False, True })] System.UIntPtr[] F2
+";
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var attributeType = module.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.NativeIntegerAttribute");
+                Assert.NotNull(attributeType);
+                AssertNativeIntegerAttributes(module, expected);
+            });
+        }
+
+        [Fact]
+        public void ExplicitAttribute_FromMetadata()
+        {
+            var comp = CreateCompilation(NativeIntegerAttributeDefinition);
+            comp.VerifyDiagnostics();
+            var ref0 = comp.EmitToImageReference();
+
+            var source =
+@"public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+}";
+            comp = CreateCompilation(source, references: new[] { ref0 }, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    [NativeInteger] System.IntPtr F1
+    [NativeInteger({ False, True })] System.UIntPtr[] F2
+";
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var attributeType = module.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.NativeIntegerAttribute");
+                Assert.Null(attributeType);
+                AssertNativeIntegerAttributes(module, expected);
+            });
+        }
+
+        [Fact]
+        public void ExplicitAttribute_MissingEmptyConstructor()
+        {
+            var source1 =
+@"namespace System.Runtime.CompilerServices
+{
+    public sealed class NativeIntegerAttribute : Attribute
+    {
+        public NativeIntegerAttribute(bool[] flags) { }
+    }
+}";
+            var source2 =
+@"public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+}";
+            var comp = CreateCompilation(new[] { source1, source2 }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (3,17): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NativeIntegerAttribute..ctor'
+                //     public nint F1;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F1").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute", ".ctor").WithLocation(3, 17),
+                // (4,20): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NativeIntegerAttribute..ctor'
+                //     public nuint[] F2;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F2").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute", ".ctor").WithLocation(4, 20));
+        }
+
+        [Fact]
+        public void ExplicitAttribute_MissingConstructor()
+        {
+            var source1 =
+@"namespace System.Runtime.CompilerServices
+{
+    public sealed class NativeIntegerAttribute : Attribute
+    {
+    }
+}";
+            var source2 =
+@"public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+}";
+            var comp = CreateCompilation(new[] { source1, source2 }, parseOptions: TestOptions.RegularPreview);
+            comp.VerifyEmitDiagnostics(
+                // (3,17): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NativeIntegerAttribute..ctor'
+                //     public nint F1;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F1").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute", ".ctor").WithLocation(3, 17),
+                // (4,20): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.NativeIntegerAttribute..ctor'
+                //     public nuint[] F2;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F2").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute", ".ctor").WithLocation(4, 20));
+        }
+
+        [Fact]
+        public void ExplicitAttribute_ReferencedInSource()
+        {
+            var sourceAttribute =
+@"namespace System.Runtime.CompilerServices
+{
+    internal class NativeIntegerAttribute : Attribute
+    {
+        internal NativeIntegerAttribute() { }
+        internal NativeIntegerAttribute(bool[] flags) { }
+    }
+}";
+            var source =
+@"#pragma warning disable 169
+using System;
+using System.Runtime.CompilerServices;
+[NativeInteger] class Program
+{
+    [NativeInteger] IntPtr F;
+    [NativeInteger(new[] { false, true })] static UIntPtr[] M1() => throw null;
+    [return: NativeInteger(new[] { false, true })] static UIntPtr[] M2() => throw null;
+}";
+
+            var comp = CreateCompilation(new[] { sourceAttribute, source }, parseOptions: TestOptions.Regular7);
+            verifyDiagnostics(comp);
+
+            comp = CreateCompilation(new[] { sourceAttribute, source }, parseOptions: TestOptions.RegularPreview);
+            verifyDiagnostics(comp);
+
+            static void verifyDiagnostics(CSharpCompilation comp)
+            {
+                // PROTOTYPE: Should report ERR_ExplicitReservedAttr for all cases where `nint` is allowed.
+                comp.VerifyDiagnostics(
+                    // (4,2): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    // [NativeInteger] class Program
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(4, 2));
+            }
+        }
+
+        [Fact]
+        public void MissingAttributeUsageAttribute()
+        {
+            var source =
+@"public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            comp.MakeTypeMissing(WellKnownType.System_AttributeUsageAttribute);
+            comp.VerifyEmitDiagnostics(
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", ".ctor").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.AllowMultiple'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "AllowMultiple").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.Inherited'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "Inherited").WithLocation(1, 1));
+        }
+
+        [Fact]
+        public void EmitAttribute_BaseClass()
+        {
+            var source =
+@"public class A<T, U>
+{
+}
+public class B : A<nint, nuint[]>
+{
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"[NativeInteger({ False, True, False, True })] B
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_Interface()
+        {
+            var source =
+@"public interface I<T>
+{
+}
+public class A : I<(nint, nuint[])>
+{
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp, validator: assembly =>
+            {
+                var reader = assembly.GetMetadataReader();
+                var typeDef = GetTypeDefinitionByName(reader, "A");
+                var interfaceImpl = reader.GetInterfaceImplementation(typeDef.GetInterfaceImplementations().Single());
+                AssertAttributes(reader, interfaceImpl.GetCustomAttributes(), "MethodDefinition:Void System.Runtime.CompilerServices.NativeIntegerAttribute..ctor(Boolean[])");
+            });
+        }
+
+        [Fact]
+        public void EmitAttribute_Fields()
+        {
+            var source =
+@"public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    [NativeInteger] System.IntPtr F1
+    [NativeInteger({ False, True })] System.UIntPtr[] F2
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_MethodReturnType()
+        {
+            var source =
+@"public class Program
+{
+    public nuint[] F() => null;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    [NativeInteger({ False, True })] System.UIntPtr[] F()
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_MethodParameters()
+        {
+            var source =
+@"public class Program
+{
+    public void F(nint x, nuint y) { }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    void F(System.IntPtr x, System.UIntPtr y)
+        [NativeInteger] System.IntPtr x
+        [NativeInteger] System.UIntPtr y
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_PropertyType()
+        {
+            var source =
+@"public class Program
+{
+    public nuint[] P => null;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    [NativeInteger({ False, True })] System.UIntPtr[] P { get; }
+        [NativeInteger({ False, True })] System.UIntPtr[] P.get
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_PropertyParameters()
+        {
+            var source =
+@"public class Program
+{
+    public object this[nint x, nuint[] y] => null;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    System.Object this[System.IntPtr x, System.UIntPtr[] y] { get; }
+        [NativeInteger] System.IntPtr x
+        [NativeInteger({ False, True })] System.UIntPtr[] y
+        System.Object this[System.IntPtr x, System.UIntPtr[] y].get
+            [NativeInteger] System.IntPtr x
+            [NativeInteger({ False, True })] System.UIntPtr[] y
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_EventType()
+        {
+            var source =
+@"using System;
+public class Program
+{
+    public event EventHandler<nuint[]> E;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"Program
+    [NativeInteger({ False, False, True })] event System.EventHandler<System.UIntPtr[]> E
+        void E.add
+            [NativeInteger({ False, False, True })] System.EventHandler<System.UIntPtr[]> value
+        void E.remove
+            [NativeInteger({ False, False, True })] System.EventHandler<System.UIntPtr[]> value
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_OperatorReturnType()
+        {
+            var source =
+@"public class C
+{
+    public static nint operator+(C a, C b) => 0;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"C
+    [NativeInteger] System.IntPtr operator +(C a, C b)
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_OperatorParameters()
+        {
+            var source =
+@"public class C
+{
+    public static C operator+(C a, nuint[] b) => a;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"C
+    C operator +(C a, System.UIntPtr[] b)
+        [NativeInteger({ False, True })] System.UIntPtr[] b
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_DelegateReturnType()
+        {
+            var source =
+@"public delegate nint D();";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"D
+    [NativeInteger] System.IntPtr Invoke()
+    [NativeInteger] System.IntPtr EndInvoke(System.IAsyncResult result)
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_DelegateParameters()
+        {
+            var source =
+@"public delegate void D(nint x, nuint[] y);";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"D
+    void Invoke(System.IntPtr x, System.UIntPtr[] y)
+        [NativeInteger] System.IntPtr x
+        [NativeInteger({ False, True })] System.UIntPtr[] y
+    System.IAsyncResult BeginInvoke(System.IntPtr x, System.UIntPtr[] y, System.AsyncCallback callback, System.Object @object)
+        [NativeInteger] System.IntPtr x
+        [NativeInteger({ False, True })] System.UIntPtr[] y
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void EmitAttribute_Constraint()
+        {
+            var source =
+@"public class A<T>
+{
+}
+public class B<T> where T : A<nint>
+{
+}
+public class C<T> where T : A<nuint[]>
+{
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var type = comp.GetMember<NamedTypeSymbol>("B");
+            Assert.Equal("A<nint>", getConstraintType(type).ToDisplayString(FormatWithSpecialTypes));
+            type = comp.GetMember<NamedTypeSymbol>("C");
+            Assert.Equal("A<nuint[]>", getConstraintType(type).ToDisplayString(FormatWithSpecialTypes));
+
+            static TypeWithAnnotations getConstraintType(NamedTypeSymbol type) => type.TypeParameters[0].ConstraintTypesNoUseSiteDiagnostics[0];
+        }
+
+        [Fact]
+        public void EmitAttribute_LambdaReturnType()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static object M()
+    {
+        Func<nint> f = () => (nint)2;
+        return f();
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            AssertNoNativeIntegerAttributes(comp);
+        }
+
+        [Fact]
+        public void EmitAttribute_LambdaParameters()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static void M()
+    {
+        Action<nuint[]> a = (nuint[] n) => { };
+        a(null);
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            AssertNoNativeIntegerAttributes(comp);
+        }
+
+        [Fact]
+        public void EmitAttribute_LocalFunctionReturnType()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static object M()
+    {
+        nint L() => (nint)2;
+        return L();
+    }
+}";
+            CompileAndVerify(
+                source,
+                parseOptions: TestOptions.RegularPreview,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
+                symbolValidator: module =>
+                {
+                    var method = module.ContainingAssembly.GetTypeByMetadataName("Program").GetMethod("<M>g__L|0_0");
+                    AssertNativeIntegerAttribute(method.GetReturnTypeAttributes());
+                    AssertAttributes(method.GetAttributes());
+                });
+        }
+
+        [Fact]
+        public void EmitAttribute_LocalFunctionParameters()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static void M()
+    {
+        void L(nuint[] n) { }
+        L(null);
+    }
+}";
+            CompileAndVerify(
+                source,
+                parseOptions: TestOptions.RegularPreview,
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
+                symbolValidator: module =>
+                {
+                    var method = module.ContainingAssembly.GetTypeByMetadataName("Program").GetMethod("<M>g__L|0_0");
+                    AssertNativeIntegerAttribute(method.Parameters[0].GetAttributes());
+                });
+        }
+
+        [Fact]
+        public void EmitAttribute_Nested()
+        {
+            var source =
+@"public class A<T>
+{
+    public class B<U> { }
+}
+unsafe public class Program
+{
+    public nint F1;
+    public nuint[] F2;
+    public nint* F3;
+    public A<nint>.B<nuint> F4;
+    public (nint, nuint) F5;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll);
+            var expected =
+@"Program
+    [NativeInteger] System.IntPtr F1
+    [NativeInteger({ False, True })] System.UIntPtr[] F2
+    [NativeInteger({ False, True })] System.IntPtr* F3
+    [NativeInteger({ False, True, True })] A<System.IntPtr>.B<System.UIntPtr> F4
+    [NativeInteger({ False, True, True })] (System.IntPtr, System.UIntPtr) F5
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
+        public void AttributeUsage()
+        {
+            var source =
+@"public class Program
+{
+    public nint F;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.ReleaseDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var attributeType = module.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.NativeIntegerAttribute");
+                AttributeUsageInfo attributeUsage = attributeType.GetAttributeUsageInfo();
+                Assert.False(attributeUsage.Inherited);
+                Assert.False(attributeUsage.AllowMultiple);
+                Assert.True(attributeUsage.HasValidAttributeTargets);
+                var expectedTargets =
+                    AttributeTargets.Class |
+                    AttributeTargets.Event |
+                    AttributeTargets.Field |
+                    AttributeTargets.GenericParameter |
+                    AttributeTargets.Parameter |
+                    AttributeTargets.Property |
+                    AttributeTargets.ReturnValue;
+                Assert.Equal(expectedTargets, attributeUsage.ValidTargets);
+            });
+        }
+
+        [Fact]
+        public void AttributeFieldExists()
+        {
+            var source =
+@"public class Program
+{
+    public nint F;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var type = module.ContainingAssembly.GetTypeByMetadataName("Program");
+                var member = type.GetMembers("F").Single();
+                var attributes = member.GetAttributes();
+                AssertNativeIntegerAttribute(attributes);
+                var attribute = GetNativeIntegerAttribute(attributes);
+                var field = attribute.AttributeClass.GetField("TransformFlags");
+                Assert.Equal("System.Boolean[]", field.TypeWithAnnotations.ToTestDisplayString());
+            });
+        }
+
+        private static TypeDefinition GetTypeDefinitionByName(MetadataReader reader, string name)
+        {
+            return reader.GetTypeDefinition(reader.TypeDefinitions.Single(h => reader.StringComparer.Equals(reader.GetTypeDefinition(h).Name, name)));
+        }
+
+        private static string GetAttributeConstructorName(MetadataReader reader, CustomAttributeHandle handle)
+        {
+            return reader.Dump(reader.GetCustomAttribute(handle).Constructor);
+        }
+
+        private static CustomAttribute GetAttributeByConstructorName(MetadataReader reader, CustomAttributeHandleCollection handles, string name)
+        {
+            return reader.GetCustomAttribute(handles.FirstOrDefault(h => GetAttributeConstructorName(reader, h) == name));
+        }
+
+        private static void AssertAttributes(MetadataReader reader, CustomAttributeHandleCollection handles, params string[] expectedNames)
+        {
+            var actualNames = handles.Select(h => GetAttributeConstructorName(reader, h)).ToArray();
+            AssertEx.SetEqual(actualNames, expectedNames);
+        }
+
+        private static void AssertNoNativeIntegerAttribute(ImmutableArray<CSharpAttributeData> attributes)
+        {
+            AssertAttributes(attributes);
+        }
+
+        private static void AssertNativeIntegerAttribute(ImmutableArray<CSharpAttributeData> attributes)
+        {
+            AssertAttributes(attributes, "System.Runtime.CompilerServices.NativeIntegerAttribute");
+        }
+
+        private static void AssertAttributes(ImmutableArray<CSharpAttributeData> attributes, params string[] expectedNames)
+        {
+            var actualNames = attributes.Select(a => a.AttributeClass.ToTestDisplayString()).ToArray();
+            AssertEx.SetEqual(actualNames, expectedNames);
+        }
+
+        private static void AssertNoNativeIntegerAttributes(CSharpCompilation comp)
+        {
+            var image = comp.EmitToArray();
+            using (var reader = new PEReader(image))
+            {
+                var metadataReader = reader.GetMetadataReader();
+                var attributes = metadataReader.GetCustomAttributeRows().Select(metadataReader.GetCustomAttributeName).ToArray();
+                Assert.False(attributes.Contains("NativeIntegerAttribute"));
+            }
+        }
+
+        private void AssertNativeIntegerAttributes(CSharpCompilation comp, string expected)
+        {
+            CompileAndVerify(comp, symbolValidator: module => AssertNativeIntegerAttributes(module, expected));
+        }
+
+        private static void AssertNativeIntegerAttributes(ModuleSymbol module, string expected)
+        {
+            var actual = NativeIntegerAttributesVisitor.GetString((PEModuleSymbol)module);
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, actual);
+        }
+
+        private static CSharpAttributeData GetNativeIntegerAttribute(ImmutableArray<CSharpAttributeData> attributes)
+        {
+            return attributes.Single(a => a.AttributeClass.ToTestDisplayString() == "System.Runtime.CompilerServices.NativeIntegerAttribute");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -146,14 +146,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     }
 }";
             var source =
-@"#pragma warning disable 169
+@"#pragma warning disable 67
+#pragma warning disable 169
 using System;
 using System.Runtime.CompilerServices;
 [NativeInteger] class Program
 {
     [NativeInteger] IntPtr F;
+    [NativeInteger] event EventHandler E;
+    [NativeInteger] object P { get; }
     [NativeInteger(new[] { false, true })] static UIntPtr[] M1() => throw null;
     [return: NativeInteger(new[] { false, true })] static UIntPtr[] M2() => throw null;
+    static void M3([NativeInteger]object arg) { }
 }";
 
             var comp = CreateCompilation(new[] { sourceAttribute, source }, parseOptions: TestOptions.Regular7);
@@ -164,11 +168,25 @@ using System.Runtime.CompilerServices;
 
             static void verifyDiagnostics(CSharpCompilation comp)
             {
-                // PROTOTYPE: Should report ERR_ExplicitReservedAttr for all cases where `nint` is allowed.
                 comp.VerifyDiagnostics(
-                    // (4,2): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    // (5,2): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
                     // [NativeInteger] class Program
-                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(4, 2));
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(5, 2),
+                    // (7,6): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    //     [NativeInteger] IntPtr F;
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(7, 6),
+                    // (8,6): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    //     [NativeInteger] event EventHandler E;
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(8, 6),
+                    // (9,6): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    //     [NativeInteger] object P { get; }
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(9, 6),
+                    // (11,14): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    //     [return: NativeInteger(new[] { false, true })] static UIntPtr[] M2() => throw null;
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger(new[] { false, true })").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(11, 14),
+                    // (12,21): error CS8335: Do not use 'System.Runtime.CompilerServices.NativeIntegerAttribute'. This is reserved for compiler usage.
+                    //     static void M3([NativeInteger]object arg) { }
+                    Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "NativeInteger").WithArguments("System.Runtime.CompilerServices.NativeIntegerAttribute").WithLocation(12, 21));
             }
         }
 
@@ -482,7 +500,7 @@ class Program
                 {
                     var method = module.ContainingAssembly.GetTypeByMetadataName("Program").GetMethod("<M>g__L|0_0");
                     AssertNativeIntegerAttribute(method.GetReturnTypeAttributes());
-                    AssertAttributes(method.GetAttributes());
+                    AssertAttributes(method.GetAttributes(), "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
                 });
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -356,6 +356,35 @@ public class A : I<(nint, nuint[])>
         }
 
         [Fact]
+        public void EmitAttribute_AllTypes()
+        {
+            var source =
+@"public enum E { }
+public class C<T>
+{
+    public delegate void D<T>();
+    public enum F { }
+    public struct S<U> { }
+    public interface I<U> { }
+    public C<T>.S<nint> F1;
+    public C<nuint>.I<T> F2;
+    public C<E>.D<nint> F3;
+    public C<nuint>.D<dynamic> F4;
+    public C<nint>.F F5;
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            var expected =
+@"C<T>
+    [NativeInteger({ False, False, True })] C<T>.S<System.IntPtr> F1
+    [NativeInteger({ False, True, False })] C<System.UIntPtr>.I<T> F2
+    [NativeInteger({ False, False, True })] C<E>.D<System.IntPtr> F3
+    [NativeInteger({ False, True, False })] C<System.UIntPtr>.D<dynamic> F4
+    [NativeInteger({ False, True })] C<System.IntPtr>.F F5
+";
+            AssertNativeIntegerAttributes(comp, expected);
+        }
+
+        [Fact]
         public void EmitAttribute_Fields()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_NativeInteger.cs
@@ -591,8 +591,7 @@ class Program
         public void EmitAttribute_LocalFunctionReturnType()
         {
             var source =
-@"using System;
-class Program
+@"class Program
 {
     static object M()
     {
@@ -616,8 +615,7 @@ class Program
         public void EmitAttribute_LocalFunctionParameters()
         {
             var source =
-@"using System;
-class Program
+@"class Program
 {
     static void M()
     {
@@ -634,6 +632,29 @@ class Program
                     var method = module.ContainingAssembly.GetTypeByMetadataName("Program").GetMethod("<M>g__L|0_0");
                     AssertNativeIntegerAttribute(method.Parameters[0].GetAttributes());
                 });
+        }
+
+        [Fact]
+        public void EmitAttribute_LocalFunctionConstraints()
+        {
+            var source =
+@"interface I<T>
+{
+}
+class Program
+{
+    static void M()
+    {
+        void L<T>() where T : I<nint> { }
+        L<I<nint>>();
+    }
+}";
+            var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                var assembly = module.ContainingAssembly;
+                Assert.NotNull(assembly.GetTypeByMetadataName("System.Runtime.CompilerServices.NativeIntegerAttribute"));
+            });
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Nullable.cs
@@ -157,6 +157,57 @@ class C
         }
 
         [Fact]
+        public void ExplicitAttribute_ReferencedInSource()
+        {
+            var sourceAttribute =
+@"namespace System.Runtime.CompilerServices
+{
+    internal class NullableAttribute : System.Attribute
+    {
+        internal NullableAttribute(byte b) { }
+    }
+}";
+            var source =
+@"#pragma warning disable 169
+using System.Runtime.CompilerServices;
+[assembly: Nullable(0)]
+[module: Nullable(0)]
+[Nullable(0)]
+class Program
+{
+    [Nullable(0)]object F;
+    [Nullable(0)]static object M1() => throw null;
+    [return: Nullable(0)]static object M2() => throw null;
+    static void M3([Nullable(0)]object arg) { }
+}";
+
+            // C#7
+            var comp = CreateCompilation(new[] { sourceAttribute, source }, parseOptions: TestOptions.Regular7);
+            verifyDiagnostics(comp);
+
+            // C#8
+            comp = CreateCompilation(new[] { sourceAttribute, source });
+            verifyDiagnostics(comp);
+
+            static void verifyDiagnostics(CSharpCompilation comp)
+            {
+                comp.VerifyDiagnostics(
+                    // (5,2): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
+                    // [Nullable(0)]
+                    Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(0)").WithLocation(5, 2),
+                    // (8,6): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
+                    //     [Nullable(0)]object F;
+                    Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(0)").WithLocation(8, 6),
+                    // (10,14): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
+                    //     [return: Nullable(0)]static object M2() => throw null;
+                    Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(0)").WithLocation(10, 14),
+                    // (11,21): error CS8623: Explicit application of 'System.Runtime.CompilerServices.NullableAttribute' is not allowed.
+                    //     static void M3([Nullable(0)]object arg) { }
+                    Diagnostic(ErrorCode.ERR_ExplicitNullableAttribute, "Nullable(0)").WithLocation(11, 21));
+            }
+        }
+
+        [Fact]
         public void AttributeFromInternalsVisibleTo_01()
         {
             var sourceA =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -599,6 +599,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_AsyncIteratorMethodBuilder:
                     case WellKnownType.System_Threading_CancellationToken:
                     case WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException:
+                    case WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute:
                         // Not yet in the platform.
                         continue;
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
@@ -950,6 +951,8 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject:
+                    case WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1009,26 +1009,46 @@ namespace Microsoft.CodeAnalysis
             return FindTargetAttribute(token, description).Handle;
         }
 
-        private static readonly ImmutableArray<bool> s_simpleDynamicTransforms = ImmutableArray.Create(true);
+        private static readonly ImmutableArray<bool> s_simpleTransformFlags = ImmutableArray.Create(true);
 
-        internal bool HasDynamicAttribute(EntityHandle token, out ImmutableArray<bool> dynamicTransforms)
+        internal bool HasDynamicAttribute(EntityHandle token, out ImmutableArray<bool> transformFlags)
         {
             AttributeInfo info = FindTargetAttribute(token, AttributeDescription.DynamicAttribute);
             Debug.Assert(!info.HasValue || info.SignatureIndex == 0 || info.SignatureIndex == 1);
 
             if (!info.HasValue)
             {
-                dynamicTransforms = default(ImmutableArray<bool>);
+                transformFlags = default;
                 return false;
             }
 
             if (info.SignatureIndex == 0)
             {
-                dynamicTransforms = s_simpleDynamicTransforms;
+                transformFlags = s_simpleTransformFlags;
                 return true;
             }
 
-            return TryExtractBoolArrayValueFromAttribute(info.Handle, out dynamicTransforms);
+            return TryExtractBoolArrayValueFromAttribute(info.Handle, out transformFlags);
+        }
+
+        internal bool HasNativeIntegerAttribute(EntityHandle token, out ImmutableArray<bool> transformFlags)
+        {
+            AttributeInfo info = FindTargetAttribute(token, AttributeDescription.NativeIntegerAttribute);
+            Debug.Assert(!info.HasValue || info.SignatureIndex == 0 || info.SignatureIndex == 1);
+
+            if (!info.HasValue)
+            {
+                transformFlags = default;
+                return false;
+            }
+
+            if (info.SignatureIndex == 0)
+            {
+                transformFlags = s_simpleTransformFlags;
+                return true;
+            }
+
+            return TryExtractBoolArrayValueFromAttribute(info.Handle, out transformFlags);
         }
 
         internal bool HasTupleElementNamesAttribute(EntityHandle token, out ImmutableArray<string> tupleElementNames)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -5,7 +5,6 @@
 #nullable enable
 
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using System.Reflection.Metadata;
 using System.Collections.Immutable;
 using Roslyn.Utilities;
@@ -419,12 +418,11 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void_Byte, s_signature_HasThis_Void_SzArray_Byte };
         private static readonly byte[][] s_signaturesOfNullableContextAttribute = { s_signature_HasThis_Void_Byte };
         private static readonly byte[][] s_signaturesOfNullablePublicOnlyAttribute = { s_signature_HasThis_Void_Boolean };
-
         private static readonly byte[][] s_signaturesOfExperimentalAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfExcludeFromCodeCoverageAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfSkipLocalsInitAttribute = { s_signature_HasThis_Void };
-
         private static readonly byte[][] s_signaturesOfEnumeratorCancellationAttribute = { s_signature_HasThis_Void };
+        private static readonly byte[][] s_signaturesOfNativeIntegerAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
 
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
@@ -554,5 +552,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription ExcludeFromCodeCoverageAttribute = new AttributeDescription("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverageAttribute", s_signaturesOfExcludeFromCodeCoverageAttribute);
         internal static readonly AttributeDescription EnumeratorCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "EnumeratorCancellationAttribute", s_signaturesOfEnumeratorCancellationAttribute);
         internal static readonly AttributeDescription SkipLocalsInitAttribute = new AttributeDescription("System.Runtime.CompilerServices", "SkipLocalsInitAttribute", s_signaturesOfSkipLocalsInitAttribute);
+        internal static readonly AttributeDescription NativeIntegerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NativeIntegerAttribute", s_signaturesOfNativeIntegerAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/DecodeWellKnownAttributeArguments.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/DecodeWellKnownAttributeArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -39,7 +38,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns true if some decoded data has been stored into <see cref="_lazyDecodeData"/>.
         /// </summary>
-        public bool HasDecodedData
+        public readonly bool HasDecodedData
         {
             get
             {
@@ -59,7 +58,7 @@ namespace Microsoft.CodeAnalysis
         /// <remarks>
         /// Assumes <see cref="HasDecodedData"/> is true.
         /// </remarks>
-        public WellKnownAttributeData DecodedData
+        public readonly WellKnownAttributeData DecodedData
         {
             get
             {

--- a/src/Compilers/Core/Portable/Symbols/TypeKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeKind.cs
@@ -4,9 +4,6 @@
 
 #nullable enable
 
-using System;
-using System.ComponentModel;
-
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -505,6 +505,9 @@ namespace Microsoft.CodeAnalysis
         System_Threading_CancellationTokenSource__Token,
         System_Threading_CancellationTokenSource__Dispose,
 
+        System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
+        System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3465,14 +3465,14 @@ namespace Microsoft.CodeAnalysis
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute - WellKnownType.ExtSentinel),                                       // DeclaringTypeId
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
                 // System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags
                 (byte)MemberFlags.Constructor,                                                                              // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute - WellKnownType.ExtSentinel),                                       // DeclaringTypeId
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
             };
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3459,6 +3459,21 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+
+                // System_Runtime_CompilerServices_NativeIntegerAttribute__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute - WellKnownType.ExtSentinel),                                       // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+
+                // System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute - WellKnownType.ExtSentinel),                                       // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3893,6 +3908,8 @@ namespace Microsoft.CodeAnalysis
                 "CreateLinkedTokenSource",                  // System_Threading_CancellationTokenSource__CreateLinkedTokenSource
                 "Token",                                    // System_Threading_CancellationTokenSource__Token
                 "Dispose",                                  // System_Threading_CancellationTokenSource__Dispose
+                ".ctor",                                    // System_Runtime_CompilerServices_NativeIntegerAttribute__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -309,6 +309,7 @@ namespace Microsoft.CodeAnalysis
         System_InvalidOperationException,
         System_Runtime_CompilerServices_SwitchExpressionException,
         System_Collections_Generic_IEqualityComparer_T,
+        System_Runtime_CompilerServices_NativeIntegerAttribute,
 
         NextAvailable,
 
@@ -611,6 +612,7 @@ namespace Microsoft.CodeAnalysis
             "System.InvalidOperationException",
             "System.Runtime.CompilerServices.SwitchExpressionException",
             "System.Collections.Generic.IEqualityComparer`1",
+            "System.Runtime.CompilerServices.NativeIntegerAttribute",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -504,6 +504,34 @@ namespace System.Runtime.CompilerServices
 }
 ";
 
+        protected const string NativeIntegerAttributeDefinition =
+@"using System.Collections.Generic;
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(
+        AttributeTargets.Class |
+        AttributeTargets.Event |
+        AttributeTargets.Field |
+        AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter |
+        AttributeTargets.Property |
+        AttributeTargets.ReturnValue,
+        AllowMultiple = false,
+        Inherited = false)]
+    public sealed class NativeIntegerAttribute : Attribute
+    {
+        public NativeIntegerAttribute()
+        {
+            TransformFlags = new[] { true };
+        }
+        public NativeIntegerAttribute(bool[] flags)
+        {
+            TransformFlags = flags;
+        }
+        public readonly IList<bool> TransformFlags;
+    }
+}";
+
         protected static CSharpCompilationOptions WithNonNullTypesTrue(CSharpCompilationOptions options = null)
         {
             return WithNonNullTypes(options, NullableContextOptions.Enable);

--- a/src/Compilers/Test/Utilities/CSharp/NativeIntegerAttributesVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/NativeIntegerAttributesVisitor.cs
@@ -1,0 +1,248 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+
+namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
+{
+    /// <summary>
+    /// Returns a string with all symbols containing NativeIntegerAttributes.
+    /// </summary>
+    internal sealed class NativeIntegerAttributesVisitor : CSharpSymbolVisitor
+    {
+        internal static string GetString(PEModuleSymbol module)
+        {
+            var builder = new StringBuilder();
+            var visitor = new NativeIntegerAttributesVisitor(builder);
+            visitor.Visit(module);
+            return builder.ToString();
+        }
+
+        private readonly StringBuilder _builder;
+        private readonly HashSet<Symbol> _reported;
+
+        private NativeIntegerAttributesVisitor(StringBuilder builder)
+        {
+            _builder = builder;
+            _reported = new HashSet<Symbol>();
+        }
+
+        public override void DefaultVisit(Symbol symbol)
+        {
+            ReportSymbol(symbol);
+        }
+
+        public override void VisitModule(ModuleSymbol module)
+        {
+            Visit(module.GlobalNamespace);
+        }
+
+        public override void VisitNamespace(NamespaceSymbol @namespace)
+        {
+            VisitList(@namespace.GetMembers());
+        }
+
+        public override void VisitNamedType(NamedTypeSymbol type)
+        {
+            ReportSymbol(type);
+            VisitList(type.TypeParameters);
+
+            foreach (var member in type.GetMembers())
+            {
+                // Skip accessors since those are covered by associated symbol.
+                if (member.IsAccessor()) continue;
+                Visit(member);
+            }
+        }
+
+        public override void VisitMethod(MethodSymbol method)
+        {
+            ReportSymbol(method);
+            VisitList(method.TypeParameters);
+            VisitList(method.Parameters);
+        }
+
+        public override void VisitEvent(EventSymbol @event)
+        {
+            ReportSymbol(@event);
+            Visit(@event.AddMethod);
+            Visit(@event.RemoveMethod);
+        }
+
+        public override void VisitProperty(PropertySymbol property)
+        {
+            ReportSymbol(property);
+            VisitList(property.Parameters);
+            Visit(property.GetMethod);
+            Visit(property.SetMethod);
+        }
+
+        public override void VisitTypeParameter(TypeParameterSymbol typeParameter)
+        {
+            ReportSymbol(typeParameter);
+        }
+
+        private void VisitList<TSymbol>(ImmutableArray<TSymbol> symbols) where TSymbol : Symbol
+        {
+            foreach (var symbol in symbols)
+            {
+                Visit(symbol);
+            }
+        }
+
+        /// <summary>
+        /// Return the containing symbol used in the hierarchy here. Specifically, the
+        /// hierarchy contains types, members, and parameters only, and accessors are
+        /// considered members of the associated symbol rather than the type.
+        /// </summary>
+        private static Symbol GetContainingSymbol(Symbol symbol)
+        {
+            if (symbol.IsAccessor())
+            {
+                return ((MethodSymbol)symbol).AssociatedSymbol;
+            }
+            var containingSymbol = symbol.ContainingSymbol;
+            return containingSymbol?.Kind == SymbolKind.Namespace ? null : containingSymbol;
+        }
+
+        private static string GetIndentString(Symbol symbol)
+        {
+            int level = 0;
+            while (true)
+            {
+                symbol = GetContainingSymbol(symbol);
+                if (symbol is null)
+                {
+                    break;
+                }
+                level++;
+            }
+            return new string(' ', level * 4);
+        }
+
+        private static readonly SymbolDisplayFormat _displayFormat = SymbolDisplayFormat.TestFormatWithConstraints.
+            WithMemberOptions(
+                SymbolDisplayMemberOptions.IncludeParameters |
+                SymbolDisplayMemberOptions.IncludeType |
+                SymbolDisplayMemberOptions.IncludeRef |
+                SymbolDisplayMemberOptions.IncludeExplicitInterface);
+
+        private void ReportContainingSymbols(Symbol symbol)
+        {
+            symbol = GetContainingSymbol(symbol);
+            if (symbol is null)
+            {
+                return;
+            }
+            if (_reported.Contains(symbol))
+            {
+                return;
+            }
+            ReportContainingSymbols(symbol);
+            _builder.Append(GetIndentString(symbol));
+            _builder.AppendLine(symbol.ToDisplayString(_displayFormat));
+            _reported.Add(symbol);
+        }
+
+        private void ReportSymbol(Symbol symbol)
+        {
+            var type = (symbol as TypeSymbol) ?? symbol.GetTypeOrReturnType().Type;
+            var attribute = GetNativeIntegerAttribute((symbol is MethodSymbol method) ? method.GetReturnTypeAttributes() : symbol.GetAttributes());
+            Debug.Assert((type?.ContainsNativeInteger() != true) || (attribute != null));
+            if (attribute == null)
+            {
+                return;
+            }
+            ReportContainingSymbols(symbol);
+            _builder.Append(GetIndentString(symbol));
+            _builder.Append($"{ReportAttribute(attribute)} ");
+            _builder.AppendLine(symbol.ToDisplayString(_displayFormat));
+            _reported.Add(symbol);
+        }
+
+        private static Symbol GetAccessSymbol(Symbol symbol)
+        {
+            while (true)
+            {
+                switch (symbol.Kind)
+                {
+                    case SymbolKind.Parameter:
+                    case SymbolKind.TypeParameter:
+                        symbol = symbol.ContainingSymbol;
+                        break;
+                    default:
+                        return symbol;
+                }
+            }
+        }
+
+        private static string ReportAttribute(CSharpAttributeData attribute)
+        {
+            var builder = new StringBuilder();
+            builder.Append("[");
+
+            var name = attribute.AttributeClass.Name;
+            if (name.EndsWith("Attribute")) name = name.Substring(0, name.Length - 9);
+            builder.Append(name);
+
+            var arguments = attribute.ConstructorArguments.ToImmutableArray();
+            if (arguments.Length > 0)
+            {
+                builder.Append("(");
+                printValues(builder, arguments);
+                builder.Append(")");
+            }
+
+            builder.Append("]");
+            return builder.ToString();
+
+            static void printValues(StringBuilder builder, ImmutableArray<TypedConstant> values)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(", ");
+                    }
+                    printValue(builder, values[i]);
+                }
+            }
+
+            static void printValue(StringBuilder builder, TypedConstant value)
+            {
+                if (value.Kind == TypedConstantKind.Array)
+                {
+                    builder.Append("{ ");
+                    printValues(builder, value.Values);
+                    builder.Append(" }");
+                }
+                else
+                {
+                    builder.Append(value.Value);
+                }
+            }
+        }
+
+        private static CSharpAttributeData GetNativeIntegerAttribute(ImmutableArray<CSharpAttributeData> attributes) =>
+            GetAttribute(attributes, "System.Runtime.CompilerServices", "NativeIntegerAttribute");
+
+        private static CSharpAttributeData GetAttribute(ImmutableArray<CSharpAttributeData> attributes, string namespaceName, string name)
+        {
+            foreach (var attribute in attributes)
+            {
+                var containingType = attribute.AttributeConstructor.ContainingType;
+                if (containingType.Name == name && containingType.ContainingNamespace.QualifiedName == namespaceName)
+                {
+                    return attribute;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -536,7 +536,8 @@ End Namespace
                          WellKnownType.System_Threading_CancellationToken,
                          WellKnownType.System_Runtime_CompilerServices_NonNullTypesAttribute,
                          WellKnownType.Microsoft_CodeAnalysis_EmbeddedAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException
+                         WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException,
+                         WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -599,7 +600,8 @@ End Namespace
                          WellKnownType.System_Threading_CancellationToken,
                          WellKnownType.System_Runtime_CompilerServices_NonNullTypesAttribute,
                          WellKnownType.Microsoft_CodeAnalysis_EmbeddedAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException
+                         WellKnownType.System_Runtime_CompilerServices_SwitchExpressionException,
+                         WellKnownType.System_Runtime_CompilerServices_NativeIntegerAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -682,7 +684,9 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_AsyncIteratorMethodBuilder__Create,
                          WellKnownMember.System_Runtime_CompilerServices_AsyncIteratorMethodBuilder__MoveNext_T,
                          WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T
+                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T,
+                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -821,7 +825,9 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_AsyncIteratorMethodBuilder__Create,
                          WellKnownMember.System_Runtime_CompilerServices_AsyncIteratorMethodBuilder__MoveNext_T,
                          WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T
+                         WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T,
+                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,

--- a/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
+++ b/src/Test/Utilities/Portable/Metadata/MetadataReaderUtils.cs
@@ -193,6 +193,11 @@ namespace Roslyn.Test.Utilities
             return ReadArray(reader, blobHandle, (ref BlobReader blobReader) => blobReader.ReadByte());
         }
 
+        public static ImmutableArray<bool> ReadBoolArray(this MetadataReader reader, BlobHandle blobHandle)
+        {
+            return ReadArray(reader, blobHandle, (ref BlobReader blobReader) => blobReader.ReadBoolean());
+        }
+
         public static IEnumerable<CustomAttributeRow> GetCustomAttributeRows(this MetadataReader reader)
         {
             foreach (var handle in reader.CustomAttributes)


### PR DESCRIPTION
Emit `NativeIntegerAttribute` to represent `nint` and `nuint` in metadata (see [NativeInt.md#metadata](https://github.com/dotnet/csharplang/blob/b75760a72480d4214bf68d3150a2ff649c80e95e/proposals/NativeInt.md#metadata)).