### PR TITLE
Delete suppressions of CA3053

### DIFF
--- a/src/Compilers/Core/Portable/Desktop/AssemblyPortabilityPolicy.cs
+++ b/src/Compilers/Core/Portable/Desktop/AssemblyPortabilityPolicy.cs
@@ -54,12 +54,6 @@ namespace Microsoft.CodeAnalysis
             DtdProcessing = DtdProcessing.Prohibit,
         };
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
-            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
-XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
-However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
-So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         internal static AssemblyPortabilityPolicy LoadFromXml(Stream input)
         {
             // Note: Unlike Fusion XML reader the XmlReader doesn't allow whitespace in front of <?xml version=""1.0"" encoding=""utf-8"" ?>

--- a/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/DocumentationCommentIncludeCache.cs
@@ -44,12 +44,6 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="IOException"></exception>
         /// <exception cref="XmlException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
-            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
-XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
-However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
-So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private static KeyValuePair<string, XDocument> MakeValue(XmlReferenceResolver resolver, string resolvedPath)
         {
             CacheMissCount++;

--- a/src/Compilers/Core/Portable/DocumentationComments/XmlDocumentationCommentTextReader.cs
+++ b/src/Compilers/Core/Portable/DocumentationComments/XmlDocumentationCommentTextReader.cs
@@ -32,12 +32,6 @@ namespace Microsoft.CodeAnalysis
         private static readonly XmlReaderSettings s_xmlSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit };
 
         // internal for testing
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
-            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
-XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
-However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
-So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         internal XmlException ParseInternal(string text)
         {
             _textReader.SetText(text);

--- a/src/Compilers/Core/Portable/RuleSet/RuleSetProcessor.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSetProcessor.cs
@@ -54,12 +54,6 @@ namespace Microsoft.CodeAnalysis
         /// Creates and loads the rule set from a file
         /// </summary>
         /// <param name="filePath">The file path to load the rule set</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
-            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
-XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
-However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
-So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         public static RuleSet LoadFromFile(string filePath)
         {
             // First read the file without doing any validation

--- a/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/XmlFragmentParser.cs
@@ -52,12 +52,6 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             DtdProcessing = DtdProcessing.Prohibit,
         };
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
-            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
-XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
-However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
-So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private void ParseInternal<TArg>(string text, Action<XmlReader, TArg> callback, TArg arg)
         {
             _textReader.SetText(text);

--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -56,12 +56,6 @@ namespace Microsoft.CodeAnalysis
             return new FileBasedXmlDocumentationProvider(xmlDocCommentFilePath);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
-            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
-XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
-However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
-So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private XDocument GetXDocument(CancellationToken cancellationToken)
         {
             using var stream = GetSourceStream(cancellationToken);


### PR DESCRIPTION
We suppressed these because we were on the .NET Portable profile and thus couldn't do the anything else. We're no longer on the portable profile.