### PR TITLE
Fix crash in speculative semantic model for local function attributes

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -259,19 +259,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var attributesBag = forReturnType ? copyFrom.GetReturnTypeAttributesBag() : copyFrom.GetAttributesBag();
                 bagCreatedOnThisThread = Interlocked.CompareExchange(ref lazyCustomAttributesBag, attributesBag, null) == null;
             }
-            else if (forReturnType)
-            {
-                bagCreatedOnThisThread = LoadAndValidateAttributes(
-                    this.GetReturnTypeAttributeDeclarations(),
-                    ref lazyCustomAttributesBag,
-                    symbolPart: AttributeLocation.Return,
-                    binderOpt: (this as LocalFunctionSymbol)?.SignatureBinder);
-            }
             else
             {
+                var (declarations, symbolPart) = forReturnType
+                    ? (GetReturnTypeAttributeDeclarations(), AttributeLocation.Return)
+                    : (GetAttributeDeclarations(), AttributeLocation.None);
                 bagCreatedOnThisThread = LoadAndValidateAttributes(
-                    this.GetAttributeDeclarations(),
+                    declarations,
                     ref lazyCustomAttributesBag,
+                    symbolPart,
                     binderOpt: (this as LocalFunctionSymbol)?.SignatureBinder);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -264,11 +264,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 bagCreatedOnThisThread = LoadAndValidateAttributes(
                     this.GetReturnTypeAttributeDeclarations(),
                     ref lazyCustomAttributesBag,
-                    symbolPart: AttributeLocation.Return);
+                    symbolPart: AttributeLocation.Return,
+                    binderOpt: (this as LocalFunctionSymbol)?.SignatureBinder);
             }
             else
             {
-                bagCreatedOnThisThread = LoadAndValidateAttributes(this.GetAttributeDeclarations(), ref lazyCustomAttributesBag);
+                bagCreatedOnThisThread = LoadAndValidateAttributes(
+                    this.GetAttributeDeclarations(),
+                    ref lazyCustomAttributesBag,
+                    binderOpt: (this as LocalFunctionSymbol)?.SignatureBinder);
             }
 
             if (bagCreatedOnThisThread)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -406,21 +406,23 @@ class C
             Assert.Equal(attrType, info.Symbol);
         }
 
-        [Fact]
-        public void LocalFunctionAttribute_SpeculativeSemanticModel()
+        [Theory]
+        [InlineData("[A]")]
+        [InlineData("[return: A]")]
+        public void LocalFunctionAttribute_SpeculativeSemanticModel(string attributes)
         {
-            var text = @"
+            var text = $@"
 using System;
 
-class A : Attribute { }
+class A : Attribute {{ }}
 
 class C
-{
+{{
     void M()
-    {
-        [A] void local1() { }
-    }
-}
+    {{
+        {attributes} void local1() {{ }}
+    }}
+}}
 ";
             var tree = SyntaxFactory.ParseSyntaxTree(text, TestOptions.RegularPreview);
             var model = CreateCompilation(tree).GetSemanticModel(tree);


### PR DESCRIPTION
Related to (but does not fix) #24135

This fixes a crash when F5ing the local function attributes feature. The fix is based off a similar change made for type parameters.

https://github.com/dotnet/roslyn/blob/91571a3bb038e05e7bf2ab87510273a1017faed0/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs#L186