### PR TITLE
Do not apply SuppressMessage suppressions to compiler diagnostics

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -133,14 +133,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         private bool IsDiagnosticSuppressed(Diagnostic diagnostic, Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
-            => IsDiagnosticSuppressed(diagnostic.Id, diagnostic.Location, getSemanticModel, out info);
-
-        private bool IsDiagnosticSuppressed(string id, Location location, Func<Compilation, SyntaxTree, SemanticModel> getSemanticModel, out SuppressMessageInfo info)
         {
-            Debug.Assert(id != null);
-            Debug.Assert(location != null);
+            info = default;
 
-            info = default(SuppressMessageInfo);
+            if (isCompilerDiagnostic(diagnostic))
+            {
+                // SuppressMessage attributes do not apply to compiler diagnostics.
+                return false;
+            }
+
+            var id = diagnostic.Id;
+            var location = diagnostic.Location;
 
             if (IsDiagnosticGloballySuppressed(id, symbolOpt: null, isImmediatelyContainingSymbol: false, info: out info))
             {
@@ -194,6 +197,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     inImmediatelyContainingSymbol = false;
                 }
                 while (namespaceSymbol != null);
+
+                return false;
+            }
+
+            static bool isCompilerDiagnostic(Diagnostic diagnostic)
+            {
+                foreach (var customTag in diagnostic.CustomTags)
+                {
+                    if (customTag == WellKnownDiagnosticTags.Compiler)
+                    {
+                        return true;
+                    }
+                }
 
                 return false;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             info = default;
 
-            if (isCompilerDiagnostic(diagnostic))
+            if (diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Compiler))
             {
                 // SuppressMessage attributes do not apply to compiler diagnostics.
                 return false;
@@ -197,19 +197,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     inImmediatelyContainingSymbol = false;
                 }
                 while (namespaceSymbol != null);
-
-                return false;
-            }
-
-            static bool isCompilerDiagnostic(Diagnostic diagnostic)
-            {
-                foreach (var customTag in diagnostic.CustomTags)
-                {
-                    if (customTag == WellKnownDiagnosticTags.Compiler)
-                    {
-                        return true;
-                    }
-                }
 
                 return false;
             }

--- a/src/Compilers/Core/Portable/InternalUtilities/IReadOnlyListExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/IReadOnlyListExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Roslyn.Utilities
+{
+    internal static class IReadOnlyListExtensions
+    {
+        public static bool Contains<T>(this IReadOnlyList<T> list, T item, IEqualityComparer<T>? comparer = null)
+        {
+            comparer ??= EqualityComparer<T>.Default;
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (comparer.Equals(item, list[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #39094
Verified that added unit test fails prior to the fix.