### PR TITLE
Use NETCOREAPP

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5849,7 +5849,7 @@ public class CS1698_a {}
             CleanupAllGeneratedFiles(binaryPath);
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP
         [WorkItem(530221, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530221")]
         [WorkItem(5660, "https://github.com/dotnet/roslyn/issues/5660")]
         [ConditionalFact(typeof(WindowsOnly), typeof(IsEnglishLocal))]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -2270,7 +2270,7 @@ public class C
             }
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP
         [ConditionalFact(typeof(WindowsDesktopOnly), Reason = ConditionalSkipReason.TestExecutionNeedsDesktopTypes)]
         [WorkItem(399, "https://github.com/dotnet/roslyn/issues/399")]
         public void Bug399()

--- a/src/Compilers/CSharp/Test/WinRT/PEParameterSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/WinRT/PEParameterSymbolTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class PEParameterSymbolTests : CSharpTestBase
     {
-#if !NETCOREAPP3_1
+#if !NETCOREAPP
         [Fact]
         public void NoParameterNames()
         {

--- a/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/CoreClrAnalyzerAssemblyLoader.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1
+#if NETCOREAPP
 
 using System.Diagnostics;
 using System.Reflection;

--- a/src/Compilers/Shared/NamedPipeUtil.cs
+++ b/src/Compilers/Shared/NamedPipeUtil.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis
             return security;
         }
 
-#elif NETCOREAPP3_1
+#elif NETCOREAPP
 
         private static PipeOptions CurrentUserOption = PipeOptions.CurrentUserOnly;
 

--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
         internal static NamedPipeClientStream CreateNamedPipeClient(string serverName, string pipeName, PipeDirection direction, PipeOptions options) =>
             new NamedPipeClientStream(serverName, pipeName, direction, options);
 
-#elif NETCOREAPP3_1
+#elif NETCOREAPP
         internal static bool IsDesktopRuntime => false;
 
         private static string DotNetHostPathEnvironmentName = "DOTNET_HOST_PATH";

--- a/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
-// The ShadowCopyAnalyzerAssemblyLoader derives from DesktopAnalyzerAssemblyLoader (NET472) OR CoreClrAnalyzerAssemblyLoader (NETCOREAPP3_1)
-#if NET472 || NETCOREAPP3_1
+// The ShadowCopyAnalyzerAssemblyLoader derives from DesktopAnalyzerAssemblyLoader (NET472) OR CoreClrAnalyzerAssemblyLoader (NETCOREAPP)
+#if NET472 || NETCOREAPP
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
+++ b/src/Test/Utilities/Portable/Compilation/RuntimeUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         internal static bool IsDesktopRuntime =>
 #if NET472
             true;
-#elif NETCOREAPP3_1
+#elif NETCOREAPP
             false;
 #elif NETSTANDARD2_0
             throw new PlatformNotSupportedException();
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
 #if NET472
             return new Roslyn.Test.Utilities.Desktop.DesktopRuntimeEnvironmentFactory();
-#elif NETCOREAPP3_1
+#elif NETCOREAPP
             return new Roslyn.Test.Utilities.CoreClr.CoreCLRRuntimeEnvironmentFactory();
 #elif NETSTANDARD2_0
             throw new PlatformNotSupportedException();
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
 #if NET472
             return new DesktopAnalyzerAssemblyLoader();
-#elif NETCOREAPP3_1
+#elif NETCOREAPP
             return new CoreClrAnalyzerAssemblyLoader();
 #elif NETSTANDARD2_0
             return new ThrowingAnalyzerAssemblyLoader();

--- a/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironment.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#if NETCOREAPP3_1
+#if NETCOREAPP
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironmentFactory.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/CoreCLRRuntimeEnvironmentFactory.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_1
+#if NETCOREAPP
 
 using System;
 using System.Collections.Generic;

--- a/src/Test/Utilities/Portable/Platform/CoreClr/SharedConsoleOutWriter.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/SharedConsoleOutWriter.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1
+﻿#if NETCOREAPP
 
 using System;
 using System.IO;

--- a/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
+++ b/src/Test/Utilities/Portable/Platform/CoreClr/TestExecutionLoadContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#if NETCOREAPP3_1
+#if NETCOREAPP
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -323,8 +323,6 @@ namespace BuildBoss
                 {
                     case "net20":
                     case "net472":
-                    case "netcoreapp2.1":
-                    case "netcoreapp3.0":
                     case "netcoreapp3.1":
                     case "$(RoslynPortableTargetFrameworks)":
                         continue;


### PR DESCRIPTION
This changes all of our uses of `NETCOREAPP3_1` to `NETCOREAPP`. There
is no value in distinguishing the exact .NET Core version we use in our
source tree as we only target one version. Also going forward it's not
expected that our .NET Core specific code will be version specific. If
that arises we can go back to version specific defines for those cases.

This also removes the last references to `netcoreapp1.1`,
`netcoreapp2.1` and `netcoreapp3.0` from our code.