### PR TITLE
Fix LookupStaticMembers(int) in incomplete code

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -2257,7 +2257,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return symbol;
             }
 
-            var memberModel = GetMemberModel(symbol.Locations[0].SourceSpan.Start);
+            var position = CheckAndAdjustPosition(symbol.Locations[0].SourceSpan.Start);
+            var memberModel = GetMemberModel(position);
             return memberModel?.RemapSymbolIfNecessaryCore(symbol) ?? symbol;
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -5179,6 +5179,35 @@ class C
         }
 
         [Fact]
+        public void TestLookupStaticMembers_PositionNeedsAdjustment()
+        {
+            var source = @"
+#nullable enable
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        void local1() { }
+
+        b
+
+        local1();
+
+    }
+}
+";
+            var comp = CreateCompilation(source);
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var node = tree.GetRoot().DescendantNodes().Single(node => node is IdentifierNameSyntax { Identifier: { ValueText: "b" } });
+            var symbols = model.LookupStaticMembers(node.SpanStart);
+            Assert.Contains(symbols, s => s.Name == "local1");
+        }
+
+        [Fact]
         public void InvalidParameterWithDefaultValue_Method()
         {
             var source =


### PR DESCRIPTION
Fixes a bug I was seeing that caused crashes in the editor in debug builds of Roslyn.

@333fred please review. Not sure if this belongs in 16.6 or 16.5, choosing 16.6 to start with.