### PR TITLE
Fix document rename when case is same

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1838,5 +1838,33 @@ End Class
                 Assert.Equal(InlineRenameFileRenameInfo.NotAllowed, session.FileRenameInfo)
             End Using
         End Sub
+
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub VerifyFileRenamesCorrectlyWhenCaseChanges()
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class [|$$Test1|]
+{
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                Dim session = StartSession(workspace)
+
+                ' Type a bit in the file
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+                Dim textBuffer = workspace.Documents.Single().GetTextBuffer()
+
+                textBuffer.Delete(New Span(caretPosition, 1))
+                textBuffer.Insert(caretPosition, "t")
+
+                session.Commit()
+                VerifyFileName(workspace, "test1")
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/ProjectItemsExtensions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Extensions/ProjectItemsExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -23,6 +25,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.E
         public static string GetUniqueName(this ProjectItems items, string itemName, string extension)
         {
             return NameGenerator.GenerateUniqueName(itemName, extension, n => items.FindItem(n, StringComparer.OrdinalIgnoreCase) == null);
+        }
+
+        public static string GetUniqueNameIgnoringProjectItem(this ProjectItems items, ProjectItem itemToIgnore, string itemName, string extension)
+        {
+            return NameGenerator.GenerateUniqueName(itemName, extension, n =>
+            {
+                var foundItem = items.FindItem(n, StringComparer.OrdinalIgnoreCase);
+                return foundItem == null ||
+                    foundItem == itemToIgnore;
+            });
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1187,9 +1187,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // Must save the document first for things like Breakpoints to be preserved.
                 projectItemForDocument.Save();
 
-                var uniqueName = projectItemForDocument.Collection.GetUniqueName(
-                    Path.GetFileNameWithoutExtension(updatedInfo.Name),
-                    Path.GetExtension(updatedInfo.Name));
+                var uniqueName = projectItemForDocument.Collection
+                    .GetUniqueNameIgnoringProjectItem(
+                        projectItemForDocument,
+                        Path.GetFileNameWithoutExtension(updatedInfo.Name),
+                        Path.GetExtension(updatedInfo.Name));
 
                 // Get the current undoManager before any file renames/documentId changes happen
                 var undoManager = TryGetUndoManager();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -576,6 +577,37 @@ class Program
     {
         var y = 1;
         y = 2;
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Rename)]
+        [WorkItem(39617, "https://github.com/dotnet/roslyn/issues/39617")]
+        public void VerifyRenameCaseChange()
+        {
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddFile(project, "Program.cs",
+@"
+class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}");
+
+            VisualStudio.SolutionExplorer.OpenFile(project, "Program.cs");
+            VisualStudio.Editor.PlaceCaret("Program");
+
+            InlineRenameDialog.Invoke();
+
+            VisualStudio.Editor.SendKeys(VirtualKey.Home, VirtualKey.Delete, VirtualKey.P, VirtualKey.Enter);
+
+            VisualStudio.SolutionExplorer.Verify.FileContents(project, "program.cs",
+@"
+class program
+{
+    static void Main(string[] args)
+    {
     }
 }");
         }


### PR DESCRIPTION
When renaming a document, we ensure that the name is unique
but include the old document name in the check. Since that's
the document that's name is changing, we can ignore it
when comparing names for uniqueness.

Fixes #39617 