### PR TITLE
Speed up TempPECompiler

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new options instance with the specified diagnostic-specific options.
         /// </summary>
-        public CompilationOptions WithSpecificDiagnosticOptions(ImmutableDictionary<string, ReportDiagnostic> value)
+        public CompilationOptions WithSpecificDiagnosticOptions(ImmutableDictionary<string, ReportDiagnostic>? value)
         {
             return CommonWithSpecificDiagnosticOptions(value);
         }
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis
         protected abstract CompilationOptions CommonWithAssemblyIdentityComparer(AssemblyIdentityComparer comparer);
         protected abstract CompilationOptions CommonWithStrongNameProvider(StrongNameProvider? provider);
         protected abstract CompilationOptions CommonWithGeneralDiagnosticOption(ReportDiagnostic generalDiagnosticOption);
-        protected abstract CompilationOptions CommonWithSpecificDiagnosticOptions(ImmutableDictionary<string, ReportDiagnostic> specificDiagnosticOptions);
+        protected abstract CompilationOptions CommonWithSpecificDiagnosticOptions(ImmutableDictionary<string, ReportDiagnostic>? specificDiagnosticOptions);
         protected abstract CompilationOptions CommonWithSpecificDiagnosticOptions(IEnumerable<KeyValuePair<string, ReportDiagnostic>> specificDiagnosticOptions);
         protected abstract CompilationOptions CommonWithReportSuppressedDiagnostics(bool reportSuppressedDiagnostics);
         protected abstract CompilationOptions CommonWithModuleName(string? moduleName);

--- a/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
@@ -497,7 +497,7 @@ namespace Microsoft.CodeAnalysis
             return CommonWithCryptoKeyContainer(cryptoKeyContainer);
         }
 
-        public CompilationOptions WithCryptoKeyFile(string cryptoKeyFile)
+        public CompilationOptions WithCryptoKeyFile(string? cryptoKeyFile)
         {
             return CommonWithCryptoKeyFile(cryptoKeyFile);
         }
@@ -538,7 +538,7 @@ namespace Microsoft.CodeAnalysis
         protected abstract CompilationOptions CommonWithMainTypeName(string? mainTypeName);
         protected abstract CompilationOptions CommonWithScriptClassName(string scriptClassName);
         protected abstract CompilationOptions CommonWithCryptoKeyContainer(string? cryptoKeyContainer);
-        protected abstract CompilationOptions CommonWithCryptoKeyFile(string cryptoKeyFile);
+        protected abstract CompilationOptions CommonWithCryptoKeyFile(string? cryptoKeyFile);
         protected abstract CompilationOptions CommonWithCryptoPublicKey(ImmutableArray<byte> cryptoPublicKey);
         protected abstract CompilationOptions CommonWithDelaySign(bool? delaySign);
         protected abstract CompilationOptions CommonWithCheckOverflow(bool checkOverflow);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/TempPECompiler.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/TempPECompiler.cs
@@ -42,21 +42,25 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
             var project = _workspace.CurrentSolution.GetRequiredProject(context.Id);
 
-            // Remove all files except the ones we care about
-            var documents = project.Documents;
-            foreach (var document in documents)
+            // Start by fetching the compilation we have already have that will have references correct
+            var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+            // Update to just the syntax trees we need to keep
+            var syntaxTrees = new List<SyntaxTree>(capacity: filesToInclude.Count);
+            foreach (var document in project.Documents)
             {
-                if (document.FilePath != null && !filesToInclude.Contains(document.FilePath))
+                if (document.FilePath != null && filesToInclude.Contains(document.FilePath))
                 {
-                    project = project.RemoveDocument(document.Id);
+                    syntaxTrees.Add(await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false));
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
+            compilation = compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(syntaxTrees);
 
             // We need to inherit most of the projects options, mainly for VB (RootNamespace, GlobalImports etc.), but we need to override about some specific things surrounding the output
-            var options = project.CompilationOptions!
+            compilation = compilation.WithOptions(compilation.Options
                     // copied from the old TempPE compiler used by legacy, for parity.
                     // See: https://github.com/dotnet/roslyn/blob/fab7134296816fc80019c60b0f5bef7400cf23ea/src/VisualStudio/CSharp/Impl/ProjectSystemShim/TempPECompilerService.cs#L58
                     .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
@@ -74,14 +78,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                     .WithDelaySign(false)
                     .WithCryptoKeyFile(null)
                     .WithPublicSign(false)
-                    .WithStrongNameProvider(null);
+                    .WithStrongNameProvider(null));
 
-            project = project
-                .WithCompilationOptions(options)
-                // AssemblyName should be set to the filename of the output file because multiple TempPE DLLs can be created for the same project
-                .WithAssemblyName(Path.GetFileName(outputFileName));
-
-            var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
+            // AssemblyName should be set to the filename of the output file because multiple TempPE DLLs can be created for the same project
+            compilation = compilation.WithAssemblyName(Path.GetFileName(outputFileName));
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/TempPECompiler.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/TempPECompiler.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                     // Turn off any warnings as errors just in case
                     .WithGeneralDiagnosticOption(ReportDiagnostic.Suppress)
                     .WithReportSuppressedDiagnostics(false)
-                    .WithSpecificDiagnosticOptions(ImmutableDictionary<string, ReportDiagnostic>.Empty)
+                    .WithSpecificDiagnosticOptions(null)
                     // Turn off any signing and strong naming
                     .WithDelaySign(false)
                     .WithCryptoKeyFile(null)


### PR DESCRIPTION
Rather than removing all the syntax trees that we aren't using, we can just directly add the syntax trees that we are.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1057089