### PR TITLE
Use correct project capability for test projects

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -39,9 +39,9 @@
     <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
   </PropertyGroup>
 
-  <!-- Add the UnitTestContainer project capability -->
+  <!-- Add the TestContainer project capability -->
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <ProjectCapability Include="UnitTestContainer" />
+    <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
   <!-- 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -39,11 +39,6 @@
     <BypassFrameworkInstallChecks>true</BypassFrameworkInstallChecks>
   </PropertyGroup>
 
-  <!-- Add the TestContainer project capability -->
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <ProjectCapability Include="TestContainer" />
-  </ItemGroup>
-
   <!-- 
     Do not copy dependencies to the output directory of a library project, unless it's a unit test project.
   -->


### PR DESCRIPTION
This was flagged in https://github.com/microsoft/VSProjectSystem/issues/328, and further investigation suggests the capability should be `TestContainer` rather than `UnitTestContainer`.

It may be that this `ItemGroup` is unneeded altogether. I'm following up with the unit testing team.