### PR TITLE
Use framework nullable annotations

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             RoslynDebug.Assert(directive.SyntaxTree.FilePath is object);
 
-            MetadataReference reference;
+            MetadataReference? reference;
             return ReferenceDirectiveMap.TryGetValue((directive.SyntaxTree.FilePath, directive.File.ValueText), out reference) ? reference : null;
         }
 
@@ -1268,13 +1268,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        private ConcurrentDictionary<string?, NamespaceSymbol>? _externAliasTargets;
+        private ConcurrentDictionary<string, NamespaceSymbol>? _externAliasTargets;
 
-        internal bool GetExternAliasTarget(string? aliasName, out NamespaceSymbol? @namespace)
+        internal bool GetExternAliasTarget(string aliasName, out NamespaceSymbol? @namespace)
         {
             if (_externAliasTargets == null)
             {
-                Interlocked.CompareExchange(ref _externAliasTargets, new ConcurrentDictionary<string?, NamespaceSymbol>(), null);
+                Interlocked.CompareExchange(ref _externAliasTargets, new ConcurrentDictionary<string, NamespaceSymbol>(), null);
             }
             else if (_externAliasTargets.TryGetValue(aliasName, out @namespace))
             {
@@ -1443,7 +1443,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // The type or namespace name '{0}' could not be found in the global namespace (are you missing an assembly reference?)
             return new CSDiagnosticInfo(
                 ErrorCode.ERR_GlobalSingleTypeNameNotFound,
-                new object[] { type.AssemblyQualifiedName },
+                new object[] { type.AssemblyQualifiedName ?? "" },
                 ImmutableArray<Symbol>.Empty,
                 ImmutableArray<Location>.Empty
             );
@@ -2045,7 +2045,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binderFactories = Interlocked.CompareExchange(ref _binderFactories, binderFactories, null) ?? binderFactories;
             }
 
-            BinderFactory previousFactory;
+            BinderFactory? previousFactory;
             var previousWeakReference = binderFactories[treeNum];
             if (previousWeakReference != null && previousWeakReference.TryGetTarget(out previousFactory))
             {
@@ -2062,7 +2062,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             while (true)
             {
-                BinderFactory previousFactory;
+                BinderFactory? previousFactory;
                 WeakReference<BinderFactory>? previousWeakReference = slot;
                 if (previousWeakReference != null && previousWeakReference.TryGetTarget(out previousFactory))
                 {
@@ -3620,7 +3620,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             private NamespaceOrTypeSymbol? GetCachedSymbol(MergedNamespaceOrTypeDeclaration declaration)
-                => _cache.TryGetValue(declaration, out NamespaceOrTypeSymbol symbol)
+                => _cache.TryGetValue(declaration, out NamespaceOrTypeSymbol? symbol)
                         ? symbol
                         : null;
 

--- a/src/Compilers/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.csproj
+++ b/src/Compilers/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.csproj
@@ -15,10 +15,6 @@
     <PackageDescription>
       .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
     </PackageDescription>
-
-    <!-- Disable the nullable warnings when compiling for netcoreapp3.1 during our transition period -->
-    <DisableNullableWarnings Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</DisableNullableWarnings>
-    <DisableNullableWarnings Condition="'$(TargetFramework)' == 'netstandard2.0'">false</DisableNullableWarnings>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -828,7 +828,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AssemblyIdentity assemblyIdentity,
                 ref Dictionary<AssemblyIdentity, MissingAssemblySymbol>? missingAssemblies)
             {
-                MissingAssemblySymbol missingAssembly;
+                MissingAssemblySymbol? missingAssembly;
 
                 if (missingAssemblies == null)
                 {

--- a/src/Compilers/Core/Portable/AssemblyUtilities.cs
+++ b/src/Compilers/Core/Portable/AssemblyUtilities.cs
@@ -63,7 +63,7 @@ namespace Roslyn.Utilities
                         var reference = metadataReader.GetAssemblyReference(handle);
                         var referenceName = metadataReader.GetString(reference.Name);
 
-                        string referencePath = Path.Combine(directory, referenceName + ".dll");
+                        string referencePath = Path.Combine(directory!, referenceName + ".dll");
 
                         if (!assemblySet.Contains(referencePath) &&
                             File.Exists(referencePath))
@@ -111,7 +111,7 @@ namespace Roslyn.Utilities
 
             var builder = ImmutableArray.CreateBuilder<string>();
 
-            string directory = Path.GetDirectoryName(filePath);
+            string? directory = Path.GetDirectoryName(filePath);
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
             string resourcesNameWithoutExtension = fileNameWithoutExtension + ".resources";
             string resourcesNameWithExtension = resourcesNameWithoutExtension + ".dll";

--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -88,19 +88,19 @@ namespace Microsoft.CodeAnalysis
                 return (c1 == c2) ? 0 : ToLower(c1) - ToLower(c2);
             }
 
-            public override int Compare(string str1, string str2)
+            public override int Compare(string? str1, string? str2)
             {
-                if ((object)str1 == str2)
+                if ((object?)str1 == str2)
                 {
                     return 0;
                 }
 
-                if ((object)str1 == null)
+                if (str1 is null)
                 {
                     return -1;
                 }
 
-                if ((object)str2 == null)
+                if (str2 is null)
                 {
                     return 1;
                 }
@@ -124,14 +124,14 @@ namespace Microsoft.CodeAnalysis
                 return c1 == c2 || ToLower(c1) == ToLower(c2);
             }
 
-            public override bool Equals(string str1, string str2)
+            public override bool Equals(string? str1, string? str2)
             {
-                if ((object)str1 == str2)
+                if ((object?)str1 == str2)
                 {
                     return true;
                 }
 
-                if ((object)str1 == null || (object)str2 == null)
+                if (str1 is null || str2 is null)
                 {
                     return false;
                 }

--- a/src/Compilers/Core/Portable/CodeAnalysisResourcesLocalizableErrorArgument.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResourcesLocalizableErrorArgument.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (_targetResourceId != null)
             {
-                return CodeAnalysisResources.ResourceManager.GetString(_targetResourceId, formatProvider as System.Globalization.CultureInfo);
+                return CodeAnalysisResources.ResourceManager.GetString(_targetResourceId, formatProvider as System.Globalization.CultureInfo) ?? "";
             }
 
             return string.Empty;

--- a/src/Compilers/Core/Portable/CodeAnalysisResourcesLocalizableErrorArgument.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResourcesLocalizableErrorArgument.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (_targetResourceId != null)
             {
-                return CodeAnalysisResources.ResourceManager.GetString(_targetResourceId, formatProvider as System.Globalization.CultureInfo) ?? "";
+                return CodeAnalysisResources.ResourceManager.GetString(_targetResourceId, formatProvider as System.Globalization.CultureInfo) ?? string.Empty;
             }
 
             return string.Empty;

--- a/src/Compilers/Core/Portable/CodeGen/ArrayMembers.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ArrayMembers.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
         private ArrayMethod GetArrayMethod(Cci.IArrayTypeReference arrayType, ArrayMethodKind id)
         {
             var key = ((byte)id, arrayType);
-            ArrayMethod result;
+            ArrayMethod? result;
 
             var dict = _dict;
             if (!dict.TryGetValue(key, out result))

--- a/src/Compilers/Core/Portable/CodeGen/LocalSlotManager.cs
+++ b/src/Compilers/Core/Portable/CodeGen/LocalSlotManager.cs
@@ -58,8 +58,8 @@ namespace Microsoft.CodeAnalysis.CodeGen
             public override int GetHashCode()
                 => Hash.Combine(_type, (int)_constraints);
 
-            public override bool Equals(object obj)
-                => Equals((LocalSignature)obj);
+            public override bool Equals(object? obj)
+                => obj is LocalSignature ls && Equals(ls);
         }
 
         // maps local identities to locals.

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         internal Cci.IFieldReference GetOrAddInstrumentationPayloadRoot(int analysisKind, Cci.ITypeReference payloadRootType)
         {
-            InstrumentationPayloadRootField payloadRootField;
+            InstrumentationPayloadRootField? payloadRootField;
             if (!_instrumentationPayloadRootFields.TryGetValue(analysisKind, out payloadRootField))
             {
                 Debug.Assert(!IsFrozen);
@@ -222,9 +222,9 @@ namespace Microsoft.CodeAnalysis.CodeGen
         }
 
         // Get method by name, if one exists. Otherwise return null.
-        internal Cci.IMethodDefinition GetMethod(string name)
+        internal Cci.IMethodDefinition? GetMethod(string name)
         {
-            Cci.IMethodDefinition method;
+            Cci.IMethodDefinition? method;
             _synthesizedMethods.TryGetValue(name, out method);
             return method;
         }

--- a/src/Compilers/Core/Portable/CodeGen/SwitchStringJumpTableEmitter.cs
+++ b/src/Compilers/Core/Portable/CodeGen/SwitchStringJumpTableEmitter.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                 uint hash = computeStringHashcodeDelegate((string?)stringConstant.Value);
 
-                HashBucket bucket;
+                HashBucket? bucket;
                 if (!stringHashMap.TryGetValue(hash, out bucket))
                 {
                     bucket = new HashBucket();

--- a/src/Compilers/Core/Portable/Collections/BitVector.cs
+++ b/src/Compilers/Core/Portable/Collections/BitVector.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis
                 && _bits.AsSpan().SequenceEqual(other._bits.AsSpan());
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is BitVector other && Equals(other);
         }

--- a/src/Compilers/Core/Portable/Collections/IdentifierCollection.cs
+++ b/src/Compilers/Core/Portable/Collections/IdentifierCollection.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
         {
             RoslynDebug.Assert(identifier != null);
 
-            object value;
+            object? value;
             if (!_map.TryGetValue(identifier, out value))
             {
                 AddInitialSpelling(identifier);
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis
 
         private bool CaseSensitiveContains(string identifier)
         {
-            object spellings;
+            object? spellings;
             if (_map.TryGetValue(identifier, out spellings))
             {
                 var spelling = spellings as string;

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -555,6 +555,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         internal static Dictionary<K, ImmutableArray<T>> ToDictionary<K, T>(this ImmutableArray<T> items, Func<T, K> keySelector, IEqualityComparer<K>? comparer = null)
+            where K : notnull
         {
             if (items.Length == 1)
             {

--- a/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifErrorLogger.cs
@@ -123,7 +123,6 @@ namespace Microsoft.CodeAnalysis
         protected static string GetUri(string path)
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
-            Uri uri;
 
             // Note that in general, these "paths" are opaque strings to be 
             // interpreted by resolvers (see SyntaxTree.FilePath documentation).
@@ -134,7 +133,7 @@ namespace Microsoft.CodeAnalysis
                 // N.B. URI does not handle multiple backslashes or `..` well, so call GetFullPath
                 // to normalize before going to URI
                 var fullPath = Path.GetFullPath(path);
-                if (Uri.TryCreate(fullPath, UriKind.Absolute, out uri))
+                if (Uri.TryCreate(fullPath, UriKind.Absolute, out var uri))
                 {
                     // We use Uri.AbsoluteUri and not Uri.ToString() because Uri.ToString()
                     // is unescaped (e.g. spaces remain unreplaced by %20) and therefore
@@ -151,7 +150,7 @@ namespace Microsoft.CodeAnalysis
                     path = PathUtilities.NormalizeWithForwardSlash(path);
                 }
 
-                if (Uri.TryCreate(path, UriKind.Relative, out uri))
+                if (Uri.TryCreate(path, UriKind.Relative, out var uri))
                 {
                     // First fallback attempt: attempt to interpret as relative path/URI.
                     // (Perhaps the resolver works that way.)

--- a/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifV1ErrorLogger.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis
             public string Add(DiagnosticDescriptor descriptor)
             {
                 // Case 1: Descriptor has already been seen -> retrieve key from cache.
-                if (_keys.TryGetValue(descriptor, out string key))
+                if (_keys.TryGetValue(descriptor, out string? key))
                 {
                     return key;
                 }

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2803,12 +2803,12 @@ namespace Microsoft.CodeAnalysis
                 }
                 catch (Cci.PeWritingException e)
                 {
-                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.InnerException.ToString()));
+                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.InnerException?.ToString() ?? ""));
                     return false;
                 }
                 catch (ResourceException e)
                 {
-                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_CantReadResource, Location.None, e.Message, e.InnerException.Message));
+                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_CantReadResource, Location.None, e.Message, e.InnerException?.Message ?? ""));
                     return false;
                 }
                 catch (PermissionSetFileReadException e)
@@ -2967,7 +2967,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 catch (Cci.PeWritingException e)
                 {
-                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.InnerException.ToString()));
+                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.InnerException?.ToString() ?? ""));
                     return null;
                 }
                 catch (PermissionSetFileReadException e)
@@ -2980,7 +2980,7 @@ namespace Microsoft.CodeAnalysis
 
         internal string? Feature(string p)
         {
-            string v;
+            string? v;
             return _features.TryGetValue(p, out v) ? v : null;
         }
 
@@ -3020,7 +3020,7 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            SmallConcurrentSetOfInts usedImports;
+            SmallConcurrentSetOfInts? usedImports;
             return syntaxTree != null &&
                 TreeToUsedImportDirectivesMap.TryGetValue(syntaxTree, out usedImports) &&
                 usedImports.Contains(position);

--- a/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/CompilationOptions.cs
@@ -599,7 +599,7 @@ namespace Microsoft.CodeAnalysis
             get { return _lazyErrors.Value; }
         }
 
-        public abstract override bool Equals(object obj);
+        public abstract override bool Equals(object? obj);
 
         protected bool EqualsHelper(CompilationOptions other)
         {

--- a/src/Compilers/Core/Portable/Compilation/LoadDirective.cs
+++ b/src/Compilers/Core/Portable/Compilation/LoadDirective.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
                 this.Diagnostics.SequenceEqual(other.Diagnostics);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is LoadDirective && Equals((LoadDirective)obj);
         }

--- a/src/Compilers/Core/Portable/Compilation/PreprocessingSymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/PreprocessingSymbolInfo.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis
                 && object.Equals(this.IsDefined, other.IsDefined);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PreprocessingSymbolInfo p && this.Equals(p);
         }

--- a/src/Compilers/Core/Portable/Compilation/SourceReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/Compilation/SourceReferenceResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        public abstract override bool Equals(object other);
+        public abstract override bool Equals(object? other);
         public abstract override int GetHashCode();
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Compilation/SubsystemVersion.cs
+++ b/src/Compilers/Core/Portable/Compilation/SubsystemVersion.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SubsystemVersion && Equals((SubsystemVersion)obj);
         }

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -782,7 +782,7 @@ namespace Microsoft.CodeAnalysis
             return this.Discriminator.GetHashCode();
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return this.Equals(obj as ConstantValue);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.DiagnosticWithProgrammaticSuppression.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis
                     Equals(_programmaticSuppressionInfo, other._programmaticSuppressionInfo);
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return this.Equals(obj as Diagnostic);
             }

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic.cs
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis
         public virtual ImmutableDictionary<string, string> Properties
             => ImmutableDictionary<string, string>.Empty;
 
-        string IFormattable.ToString(string ignored, IFormatProvider formatProvider)
+        string IFormattable.ToString(string? ignored, IFormatProvider? formatProvider)
         {
             return DiagnosticFormatter.Instance.Format(this, formatProvider);
         }
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis
             return DiagnosticFormatter.Instance.Format(this, CultureInfo.CurrentUICulture);
         }
 
-        public abstract override bool Equals(object obj);
+        public abstract override bool Equals(object? obj);
 
         public abstract override int GetHashCode();
 
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis
     {
         public abstract override string ToString();
 
-        string IFormattable.ToString(string format, IFormatProvider formatProvider)
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider)
         {
             return ToString();
         }

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticInfo.cs
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis
             return ((IFormattable)this).ToString(null, formatProvider);
         }
 
-        string IFormattable.ToString(string format, IFormatProvider? formatProvider)
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider)
         {
             return String.Format(formatProvider, "{0}: {1}",
                 _messageProvider.GetMessagePrefix(this.MessageIdentifier, this.Severity, this.IsWarningAsError, formatProvider as CultureInfo),

--- a/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Diagnostic_SimpleDiagnostic.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis
                     && _warningLevel == other._warningLevel;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return this.Equals(obj as Diagnostic);
             }

--- a/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/FileLinePositionSpan.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Determines if two FileLinePositionSpan objects are equal.
         /// </summary>
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             return other is FileLinePositionSpan && Equals((FileLinePositionSpan)other);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableString.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis
             return ToString(null);
         }
 
-        string? IFormattable.ToString(string? ignored, IFormatProvider? formatProvider)
+        string IFormattable.ToString(string? ignored, IFormatProvider? formatProvider)
         {
             return ToString(formatProvider);
         }

--- a/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ProgrammaticSuppressionInfo.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 this.Suppressions.SetEquals(other.Suppressions);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as ProgrammaticSuppressionInfo);
         }

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Text
             // For small streams, see if we can read the byte buffer directly.
             if (encoding.GetMaxCharCountOrThrowIfHuge(data) < LargeObjectHeapLimitInChars)
             {
-                if (TryGetBytesFromStream(data, out ArraySegment<byte> bytes) && bytes.Offset == 0)
+                if (TryGetBytesFromStream(data, out ArraySegment<byte> bytes) && bytes.Offset == 0 && bytes.Array is object)
                 {
                     return SourceText.From(bytes.Array,
                                            (int)data.Length,

--- a/src/Compilers/Core/Portable/FileKey.cs
+++ b/src/Compilers/Core/Portable/FileKey.cs
@@ -49,7 +49,7 @@ namespace Roslyn.Utilities
                 this.Timestamp.GetHashCode());
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is FileKey && Equals((FileKey)obj);
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentLruCache.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentLruCache.cs
@@ -103,8 +103,8 @@ namespace Microsoft.CodeAnalysis.InternalUtilities
         {
             Debug.Assert(_capacity > 0);
             var lastNode = _nodeList.Last;
-            _nodeList.Remove(lastNode);
-            _cache.Remove(lastNode.Value);
+            _nodeList.Remove(lastNode!);
+            _cache.Remove(lastNode!.Value);
         }
 
         private void UnsafeAddNodeToTop(K key, V value)

--- a/src/Compilers/Core/Portable/InternalUtilities/OrderedMultiDictionary.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OrderedMultiDictionary.cs
@@ -25,7 +25,7 @@ namespace Roslyn.Utilities
         {
             get
             {
-                SetWithInsertionOrder<V> set;
+                SetWithInsertionOrder<V>? set;
                 return _dictionary.TryGetValue(k, out set)
                     ? set : new SetWithInsertionOrder<V>();
             }
@@ -39,7 +39,7 @@ namespace Roslyn.Utilities
 
         public void Add(K k, V v)
         {
-            SetWithInsertionOrder<V> set;
+            SetWithInsertionOrder<V>? set;
             if (!_dictionary.TryGetValue(k, out set))
             {
                 _keys.Add(k);

--- a/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
@@ -32,7 +32,8 @@ namespace Roslyn.Utilities
 
         public static int GetHashCode(object? a)
         {
-            return a is object ? RuntimeHelpers.GetHashCode(a) : 0;
+            // https://github.com/dotnet/roslyn/issues/41539
+            return RuntimeHelpers.GetHashCode(a!);
         }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
@@ -32,7 +32,7 @@ namespace Roslyn.Utilities
 
         public static int GetHashCode(object? a)
         {
-            return RuntimeHelpers.GetHashCode(a);
+            return a is object ? RuntimeHelpers.GetHashCode(a) : 0;
         }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
@@ -63,7 +63,7 @@ namespace Roslyn.Utilities
             try
             {
                 var type = typeof(object).GetTypeInfo().Assembly.GetType(threadTypeName);
-                if ((object)type == null)
+                if (type is null)
                 {
                     setter = null;
                     return false;

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
@@ -33,8 +33,7 @@ namespace Roslyn.Utilities
             int firstDead = -1;
             for (int i = 0; i < _items.Length; i++)
             {
-                T target;
-                if (!_items[i].TryGetTarget(out target))
+                if (!_items[i].TryGetTarget(out var _))
                 {
                     if (firstDead == -1)
                     {
@@ -113,7 +112,7 @@ namespace Roslyn.Utilities
             {
                 var item = _items[i];
 
-                T target;
+                T? target;
                 if (item.TryGetTarget(out target))
                 {
                     result[j++] = item;
@@ -170,7 +169,7 @@ namespace Roslyn.Utilities
 
             for (int i = 0; i < count; i++)
             {
-                T item;
+                T? item;
                 if (_items[i].TryGetTarget(out item))
                 {
                     yield return item;

--- a/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/WeakList.cs
@@ -33,7 +33,7 @@ namespace Roslyn.Utilities
             int firstDead = -1;
             for (int i = 0; i < _items.Length; i++)
             {
-                if (!_items[i].TryGetTarget(out var _))
+                if (!_items[i].TryGetTarget(out _))
                 {
                     if (firstDead == -1)
                     {
@@ -112,8 +112,7 @@ namespace Roslyn.Utilities
             {
                 var item = _items[i];
 
-                T? target;
-                if (item.TryGetTarget(out target))
+                if (item.TryGetTarget(out _))
                 {
                     result[j++] = item;
                 }

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceResolver.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceResolver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public abstract class MetadataReferenceResolver
     {
-        public abstract override bool Equals(object other);
+        public abstract override bool Equals(object? other);
         public abstract override int GetHashCode();
         public abstract ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string? baseFilePath, MetadataReferenceProperties properties);
 

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -18,10 +18,6 @@
       A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").
       Do not install this package manually, it will be added as a prerequisite by other packages that require it.
     </PackageDescription>
-
-    <!-- Disable the nullable warnings when compiling for netcoreapp3.1 during our transition period -->
-    <DisableNullableWarnings Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</DisableNullableWarnings>
-    <DisableNullableWarnings Condition="'$(TargetFramework)' == 'netstandard2.0'">false</DisableNullableWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Compilers/Core/Portable/SourceFileResolver.cs
+++ b/src/Compilers/Core/Portable/SourceFileResolver.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis
             return File.Exists(resolvedPath);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             // Explicitly check that we're not comparing against a derived type
             if (obj == null || GetType() != obj.GetType())

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeUsageInfo.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeUsageInfo.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis
             return left._flags != right._flags;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is AttributeUsageInfo)
             {

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (this.ContainsAnnotations)
             {
-                SyntaxAnnotation[] annotations;
+                SyntaxAnnotation[]? annotations;
                 if (s_annotationsTable.TryGetValue(this, out annotations))
                 {
                     System.Diagnostics.Debug.Assert(annotations.Length != 0, "we should return nonempty annotations or NoAnnotations");
@@ -616,7 +616,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (this.ContainsDiagnostics)
             {
-                DiagnosticInfo[] diags;
+                DiagnosticInfo[]? diags;
                 if (s_diagnosticsTable.TryGetValue(this, out diags))
                 {
                     return diags;

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SeparatedSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SeparatedSyntaxList.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             return _list == other._list;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is SeparatedSyntaxList<TNode>) && Equals((SeparatedSyntaxList<TNode>)obj);
         }

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList`1.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
             return _node == other._node;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is SyntaxList<TNode>) && Equals((SyntaxList<TNode>)obj);
         }

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
@@ -278,9 +278,8 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
         {
             int code = (int)(flags) ^ kind;
             // the only child is never null
-            code = Hash.Combine(
-                child1 is object ? System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1) : 0,
-                code);
+            // https://github.com/dotnet/roslyn/issues/41539
+            code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1!), code);
 
             // ensure nonnegative hash
             return code & Int32.MaxValue;

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
@@ -278,7 +278,9 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
         {
             int code = (int)(flags) ^ kind;
             // the only child is never null
-            code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code);
+            code = Hash.Combine(
+                child1 is object ? System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1) : 0,
+                code);
 
             // ensure nonnegative hash
             return code & Int32.MaxValue;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.Enumerator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.Enumerator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis
                 _index = -1;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 throw new NotSupportedException();
             }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrTokenList.cs
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis
         /// <returns>
         ///   <c>true</c> if the specified <see cref="object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SyntaxNodeOrTokenList && Equals((SyntaxNodeOrTokenList)obj);
         }
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis
             {
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 throw new NotSupportedException();
             }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis
         /// Determines whether the supplied <see cref="SyntaxToken"/> is equal to this
         /// <see cref="SyntaxToken"/>.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SyntaxToken && Equals((SyntaxToken)obj);
         }

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Text
                 ChangeInfo? lastInfo = this;
                 for (ChangeInfo? info = this; info != null; info = info.Previous)
                 {
-                    SourceText tmp;
+                    SourceText? tmp;
                     if (info.WeakOldText.TryGetTarget(out tmp))
                     {
                         lastInfo = info;
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Text
             }
 
             // try this quick check first
-            SourceText actualOldText;
+            SourceText? actualOldText;
             if (_info.WeakOldText.TryGetTarget(out actualOldText) && actualOldText == oldText)
             {
                 // the supplied old text is the one we directly reference, so the changes must be the ones we have.
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Text
         {
             for (ChangeInfo? info = _info; info != null; info = info.Previous)
             {
-                SourceText text;
+                SourceText? text;
                 if (info.WeakOldText.TryGetTarget(out text) && text == oldText)
                 {
                     return true;
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.Text
 
             while (change != null)
             {
-                SourceText actualOldText;
+                SourceText? actualOldText;
                 change.WeakOldText.TryGetTarget(out actualOldText);
 
                 if (actualOldText == oldText)
@@ -390,7 +390,7 @@ tryAgain:
         /// </summary>
         protected override TextLineCollection GetLinesCore()
         {
-            SourceText oldText;
+            SourceText? oldText;
             TextLineCollection? oldLineInfo;
 
             if (!_info.WeakOldText.TryGetTarget(out oldText) || !oldText.TryGetLines(out oldLineInfo))

--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis
                 return symbol.ToDisplayString(SymbolDisplayFormat.TestFormat);
             }
 
-            return o?.ToString() ?? "";
+            return o.ToString() ?? "";
         }
     }
 

--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -166,8 +166,13 @@ namespace Microsoft.CodeAnalysis
         private static bool IsDefaultImmutableArray(Object o)
         {
             var ti = o.GetType().GetTypeInfo();
-            return ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(ImmutableArray<>) &&
-                (bool)ti.GetDeclaredMethod("get_IsDefault").Invoke(o, Array.Empty<object>());
+            if (ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(ImmutableArray<>))
+            {
+                var result = ti?.GetDeclaredMethod("get_IsDefault")?.Invoke(o, Array.Empty<object>());
+                return result is bool b && b;
+            }
+
+            return false;
         }
 
         protected virtual string DumperString(object o)
@@ -200,7 +205,7 @@ namespace Microsoft.CodeAnalysis
                 return symbol.ToDisplayString(SymbolDisplayFormat.TestFormat);
             }
 
-            return o.ToString();
+            return o?.ToString() ?? "";
         }
     }
 


### PR DESCRIPTION
This changes all of our projects which have a `netcoreapp3.1` target to use the framework nullable annotations instead of `netstandard2.0`. 