### PR TITLE
A couple of Pythia External Access fixes

### DIFF
--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaObjectPool.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaObjectPool.cs
@@ -3,15 +3,31 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 {
     internal static class PythiaObjectPool
     {
+        [Obsolete("Use specific GetInstance overloads")]
         public static IDisposable GetInstance<T>(out T instance) where T : class, new()
         {
             var disposer = Default<T>().GetPooledObject<T>();
+            instance = disposer.Object;
+            return disposer;
+        }
+
+        public static IDisposable GetInstance<T>(out Stack<T> instance)
+        {
+            var disposer = Default<Stack<T>>().GetPooledObject();
+            instance = disposer.Object;
+            return disposer;
+        }
+
+        public static IDisposable GetInstance<T>(out HashSet<T> instance)
+        {
+            var disposer = Default<HashSet<T>>().GetPooledObject();
             instance = disposer.Object;
             return disposer;
         }


### PR DESCRIPTION
Add specific overloads that implement clearing of the pooled instance when retrieved from the pool.