### PR TITLE
Remove dependency on TPA list for testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Compilers/CSharp/csc/bin/Debug/netcoreapp2.1/csc.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Compilers/CSharp/csc",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -21,17 +21,13 @@ namespace Roslyn.Test.Utilities.CoreClr
 {
     internal sealed class TestExecutionLoadContext : AssemblyLoadContext
     {
-        private readonly static Dictionary<string, Assembly> s_loadedPlatformAssemblies = new Dictionary<string, Assembly>(StringComparer.Ordinal);
-
-        private readonly Dictionary<string, ModuleData> _dependencies;
+        private readonly ImmutableDictionary<string, ModuleData> _dependencies;
 
         public TestExecutionLoadContext(IList<ModuleData> dependencies)
         {
-            _dependencies = new Dictionary<string, ModuleData>(dependencies.Count, StringComparer.Ordinal);
-            foreach (var dep in dependencies)
-            {
-                _dependencies.Add(dep.FullName, dep);
-            }
+            _dependencies = dependencies
+                .Select(x => new KeyValuePair<string, ModuleData>(x.FullName, x))
+                .ToImmutableDictionary(StringComparer.Ordinal);
         }
 
         protected override Assembly Load(AssemblyName assemblyName)

--- a/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -40,7 +40,8 @@ namespace Roslyn.Test.Utilities.CoreClr
             var comparison = StringComparison.OrdinalIgnoreCase;
             if (assemblyName.Name.StartsWith("System.", comparison) ||
                 assemblyName.Name.StartsWith("Microsoft.", comparison) ||
-                comparer.Equals(assemblyName.Name, "mscorlib"))
+                comparer.Equals(assemblyName.Name, "mscorlib") ||
+                comparer.Equals(assemblyName.Name, "netstandard"))
             {
                 return null;
             }

--- a/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -94,52 +94,6 @@ namespace Roslyn.Test.Utilities.CoreClr
             return (exitCode, output);
         }
 
-        private static ImmutableDictionary<string, string> GetPlatformAssemblyPaths()
-        {
-            var assemblyNames = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            // AppContext.GetData returns a string containing a separated list
-            // of paths to the Trusted Platform Assemblies for this program. The TPA is the
-            // set of assemblies we will always load from this location, regardless
-            // of whether or not a load from another location is requested.
-            var platformAssemblies = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")).Split(Path.PathSeparator);
-            foreach (var assemblyPath in platformAssemblies)
-            {
-                if (!String.IsNullOrEmpty(assemblyPath) && TryGetAssemblyName(assemblyPath, out string assemblyName))
-                {
-                    assemblyNames.Add(assemblyName, assemblyPath);
-                }
-            }
-
-            return assemblyNames.ToImmutable();
-        }
-
-        private static bool TryGetAssemblyName(string filePath, out string name)
-        {
-            try
-            {
-                using (var fileStream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                using (var peReader = new PEReader(fileStream))
-                {
-                    if (peReader.HasMetadata)
-                    {
-                        var mdReader = peReader.GetMetadataReader();
-                        if (mdReader.IsAssembly)
-                        {
-                            var assemblyDef = mdReader.GetAssemblyDefinition();
-                            name = mdReader.GetString(assemblyDef.Name);
-
-                            return true;
-                        }
-                    }
-                }
-            }
-            catch (BadImageFormatException) { } // Fall through
-
-            name = null;
-            return false;
-        }
-
         public SortedSet<string> GetMemberSignaturesFromMetadata(string fullyQualifiedTypeName, string memberName, IEnumerable<ModuleDataId> searchModules)
         {
             try


### PR DESCRIPTION
This removes our dependency on the `TRUSTED_PLATFORM_ASSEMBLIES`. This is a value, supplied by the runtime, that effectively lists the DLLs that are considered part of the application and / or .NET platform. 

Our test execution infrastructure had been using that list as a heuristic for determining whether or not we should load the assembly the compiler test compiled against vs. the one which the runtime would naturally load. The goal being that the tests always load an assembly if it exists in the .NET Core runtime and use the referenced assembly otherwise.

This heuristic has historically been fragile because of changes in the content of `TRUSTED_PLATFORMM_ASSEMBLIES` between various .NET Core versions. This hit us between 1.X and 2.X and is hitting again between 2.X and 3.X. After some discussion we decided to try a much simpler heuristic. 

The core goal here is to prefer runtime assemblies over referenced ones. The runtime assemblies have a very specific set of naming patterns: System., Microsoft., etc ... Turns out that simple hueristic actually works extremely well and should be much more stable over time.
