### PR TITLE
Switch to UI thread before invoking Workspace.TryApplyChanges

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/KeybindingResetDetector.cs
@@ -212,7 +212,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                     break;
             }
 
+            // Apply the new options.
+            // We need to switch to UI thread to invoke TryApplyChanges.
+            await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             _workspace.TryApplyChanges(_workspace.CurrentSolution.WithOptions(options));
+
             if (options.GetOption(KeybindingResetOptions.NeedsReset))
             {
                 ShowGoldBar();


### PR DESCRIPTION
We recently changed this code to switch from using the Workspace Options setter (now deprecated) to Workspace.TryApplyChanges. This causes an intermittent exception [here](https://github.com/dotnet/roslyn/blob/aeb47891e92341b700c3a290a92553b8a91b445a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs#L374-L377) when TryApplyChanges is invoked from a background thread.

Fixes internal Watson bug [#1062942](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1062942)