### PR TITLE
Call AsyncMethodBuilder.Start on field not on local

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncRewriter.cs
@@ -206,7 +206,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
-            var builderVariable = F.SynthesizedLocal(methodScopeAsyncMethodBuilderMemberCollection.BuilderType, null);
 
             // local.$builder = System.Runtime.CompilerServices.AsyncTaskMethodBuilder<typeArgs>.Create();
             bodyBuilder.Add(
@@ -222,11 +221,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     F.Field(F.Local(stateMachineVariable), stateField.AsMember(frameType)),
                     F.Literal(StateMachineStates.NotStartedStateMachine)));
 
-            bodyBuilder.Add(
-                F.Assignment(
-                    F.Local(builderVariable),
-                    F.Field(F.Local(stateMachineVariable), _builderField.AsMember(frameType))));
-
             // local.$builder.Start(ref local) -- binding to the method AsyncTaskMethodBuilder<typeArgs>.Start()
             var startMethod = methodScopeAsyncMethodBuilderMemberCollection.Start.Construct(frameType);
             if (methodScopeAsyncMethodBuilderMemberCollection.CheckGenericMethodConstraints)
@@ -236,7 +230,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bodyBuilder.Add(
                 F.ExpressionStatement(
                     F.Call(
-                        F.Local(builderVariable),
+                        F.Field(F.Local(stateMachineVariable), _builderField.AsMember(frameType)),
                         startMethod,
                         ImmutableArray.Create<BoundExpression>(F.Local(stateMachineVariable)))));
 
@@ -247,9 +241,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         F.Field(F.Local(stateMachineVariable), _builderField.AsMember(frameType)),
                         methodScopeAsyncMethodBuilderMemberCollection.Task)));
 
-            return F.Block(
-                ImmutableArray.Create(builderVariable),
-                bodyBuilder.ToImmutableAndFree());
+            return F.Block(bodyBuilder.ToImmutableAndFree());
         }
 
         protected virtual void GenerateMoveNext(SynthesizedImplementationMethod moveNextMethod)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -1987,26 +1987,23 @@ class Test
 
             c.VerifyIL("Test.F", @"
 {
-  // Code size       49 (0x31)
+  // Code size       47 (0x2f)
   .maxstack  2
-  .locals init (Test.<F>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> V_1)
+  .locals init (Test.<F>d__0 V_0)
   IL_0000:  ldloca.s   V_0
   IL_0002:  call       ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Create()""
   IL_0007:  stfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
   IL_000c:  ldloca.s   V_0
   IL_000e:  ldc.i4.m1
   IL_000f:  stfld      ""int Test.<F>d__0.<>1__state""
-  IL_0014:  ldloc.0
-  IL_0015:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  ldloca.s   V_0
-  IL_001f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<Test.<F>d__0>(ref Test.<F>d__0)""
-  IL_0024:  ldloca.s   V_0
-  IL_0026:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_002b:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
-  IL_0030:  ret
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<Test.<F>d__0>(ref Test.<F>d__0)""
+  IL_0022:  ldloca.s   V_0
+  IL_0024:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_0029:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
+  IL_002e:  ret
 }
 ");
 
@@ -2135,26 +2132,23 @@ class Test
 
             c.VerifyIL("Test.F", @"
 {
-  // Code size       49 (0x31)
+  // Code size       47 (0x2f)
   .maxstack  2
-  .locals init (Test.<F>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> V_1)
+  .locals init (Test.<F>d__0 V_0)
   IL_0000:  ldloca.s   V_0
   IL_0002:  call       ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Create()""
   IL_0007:  stfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
   IL_000c:  ldloca.s   V_0
   IL_000e:  ldc.i4.m1
   IL_000f:  stfld      ""int Test.<F>d__0.<>1__state""
-  IL_0014:  ldloc.0
-  IL_0015:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  ldloca.s   V_0
-  IL_001f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<Test.<F>d__0>(ref Test.<F>d__0)""
-  IL_0024:  ldloca.s   V_0
-  IL_0026:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_002b:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
-  IL_0030:  ret
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<Test.<F>d__0>(ref Test.<F>d__0)""
+  IL_0022:  ldloca.s   V_0
+  IL_0024:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_0029:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
+  IL_002e:  ret
 }
 ");
 
@@ -2286,10 +2280,9 @@ class Test
 
             c.VerifyIL("Test.F", @"
 {
-  // Code size       52 (0x34)
+  // Code size       49 (0x31)
   .maxstack  2
-  .locals init (Test.<F>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> V_1)
+  .locals init (Test.<F>d__0 V_0)
   IL_0000:  newobj     ""Test.<F>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -2299,15 +2292,13 @@ class Test
   IL_0012:  ldc.i4.m1
   IL_0013:  stfld      ""int Test.<F>d__0.<>1__state""
   IL_0018:  ldloc.0
-  IL_0019:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_001e:  stloc.1
-  IL_001f:  ldloca.s   V_1
-  IL_0021:  ldloca.s   V_0
-  IL_0023:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<Test.<F>d__0>(ref Test.<F>d__0)""
-  IL_0028:  ldloc.0
-  IL_0029:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_002e:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
-  IL_0033:  ret
+  IL_0019:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<Test.<F>d__0>(ref Test.<F>d__0)""
+  IL_0025:  ldloc.0
+  IL_0026:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_002b:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
+  IL_0030:  ret
 }
 ");
 
@@ -2444,26 +2435,23 @@ class Test
 
             c.VerifyIL("Test.F", @"
 {
-  // Code size       49 (0x31)
+  // Code size       47 (0x2f)
   .maxstack  2
-  .locals init (Test.<F>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder V_1)
+  .locals init (Test.<F>d__0 V_0)
   IL_0000:  ldloca.s   V_0
   IL_0002:  call       ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Create()""
   IL_0007:  stfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
   IL_000c:  ldloca.s   V_0
   IL_000e:  ldc.i4.m1
   IL_000f:  stfld      ""int Test.<F>d__0.<>1__state""
-  IL_0014:  ldloc.0
-  IL_0015:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  ldloca.s   V_0
-  IL_001f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start<Test.<F>d__0>(ref Test.<F>d__0)""
-  IL_0024:  ldloca.s   V_0
-  IL_0026:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
-  IL_002b:  call       ""System.Threading.Tasks.Task System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Task.get""
-  IL_0030:  ret
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start<Test.<F>d__0>(ref Test.<F>d__0)""
+  IL_0022:  ldloca.s   V_0
+  IL_0024:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
+  IL_0029:  call       ""System.Threading.Tasks.Task System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Task.get""
+  IL_002e:  ret
 }
 ");
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
@@ -2582,10 +2570,9 @@ class Test
 ";
             CompileAndVerify(source, expectedOutput: expected).VerifyIL("Test.F", @"
 {
-  // Code size       45 (0x2d)
+  // Code size       43 (0x2b)
   .maxstack  2
-  .locals init (Test.<F>d__1 V_0,
-  System.Runtime.CompilerServices.AsyncVoidMethodBuilder V_1)
+  .locals init (Test.<F>d__1 V_0)
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldarg.0
   IL_0003:  stfld      ""System.Threading.AutoResetEvent Test.<F>d__1.handle""
@@ -2595,13 +2582,11 @@ class Test
   IL_0014:  ldloca.s   V_0
   IL_0016:  ldc.i4.m1
   IL_0017:  stfld      ""int Test.<F>d__1.<>1__state""
-  IL_001c:  ldloc.0
-  IL_001d:  ldfld      ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<F>d__1.<>t__builder""
-  IL_0022:  stloc.1
-  IL_0023:  ldloca.s   V_1
-  IL_0025:  ldloca.s   V_0
-  IL_0027:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Start<Test.<F>d__1>(ref Test.<F>d__1)""
-  IL_002c:  ret
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<F>d__1.<>t__builder""
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Start<Test.<F>d__1>(ref Test.<F>d__1)""
+  IL_002a:  ret
 }
 ").VerifyIL("Test.<F>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDisplayClassOptimisationTests.cs
@@ -1409,7 +1409,7 @@ public class Program
 		.method assembly hidebysig 
 			instance void '<M>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209e
 			// Code size 35 (0x23)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1438,7 +1438,7 @@ public class Program
 		.method private hidebysig specialname rtspecialname static 
 			void .cctor () cil managed 
 		{
-			// Method begins at RVA 0x20c4
+			// Method begins at RVA 0x20c2
 			// Code size 11 (0xb)
 			.maxstack 8
 			IL_0000: newobj instance void Program/'<>c'::.ctor()
@@ -1458,7 +1458,7 @@ public class Program
 		.method assembly hidebysig 
 			instance void '<M>b__0_1' () cil managed 
 		{
-			// Method begins at RVA 0x20d0
+			// Method begins at RVA 0x20ce
 			// Code size 1 (0x1)
 			.maxstack 8
 			IL_0000: ret
@@ -1484,7 +1484,7 @@ public class Program
 			instance void MoveNext () cil managed 
 		{
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext()
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20d0
 			// Code size 416 (0x1a0)
 			.maxstack 4
 			.locals init (
@@ -1647,7 +1647,7 @@ public class Program
 				01 00 00 00
 			)
 			.override method instance void [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine::SetStateMachine(class [mscorlib]System.Runtime.CompilerServices.IAsyncStateMachine)
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2298
 			// Code size 13 (0xd)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -1668,11 +1668,10 @@ public class Program
 			5f 30 00 00
 		)
 		// Method begins at RVA 0x205c
-		// Code size 45 (0x2d)
+		// Code size 43 (0x2b)
 		.maxstack 2
 		.locals init (
-			[0] valuetype Program/'<M>d__0',
-			[1] valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder
+			[0] valuetype Program/'<M>d__0'
 		)
 		IL_0000: ldloca.s 0
 		IL_0002: ldarg.0
@@ -1683,13 +1682,11 @@ public class Program
 		IL_0014: ldloca.s 0
 		IL_0016: ldc.i4.m1
 		IL_0017: stfld int32 Program/'<M>d__0'::'<>1__state'
-		IL_001c: ldloc.0
-		IL_001d: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
-		IL_0022: stloc.1
-		IL_0023: ldloca.s 1
-		IL_0025: ldloca.s 0
-		IL_0027: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::Start<valuetype Program/'<M>d__0'>(!!0&)
-		IL_002c: ret
+		IL_001c: ldloca.s 0
+		IL_001e: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder Program/'<M>d__0'::'<>t__builder'
+		IL_0023: ldloca.s 0
+		IL_0025: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncVoidMethodBuilder::Start<valuetype Program/'<M>d__0'>(!!0&)
+		IL_002a: ret
 	} // end of method Program::M
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
@@ -8057,7 +8054,7 @@ public class C {
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x208d
+			// Method begins at RVA 0x208b
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -8079,7 +8076,7 @@ public class C {
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x208d
+			// Method begins at RVA 0x208b
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -8100,7 +8097,7 @@ public class C {
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x208d
+			// Method begins at RVA 0x208b
 			// Code size 7 (0x7)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -8110,7 +8107,7 @@ public class C {
 		.method assembly hidebysig 
 			instance void '<M>b__0' () cil managed 
 		{
-			// Method begins at RVA 0x2095
+			// Method begins at RVA 0x2093
 			// Code size 53 (0x35)
 			.maxstack 8
 			IL_0000: ldarg.0
@@ -8471,11 +8468,10 @@ public class C {
 			01 00 09 43 2b 3c 4d 3e 64 5f 5f 30 00 00
 		)
 		// Method begins at RVA 0x2050
-		// Code size 49 (0x31)
+		// Code size 47 (0x2f)
 		.maxstack 2
 		.locals init (
-			[0] valuetype C/'<M>d__0',
-			[1] valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder
+			[0] valuetype C/'<M>d__0'
 		)
 		IL_0000: ldloca.s 0
 		IL_0002: call valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Create()
@@ -8483,21 +8479,19 @@ public class C {
 		IL_000c: ldloca.s 0
 		IL_000e: ldc.i4.m1
 		IL_000f: stfld int32 C/'<M>d__0'::'<>1__state'
-		IL_0014: ldloc.0
-		IL_0015: ldfld valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
-		IL_001a: stloc.1
-		IL_001b: ldloca.s 1
-		IL_001d: ldloca.s 0
-		IL_001f: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype C/'<M>d__0'>(!!0&)
-		IL_0024: ldloca.s 0
-		IL_0026: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
-		IL_002b: call instance class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
-		IL_0030: ret
+		IL_0014: ldloca.s 0
+		IL_0016: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
+		IL_001b: ldloca.s 0
+		IL_001d: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::Start<valuetype C/'<M>d__0'>(!!0&)
+		IL_0022: ldloca.s 0
+		IL_0024: ldflda valuetype [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder C/'<M>d__0'::'<>t__builder'
+		IL_0029: call instance class [mscorlib]System.Threading.Tasks.Task [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::get_Task()
+		IL_002e: ret
 	} // end of method C::M
 	.method public hidebysig specialname rtspecialname 
 		instance void .ctor () cil managed 
 	{
-		// Method begins at RVA 0x208d
+		// Method begins at RVA 0x208b
 		// Code size 7 (0x7)
 		.maxstack 8
 		IL_0000: ldarg.0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenScriptTests.cs
@@ -497,10 +497,9 @@ public abstract class C
             Assert.Equal("System.Threading.Tasks.Task<object>", ((MethodSymbol)methodData.Method).ReturnType.ToDisplayString());
             methodData.VerifyIL(
 @"{
-  // Code size       60 (0x3c)
+  // Code size       57 (0x39)
   .maxstack  2
-  .locals init (<<Initialize>>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> V_1)
+  .locals init (<<Initialize>>d__0 V_0)
   IL_0000:  newobj     ""<<Initialize>>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -513,16 +512,14 @@ public abstract class C
   IL_0019:  ldc.i4.m1
   IL_001a:  stfld      ""int <<Initialize>>d__0.<>1__state""
   IL_001f:  ldloc.0
-  IL_0020:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_0025:  stloc.1
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<<<Initialize>>d__0>(ref <<Initialize>>d__0)""
-  IL_002f:  nop
-  IL_0030:  ldloc.0
-  IL_0031:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_0036:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
-  IL_003b:  ret
+  IL_0020:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<<<Initialize>>d__0>(ref <<Initialize>>d__0)""
+  IL_002c:  nop
+  IL_002d:  ldloc.0
+  IL_002e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_0033:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
+  IL_0038:  ret
 }");
             methodData = verifier.TestData.GetMethodData("<Main>");
             Assert.True(((MethodSymbol)methodData.Method).ReturnsVoid);
@@ -560,10 +557,9 @@ public abstract class C
             Assert.Equal("System.Threading.Tasks.Task<object>", ((MethodSymbol)methodData.Method).ReturnType.ToDisplayString());
             methodData.VerifyIL(
 @"{
-  // Code size       60 (0x3c)
+  // Code size       57 (0x39)
   .maxstack  2
-  .locals init (<<Initialize>>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> V_1)
+  .locals init (<<Initialize>>d__0 V_0)
   IL_0000:  newobj     ""<<Initialize>>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -576,16 +572,14 @@ public abstract class C
   IL_0019:  ldc.i4.m1
   IL_001a:  stfld      ""int <<Initialize>>d__0.<>1__state""
   IL_001f:  ldloc.0
-  IL_0020:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_0025:  stloc.1
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<<<Initialize>>d__0>(ref <<Initialize>>d__0)""
-  IL_002f:  nop
-  IL_0030:  ldloc.0
-  IL_0031:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_0036:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
-  IL_003b:  ret
+  IL_0020:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<<<Initialize>>d__0>(ref <<Initialize>>d__0)""
+  IL_002c:  nop
+  IL_002d:  ldloc.0
+  IL_002e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_0033:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
+  IL_0038:  ret
 }");
             methodData = verifier.TestData.GetMethodData("<Factory>");
             Assert.Equal("System.Threading.Tasks.Task<object>", ((MethodSymbol)methodData.Method).ReturnType.ToDisplayString());

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -4212,10 +4212,9 @@ class C
 
             diff1.VerifyIL("C.G", @"
 {
-  // Code size       59 (0x3b)
+  // Code size       56 (0x38)
   .maxstack  2
-  .locals init (C.<G>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> V_1)
+  .locals init (C.<G>d__0 V_0)
  ~IL_0000:  newobj     ""C.<G>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -4228,15 +4227,13 @@ class C
  -IL_0019:  ldc.i4.m1
  -IL_001a:  stfld      ""int C.<G>d__0.<>1__state""
   IL_001f:  ldloc.0
-  IL_0020:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
-  IL_0025:  stloc.1
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<C.<G>d__0>(ref C.<G>d__0)""
-  IL_002f:  ldloc.0
-  IL_0030:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
-  IL_0035:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
-  IL_003a:  ret
+  IL_0020:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<C.<G>d__0>(ref C.<G>d__0)""
+  IL_002c:  ldloc.0
+  IL_002d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
+  IL_0032:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
+  IL_0037:  ret
 }
 ", methodToken: diff1.UpdatedMethods.Single());
         }
@@ -4275,10 +4272,9 @@ class C
 
             diff1.VerifyIL("C.G", @"
 {
-  // Code size       59 (0x3b)
+  // Code size       56 (0x38)
   .maxstack  2
-  .locals init (C.<G>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> V_1)
+  .locals init (C.<G>d__0 V_0)
  ~IL_0000:  newobj     ""C.<G>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -4291,15 +4287,13 @@ class C
   IL_0019:  ldc.i4.m1
   IL_001a:  stfld      ""int C.<G>d__0.<>1__state""
   IL_001f:  ldloc.0
-  IL_0020:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
-  IL_0025:  stloc.1
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<C.<G>d__0>(ref C.<G>d__0)""
-  IL_002f:  ldloc.0
-  IL_0030:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
-  IL_0035:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
-  IL_003a:  ret
+  IL_0020:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Start<C.<G>d__0>(ref C.<G>d__0)""
+  IL_002c:  ldloc.0
+  IL_002d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<G>d__0.<>t__builder""
+  IL_0032:  call       ""System.Threading.Tasks.Task<object> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.Task.get""
+  IL_0037:  ret
 }
 ", methodToken: diff1.UpdatedMethods.Single());
         }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -609,10 +609,9 @@ class C
 
             v.VerifyIL("C.F", @"
 {
-  // Code size       52 (0x34)
+  // Code size       49 (0x31)
   .maxstack  2
-  .locals init (C.<F>d__0 V_0,
-                System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> V_1)
+  .locals init (C.<F>d__0 V_0)
   IL_0000:  newobj     ""C.<F>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -622,15 +621,13 @@ class C
   IL_0012:  ldc.i4.m1
   IL_0013:  stfld      ""int C.<F>d__0.<>1__state""
   IL_0018:  ldloc.0
-  IL_0019:  ldfld      ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_001e:  stloc.1
-  IL_001f:  ldloca.s   V_1
-  IL_0021:  ldloca.s   V_0
-  IL_0023:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<C.<F>d__0>(ref C.<F>d__0)""
-  IL_0028:  ldloc.0
-  IL_0029:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_002e:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
-  IL_0033:  ret
+  IL_0019:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Start<C.<F>d__0>(ref C.<F>d__0)""
+  IL_0025:  ldloc.0
+  IL_0026:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_002b:  call       ""System.Threading.Tasks.Task<int> System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.Task.get""
+  IL_0030:  ret
 }",
 sequencePoints: "C.F");
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
@@ -113,10 +113,9 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
             Assert.True(method.IsGenericTaskReturningAsync(compilation));
             verifier.VerifyIL("C.F()",
 @"{
-  // Code size       52 (0x34)
+  // Code size       49 (0x31)
   .maxstack  2
-  .locals init (C.<F>d__0 V_0,
-                MyTaskMethodBuilder V_1)
+  .locals init (C.<F>d__0 V_0)
   IL_0000:  newobj     ""C.<F>d__0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -126,22 +125,19 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
   IL_0012:  ldc.i4.m1
   IL_0013:  stfld      ""int C.<F>d__0.<>1__state""
   IL_0018:  ldloc.0
-  IL_0019:  ldfld      ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
-  IL_001e:  stloc.1
-  IL_001f:  ldloca.s   V_1
-  IL_0021:  ldloca.s   V_0
-  IL_0023:  call       ""void MyTaskMethodBuilder.Start<C.<F>d__0>(ref C.<F>d__0)""
-  IL_0028:  ldloc.0
-  IL_0029:  ldflda     ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
-  IL_002e:  call       ""MyTask MyTaskMethodBuilder.Task.get""
-  IL_0033:  ret
+  IL_0019:  ldflda     ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  call       ""void MyTaskMethodBuilder.Start<C.<F>d__0>(ref C.<F>d__0)""
+  IL_0025:  ldloc.0
+  IL_0026:  ldflda     ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_002b:  call       ""MyTask MyTaskMethodBuilder.Task.get""
+  IL_0030:  ret
 }");
             verifier.VerifyIL("C.G<T>(T)",
 @"{
-  // Code size       59 (0x3b)
+  // Code size       56 (0x38)
   .maxstack  2
-  .locals init (C.<G>d__1<T> V_0,
-                MyTaskMethodBuilder<T> V_1)
+  .locals init (C.<G>d__1<T> V_0)
   IL_0000:  newobj     ""C.<G>d__1<T>..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -154,15 +150,13 @@ namespace System.Runtime.CompilerServices { class AsyncMethodBuilderAttribute : 
   IL_0019:  ldc.i4.m1
   IL_001a:  stfld      ""int C.<G>d__1<T>.<>1__state""
   IL_001f:  ldloc.0
-  IL_0020:  ldfld      ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
-  IL_0025:  stloc.1
-  IL_0026:  ldloca.s   V_1
-  IL_0028:  ldloca.s   V_0
-  IL_002a:  call       ""void MyTaskMethodBuilder<T>.Start<C.<G>d__1<T>>(ref C.<G>d__1<T>)""
-  IL_002f:  ldloc.0
-  IL_0030:  ldflda     ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
-  IL_0035:  call       ""MyTask<T> MyTaskMethodBuilder<T>.Task.get""
-  IL_003a:  ret
+  IL_0020:  ldflda     ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  call       ""void MyTaskMethodBuilder<T>.Start<C.<G>d__1<T>>(ref C.<G>d__1<T>)""
+  IL_002c:  ldloc.0
+  IL_002d:  ldflda     ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0032:  call       ""MyTask<T> MyTaskMethodBuilder<T>.Task.get""
+  IL_0037:  ret
 }");
         }
 


### PR DESCRIPTION
Removes an unnecessary struct copy to local of the AsyncMethodBuilder-like; and calls `.Start` on the mutable field and not the inert local copy.

As well as being more semantically correct (see https://github.com/dotnet/roslyn/issues/41222) helps most with `AsyncValueTaskMethodBuilder<TResult>` as they can be quite large.

e.g. the `AsyncValueTaskMethodBuilder` for System.IO.Pipelines `ValueTask<ReadResult>` at 48 bytes with 3 object references
```
Type layout for 'AsyncValueTaskMethodBuilder`1'
Size: 48 bytes. Paddings: 13 bytes (%27 of empty space)
|==========================================================|
|     0: Boolean _haveResult (1 byte)                      |
|----------------------------------------------------------|
|     1: Boolean _useBuilder (1 byte)                      |
|----------------------------------------------------------|
|   2-7: padding (6 bytes)                                 |
|----------------------------------------------------------|
|  8-15: AsyncTaskMethodBuilder`1 _methodBuilder (8 bytes) |
|----------------------------------------------------------|
| 16-47: ReadResult _result (32 bytes)                     |
| |====================================================|   |
| |     0: ResultFlags _resultFlags (1 byte)           |   |
| |----------------------------------------------------|   |
| |   1-7: padding (7 bytes)                           |   |
| |----------------------------------------------------|   |
| |  8-31: ReadOnlySequence`1 _resultBuffer (24 bytes) |   |
| | |======================================|           |   |
| | |   0-7: Object _startObject (8 bytes) |           |   |
| | |--------------------------------------|           |   |
| | |  8-15: Object _endObject (8 bytes)   |           |   |
| | |--------------------------------------|           |   |
| | | 16-19: Int32 _startInteger (4 bytes) |           |   |
| | |--------------------------------------|           |   |
| | | 20-23: Int32 _endInteger (4 bytes)   |           |   |
| | |======================================|           |   |
| |====================================================|   |
|==========================================================|
```

Resolves: https://github.com/dotnet/roslyn/issues/20606