### PR TITLE
Make importing streaming find usages presenter lazy and avoid doing g…

### DIFF
--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToDefinitionService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Editor.GoToDefinition;
 using Microsoft.CodeAnalysis.Editor.Host;
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.GoToDefinition
     internal class CSharpGoToDefinitionService : AbstractGoToDefinitionService
     {
         [ImportingConstructor]
-        public CSharpGoToDefinitionService(IStreamingFindUsagesPresenter streamingPresenter)
+        public CSharpGoToDefinitionService(Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
             : base(streamingPresenter)
         {
         }

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -17,9 +18,13 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
     // GoToDefinition
     internal abstract class AbstractGoToDefinitionService : IGoToDefinitionService
     {
-        private readonly IStreamingFindUsagesPresenter _streamingPresenter;
+        /// <summary>
+        /// Presenter used for <see cref="TryGoToDefinition(Document, int, CancellationToken)"/>
+        /// Import lazily as this requires the UI thread.
+        /// </summary>
+        private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
 
-        protected AbstractGoToDefinitionService(IStreamingFindUsagesPresenter streamingPresenter)
+        protected AbstractGoToDefinitionService(Lazy<IStreamingFindUsagesPresenter> streamingPresenter)
         {
             _streamingPresenter = streamingPresenter;
         }
@@ -54,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
 
             return GoToDefinitionHelpers.TryGoToDefinition(symbol,
                 document.Project,
-                _streamingPresenter,
+                _streamingPresenter.Value,
                 thirdPartyNavigationAllowed: isThirdPartyNavigationAllowed,
                 throwOnHiddenDefinition: true,
                 cancellationToken: cancellationToken);

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -18,6 +18,11 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
     // GoToDefinition
     internal abstract class AbstractGoToDefinitionService : IGoToDefinitionService
     {
+        /// <summary>
+        /// Used to present go to definition results in <see cref="TryGoToDefinition(Document, int, CancellationToken)"/>
+        /// This is lazily created as the LSP server only calls <see cref="FindDefinitionsAsync(Document, int, CancellationToken)"/>
+        /// and therefore never needs to construct the presenter.
+        /// </summary>
         private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
 
         protected AbstractGoToDefinitionService(Lazy<IStreamingFindUsagesPresenter> streamingPresenter)

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -18,10 +18,6 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
     // GoToDefinition
     internal abstract class AbstractGoToDefinitionService : IGoToDefinitionService
     {
-        /// <summary>
-        /// Presenter used for <see cref="TryGoToDefinition(Document, int, CancellationToken)"/>
-        /// Import lazily as this requires the UI thread.
-        /// </summary>
         private readonly Lazy<IStreamingFindUsagesPresenter> _streamingPresenter;
 
         protected AbstractGoToDefinitionService(Lazy<IStreamingFindUsagesPresenter> streamingPresenter)

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionCommandHandlerTests.vb
@@ -102,7 +102,7 @@ class C
                 Dim cursorBuffer = cursorDocument.GetTextBuffer()
                 Dim document = workspace.CurrentSolution.GetDocument(cursorDocument.Id)
 
-                Dim goToDefService = New CSharpGoToDefinitionService(presenter)
+                Dim goToDefService = New CSharpGoToDefinitionService(New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter))
 
                 Dim waitContext = New TestUIThreadOperationContext(updatesBeforeCancel)
                 Dim commandHandler = New GoToDefinitionCommandHandler()

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -106,9 +106,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
         Private Sub Test(workspaceDefinition As XElement, Optional expectedResult As Boolean = True)
             Test(workspaceDefinition, expectedResult,
                 Function(document As Document, cursorPosition As Integer, presenter As IStreamingFindUsagesPresenter)
+                    Dim lazyPresenter = New Lazy(Of IStreamingFindUsagesPresenter)(Function() presenter)
                     Dim goToDefService = If(document.Project.Language = LanguageNames.CSharp,
-                        DirectCast(New CSharpGoToDefinitionService(presenter), IGoToDefinitionService),
-                        New VisualBasicGoToDefinitionService(presenter))
+                        DirectCast(New CSharpGoToDefinitionService(lazyPresenter), IGoToDefinitionService),
+                        New VisualBasicGoToDefinitionService(lazyPresenter))
 
                     Return goToDefService.TryGoToDefinition(document, cursorPosition, CancellationToken.None)
                 End Function)

--- a/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
+++ b/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToDefinitionService.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
         Inherits AbstractGoToDefinitionService
 
         <ImportingConstructor>
-        Public Sub New(streamingPresenter As IStreamingFindUsagesPresenter)
+        Public Sub New(streamingPresenter As Lazy(Of IStreamingFindUsagesPresenter))
             MyBase.New(streamingPresenter)
         End Sub
     End Class

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/StreamingFindUsagesPresenter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/StreamingFindUsagesPresenter.cs
@@ -37,7 +37,6 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
         public readonly IEditorFormatMapService FormatMapService;
         public readonly IClassificationFormatMap ClassificationFormatMap;
 
-        private readonly IFindAllReferencesService _vsFindAllReferencesService;
         private readonly Workspace _workspace;
 
         private readonly HashSet<AbstractTableDataSourceFindUsagesContext> _currentContexts =
@@ -94,7 +93,6 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             FormatMapService = formatMapService;
             ClassificationFormatMap = classificationFormatMapService.GetClassificationFormatMap("tooltip");
 
-            _vsFindAllReferencesService = (IFindAllReferencesService)_serviceProvider.GetService(typeof(SVsFindAllReferences));
             _customColumns = columns.ToImmutableArray();
         }
 
@@ -170,8 +168,9 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
         {
             this.AssertIsForeground();
 
+            var vsFindAllReferencesService = (IFindAllReferencesService)_serviceProvider.GetService(typeof(SVsFindAllReferences));
             // Get the appropriate window for FAR results to go into.
-            var window = _vsFindAllReferencesService.StartSearch(title);
+            var window = vsFindAllReferencesService.StartSearch(title);
 
             // Keep track of the users preference for grouping by definition if we don't already know it.
             // We need this because we disable the Definition column when we're not showing references

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/StreamingFindUsagesPresenter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/StreamingFindUsagesPresenter.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             IEditorFormatMapService formatMapService,
             IClassificationFormatMapService classificationFormatMapService,
             IEnumerable<ITableColumnDefinition> columns)
-            : base(threadingContext)
+            : base(threadingContext, assertIsForeground: false)
         {
             _workspace = workspace;
             _serviceProvider = serviceProvider;


### PR DESCRIPTION
…et service calls on UI thread.

Fixes a cloud env issue with gotodef where it was trying to construct the StreamingFindUsagesPresenter and call GetService on a background thread.