### PR TITLE
double checked locking for AdditionalTextFile.GetText

### DIFF
--- a/src/Compilers/Core/Portable/AdditionalTextFile.cs
+++ b/src/Compilers/Core/Portable/AdditionalTextFile.cs
@@ -43,18 +43,20 @@ namespace Microsoft.CodeAnalysis
         /// Returns a <see cref="SourceText"/> with the contents of this file, or <c>null</c> if
         /// there were errors reading the file.
         /// </summary>
-        public override SourceText GetText(CancellationToken cancellationToken = default)
+        public override SourceText? GetText(CancellationToken cancellationToken = default)
         {
-            lock (_lockObject)
+            if (_text == null && _diagnostics == null)
             {
-                if (_text == null)
+                lock (_lockObject)
                 {
-                    var diagnostics = new List<DiagnosticInfo>();
-                    _text = _compiler.TryReadFileContent(_sourceFile, diagnostics);
-                    _diagnostics = diagnostics;
+                    if (_text == null && _diagnostics == null)
+                    {
+                        var diagnostics = new List<DiagnosticInfo>();
+                        _text = _compiler.TryReadFileContent(_sourceFile, diagnostics);
+                        _diagnostics = diagnostics;
+                    }
                 }
             }
-
             return _text;
         }
 

--- a/src/Compilers/Core/Portable/AdditionalTextFile.cs
+++ b/src/Compilers/Core/Portable/AdditionalTextFile.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
     {
         private readonly CommandLineSourceFile _sourceFile;
         private readonly CommonCompiler _compiler;
-        private Lazy<SourceText?> _text;
+        private readonly Lazy<SourceText?> _text;
         private IList<DiagnosticInfo> _diagnostics;
 
         public AdditionalTextFile(CommandLineSourceFile sourceFile, CommonCompiler compiler)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41301

cc @sharwell 