### PR TITLE
Add tests validating proper handling of quantifiers.

### DIFF
--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
@@ -2117,23 +2117,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
         [Fact, WorkItem(41425, "https://github.com/dotnet/roslyn/issues/41425")]
         public void TestDanglingNumericQuantifier1()
         {
-            Test(@"@""{1}""", @"<Tree>
+            Test(@"@""{1}""", $@"<Tree>
   <CompilationUnit>
     <Sequence>
       <Text>
-        <TextToken>{</TextToken>
+        <TextToken>{{</TextToken>
       </Text>
       <Text>
-        <TextToken>1}</TextToken>
+        <TextToken>1}}</TextToken>
       </Text>
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
   <Diagnostics>
-    <Diagnostic Message=""Quantifier {x,y} following nothing"" Span=""[10..11)"" Text=""{"" />
+    <Diagnostic Message=""{WorkspacesResources.Quantifier_x_y_following_nothing}"" Span=""[10..11)"" Text=""{{"" />
   </Diagnostics>
   <Captures>
-    <Capture Name=""0"" Span=""[10..13)"" Text=""{1}"" />
+    <Capture Name=""0"" Span=""[10..13)"" Text=""{{1}}"" />
   </Captures>
 </Tree>", RegexOptions.None);
         }
@@ -2141,23 +2141,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
         [Fact, WorkItem(41425, "https://github.com/dotnet/roslyn/issues/41425")]
         public void TestDanglingNumericQuantifier2()
         {
-            Test(@"@""{1,2}""", @"<Tree>
+            Test(@"@""{1,2}""", $@"<Tree>
   <CompilationUnit>
     <Sequence>
       <Text>
-        <TextToken>{</TextToken>
+        <TextToken>{{</TextToken>
       </Text>
       <Text>
-        <TextToken>1,2}</TextToken>
+        <TextToken>1,2}}</TextToken>
       </Text>
     </Sequence>
     <EndOfFile />
   </CompilationUnit>
   <Diagnostics>
-    <Diagnostic Message=""Quantifier {x,y} following nothing"" Span=""[10..11)"" Text=""{"" />
+    <Diagnostic Message=""{WorkspacesResources.Quantifier_x_y_following_nothing}"" Span=""[10..11)"" Text=""{{"" />
   </Diagnostics>
   <Captures>
-    <Capture Name=""0"" Span=""[10..15)"" Text=""{1,2}"" />
+    <Capture Name=""0"" Span=""[10..15)"" Text=""{{1,2}}"" />
   </Captures>
 </Tree>", RegexOptions.None);
         }

--- a/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
+++ b/src/Workspaces/CSharpTest/EmbeddedLanguages/RegularExpressions/CSharpRegexParserTests_BasicTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.RegularExpressions;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpressions
@@ -2075,6 +2076,90 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EmbeddedLanguages.RegularExpre
     <Capture Name=""0"" Span=""[9..16)"" Text=""a{0,1 }"" />
   </Captures>
 </Tree>", RegexOptions.IgnorePatternWhitespace);
+        }
+
+        [Fact, WorkItem(41425, "https://github.com/dotnet/roslyn/issues/41425")]
+        public void TestLegalOpenCloseBrace1()
+        {
+            Test(@"@""{}""", @"<Tree>
+  <CompilationUnit>
+    <Sequence>
+      <Text>
+        <TextToken>{}</TextToken>
+      </Text>
+    </Sequence>
+    <EndOfFile />
+  </CompilationUnit>
+  <Captures>
+    <Capture Name=""0"" Span=""[10..12)"" Text=""{}"" />
+  </Captures>
+</Tree>", RegexOptions.None);
+        }
+
+        [Fact, WorkItem(41425, "https://github.com/dotnet/roslyn/issues/41425")]
+        public void TestLegalOpenCloseBrace2()
+        {
+            Test(@"@""{1, 2}""", @"<Tree>
+  <CompilationUnit>
+    <Sequence>
+      <Text>
+        <TextToken>{1, 2}</TextToken>
+      </Text>
+    </Sequence>
+    <EndOfFile />
+  </CompilationUnit>
+  <Captures>
+    <Capture Name=""0"" Span=""[10..16)"" Text=""{1, 2}"" />
+  </Captures>
+</Tree>", RegexOptions.None);
+        }
+
+        [Fact, WorkItem(41425, "https://github.com/dotnet/roslyn/issues/41425")]
+        public void TestDanglingNumericQuantifier1()
+        {
+            Test(@"@""{1}""", @"<Tree>
+  <CompilationUnit>
+    <Sequence>
+      <Text>
+        <TextToken>{</TextToken>
+      </Text>
+      <Text>
+        <TextToken>1}</TextToken>
+      </Text>
+    </Sequence>
+    <EndOfFile />
+  </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""Quantifier {x,y} following nothing"" Span=""[10..11)"" Text=""{"" />
+  </Diagnostics>
+  <Captures>
+    <Capture Name=""0"" Span=""[10..13)"" Text=""{1}"" />
+  </Captures>
+</Tree>", RegexOptions.None);
+        }
+
+        [Fact, WorkItem(41425, "https://github.com/dotnet/roslyn/issues/41425")]
+        public void TestDanglingNumericQuantifier2()
+        {
+            Test(@"@""{1,2}""", @"<Tree>
+  <CompilationUnit>
+    <Sequence>
+      <Text>
+        <TextToken>{</TextToken>
+      </Text>
+      <Text>
+        <TextToken>1,2}</TextToken>
+      </Text>
+    </Sequence>
+    <EndOfFile />
+  </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""Quantifier {x,y} following nothing"" Span=""[10..11)"" Text=""{"" />
+  </Diagnostics>
+  <Captures>
+    <Capture Name=""0"" Span=""[10..15)"" Text=""{1,2}"" />
+  </Captures>
+</Tree>", RegexOptions.None);
         }
 
         [Fact]


### PR DESCRIPTION
Validates that bug report https://github.com/dotnet/roslyn/issues/41425 is incorrect.