### PR TITLE
Code block callbacks

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -31,6 +31,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
                 SyntaxKind.SimpleMemberAccessExpression,
                 SyntaxKind.QualifiedCref);
 
+        protected override bool IsIgnoredCodeBlock(ref CodeBlockAnalysisContext context)
+        {
+            return context.CodeBlock.IsKind(
+                SyntaxKind.CompilationUnit,
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.StructDeclaration,
+                SyntaxKind.InterfaceDeclaration,
+                SyntaxKind.DelegateDeclaration,
+                SyntaxKind.EnumDeclaration);
+        }
+
         protected override void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
         {
             var semanticModel = context.SemanticModel;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
 
             var simplifier = new TypeSyntaxSimplifierWalker(this, semanticModel, optionSet, ignoredSpans: null, cancellationToken);
             simplifier.Visit(context.CodeBlock);
+            if (!simplifier.HasDiagnostics)
+                return;
 
             foreach (var diagnostic in simplifier.Diagnostics)
             {
@@ -61,6 +63,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
 
             var simplifier = new TypeSyntaxSimplifierWalker(this, semanticModel, optionSet, ignoredSpans: codeBlockIntervalTree, cancellationToken);
             simplifier.Visit(root);
+            if (!simplifier.HasDiagnostics)
+                return;
 
             foreach (var diagnostic in simplifier.Diagnostics)
             {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -31,9 +31,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
                 SyntaxKind.SimpleMemberAccessExpression,
                 SyntaxKind.QualifiedCref);
 
-        protected override bool IsIgnoredCodeBlock(ref CodeBlockAnalysisContext context)
+        protected override bool IsIgnoredCodeBlock(SyntaxNode codeBlock)
         {
-            return context.CodeBlock.IsKind(
+            // Avoid analysis of compilation units and types in AnalyzeCodeBlock. These nodes appear in code block
+            // callbacks when they include attributes, but analysis of the node at this level would block more efficient
+            // analysis of descendant members.
+            return codeBlock.IsKind(
                 SyntaxKind.CompilationUnit,
                 SyntaxKind.ClassDeclaration,
                 SyntaxKind.StructDeclaration,

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.cs
@@ -49,6 +49,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
         private readonly SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? _ignoredSpans;
         private readonly CancellationToken _cancellationToken;
 
+        private List<Diagnostic>? _diagnostics;
+
         /// <summary>
         /// Set of type and namespace names that have an alias associated with them.  i.e. if the
         /// user has <c>using X = System.DateTime</c>, then <c>DateTime</c> will be in this set.
@@ -57,7 +59,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
         /// </summary>
         private readonly ImmutableHashSet<string> _aliasedNames;
 
-        public List<Diagnostic> Diagnostics { get; } = new List<Diagnostic>();
+        public bool HasDiagnostics => _diagnostics?.Count > 0;
+
+        public List<Diagnostic> Diagnostics
+        {
+            get
+            {
+                if (_diagnostics is null)
+                    Interlocked.CompareExchange(ref _diagnostics, new List<Diagnostic>(), null);
+
+                return _diagnostics;
+            }
+        }
 
         public TypeSyntaxSimplifierWalker(CSharpSimplifyTypeNamesDiagnosticAnalyzer analyzer, SemanticModel semanticModel, OptionSet optionSet, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? ignoredSpans, CancellationToken cancellationToken)
             : base(SyntaxWalkerDepth.StructuredTrivia)

--- a/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -106,7 +106,15 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             context.RegisterSemanticModelAction(analyzer.AnalyzeSemanticModel);
         }
 
-        protected abstract bool IsIgnoredCodeBlock(ref CodeBlockAnalysisContext context);
+        /// <summary>
+        /// Determine if a code block is eligible for analysis by <see cref="AnalyzeCodeBlock"/>.
+        /// </summary>
+        /// <param name="codeBlock">The syntax node provided via <see cref="CodeBlockAnalysisContext.CodeBlock"/>.</param>
+        /// <returns><see langword="true"/> if the code block should be analyzed by <see cref="AnalyzeCodeBlock"/>;
+        /// otherwise, <see langword="false"/> to skip analysis of the block. If a block is skipped, one or more child
+        /// blocks may be analyzed by <see cref="AnalyzeCodeBlock"/>, and any remaining spans can be analyzed by
+        /// <see cref="AnalyzeSemanticModel"/>.</returns>
+        protected abstract bool IsIgnoredCodeBlock(SyntaxNode codeBlock);
         protected abstract void AnalyzeCodeBlock(CodeBlockAnalysisContext context);
         protected abstract void AnalyzeSemanticModel(SemanticModelAnalysisContext context, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? codeBlockIntervalTree);
 
@@ -232,7 +240,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
 
             public void AnalyzeCodeBlock(CodeBlockAnalysisContext context)
             {
-                if (_analyzer.IsIgnoredCodeBlock(ref context))
+                if (_analyzer.IsIgnoredCodeBlock(context.CodeBlock))
                     return;
 
                 var (completed, intervalTree) = _codeBlockIntervals.GetOrAdd(context.CodeBlock.SyntaxTree, _ => (new StrongBox<bool>(false), SimpleIntervalTree.Create(new TextSpanIntervalIntrospector(), Array.Empty<TextSpan>())));

--- a/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -106,6 +106,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             context.RegisterSemanticModelAction(analyzer.AnalyzeSemanticModel);
         }
 
+        protected abstract bool IsIgnoredCodeBlock(ref CodeBlockAnalysisContext context);
         protected abstract void AnalyzeCodeBlock(CodeBlockAnalysisContext context);
         protected abstract void AnalyzeSemanticModel(SemanticModelAnalysisContext context, SimpleIntervalTree<TextSpan, TextSpanIntervalIntrospector>? codeBlockIntervalTree);
 

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/TypeSyntaxSimplifierWalker.vb
@@ -40,6 +40,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         Private ReadOnly _ignoredSpans As SimpleIntervalTree(Of TextSpan, TextSpanIntervalIntrospector)
         Private ReadOnly _cancellationToken As CancellationToken
 
+        Private _diagnostics As List(Of Diagnostic)
+
         ''' <summary>
         ''' Set of type and namespace names that have an alias associated with them.  i.e. if the
         ''' user has <c>Imports X = System.DateTime</c>, then <c>DateTime</c> will be in this set.
@@ -48,7 +50,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
         ''' </summary>
         Private ReadOnly _aliasedNames As ImmutableHashSet(Of String)
 
-        Public ReadOnly Property Diagnostics As List(Of Diagnostic) = New List(Of Diagnostic)()
+        Public ReadOnly Property HasDiagnostics As Boolean
+            Get
+                Return _diagnostics IsNot Nothing AndAlso _diagnostics.Count > 0
+            End Get
+        End Property
+
+        Public ReadOnly Property Diagnostics As List(Of Diagnostic)
+            Get
+                If _diagnostics Is Nothing Then
+                    Interlocked.CompareExchange(_diagnostics, New List(Of Diagnostic)(), Nothing)
+                End If
+
+                Return _diagnostics
+            End Get
+        End Property
 
         Public Sub New(analyzer As VisualBasicSimplifyTypeNamesDiagnosticAnalyzer, semanticModel As SemanticModel, optionSet As OptionSet, ignoredSpans As SimpleIntervalTree(Of TextSpan, TextSpanIntervalIntrospector), cancellationToken As CancellationToken)
             MyBase.New(SyntaxWalkerDepth.StructuredTrivia)

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -35,6 +35,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 
             Dim simplifier As New TypeSyntaxSimplifierWalker(Me, semanticModel, optionSet, ignoredSpans:=Nothing, cancellationToken)
             simplifier.Visit(context.CodeBlock)
+            If Not simplifier.HasDiagnostics Then
+                Return
+            End If
 
             For Each diagnostic In simplifier.Diagnostics
                 context.ReportDiagnostic(diagnostic)
@@ -52,6 +55,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 
             Dim simplifier As New TypeSyntaxSimplifierWalker(Me, semanticModel, optionSet, ignoredSpans:=codeBlockIntervalTree, cancellationToken)
             simplifier.Visit(root)
+            If Not simplifier.HasDiagnostics Then
+                Return
+            End If
 
             For Each diagnostic In simplifier.Diagnostics
                 context.ReportDiagnostic(diagnostic)

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -25,6 +25,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             SyntaxKind.IdentifierName,
             SyntaxKind.GenericName)
 
+        Protected Overrides Function IsIgnoredCodeBlock(ByRef context As CodeBlockAnalysisContext) As Boolean
+            Return context.CodeBlock.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) OrElse
+                context.CodeBlock.IsKind(SyntaxKind.InterfaceBlock, SyntaxKind.ModuleBlock, SyntaxKind.EnumBlock) OrElse
+                context.CodeBlock.IsKind(SyntaxKind.DelegateFunctionStatement)
+        End Function
+
         Protected Overrides Sub AnalyzeCodeBlock(context As CodeBlockAnalysisContext)
             Dim semanticModel = context.SemanticModel
             Dim cancellationToken = context.CancellationToken

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -25,10 +25,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             SyntaxKind.IdentifierName,
             SyntaxKind.GenericName)
 
-        Protected Overrides Function IsIgnoredCodeBlock(ByRef context As CodeBlockAnalysisContext) As Boolean
-            Return context.CodeBlock.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) OrElse
-                context.CodeBlock.IsKind(SyntaxKind.InterfaceBlock, SyntaxKind.ModuleBlock, SyntaxKind.EnumBlock) OrElse
-                context.CodeBlock.IsKind(SyntaxKind.DelegateFunctionStatement)
+        Protected Overrides Function IsIgnoredCodeBlock(codeBlock As SyntaxNode) As Boolean
+            ' Avoid analysis of compilation units and types in AnalyzeCodeBlock. These nodes appear in code block
+            ' callbacks when they include attributes, but analysis of the node at this level would block more efficient
+            ' analysis of descendant members.
+            Return codeBlock.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) OrElse
+                codeBlock.IsKind(SyntaxKind.InterfaceBlock, SyntaxKind.ModuleBlock, SyntaxKind.EnumBlock) OrElse
+                codeBlock.IsKind(SyntaxKind.DelegateFunctionStatement)
         End Function
 
         Protected Overrides Sub AnalyzeCodeBlock(context As CodeBlockAnalysisContext)


### PR DESCRIPTION
Use a hybrid callback strategy to improve Simplify Type Names performance.

### Prior to this change

C#:

```text
Found 4966 diagnostics in 37833ms (46204767440 bytes allocated)
CSharpSimplifyTypeNamesDiagnosticAnalyzer: 1350190
```

Visual Basic:

```text
Found 19240 diagnostics in 46900ms (52825758560 bytes allocated)
VisualBasicSimplifyTypeNamesDiagnosticAnalyzer: 1537722
```

### After this change


C#:

```text
Found 4966 diagnostics in 31580ms (39733184912 bytes allocated)
CSharpSimplifyTypeNamesDiagnosticAnalyzer: 1148169
```

Visual Basic:

```text
Found 19240 diagnostics in 44924ms (51672203504 bytes allocated)
VisualBasicSimplifyTypeNamesDiagnosticAnalyzer: 1263130
```

### Notes

The C# implementation is benefitting heavily from #19258. The corresponding change was not implemented for Visual Basic, and cannot be implemented in the same manner without triggering and overwhelming increase in allocations (20GB) due to symbol retargeting.