### PR TITLE
Set TEMP environment variable to $TempDir on CI machines

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -571,6 +571,9 @@ function Setup-IntegrationTestRun() {
 }
 
 function Prepare-TempDir() {
+  $env:TEMP=$TempDir	
+  $env:TMP=$TempDir
+
   Copy-Item (Join-Path $RepoRoot "src\Workspaces\MSBuildTest\Resources\.editorconfig") $TempDir
   Copy-Item (Join-Path $RepoRoot "src\Workspaces\MSBuildTest\Resources\Directory.Build.props") $TempDir
   Copy-Item (Join-Path $RepoRoot "src\Workspaces\MSBuildTest\Resources\Directory.Build.targets") $TempDir

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -571,7 +571,7 @@ function Setup-IntegrationTestRun() {
 }
 
 function Prepare-TempDir() {
-  $env:TEMP=$TempDir	
+  $env:TEMP=$TempDir
   $env:TMP=$TempDir
 
   Copy-Item (Join-Path $RepoRoot "src\Workspaces\MSBuildTest\Resources\.editorconfig") $TempDir


### PR DESCRIPTION
<s>Ensures that we don't leave temp files behind in global TEMP dir on CI machine.</s>
UPDATE: ADO cleans Agent.TempDirectory. So setting TEMP is not needed in order to get clean temp dir. 

`Prepare-TempDir` and maybe other infra seem to expect TEMP to be set to `$TempDir`.

https://github.com/dotnet/arcade/pull/4744 reverted setting the variable in `tools.ps1` due to issues it caused in other repos.