### PR TITLE
Check for generated code with a walker instead of literal text

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GeneratedCodeTokenWalker.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GeneratedCodeTokenWalker.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.CodeDom.Compiler;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal abstract partial class AnalyzerDriver
+    {
+        private sealed class GeneratedCodeTokenWalker : SyntaxWalker
+        {
+            public GeneratedCodeTokenWalker()
+                : base(SyntaxWalkerDepth.Token)
+            {
+            }
+
+            public bool HasGeneratedCodeIdentifier { get; private set; }
+
+            public override void Visit(SyntaxNode node)
+            {
+                if (HasGeneratedCodeIdentifier)
+                    return;
+
+                base.Visit(node);
+            }
+
+            protected override void VisitToken(SyntaxToken token)
+            {
+                HasGeneratedCodeIdentifier |= string.Equals(token.ValueText, "GeneratedCode", StringComparison.Ordinal)
+                    || string.Equals(token.ValueText, nameof(GeneratedCodeAttribute), StringComparison.Ordinal);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -944,8 +944,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private ImmutableHashSet<ISymbol> ComputeGeneratedCodeSymbolsInTree(SyntaxTree tree, Compilation compilation, CancellationToken cancellationToken)
         {
             // PERF: Bail out early if file doesn't have "GeneratedCode" text.
-            var text = tree.GetText(cancellationToken).ToString();
-            if (!text.Contains("GeneratedCode"))
+            var walker = new GeneratedCodeTokenWalker();
+            walker.Visit(tree.GetRoot(cancellationToken));
+            if (!walker.HasGeneratedCodeIdentifier)
             {
                 return ImmutableHashSet<ISymbol>.Empty;
             }


### PR DESCRIPTION
I ran three passes before and after. The execution time seems about the same, while the allocations are reduced by about 1GB.

### Before

```text
Found 253253 diagnostics in 15510ms (22804270760 bytes allocated)
Execution times (ms):
CSharpUseExplicitTypeDiagnosticAnalyzer:  192940

Found 253253 diagnostics in 15180ms (23004576328 bytes allocated)
Execution times (ms):
CSharpUseExplicitTypeDiagnosticAnalyzer:  207948

Found 253253 diagnostics in 15088ms (23770091952 bytes allocated)
Execution times (ms):
CSharpUseExplicitTypeDiagnosticAnalyzer:  249500
```

### After

```text
Found 253253 diagnostics in 14788ms (22023743928 bytes allocated)
Execution times (ms):
CSharpUseExplicitTypeDiagnosticAnalyzer:  243923

Found 253253 diagnostics in 15459ms (21835217016 bytes allocated)
Execution times (ms):
CSharpUseExplicitTypeDiagnosticAnalyzer:  199311

Found 253253 diagnostics in 15053ms (21990864312 bytes allocated)
Execution times (ms):
CSharpUseExplicitTypeDiagnosticAnalyzer:  212039
```