### PR TITLE
Do not simplify interpolation expressions on implicit receivers.

### DIFF
--- a/src/Features/Core/Portable/SimplifyInterpolation/Helpers.cs
+++ b/src/Features/Core/Portable/SimplifyInterpolation/Helpers.cs
@@ -148,9 +148,7 @@ namespace Microsoft.CodeAnalysis.SimplifyInterpolation
         }
 
         private static bool HasNonImplicitInstance(IInvocationOperation invocation)
-        {
-            return invocation.Instance != null && !invocation.Instance.IsImplicit;
-        }
+            => invocation.Instance != null && !invocation.Instance.IsImplicit;
 
         private static bool IsSpaceChar(IArgumentOperation argument)
             => argument.Value.ConstantValue is { HasValue: true, Value: ' ' };


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41381

Should be viewed with whitespace diffs off.