### PR TITLE
Fix for Visual Studio crashes when adding a parameter to a function

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -1971,7 +1971,6 @@ End Class
             Await TestAsync(markup, expectedOrderedItems)
         End Function
 
-
         <WorkItem(40451, "https://github.com/dotnet/roslyn/issues/40451")>
         <Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
         Public Async Function TestSigHelpIsVisibleWithDuplicateMethodNames() As Task

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.vb
@@ -1970,5 +1970,26 @@ End Class
 
             Await TestAsync(markup, expectedOrderedItems)
         End Function
+
+
+        <WorkItem(40451, "https://github.com/dotnet/roslyn/issues/40451")>
+        <Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
+        Public Async Function TestSigHelpIsVisibleWithDuplicateMethodNames() As Task
+            Dim markup = "
+Class C
+    Shared Sub Test()
+        M(1, 2$$)
+    End Sub
+
+    Sub M(y As Integer)
+    End Sub
+
+    Shared Sub M(x As Integer, y As Integer)
+    End Sub
+End Class
+"
+
+            Await TestAsync(markup, {New SignatureHelpTestItem("C.M(x As Integer, y As Integer)")})
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
+++ b/src/Features/Core/Portable/SignatureHelp/AbstractSignatureHelpProvider.cs
@@ -338,7 +338,6 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
             foreach (var relatedDocumentId in relatedDocuments)
             {
                 var relatedDocument = document.Project.Solution.GetDocument(relatedDocumentId);
-                var semanticModel = await relatedDocument.GetSemanticModelForSpanAsync(new TextSpan(position, 0), cancellationToken).ConfigureAwait(false);
                 var result = await GetItemsWorkerAsync(relatedDocument, position, triggerInfo, cancellationToken).ConfigureAwait(false);
 
                 supportedPlatforms.Add(Tuple.Create(relatedDocument, result != null ? result.Items : SpecializedCollections.EmptyEnumerable<SignatureHelpItem>()));

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 memberGroup = memberGroup.Where(Function(m) m.IsStatic)
             End If
 
-            Return memberGroup.WhereAsArray(Function(m) m.IsAccessibleWithin(within, throughType))
+            Return memberGroup.Where(Function(m) m.IsAccessibleWithin(within, throughType)).ToImmutableArray()
         End Function
 
         Private Function GetMemberGroupItems(accessibleMembers As ImmutableArray(Of ISymbol),

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.MemberGroup.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 memberGroup = memberGroup.Where(Function(m) m.IsStatic)
             End If
 
-            Return memberGroup.Where(Function(m) m.IsAccessibleWithin(within, throughType)).ToImmutableArray()
+            Return memberGroup.WhereAsArray(Function(m) m.IsAccessibleWithin(within, throughType))
         End Function
 
         Private Function GetMemberGroupItems(accessibleMembers As ImmutableArray(Of ISymbol),

--- a/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.vb
+++ b/src/Features/VisualBasic/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.vb
@@ -31,9 +31,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
         Public Overrides Function GetCurrentArgumentState(root As SyntaxNode, position As Integer, syntaxFacts As ISyntaxFactsService, currentSpan As TextSpan, cancellationToken As CancellationToken) As SignatureHelpState
             Dim expression As InvocationExpressionSyntax = Nothing
             If TryGetInvocationExpression(root, position, syntaxFacts, SignatureHelpTriggerReason.InvokeSignatureHelpCommand, cancellationToken, expression) AndAlso
-                currentSpan.Start = SignatureHelpUtilities.GetSignatureHelpSpan(expression.ArgumentList).Start Then
+                currentSpan.Start = GetSignatureHelpSpan(expression.ArgumentList).Start Then
 
-                Return SignatureHelpUtilities.GetSignatureHelpState(expression.ArgumentList, position)
+                Return GetSignatureHelpState(expression.ArgumentList, position)
             End If
 
             Return Nothing
@@ -114,8 +114,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
             Dim documentationCommentFormattingService = document.GetLanguageService(Of IDocumentationCommentFormattingService)()
 
             Dim items = New List(Of SignatureHelpItem)
+            Dim accessibleMembers = New ImmutableArray(Of ISymbol)
             If memberGroup.Length > 0 Then
-                items.AddRange(GetMemberGroupItems(document, invocationExpression, semanticModel, within, memberGroup, cancellationToken))
+                accessibleMembers = GetAccessibleMembers(invocationExpression, semanticModel, within, memberGroup, cancellationToken)
+                items.AddRange(GetMemberGroupItems(accessibleMembers, document, invocationExpression, semanticModel, cancellationToken))
             End If
 
             If expressionType.IsDelegateType() Then
@@ -126,10 +128,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SignatureHelp
                 items.AddRange(GetElementAccessItems(targetExpression, semanticModel, symbolDisplayService, anonymousTypeDisplayService, documentationCommentFormattingService, within, defaultProperties, cancellationToken))
             End If
 
-            Dim textSpan = SignatureHelpUtilities.GetSignatureHelpSpan(invocationExpression.ArgumentList)
+            Dim textSpan = GetSignatureHelpSpan(invocationExpression.ArgumentList)
             Dim syntaxFacts = document.GetLanguageService(Of ISyntaxFactsService)
 
-            Dim selectedItem = TryGetSelectedIndex(memberGroup, symbolInfo)
+            Dim selectedItem = TryGetSelectedIndex(accessibleMembers, symbolInfo)
             Return CreateSignatureHelpItems(items, textSpan, GetCurrentArgumentState(root, position, syntaxFacts, textSpan, cancellationToken), selectedItem)
         End Function
     End Class


### PR DESCRIPTION
Fixes #40451.

Thanks to @dpoeschl for providing a very helpful simple repro in the original GitHub issue. 🎉 