### PR TITLE
Fixes IntelliCode team model training feature when Roslyn OOP is 64bit

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.Services;
+using Microsoft.CodeAnalysis.Test.Utilities.RemoteHost;
 using Microsoft.VisualStudio.LanguageServices.Remote;
 using Nerdbank;
 using Roslyn.Utilities;
@@ -90,6 +91,7 @@ namespace Roslyn.Test.Utilities.Remote
         }
 
         public override string ClientId { get; }
+        public override bool IsRemoteHost64Bit => IntPtr.Size == 8;
 
         public override async Task<Connection?> TryCreateConnectionAsync(
             string serviceName, object? callbackTarget, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -190,11 +190,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             private void SetRemoteHostBitness()
             {
-                var x64 = _workspace.Options.GetOption(RemoteHostOptions.OOP64Bit);
-                if (!x64)
-                {
-                    x64 = _workspace.Services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(WellKnownExperimentNames.RoslynOOP64bit);
-                }
+                bool x64 = RemoteHostOptions.IsServiceHubProcess64Bit(_workspace);
 
                 // log OOP bitness
                 Logger.Log(FunctionId.RemoteHost_Bitness, KeyValueLogMessage.Create(LogType.Trace, m => m["64bit"] = x64));

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -4,7 +4,9 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
 
@@ -53,6 +55,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         public static readonly Option<int> MaxPoolConnection = new Option<int>(
             nameof(InternalFeatureOnOffOptions), nameof(MaxPoolConnection), defaultValue: 15,
             storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(MaxPoolConnection)));
+
+        public static bool IsServiceHubProcess64Bit(Workspace workspace)
+            => workspace.Options.GetOption(OOP64Bit) ||
+               workspace.Services.GetRequiredService<IExperimentationService>().IsExperimentEnabled(WellKnownExperimentNames.RoslynOOP64bit);
     }
 
     [ExportOptionProvider, Shared]

--- a/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/ServiceHubRemoteHostClient.cs
@@ -160,6 +160,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         }
 
         public override string ClientId => _connectionManager.HostGroup.Id;
+        public override bool IsRemoteHost64Bit => RemoteHostOptions.IsServiceHubProcess64Bit(Workspace);
 
         public override Task<Connection?> TryCreateConnectionAsync(string serviceName, object? callbackTarget, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/ExternalAccess/Pythia/Api/PythiaRemoteHostClient.cs
@@ -22,6 +22,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
                 return default;
             }
 
+            if (client.IsRemoteHost64Bit)
+            {
+                serviceName += "64";
+            }
+
             using var connection = await client.TryCreateConnectionAsync(serviceName, callbackTarget: null, cancellationToken).ConfigureAwait(false);
             if (connection == null)
             {

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -46,6 +46,8 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public abstract Task<Connection?> TryCreateConnectionAsync(string serviceName, object? callbackTarget, CancellationToken cancellationToken);
 
+        public abstract bool IsRemoteHost64Bit { get; }
+
         protected abstract void OnStarted();
 
         protected void Started()
@@ -184,6 +186,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             public override string ClientId => nameof(NoOpClient);
+            public override bool IsRemoteHost64Bit => false;
 
             public override Task<Connection?> TryCreateConnectionAsync(string serviceName, object? callbackTarget, CancellationToken cancellationToken)
             {


### PR DESCRIPTION
The feature is currently not working on any VS installation because of ServiceHub bitness mismatch.
 https://devdiv.visualstudio.com/DevDiv/_git/Pythia/pullrequest/227928 fixes the problem when Roslyn ServiceHub process is 64-bit. This change makes it work even in the case when we use 64-bit process.

Part of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1065328