### PR TITLE
Fill in test gaps for local-function-attributes

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -1035,6 +1035,37 @@ class Program
             Assert.Contains(expected_in_lookupSymbols[0], actual_lookupSymbols_as_string);
         }
 
+        [Fact]
+        public void LookupInsideLocalFunctionAttribute()
+        {
+            var testSrc = @"
+using System;
+
+class Program
+{
+    const int w = 0451;
+
+    void M()
+    {
+        int x = 42;
+        const int y = 123;
+        [ObsoleteAttribute(/*pos*/
+        static void local1(int z)
+        {
+        }
+    }
+}
+";
+
+            var lookupNames = GetLookupNames(testSrc);
+            var lookupSymbols = GetLookupSymbols(testSrc).Select(e => e.ToTestDisplayString()).ToList();
+
+            Assert.Contains("w", lookupNames);
+            Assert.Contains("y", lookupNames);
+            Assert.Contains("System.Int32 Program.w", lookupSymbols);
+            Assert.Contains("System.Int32 y", lookupSymbols);
+        }
+
         [WorkItem(541909, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541909")]
         [Fact]
         public void LookupFromRangeVariableAfterFromClause()


### PR DESCRIPTION
Related to #38801

Some of the other scenarios like keyword recommending that I wanted to add support for in this PR are proving trickier than expected. So I will send that in a separate PR.