### PR TITLE
Allow -launch to be used without -build

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -652,6 +652,10 @@ try {
   }
 
   if ($launch) {
+    if (-not $build) {
+      InitializeBuildTool
+    }
+
     $devenvExe = Join-Path $env:VSINSTALLDIR 'Common7\IDE\devenv.exe'
     &$devenvExe /rootSuffix RoslynDev
   }


### PR DESCRIPTION
This allows the experimental instance to be launched without a build:

```ps
.\eng\build.ps1 -launch
```

/cc @rolandh https://github.com/dotnet/roslyn/pull/39974#issuecomment-578654492