### PR TITLE
Pure null test on unconstrained type

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2982,11 +2982,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (slot > 0 && PossiblyNullableType(expressionType))
             {
-                if (state[slot] == NullableFlowState.NotNull)
-                {
-                    // Note: We leave a MaybeDefault state as-is
-                    state[slot] = NullableFlowState.MaybeNull;
-                }
+                state[slot] = NullableFlowState.MaybeDefault;
 
                 if (markDependentSlotsNotNull)
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -2982,7 +2982,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (slot > 0 && PossiblyNullableType(expressionType))
             {
-                state[slot] = NullableFlowState.MaybeDefault;
+                if (state[slot] == NullableFlowState.NotNull)
+                {
+                    // Note: We leave a MaybeDefault state as-is
+                    state[slot] = NullableFlowState.MaybeNull;
+                }
 
                 if (markDependentSlotsNotNull)
                 {


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/35602 as "won't fix". 

Confirmed in LDM 2/5/2020 that `t is null` should not change the state of `t` to maybe-default. The current behavior of changing its state to maybe-null is sufficient.