### PR TITLE
Null out compilation factory for remote

### DIFF
--- a/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/CSharpRemoteCompilationFactoryService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/CSharpRemoteCompilationFactoryService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -11,9 +13,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.LocalForwarde
     [ExportLanguageServiceFactory(typeof(ICompilationFactoryService), StringConstants.CSharpLspLanguageName), Shared]
     internal class CSharpRemoteCompilationFactoryService : ILanguageServiceFactory
     {
-        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        public ILanguageService? CreateLanguageService(HostLanguageServices languageServices)
         {
-            return languageServices.GetOriginalLanguageService<ICompilationFactoryService>();
+            // Don't allow the remote workspace to create C# compilations; since we don't have references, any attempt to use semantics in the workspace
+            // on the client side is incorrect.
+            return null;
         }
     }
 }

--- a/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/VBRemoteCompilationFactoryService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/LocalForwarders/VBRemoteCompilationFactoryService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Composition;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -11,9 +13,11 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.LocalForwarde
     [ExportLanguageServiceFactory(typeof(ICompilationFactoryService), StringConstants.VBLspLanguageName), Shared]
     internal class VBRemoteCompilationFactoryService : ILanguageServiceFactory
     {
-        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        public ILanguageService? CreateLanguageService(HostLanguageServices languageServices)
         {
-            return languageServices.GetOriginalLanguageService<ICompilationFactoryService>();
+            // Don't allow the remote workspace to create VB compilations; since we don't have references, any attempt to use semantics in the workspace
+            // on the client side is incorrect.
+            return null;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ILanguageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ILanguageServiceFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 
 namespace Microsoft.CodeAnalysis.Host.Mef
 {
@@ -16,6 +17,6 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         /// Creates a new <see cref="ILanguageService"/> instance.
         /// </summary>
         /// <param name="languageServices">The <see cref="HostLanguageServices"/> that can be used to access other services.</param>
-        ILanguageService CreateLanguageService(HostLanguageServices languageServices);
+        ILanguageService? CreateLanguageService(HostLanguageServices languageServices);
     }
 }


### PR DESCRIPTION
This was an idea that @dibarbet and I had -- we should stop producing compilations for the remote workspace entirely, because any attempt to use them is going to be incorrect since there are never any references whatsoever. The first commit here null-annotates the language service MEF support to explicitly allow language service factories to return null, which it looks like was the existing supported behavior. The second commit forces the language services to return null.

I realized after writing this that I could have just deleted the factories, since we're applying these to the C# special 'remote' language service. We might be able to just remove the separate language name at this point, although that might make things more confusing than not.