### PR TITLE
Add conversion to the BoundTree when performing a binary equals on a Nullable<T> type and a null literal

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -591,6 +591,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Otherwise, we'll have reported the problem in ReportBinaryOperatorError.
                 resultLeft = BindToNaturalType(resultLeft, diagnostics, reportDefaultMissingType: false);
                 resultRight = BindToNaturalType(resultRight, diagnostics, reportDefaultMissingType: false);
+
+                if (foundOperator && (resultOperatorKind.OperandTypes() == BinaryOperatorKind.NullableNull))
+                {
+                    RoslynDebug.Assert(best.Signature.LeftType is object);
+                    RoslynDebug.Assert(best.Signature.RightType is object);
+
+                    if (resultLeft.IsLiteralNull())
+                    {
+                        resultLeft = CreateConversion(resultLeft, best.LeftConversion, best.Signature.LeftType, diagnostics);
+                    }
+
+                    if (resultRight.IsLiteralNull())
+                    {
+                        resultRight = CreateConversion(resultRight, best.RightConversion, best.Signature.RightType, diagnostics);
+                    }
+                }
             }
 
             hasErrors = hasErrors || resultConstant != null && resultConstant.IsBad;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -591,22 +591,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Otherwise, we'll have reported the problem in ReportBinaryOperatorError.
                 resultLeft = BindToNaturalType(resultLeft, diagnostics, reportDefaultMissingType: false);
                 resultRight = BindToNaturalType(resultRight, diagnostics, reportDefaultMissingType: false);
-
-                if (foundOperator && (resultOperatorKind.OperandTypes() == BinaryOperatorKind.NullableNull))
-                {
-                    RoslynDebug.Assert(best.Signature.LeftType is object);
-                    RoslynDebug.Assert(best.Signature.RightType is object);
-
-                    if (resultLeft.IsLiteralNull())
-                    {
-                        resultLeft = CreateConversion(resultLeft, best.LeftConversion, best.Signature.LeftType, diagnostics);
-                    }
-
-                    if (resultRight.IsLiteralNull())
-                    {
-                        resultRight = CreateConversion(resultRight, best.RightConversion, best.Signature.RightType, diagnostics);
-                    }
-                }
             }
 
             hasErrors = hasErrors || resultConstant != null && resultConstant.IsBad;

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IBinaryOperatorExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IBinaryOperatorExpression.cs
@@ -152,6 +152,35 @@ IBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.Binary, Type: System
 
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact]
+        public void VerifyNonLiftedBinaryOperators3()
+        {
+            var source = @"
+class C
+{
+    void F(string x, string y)
+    {
+        if (/*<bind>*/x == null/*</bind>*/)
+            x = y;
+    }
+}";
+
+            string expectedOperationTree =
+@"
+IBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x == null')
+  Left: 
+    IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.String) (Syntax: 'x')
+  Right: 
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.String, Constant: null, IsImplicit) (Syntax: 'null')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+      Operand: 
+        ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
+";
+
+            VerifyOperationTreeForTest<BinaryExpressionSyntax>(source, expectedOperationTree);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact]
         public void VerifyNonLiftedBinaryOperators1()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IBinaryOperatorExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IBinaryOperatorExpression.cs
@@ -142,8 +142,10 @@ IBinaryOperation (BinaryOperatorKind.Equals) (OperationKind.Binary, Type: System
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32?) (Syntax: 'x')
   Right: 
-    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
-";
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int32?, Constant: null, IsImplicit) (Syntax: 'null')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+      Operand: 
+        ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')";
 
             VerifyOperationTreeForTest<BinaryExpressionSyntax>(source, expectedOperationTree);
         }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -4175,6 +4175,25 @@ class C
             Assert.NotNull(typeInfo.ConvertedType);
             Assert.True(typeInfo.ConvertedType.IsNullableType());
             Assert.Equal(SpecialType.System_Int32, ((INamedTypeSymbol)typeInfo.ConvertedType).TypeArguments.Single().SpecialType);
+
+            CompileAndVerify(comp)
+                .VerifyIL("C.M", expectedIL: @"
+    {
+      // Code size       25 (0x19)
+      .maxstack  2
+      .locals init (int? V_0) //i
+      IL_0000:  ldloca.s   V_0
+      IL_0002:  ldc.i4.0
+      IL_0003:  call       ""int?..ctor(int)""
+      IL_0008:  ldloca.s   V_0
+      IL_000a:  call       ""bool int?.HasValue.get""
+      IL_000f:  pop
+      IL_0010:  ldloca.s   V_0
+      IL_0012:  call       ""bool int?.HasValue.get""
+      IL_0017:  pop
+      IL_0018:  ret
+    }
+");
         }
 
         #region "regression helper"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/40628. @dotnet/roslyn-compiler for review.