### PR TITLE
Add UnitTests for Issue #38513

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
@@ -1231,5 +1231,50 @@ namespace Microsoft.CodeAnalysis.Host
             Assert.Equal("c", symbolRenamedOperation._symbol.Name);
             Assert.Equal("C", symbolRenamedOperation._newName);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [WorkItem(38513, "https://github.com/dotnet/roslyn/issues/38513")]
+        public async Task TestRefactorNotifyInterfaceNamesStartWithI()
+        {
+            var markup = @"public interface [|test|] { }";
+            var testParameters = new TestParameters(options: options.InterfaceNamesStartWithI);
+
+            using var workspace = CreateWorkspaceFromOptions(markup, testParameters);
+            var (_, action) = await GetCodeActionsAsync(workspace, testParameters);
+
+            var previewOperations = await action.GetPreviewOperationsAsync(CancellationToken.None);
+            Assert.Empty(previewOperations.OfType<TestSymbolRenamedCodeActionOperationFactoryWorkspaceService.Operation>());
+
+            var commitOperations = await action.GetOperationsAsync(CancellationToken.None);
+            Assert.Equal(2, commitOperations.Length);
+
+            var symbolRenamedOperation = (TestSymbolRenamedCodeActionOperationFactoryWorkspaceService.Operation)commitOperations[1];
+            Assert.Equal("test", symbolRenamedOperation._symbol.Name);
+            Assert.Equal("ITest", symbolRenamedOperation._newName);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [WorkItem(38513, "https://github.com/dotnet/roslyn/issues/38513")]
+        public async Task TestRefactorNotifyTypeParameterNamesStartWithT()
+        {
+            var markup = @"public class A
+{
+    void DoOtherThing<[|arg|]>() { }
+}";
+            var testParameters = new TestParameters(options: options.TypeParameterNamesStartWithT);
+
+            using var workspace = CreateWorkspaceFromOptions(markup, testParameters);
+            var (_, action) = await GetCodeActionsAsync(workspace, testParameters);
+
+            var previewOperations = await action.GetPreviewOperationsAsync(CancellationToken.None);
+            Assert.Empty(previewOperations.OfType<TestSymbolRenamedCodeActionOperationFactoryWorkspaceService.Operation>());
+
+            var commitOperations = await action.GetOperationsAsync(CancellationToken.None);
+            Assert.Equal(2, commitOperations.Length);
+
+            var symbolRenamedOperation = (TestSymbolRenamedCodeActionOperationFactoryWorkspaceService.Operation)commitOperations[1];
+            Assert.Equal("arg", symbolRenamedOperation._symbol.Name);
+            Assert.Equal("TArg", symbolRenamedOperation._newName);
+        }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Diagnostics/NamingStyles/NamingStylesTestOptionSets.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/NamingStyles/NamingStylesTestOptionSets.cs
@@ -72,6 +72,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.NamingStyles
         public IDictionary<OptionKey, object> InterfaceNamesStartWithI =>
             Options(new OptionKey(SimplificationOptions.NamingPreferences, languageName), InterfaceNamesStartWithIOption());
 
+        public IDictionary<OptionKey, object> TypeParameterNamesStartWithT =>
+            Options(new OptionKey(SimplificationOptions.NamingPreferences, languageName), TypeParameterNamesStartWithTOption());
+
         public IDictionary<OptionKey, object> ConstantsAreUpperCase =>
             Options(new OptionKey(SimplificationOptions.NamingPreferences, languageName), ConstantsAreUpperCaseOption());
 
@@ -586,6 +589,38 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.NamingStyles
                 capitalizationScheme: Capitalization.PascalCase,
                 name: "Name",
                 prefix: "I",
+                suffix: "",
+                wordSeparator: "");
+
+            var namingRule = new SerializableNamingRule()
+            {
+                SymbolSpecificationID = symbolSpecification.ID,
+                NamingStyleID = namingStyle.ID,
+                EnforcementLevel = ReportDiagnostic.Error
+            };
+
+            var info = new NamingStylePreferences(
+                ImmutableArray.Create(symbolSpecification),
+                ImmutableArray.Create(namingStyle),
+                ImmutableArray.Create(namingRule));
+
+            return info;
+        }
+
+        private static NamingStylePreferences TypeParameterNamesStartWithTOption()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                null,
+                "Name",
+                ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.TypeParameter)),
+                accessibilityList: default,
+                modifiers: default);
+
+            var namingStyle = new NamingStyle(
+                Guid.NewGuid(),
+                capitalizationScheme: Capitalization.PascalCase,
+                name: "Name",
+                prefix: "T",
                 suffix: "",
                 wordSeparator: "");
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/NamingStyles/NamingStylesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/NamingStyles/NamingStylesTests.vb
@@ -470,5 +470,27 @@ end module",
                 options:=options.LocalsAreCamelCaseConstantsAreUpperCase)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        <WorkItem(38513, "https://github.com/dotnet/roslyn/issues/38513")>
+        Public Async Function TestInterfaceNamesStartWithI() As Task
+            Await TestInRegularAndScriptAsync(
+"Interface [|test|]
+End Interface",
+"Interface ITest
+End Interface",
+                options:=options.InterfaceNamesStartWithI)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        <WorkItem(38513, "https://github.com/dotnet/roslyn/issues/38513")>
+        Public Async Function TestTypeParameterNamesStartWithT() As Task
+            Await TestInRegularAndScriptAsync(
+"Public Class classHolder(Of [|type|])
+End Class",
+"Public Class classHolder(Of TType)
+End Class",
+                options:=options.TypeParameterNamesStartWithT)
+        End Function
+
     End Class
 End Namespace


### PR DESCRIPTION
I was unable to reproduce the issue described in #38513 with 16.4.4. Added unit tests for the parsing of the EditorConfig as well as the application of the naming style rules.