### PR TITLE
Print the VS display version in CI logs

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -466,9 +466,10 @@ function Deploy-VsixViaTool() {
   $vsDir = $vsInfo.installationPath.TrimEnd("\")
   $vsId = $vsInfo.instanceId
   $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
+  $displayVersion = $vsInfo.catalog.productDisplayVersion
 
   $hive = "RoslynDev"
-  Write-Host "Using VS Instance $vsId ($vsInfo.catalog.productDisplayVersion) at `"$vsDir`""
+  Write-Host "Using VS Instance $vsId ($displayVersion) at `"$vsDir`""
   $baseArgs = "/rootSuffix:$hive /vsInstallDir:`"$vsDir`""
 
   Write-Host "Uninstalling old Roslyn VSIX"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -468,7 +468,7 @@ function Deploy-VsixViaTool() {
   $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
 
   $hive = "RoslynDev"
-  Write-Host "Using VS Instance $vsId at `"$vsDir`""
+  Write-Host "Using VS Instance $vsId ($vsInfo.catalog.productDisplayVersion) at `"$vsDir`""
   $baseArgs = "/rootSuffix:$hive /vsInstallDir:`"$vsDir`""
 
   Write-Host "Uninstalling old Roslyn VSIX"


### PR DESCRIPTION
Before:
```console
Time Elapsed 00:12:19.01
Downloading https://raw.githubusercontent.com/dotnet/roslyn/master/eng/config/PublishData.json
Using VS Instance 1dd8ef0c at "C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview"
Uninstalling old Roslyn VSIX
```

After:
```console
Time Elapsed 00:12:19.01
Downloading https://raw.githubusercontent.com/dotnet/roslyn/master/eng/config/PublishData.json
Using VS Instance 1dd8ef0c (16.4.0 Preview 1.0) at "C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview"
Uninstalling old Roslyn VSIX
```