### PR TITLE
Update RegexParser to match latest corefx regex parsing behavior.

### DIFF
--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
@@ -40,10 +40,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
             bool runSubTreeTests = true, [CallerMemberName]string name = "",
             bool allowIndexOutOfRange = false,
             bool allowNullReference = false,
-            bool allowOutOfMemory = false)
+            bool allowOutOfMemory = false,
+            bool allowDiagnosticsMismatch = false)
         {
             var (tree, sourceText) = TryParseTree(stringText, options, conversionFailureOk: false,
-                allowIndexOutOfRange, allowNullReference, allowOutOfMemory);
+                allowIndexOutOfRange, allowNullReference, allowOutOfMemory, allowDiagnosticsMismatch);
 
             // Tests are allowed to not run the subtree tests.  This is because some
             // subtrees can cause the native regex parser to exhibit very bad behavior
@@ -51,9 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
             if (runSubTreeTests)
             {
                 TryParseSubTrees(stringText, options,
-                    allowIndexOutOfRange,
-                    allowNullReference,
-                    allowOutOfMemory);
+                    allowIndexOutOfRange, allowNullReference, allowOutOfMemory, allowDiagnosticsMismatch);
             }
 
             var actual = TreeToText(sourceText, tree).Replace("\"", "\"\"");
@@ -64,7 +63,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
             string stringText, RegexOptions options,
             bool allowIndexOutOfRange,
             bool allowNullReference,
-            bool allowOutOfMemory)
+            bool allowOutOfMemory,
+            bool allowDiagnosticsMismatch)
         {
             // Trim the input from the right and make sure tree invariants hold
             var current = stringText;
@@ -72,9 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
             {
                 current = current.Substring(0, current.Length - 2) + "\"";
                 TryParseTree(current, options, conversionFailureOk: true,
-                    allowIndexOutOfRange,
-                    allowNullReference,
-                    allowOutOfMemory);
+                    allowIndexOutOfRange, allowNullReference, allowOutOfMemory, allowDiagnosticsMismatch);
             }
 
             // Trim the input from the left and make sure tree invariants hold
@@ -91,9 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
                 }
 
                 TryParseTree(current, options, conversionFailureOk: true,
-                    allowIndexOutOfRange,
-                    allowNullReference,
-                    allowOutOfMemory);
+                    allowIndexOutOfRange, allowNullReference, allowOutOfMemory, allowDiagnosticsMismatch);
             }
 
             for (var start = stringText[0] == '@' ? 2 : 1; start < stringText.Length - 1; start++)
@@ -102,9 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
                     stringText.Substring(0, start) +
                     stringText.Substring(start + 1, stringText.Length - (start + 1)),
                     options, conversionFailureOk: true,
-                    allowIndexOutOfRange,
-                    allowNullReference,
-                    allowOutOfMemory);
+                    allowIndexOutOfRange, allowNullReference, allowOutOfMemory, allowDiagnosticsMismatch);
             }
         }
 
@@ -128,7 +122,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
             bool conversionFailureOk,
             bool allowIndexOutOfRange,
             bool allowNullReference,
-            bool allowOutOfMemeory)
+            bool allowOutOfMemeory,
+            bool allowDiagnosticsMismatch = false)
         {
             var (token, tree, allChars) = JustParseTree(stringText, options, conversionFailureOk);
             if (tree == null)
@@ -164,21 +159,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
             }
             catch (ArgumentException ex)
             {
-                Assert.NotEmpty(tree.Diagnostics);
-
-                // Ensure the diagnostic we emit is the same as the .NET one. Note: we can only
-                // do this in en-US as that's the only culture where we control the text exactly
-                // and can ensure it exactly matches Regex.  We depend on localization to do a 
-                // good enough job here for other languages.
-                if (Thread.CurrentThread.CurrentCulture.Name == "en-US")
+                if (!allowDiagnosticsMismatch)
                 {
-                    Assert.True(tree.Diagnostics.Any(d => ex.Message.Contains(d.Message)));
+                    Assert.NotEmpty(tree.Diagnostics);
+
+                    // Ensure the diagnostic we emit is the same as the .NET one. Note: we can only
+                    // do this in en-US as that's the only culture where we control the text exactly
+                    // and can ensure it exactly matches Regex.  We depend on localization to do a 
+                    // good enough job here for other languages.
+                    if (Thread.CurrentThread.CurrentCulture.Name == "en-US")
+                    {
+                        Assert.True(tree.Diagnostics.Any(d => ex.Message.Contains(d.Message)));
+                    }
                 }
 
                 return treeAndText;
             }
 
-            Assert.Empty(tree.Diagnostics);
+            if (!tree.Diagnostics.IsEmpty && !allowDiagnosticsMismatch)
+            {
+                var expectedDiagnostics = CreateDiagnosticsElement(sourceText, tree);
+                Assert.False(true, "Expected diagnostics: \r\n" + expectedDiagnostics.ToString().Replace(@"""", @""""""));
+            }
 
             Assert.True(regex.GetGroupNumbers().OrderBy(v => v).SequenceEqual(
                 tree.CaptureNumbersToSpan.Keys.OrderBy(v => v)));
@@ -196,12 +198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
 
             if (tree.Diagnostics.Length > 0)
             {
-                element.Add(new XElement("Diagnostics",
-                    tree.Diagnostics.Select(d =>
-                        new XElement("Diagnostic",
-                            new XAttribute("Message", d.Message),
-                            new XAttribute("Span", d.Span),
-                            GetTextAttribute(text, d.Span)))));
+                element.Add(CreateDiagnosticsElement(text, tree));
             }
 
             element.Add(new XElement("Captures",
@@ -211,6 +208,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
                     new XElement("Capture", new XAttribute("Name", kvp.Key), new XAttribute("Span", kvp.Value), GetTextAttribute(text, kvp.Value)))));
 
             return element.ToString();
+        }
+
+        private static XElement CreateDiagnosticsElement(SourceText text, RegexTree tree)
+        {
+            return new XElement("Diagnostics",
+                                tree.Diagnostics.Select(d =>
+                                    new XElement("Diagnostic",
+                                        new XAttribute("Message", d.Message),
+                                        new XAttribute("Span", d.Span),
+                                        GetTextAttribute(text, d.Span))));
         }
 
         private static XAttribute GetTextAttribute(SourceText text, TextSpan span)

--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests.cs
@@ -211,14 +211,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
         }
 
         private static XElement CreateDiagnosticsElement(SourceText text, RegexTree tree)
-        {
-            return new XElement("Diagnostics",
-                                tree.Diagnostics.Select(d =>
-                                    new XElement("Diagnostic",
-                                        new XAttribute("Message", d.Message),
-                                        new XAttribute("Span", d.Span),
-                                        GetTextAttribute(text, d.Span))));
-        }
+            => new XElement("Diagnostics",
+                tree.Diagnostics.Select(d =>
+                    new XElement("Diagnostic",
+                        new XAttribute("Message", d.Message),
+                        new XAttribute("Span", d.Span),
+                        GetTextAttribute(text, d.Span))));
 
         private static XAttribute GetTextAttribute(SourceText text, TextSpan span)
             => new XAttribute("Text", text.ToString(span));

--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
@@ -11948,7 +11948,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
         [Fact]
         public void TestCharacterClassRange7()
         {
-            Test(@"@""[a-\-]""", @"<Tree>
+            Test(@"@""[a-\-]""", $@"<Tree>
   <CompilationUnit>
     <Sequence>
       <CharacterClass>
@@ -11959,12 +11959,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>a</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
@@ -11972,10 +11970,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[12..13)"" Text=""-"" />
+  </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..16)"" Text=""[a-\-]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13525,7 +13526,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
         [Fact]
         public void TestCharacterClassRange54()
         {
-            Test(@"@""[a-\-]""", @"<Tree>
+            Test(@"@""[a-\-]""", $@"<Tree>
   <CompilationUnit>
     <Sequence>
       <CharacterClass>
@@ -13536,12 +13537,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>a</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
@@ -13549,16 +13548,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[12..13)"" Text=""-"" />
+  </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..16)"" Text=""[a-\-]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
         public void TestCharacterClassRange55()
         {
-            Test(@"@""[a-\-b]""", @"<Tree>
+            Test(@"@""[a-\-b]""", $@"<Tree>
   <CompilationUnit>
     <Sequence>
       <CharacterClass>
@@ -13569,32 +13571,33 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>a</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <Text>
-                <TextToken>b</TextToken>
-              </Text>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <Text>
+            <TextToken>b</TextToken>
+          </Text>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[12..13)"" Text=""-"" />
+  </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..17)"" Text=""[a-\-b]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
         public void TestCharacterClassRange56()
         {
-            Test(@"@""[a-\-\-b]""", @"<Tree>
+            Test(@"@""[a-\-\-b]""", $@"<Tree>
   <CompilationUnit>
     <Sequence>
       <CharacterClass>
@@ -13605,30 +13608,31 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>a</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <Text>
-                <TextToken>b</TextToken>
-              </Text>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <SimpleEscape>
+            <BackslashToken>\</BackslashToken>
+            <TextToken>-</TextToken>
+          </SimpleEscape>
+          <Text>
+            <TextToken>b</TextToken>
+          </Text>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[12..13)"" Text=""-"" />
+  </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..19)"" Text=""[a-\-\-b]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13645,16 +13649,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>b</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <Text>
-                <TextToken>a</TextToken>
-              </Text>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <Text>
+            <TextToken>a</TextToken>
+          </Text>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
@@ -13667,7 +13669,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
   <Captures>
     <Capture Name=""0"" Span=""[10..17)"" Text=""[b-\-a]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13684,20 +13686,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>b</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <Text>
-                <TextToken>a</TextToken>
-              </Text>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <SimpleEscape>
+            <BackslashToken>\</BackslashToken>
+            <TextToken>-</TextToken>
+          </SimpleEscape>
+          <Text>
+            <TextToken>a</TextToken>
+          </Text>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
@@ -13710,7 +13710,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
   <Captures>
     <Capture Name=""0"" Span=""[10..19)"" Text=""[b-\-\-a]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13727,17 +13727,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>a</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <CharacterClassEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>D</TextToken>
-              </CharacterClassEscape>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <CharacterClassEscape>
+            <BackslashToken>\</BackslashToken>
+            <TextToken>D</TextToken>
+          </CharacterClassEscape>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
@@ -13745,12 +13743,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
     <EndOfFile />
   </CompilationUnit>
   <Diagnostics>
-    <Diagnostic Message=""{string.Format(WorkspacesResources.Cannot_include_class_0_in_character_range, "D")}"" Span=""[15..17)"" Text=""\D"" />
+    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[12..13)"" Text=""-"" />
   </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..18)"" Text=""[a-\-\D]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13767,21 +13765,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>a</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <CharacterClassEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>D</TextToken>
-              </CharacterClassEscape>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <SimpleEscape>
+            <BackslashToken>\</BackslashToken>
+            <TextToken>-</TextToken>
+          </SimpleEscape>
+          <CharacterClassEscape>
+            <BackslashToken>\</BackslashToken>
+            <TextToken>D</TextToken>
+          </CharacterClassEscape>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
@@ -13789,12 +13785,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
     <EndOfFile />
   </CompilationUnit>
   <Diagnostics>
-    <Diagnostic Message=""{string.Format(WorkspacesResources.Cannot_include_class_0_in_character_range, "D")}"" Span=""[17..19)"" Text=""\D"" />
+    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[12..13)"" Text=""-"" />
   </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..20)"" Text=""[a-\-\-\D]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13814,30 +13810,25 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken> </TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>b</TextToken>
-              </SimpleEscape>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <SimpleEscape>
+            <BackslashToken>\</BackslashToken>
+            <TextToken>b</TextToken>
+          </SimpleEscape>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
-  <Diagnostics>
-    <Diagnostic Message=""{WorkspacesResources.x_y_range_in_reverse_order}"" Span=""[13..14)"" Text=""-"" />
-  </Diagnostics>
   <Captures>
     <Capture Name=""0"" Span=""[10..19)"" Text=""[a -\-\b]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]
@@ -13857,16 +13848,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
               <TextToken>b</TextToken>
             </Text>
             <MinusToken>-</MinusToken>
-            <Sequence>
-              <SimpleEscape>
-                <BackslashToken>\</BackslashToken>
-                <TextToken>-</TextToken>
-              </SimpleEscape>
-              <Text>
-                <TextToken>a</TextToken>
-              </Text>
-            </Sequence>
+            <SimpleEscape>
+              <BackslashToken>\</BackslashToken>
+              <TextToken>-</TextToken>
+            </SimpleEscape>
           </CharacterClassRange>
+          <Text>
+            <TextToken>a</TextToken>
+          </Text>
         </Sequence>
         <CloseBracketToken>]</CloseBracketToken>
       </CharacterClass>
@@ -13879,7 +13868,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
   <Captures>
     <Capture Name=""0"" Span=""[10..18)"" Text=""[ab-\-a]"" />
   </Captures>
-</Tree>", RegexOptions.None);
+</Tree>", RegexOptions.None, allowDiagnosticsMismatch: true);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41291