### PR TITLE
Error if function pointer is declared in a safe context. Support local function pointer declaration.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -445,7 +445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                      asterisk.LeadingWidth + asterisk.Width;
 
                         RoslynDebug.Assert(@delegate.SyntaxTree is object);
-                        diagnostics.Add(info, Location.Create(@delegate.SyntaxTree, new TextSpan(@delegate.SpanStart, length)));
+                        diagnostics.Add(info, Location.Create(@delegate.SyntaxTree, TextSpan.FromBounds(@delegate.SpanStart, asterisk.Span.End)));
                     }
 
                     return TypeWithAnnotations.Create(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -441,9 +441,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var @delegate = functionPointerTypeSyntax.DelegateKeyword;
                         var asterisk = functionPointerTypeSyntax.AsteriskToken;
-                        var length = @delegate.Width + @delegate.TrailingWidth +
-                                     asterisk.LeadingWidth + asterisk.Width;
-
                         RoslynDebug.Assert(@delegate.SyntaxTree is object);
                         diagnostics.Add(info, Location.Create(@delegate.SyntaxTree, TextSpan.FromBounds(@delegate.SpanStart, asterisk.Span.End)));
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.RuntimeMembers;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -435,9 +436,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return bindPointer();
 
                 case SyntaxKind.FunctionPointerType:
+                    var functionPointerTypeSyntax = (FunctionPointerTypeSyntax)syntax;
+                    if (GetUnsafeDiagnosticInfo(sizeOfTypeOpt: null) is CSDiagnosticInfo info)
+                    {
+                        var @delegate = functionPointerTypeSyntax.DelegateKeyword;
+                        var asterisk = functionPointerTypeSyntax.AsteriskToken;
+                        var length = @delegate.Width + @delegate.TrailingWidth +
+                                     asterisk.LeadingWidth + asterisk.Width;
+
+                        RoslynDebug.Assert(@delegate.SyntaxTree is object);
+                        diagnostics.Add(info, Location.Create(@delegate.SyntaxTree, new TextSpan(@delegate.SpanStart, length)));
+                    }
+
                     return TypeWithAnnotations.Create(
                         FunctionPointerTypeSymbol.CreateFromSource(
-                            (FunctionPointerTypeSyntax)syntax,
+                            functionPointerTypeSyntax,
                             this,
                             diagnostics,
                             basesBeingResolved,

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6074,7 +6074,7 @@ done:
                         {
                             // These are the fast tests for (in)applicability.
                             // More expensive tests are in `EatNullableQualifierIfApplicable`
-                            if (type.Kind == SyntaxKind.NullableType || type.Kind == SyntaxKind.PointerType)
+                            if (type.Kind == SyntaxKind.NullableType || type.Kind == SyntaxKind.PointerType || type.Kind == SyntaxKind.FunctionPointerType)
                                 return false;
                             if (this.PeekToken(1).Kind == SyntaxKind.OpenBracketToken)
                                 return true;

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -19,13 +19,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed partial class FunctionPointerTypeSymbol : TypeSymbol
     {
         public static FunctionPointerTypeSymbol CreateFromSource(FunctionPointerTypeSyntax syntax, Binder typeBinder, DiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics)
-            => new FunctionPointerTypeSymbol(
-                FunctionPointerMethodSymbol.CreateFromSource(
-                    syntax,
-                    typeBinder,
-                    diagnostics,
-                    basesBeingResolved,
-                    suppressUseSiteDiagnostics));
+        {
+            if (!typeBinder.InUnsafeRegion)
+            {
+                diagnostics.Add(ErrorCode.ERR_UnsafeNeeded, syntax.Location);
+            }
+
+            return new FunctionPointerTypeSymbol(
+                           FunctionPointerMethodSymbol.CreateFromSource(
+                               syntax,
+                               typeBinder,
+                               diagnostics,
+                               basesBeingResolved,
+                               suppressUseSiteDiagnostics));
+        }
 
         public static FunctionPointerTypeSymbol CreateFromMetadata(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
             => new FunctionPointerTypeSymbol(

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -20,12 +20,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         public static FunctionPointerTypeSymbol CreateFromSource(FunctionPointerTypeSyntax syntax, Binder typeBinder, DiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics)
             => new FunctionPointerTypeSymbol(
-                           FunctionPointerMethodSymbol.CreateFromSource(
-                               syntax,
-                               typeBinder,
-                               diagnostics,
-                               basesBeingResolved,
-                               suppressUseSiteDiagnostics));
+                FunctionPointerMethodSymbol.CreateFromSource(
+                    syntax,
+                    typeBinder,
+                    diagnostics,
+                    basesBeingResolved,
+                    suppressUseSiteDiagnostics));
 
         public static FunctionPointerTypeSymbol CreateFromMetadata(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
             => new FunctionPointerTypeSymbol(

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -19,20 +19,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal sealed partial class FunctionPointerTypeSymbol : TypeSymbol
     {
         public static FunctionPointerTypeSymbol CreateFromSource(FunctionPointerTypeSyntax syntax, Binder typeBinder, DiagnosticBag diagnostics, ConsList<TypeSymbol> basesBeingResolved, bool suppressUseSiteDiagnostics)
-        {
-            if (!typeBinder.InUnsafeRegion)
-            {
-                diagnostics.Add(ErrorCode.ERR_UnsafeNeeded, syntax.Location);
-            }
-
-            return new FunctionPointerTypeSymbol(
+            => new FunctionPointerTypeSymbol(
                            FunctionPointerMethodSymbol.CreateFromSource(
                                syntax,
                                typeBinder,
                                diagnostics,
                                basesBeingResolved,
                                suppressUseSiteDiagnostics));
-        }
 
         public static FunctionPointerTypeSymbol CreateFromMetadata(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
             => new FunctionPointerTypeSymbol(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -374,9 +374,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_lazyType != null)
                 {
                     Debug.Assert(_lazyType.Value.DefaultType.IsPointerType() ==
-                        IsPointerFieldSyntactically());
+                        IsPointerFieldSyntactically() ||
+                        _lazyType.Value.DefaultType.Kind == SymbolKind.FunctionPointer);
 
-                    return _lazyType.Value.DefaultType.IsPointerType();
+                    return _lazyType.Value.DefaultType.IsPointerType() || _lazyType.Value.DefaultType.Kind == SymbolKind.FunctionPointer;
                 }
 
                 return IsPointerFieldSyntactically();
@@ -386,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private bool IsPointerFieldSyntactically()
         {
             var declaration = GetFieldDeclaration(VariableDeclaratorNode).Declaration;
-            if (declaration.Type.Kind() == SyntaxKind.PointerType)
+            if (declaration.Type.Kind() == SyntaxKind.PointerType || declaration.Type.Kind() == SyntaxKind.FunctionPointerType)
             {
                 // public int * Blah;   // pointer
                 return true;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -373,11 +373,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (_lazyType != null)
                 {
-                    Debug.Assert(_lazyType.Value.DefaultType.IsPointerType() ==
-                        IsPointerFieldSyntactically() ||
-                        _lazyType.Value.DefaultType.Kind == SymbolKind.FunctionPointer);
-
-                    return _lazyType.Value.DefaultType.IsPointerType() || _lazyType.Value.DefaultType.Kind == SymbolKind.FunctionPointer;
+                    bool isPointerType = _lazyType.Value.DefaultType.Kind switch
+                    {
+                        SymbolKind.PointerType => true,
+                        SymbolKind.FunctionPointer => true,
+                        _ => false
+                    };
+                    Debug.Assert(isPointerType == IsPointerFieldSyntactically());
+                    return isPointerType;
                 }
 
                 return IsPointerFieldSyntactically();
@@ -387,7 +390,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private bool IsPointerFieldSyntactically()
         {
             var declaration = GetFieldDeclaration(VariableDeclaratorNode).Declaration;
-            if (declaration.Type.Kind() == SyntaxKind.PointerType || declaration.Type.Kind() == SyntaxKind.FunctionPointerType)
+            if (declaration.Type.Kind() switch { SyntaxKind.PointerType => true, SyntaxKind.FunctionPointerType => true, _ => false })
             {
                 // public int * Blah;   // pointer
                 return true;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var syntax = (BasePropertyDeclarationSyntax)_syntaxRef.GetSyntax();
                 RefKind refKind;
                 var typeSyntax = syntax.Type.SkipRef(out refKind);
-                return typeSyntax.Kind() == SyntaxKind.PointerType || typeSyntax.Kind() == SyntaxKind.FunctionPointerType;
+                return typeSyntax.Kind() switch { SyntaxKind.PointerType => true, SyntaxKind.FunctionPointerType => true, _ => false };
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var syntax = (BasePropertyDeclarationSyntax)_syntaxRef.GetSyntax();
                 RefKind refKind;
                 var typeSyntax = syntax.Type.SkipRef(out refKind);
-                return typeSyntax.Kind() == SyntaxKind.PointerType;
+                return typeSyntax.Kind() == SyntaxKind.PointerType || typeSyntax.Kind() == SyntaxKind.FunctionPointerType;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1053,7 +1053,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type is SourceNamedTypeSymbol { IsPartial: true };
         }
 
-        // PROTOTYPE(func-ptr): Follow up on usages of this API and add FunctionPointers where necessary.
+        // PROTOTYPE(func-ptr): Follow up on usages of this API and add FunctionPointers where necessary, and type/kind checks.
         public static bool IsPointerType(this TypeSymbol type)
         {
             return type is PointerTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1053,6 +1053,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type is SourceNamedTypeSymbol { IsPartial: true };
         }
 
+        // PROTOTYPE(func-ptr): Follow up on usages of this API and add FunctionPointers where necessary.
         public static bool IsPointerType(this TypeSymbol type)
         {
             return type is PointerTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -417,6 +417,13 @@ recurse:
                     var pointerTypeSyntax = (PointerTypeSyntax)type;
                     type = pointerTypeSyntax.ElementType;
                     goto recurse;
+                case SyntaxKind.FunctionPointerType:
+                    var functionPointerTypeSyntax = (FunctionPointerTypeSyntax)type;
+                    foreach (var param in functionPointerTypeSyntax.Parameters)
+                    {
+                        param.Type.VisitRankSpecifiers(action, argument);
+                    }
+                    break;
                 case SyntaxKind.TupleType:
                     var tupleTypeSyntax = (TupleTypeSyntax)type;
                     var elementsCount = tupleTypeSyntax.Elements.Count;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -418,11 +418,7 @@ recurse:
                     type = pointerTypeSyntax.ElementType;
                     goto recurse;
                 case SyntaxKind.FunctionPointerType:
-                    var functionPointerTypeSyntax = (FunctionPointerTypeSyntax)type;
-                    foreach (var param in functionPointerTypeSyntax.Parameters)
-                    {
-                        param.Type.VisitRankSpecifiers(action, argument);
-                    }
+                    visitFunctionPointerType(type, action, argument);
                     break;
                 case SyntaxKind.TupleType:
                     var tupleTypeSyntax = (TupleTypeSyntax)type;
@@ -471,6 +467,15 @@ recurse:
                     break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(type.Kind());
+            }
+
+            static void visitFunctionPointerType(TypeSyntax type, Action<ArrayRankSpecifierSyntax, TArg> action, TArg argument)
+            {
+                var functionPointerTypeSyntax = (FunctionPointerTypeSyntax)type;
+                foreach (var param in functionPointerTypeSyntax.Parameters)
+                {
+                    param.Type.VisitRankSpecifiers(action, argument);
+                }
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -91,6 +91,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case PointerType:
                         return ((PointerTypeSyntax)parent).ElementType == node;
 
+                    case FunctionPointerType:
+                        // Any type children of a function pointer type are encapsulated
+                        // in a parameter syntax.
+                        return false;
+
                     case PredefinedType:
                         return true;
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -92,9 +92,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return ((PointerTypeSyntax)parent).ElementType == node;
 
                     case FunctionPointerType:
-                        // Any type children of a function pointer type are encapsulated
-                        // in a parameter syntax.
-                        return false;
+                        // FunctionPointerTypeSyntax has no direct children that are ExpressionSyntaxes
+                        throw ExceptionUtilities.Unreachable;
 
                     case PredefinedType:
                         return true;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -309,6 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.NullableType:
                 case SyntaxKind.PredefinedType:
                 case SyntaxKind.TupleType:
+                case SyntaxKind.FunctionPointerType:
                     return true;
                 default:
                     return IsName(kind);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenFunctionPointersTests : CSharpTestBase
     {
-        private CompilationVerifier CompileAndVerifyFunctionPointers(string source, Action<ModuleSymbol>? symbolValidator = null)
+        private CompilationVerifier CompileAndVerifyFunctionPointers(string source, Action<ModuleSymbol>? symbolValidator = null, Verification verify = Verification.Passes)
         {
-            return CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll, symbolValidator: symbolValidator);
+            return CompileAndVerify(source, parseOptions: TestOptions.RegularPreview, options: TestOptions.UnsafeReleaseDll, symbolValidator: symbolValidator, verify: verify);
         }
 
         [Theory]
@@ -248,7 +248,7 @@ public unsafe class C
 {
     public delegate*<string, void> Prop1 { get; set; }
     public delegate* stdcall<int> Prop2 { get => throw null; set => throw null; }
-}", symbolValidator: symbolValidator);
+}", symbolValidator: symbolValidator, verify: Verification.Skipped);
 
             compVerifier.VerifyIL("C.Prop1.get", expectedIL: @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -430,7 +430,7 @@ unsafe struct S
 {
     public delegate*<S, S> Field;
     public delegate*<S, S> Property { get; set; }
-}");
+}", verify: Verification.Skipped);
         }
 
         private static void VerifyFunctionPointerSymbol(TypeSymbol type, CallingConvention expectedConvention, (RefKind RefKind, Action<TypeSymbol> TypeVerifier) returnVerifier, params (RefKind RefKind, Action<TypeSymbol> TypeVerifier)[] argumentVerifiers)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -422,6 +422,17 @@ class D : C
                 (RefKind.None, IsVoidType()));
         }
 
+        [Fact]
+        public void StructWithFunctionPointerThatReferencesStruct()
+        {
+            CompileAndVerifyFunctionPointers(@"
+unsafe struct S
+{
+    public delegate*<S, S> Field;
+    public delegate*<S, S> Property { get; set; }
+}");
+        }
+
         private static void VerifyFunctionPointerSymbol(TypeSymbol type, CallingConvention expectedConvention, (RefKind RefKind, Action<TypeSymbol> TypeVerifier) returnVerifier, params (RefKind RefKind, Action<TypeSymbol> TypeVerifier)[] argumentVerifiers)
         {
             FunctionPointerTypeSymbol funcPtr = (FunctionPointerTypeSymbol)type;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/FunctionPointerTests.cs
@@ -3048,5 +3048,11 @@ void C()
             }
             EOF();
         }
+
+        [Fact]
+        public void SyntaxFacts()
+        {
+            Assert.True(CSharp.SyntaxFacts.IsTypeSyntax(SyntaxKind.FunctionPointerType));
+        }
     }
 }


### PR DESCRIPTION
@AlekseyTs @dotnet/roslyn-compiler for a quick review.