### PR TITLE
Use less stack space to parse if statements with attributes

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -202,10 +202,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             {
                 return parseFunc();
             }
-            catch (InsufficientExecutionStackException)
-            {
-                return CreateForGlobalFailure(lexer.TextWindow.Position, createEmptyNodeFunc());
-            }
+            finally { }
+            //catch (InsufficientExecutionStackException)
+            //{
+            //    return CreateForGlobalFailure(lexer.TextWindow.Position, createEmptyNodeFunc());
+            //}
         }
 
         private TNode CreateForGlobalFailure<TNode>(int position, TNode node) where TNode : CSharpSyntaxNode

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -223,7 +223,7 @@ public class Test
             }
         }
 
-        [ConditionalFact(typeof(WindowsOnly), AlwaysSkip = "PROTOTYPE(local-function-attributes)")]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void NestedIfStatements()
         {
             int nestingLevel = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
@@ -234,6 +234,8 @@ public class Test
                 (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 780,
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
+
+            nestingLevel = 5000;
 
             RunTest(nestingLevel, runTest);
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -235,8 +235,6 @@ public class Test
                 _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
             };
 
-            nestingLevel = 5000;
-
             RunTest(nestingLevel, runTest);
 
             static void runTest(int nestingLevel)


### PR DESCRIPTION
This PR is basically exploratory--trying to figure out what it would take to fix the stack depth issue discussed in #41240 without reverting the attributes change. There are some temporary tweaks such as commenting out catch blocks which would be reverted before merge.

The nature of the change is to inline more things (particularly on x64) and to pull more locals off the stack (in the case of x86). At this time I am leaning toward reverting the statement attributes change in #38937, and possibly taking it back in at a future point, after the feature has been merged. But I would like to get input on this. I will open another PR to explore a revert strategy while still having decent diagnostics on incomplete code (i.e. an attribute list in the middle of a method, or an attribute list on an incomplete local function).

Here are some native stack measurements based on the scenario in EndToEndTest.NestedIfStatements:

## x64 measurements
### csc master branch, x64

Bytes | Method
-- | --
**640.00** | **Total**
160.00 | LanguageParser.ParseIfStatement+0x106
80.00 | LanguageParser.ParseStatementCore+0xa2
112.00 | LanguageParser.ParseStatements+0x6c
112.00 | LanguageParser.ParseBlock+0x15e
80.00 | LanguageParser.ParseStatementCore+0xa2
96.00 | LanguageParser.ParseEmbeddedStatement+0x17

### csc features/local-function-attributes branch, x64

Bytes | Method
-- | --
**928.00** | **Total**
176.00 | LanguageParser.ParseIfStatement(SyntaxList)
80.00 | LanguageParser.TryParseStatementNoDeclaration(SyntaxList\`1, Boolean)
128.00 | LanguageParser.TryParseStatementCore()
112.00 | LanguageParser.ParseStatements(CSharpSyntaxNode ByRef, SyntaxListBuilder\`1, Boolean)
128.00 | LanguageParser.ParseBlock(SyntaxList\`1, Boolean, Boolean)
80.00 | LanguageParser.TryParseStatementNoDeclaration(SyntaxList\`1, Boolean)
128.00 | LanguageParser.TryParseStatementCore()
96.00 | LanguageParser.ParseEmbeddedStatement()


## csc lfa branch after fix ba602a6, x64
Bytes | Method
-- | --
**608.00** | **Total**
160.00 | LanguageParser.ParseIfStatement+0x103
144.00 | LanguageParser.TryParseStatementCore+0xe1
160.00 | LanguageParser.ParseBlock+0x1ed
144.00 | LanguageParser.TryParseStatementCore+0xe1

(This measurement is probably an *overestimate* now, as more progress was made in d5d7007)

---

## x86 measurements
### csc master branch, x86

Bytes | Method
-- | --
**276.00** | **Total**
40.00 | LanguageParser.ParseIfStatement+0xca
20.00 | LanguageParser.ParseStatementNoDeclaration+0x10b
44.00 | LanguageParser.ParseStatementCore+0x9f
40.00 | LanguageParser.ParseStatements+0x55
68.00 | LanguageParser.ParseBlock+0x121
20.00 | LanguageParser.ParseStatementNoDeclaration+0x1ad
44.00 | LanguageParser.ParseStatementCore+0x9f
36.00 | LanguageParser.ParseEmbeddedStatement+0x12

### csc lfa branch, x86

Bytes | Method
-- | --
**372.00** | **Total**
56.00 | LanguageParser.ParseIfStatement+0xce
20.00 | LanguageParser.TryParseStatementNoDeclaration+0xb4
80.00 | LanguageParser.TryParseStatementCore+0xd7
116.00 | LanguageParser.ParseBlock+0x19b
20.00 | LanguageParser.TryParseStatementNoDeclaration+0xf3
80.00 | LanguageParser.TryParseStatementCore+0xd7

## csc lfa branch after fix d5d7007, x86
Note that the size of the stack cycle went up compared to master, but we still can parse at the expected complexity in EndToEndTests.

Bytes | Method
-- | --
**312.00** | **Total**
44.00 | LanguageParser.ParseIfStatement+0x102
20.00 | LanguageParser.TryParseStatementNoDeclaration+0xb4
56.00 | LanguageParser.TryParseStatementCore+0xd7
116.00 | LanguageParser.ParseBlock+0x19b
20.00 | LanguageParser.TryParseStatementNoDeclaration+0xf3
56.00 | LanguageParser.TryParseStatementCore+0xd7
