### PR TITLE
Check for updated live share roots after session variables set and do…

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,7 +158,7 @@
     <MicrosoftVisualStudioUtilitiesVersion>16.4.29417.175</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.5.31</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
-    <MicrosoftVisualStudioWorkspaceVSIntegration>16.3.43</MicrosoftVisualStudioWorkspaceVSIntegration>
+    <MicrosoftVisualStudioWorkspaceVSIntegrationVersion>16.3.43</MicrosoftVisualStudioWorkspaceVSIntegrationVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MicrosoftWin32RegistryVersion>4.6.0</MicrosoftWin32RegistryVersion>
     <MSBuildStructuredLoggerVersion>2.0.61</MSBuildStructuredLoggerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,6 +158,7 @@
     <MicrosoftVisualStudioUtilitiesVersion>16.4.29417.175</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.5.31</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
+    <MicrosoftVisualStudioWorkspaceVSIntegration>16.3.43</MicrosoftVisualStudioWorkspaceVSIntegration>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MicrosoftWin32RegistryVersion>4.6.0</MicrosoftWin32RegistryVersion>
     <MSBuildStructuredLoggerVersion>2.0.61</MSBuildStructuredLoggerVersion>

--- a/src/VisualStudio/LiveShare/Impl/Client/Classification/RoslynSyntaxClassificationService.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Classification/RoslynSyntaxClassificationService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Classificatio
             }
         }
 
-        public void AddSemanticClassifications(SemanticModel semanticModel, TextSpan textSpan, Workspace workspace, Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers, Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public void AddSemanticClassifications(SemanticModel semanticModel, TextSpan textSpan, CodeAnalysis.Workspace workspace, Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers, Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
         {
             _threadingContext.JoinableTaskFactory.Run(async () =>
             {

--- a/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynRemoteCodeActionOperation.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/CodeActions/RoslynRemoteCodeActionOperation.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.CodeActions
             _lspClient = lspClient ?? throw new ArgumentNullException(nameof(lspClient));
         }
 
-        public override void Apply(Workspace workspace, CancellationToken cancellationToken)
+        public override void Apply(CodeAnalysis.Workspace workspace, CancellationToken cancellationToken)
         {
             Task.Run(async () =>
             {

--- a/src/VisualStudio/LiveShare/Impl/Client/Projects/FileTextLoaderNoException.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Projects/FileTextLoaderNoException.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Projects
         {
         }
 
-        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(CodeAnalysis.Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
         {
             if (!File.Exists(Path))
             {

--- a/src/VisualStudio/LiveShare/Impl/Client/Razor/CSharpLspRazorProjectFactory.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Razor/CSharpLspRazorProjectFactory.cs
@@ -24,14 +24,14 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Razor
 
             var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(projectName), VersionStamp.Default, projectName, projectName, StringConstants.CSharpLspLanguageName);
 
-            _remoteLanguageServiceWorkspaceHost.Workspace.OnManagedProjectAdded(projectInfo);
+            _remoteLanguageServiceWorkspaceHost.Workspace.OnProjectAdded(projectInfo);
 
             _projects.Add(projectName, projectInfo.Id);
 
             return projectInfo.Id;
         }
 
-        public Workspace Workspace => _remoteLanguageServiceWorkspaceHost.Workspace;
+        public CodeAnalysis.Workspace Workspace => _remoteLanguageServiceWorkspaceHost.Workspace;
 
         [ImportingConstructor]
         public CSharpLspRazorProjectFactory(RemoteLanguageServiceWorkspaceHost remoteLanguageServiceWorkspaceHost)

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteDiagnosticListTable.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteDiagnosticListTable.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
             ConnectWorkspaceEvents();
         }
 
-        private RemoteDiagnosticListTable(Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
+        private RemoteDiagnosticListTable(CodeAnalysis.Workspace workspace, IDiagnosticService diagnosticService, ITableManagerProvider provider)
             : base(workspace, provider)
         {
             _source = new LiveTableDataSource(workspace, diagnosticService, IdentifierString);

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
@@ -17,7 +17,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
- using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Projects;

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
@@ -93,7 +93,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
             _threadingContext = threadingContext;
 
             _vsFolderWorkspaceService = vsFolderWorkspaceService;
-            _vsFolderWorkspaceService.OnActiveWorkspaceChanged += OnActiveWorkspaceChangedAsync;
 
             _remoteWorkspaceRootPaths = ImmutableHashSet<string>.Empty;
             _registeredExternalPaths = ImmutableHashSet<string>.Empty;
@@ -122,6 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
             // Get the initial workspace roots and update any files that have been opened.
             await UpdatePathsToRemoteFilesAsync(session).ConfigureAwait(false);
 
+            _vsFolderWorkspaceService.OnActiveWorkspaceChanged += OnActiveWorkspaceChangedAsync;
             session.RemoteServicesChanged += (object sender, RemoteServicesChangedEventArgs e) =>
             {
                 _remoteDiagnosticListTable.UpdateWorkspaceDiagnosticsPresent(_session.RemoteServiceNames.Contains("workspaceDiagnostics"));
@@ -193,6 +193,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
         public void EndSession()
         {
             _session = null;
+            _vsFolderWorkspaceService.OnActiveWorkspaceChanged -= OnActiveWorkspaceChangedAsync;
             StopSolutionCrawler();
 
             // Clear the remote paths on end of session.  Live share handles closing all the files.
@@ -446,7 +447,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            _vsFolderWorkspaceService.OnActiveWorkspaceChanged -= OnActiveWorkspaceChangedAsync;
             base.Dispose(disposing);
         }
 

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspaceHost.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspaceHost.cs
@@ -63,10 +63,9 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
 
         public async Task<ICollaborationService> CreateServiceAsync(CollaborationSession collaborationSession, CancellationToken cancellationToken)
         {
-            await _remoteLanguageServiceWorkspace.SetSession(collaborationSession).ConfigureAwait(false);
-
             await LoadRoslynPackage(cancellationToken).ConfigureAwait(false);
-            _remoteLanguageServiceWorkspace.Init();
+
+            await _remoteLanguageServiceWorkspace.SetSessionAsync(collaborationSession).ConfigureAwait(false);
 
             // Kick off loading the projects in the background.
             // Clients can call EnsureProjectsLoadedAsync to await completion.

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspaceHost.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspaceHost.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
 
                         // Adds the Roslyn project into the current solution;
                         // and raise WorkspaceChanged event (WorkspaceChangeKind.ProjectAdded)
-                        _remoteLanguageServiceWorkspace.OnManagedProjectAdded(projectInfo);
+                        _remoteLanguageServiceWorkspace.OnProjectAdded(projectInfo);
 
                         _loadedProjects = _loadedProjects.Add(projectName, projectId);
                         _loadedProjectInfo = _loadedProjectInfo.Add(projectName, projectInfo);
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
                     {
                         if (_loadedProjectInfo.TryGetValue(projectName, out ProjectInfo projInfo))
                         {
-                            _remoteLanguageServiceWorkspace.OnManagedProjectReloaded(projInfo);
+                            _remoteLanguageServiceWorkspace.OnProjectReloaded(projectInfo);
                         }
                     }
                 }

--- a/src/VisualStudio/LiveShare/Impl/Client/Tagger/SyntacticClassificationModeSelector.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Tagger/SyntacticClassificationModeSelector.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
                 return (SyntacticClassificationMode)_modeCache;
             }
 
-            if (!Workspace.TryGetWorkspace(_buffer.AsTextContainer(), out var workspace))
+            if (!CodeAnalysis.Workspace.TryGetWorkspace(_buffer.AsTextContainer(), out var workspace))
             {
                 return SyntacticClassificationMode.TextMate;
             }

--- a/src/VisualStudio/LiveShare/Impl/Client/Tagger/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Tagger/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -21,6 +21,8 @@ using Microsoft.VisualStudio.Text.Tagging;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Tagger
 {
+    using Workspace = CodeAnalysis.Workspace;
+
     /// <summary>
     /// this is almost straight copy from typescript for syntatic LSP experiement.
     /// we won't attempt to change code to follow Roslyn style until we have result of the experiement

--- a/src/VisualStudio/LiveShare/Impl/Microsoft.VisualStudio.LanguageServices.LiveShare.csproj
+++ b/src/VisualStudio/LiveShare/Impl/Microsoft.VisualStudio.LanguageServices.LiveShare.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="$(MicrosoftVisualStudioWorkspaceVSIntegration)" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="$(MicrosoftVisualStudioWorkspaceVSIntegrationVersion)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>

--- a/src/VisualStudio/LiveShare/Impl/Microsoft.VisualStudio.LanguageServices.LiveShare.csproj
+++ b/src/VisualStudio/LiveShare/Impl/Microsoft.VisualStudio.LanguageServices.LiveShare.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="$(MicrosoftVisualStudioWorkspaceVSIntegration)" />
     <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>

--- a/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
+++ b/src/VisualStudio/LiveShare/Test/MockDocumentNavigationServiceFactory.cs
@@ -12,6 +12,8 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests
 {
+    using Workspace = CodeAnalysis.Workspace;
+
     [Shared]
     [ExportWorkspaceServiceFactory(typeof(IDocumentNavigationService), WorkspaceKind.Test)]
     [PartNotDiscoverable]


### PR DESCRIPTION
…cuments opened.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1059903

Note I had to add the CodeAnalysis.Workspace references everywhere because the namespace in the package I added conflicts.

### Overview
The remote workspace root paths can change when a sln is opened.  We were originally only storing the root(s) once.  This changes us to update the root(s) on sln events as suggested by project team.

E.g. initial workspace root:
```
"C:\\Users\\dabarbet\\AppData\\Local\\Temp\\2BDF31FFB0E00B10987D79EBD3978A1F1E38\\6\\workspace"
```

when the file is opened, it has path:

```
"C:\\Users\\dabarbet\\AppData\\Local\\Temp\\2BDF31FFB0E00B10987D79EBD3978A1F1E38\\6\\project-system\\src\\Microsoft.VisualStudio.ProjectSystem.Managed\\Annotations.cs"
``` 

which is not under the original root, so it isn't caught.

The updated workspace root is:
```
"C:\\Users\\dabarbet\\AppData\\Local\\Temp\\2BDF31FFB0E00B10987D79EBD3978A1F1E38\\6\\project-system"
```

<details>
Customer and scenario info

    Who is impacted by this bug? - Nexus dogfooders
    What is the customer scenario and impact of the bug? - Files always open in misc workspace in nexus
    What is the workaround? - None.
    How was the bug found? - Dogfooding.
    If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed? - Not regression, starting nexus dogfooding.

Additional information during QB mode

    Which engineering DIRECTOR is accountable for the code change and quality? - John Cunningham
    What are you doing to ensure that this bug does not happen again? - Dogfooding + regular vendor testing.
    Which part of the Escrow Bar does this fall under?

Dual Check-in Requirements (to avoid regressions)

    Have you checked the fix into Master prior to submitting to the REL branch? - Will flow into master as part of regular Roslyn insertions.
    Is the fix required in any other REL branch? - No.
    Link the PR for master to the ask mode bug - To be created.

Bug fix details

    Overview of the fix? - Check for updated remote workspace roots from liveshare whenever the workspace is changed.
    Which VS products, SKUs, or components need the fix? - All
    What branch does the fix go into? -rel/d16.5
    What feature areas are impacted by the fix? - Live share, nexus.
    Is this checkin an insertion? - Yes.
    What is the risk of the code change? - Low, can only impact Live share / Nexus clients.
    Does this change have impact on anything else (e.g., setup, perf, stress, ux, visual freeze, go live, breaking -change, samples)? - No.
    How is this fix rolling forward to the next major release / sprintly train (e.g., Dev16)? - Regular roslyn code flow.

Validation

    What testing/validation was done on the fix, and what were the results? - Manual testing.
    (Binary/Component Insertions only) Have you validated that your insertion does not regress DDRIT / RPS - Will be done as part of Roslyn insertion.
    Which engineering partner teams have signed off on the fix? - Roslyn
    Who code reviewed the fix? - Jason Malinowski.  
</details>