### PR TITLE
Remove intermediary stack frame from statement parsing.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -12,6 +12,7 @@ using System.Transactions;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -308,9 +309,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.ERR_BadEmbeddedStmt, node.GetLocation());
 
                     // fall through
-                    goto case SyntaxKind.ExpressionStatement;
+                    goto case SyntaxKind.LockStatement;
 
                 case SyntaxKind.ExpressionStatement:
+                    // In Scripts, we allow statements to not have semicolons.  However, that only
+                    // applies to non-embedded statements.  So check if we haven't emitted an error
+                    // for that case and do that here.  We don't do this in the parser for
+                    // simplicity of that impl and to prevent unnecessary helper methods in a hot
+                    // path where we're trying to keep the number of stack frames we have low.
+                    if (node.SyntaxTree.Options.Kind == SourceCodeKind.Script)
+                    {
+                        var expressionStatement = (ExpressionStatementSyntax)node;
+                        var semicolonToken = expressionStatement.SemicolonToken;
+
+                        // Do not add a new error if the same error was already added.
+                        if (semicolonToken.IsMissing &&
+                            !semicolonToken.GetDiagnostics().Contains(diagnosticInfo => (ErrorCode)diagnosticInfo.Code == ErrorCode.ERR_SemicolonExpected))
+                        {
+                            diagnostics.Add(
+                                ErrorCode.ERR_SemicolonExpected,
+                                Location.Create(node.SyntaxTree,
+                                    new TextSpan(expressionStatement.Expression.GetLastToken().Span.End, 0)));
+                        }
+                    }
+
+                    // fall through
+                    goto case SyntaxKind.LockStatement;
                 case SyntaxKind.LockStatement:
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.YieldReturnStatement:

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7496,7 +7496,7 @@ done:;
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var statement = this.ParseEmbeddedStatement();
+                var statement = ParseEmbeddedStatement();
                 return _syntaxFactory.ForStatement(forToken, openParen, decl, initializers, semi, condition, semi2, incrementors, closeParen, statement);
             }
             finally

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7161,12 +7161,9 @@ done:;
             _termState = saveTerm;
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            StatementSyntax statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            StatementSyntax statement = ParseEmbeddedStatement();
             return _syntaxFactory.FixedStatement(@fixed, openParen, decl, closeParen, statement);
         }
-
-        private EmptyStatementSyntax ParseEmptyStatement()
-            => SyntaxFactory.EmptyStatement(EatToken(SyntaxKind.SemicolonToken));
 
         private bool IsEndOfFixedStatement()
         {
@@ -7174,6 +7171,17 @@ done:;
                 || this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
                 || this.CurrentToken.Kind == SyntaxKind.SemicolonToken;
         }
+
+        private StatementSyntax ParseEmbeddedStatement()
+        {
+            // The consumers of embedded statements are expecting to receive a non-null statement 
+            // yet there are several error conditions that can lead ParseStatementCore to return 
+            // null.  When that occurs create an error empty Statement and return it to the caller.
+            return this.ParseStatementCore() ?? ParseEmptyStatement();
+        }
+
+        private EmptyStatementSyntax ParseEmptyStatement()
+            => SyntaxFactory.EmptyStatement(EatToken(SyntaxKind.SemicolonToken));
 
         private BreakStatementSyntax ParseBreakStatement()
         {
@@ -7367,7 +7375,7 @@ done:;
         {
             Debug.Assert(this.CurrentToken.Kind == SyntaxKind.DoKeyword);
             var @do = this.EatToken(SyntaxKind.DoKeyword);
-            var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             var @while = this.EatToken(SyntaxKind.WhileKeyword);
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
 
@@ -7488,7 +7496,7 @@ done:;
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+                var statement = ParseEmbeddedStatement();
                 return _syntaxFactory.ForStatement(forToken, openParen, decl, initializers, semi, condition, semi2, incrementors, closeParen, statement);
             }
             finally
@@ -7588,7 +7596,7 @@ tryAgain:
 
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
 
             if (variable is DeclarationExpressionSyntax decl)
             {
@@ -7690,7 +7698,7 @@ tryAgain:
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
             var statement = firstTokenIsElse
                 ? this.ParseExpressionStatement()
-                : (this.ParseStatementCore() ?? ParseEmptyStatement());
+                : this.ParseEmbeddedStatement();
             var elseClause = this.ParseElseClauseOpt();
 
             return _syntaxFactory.IfStatement(@if, openParen, condition, closeParen, statement, elseClause);
@@ -7704,7 +7712,7 @@ tryAgain:
             }
 
             var elseToken = this.EatToken(SyntaxKind.ElseKeyword);
-            var elseStatement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var elseStatement = ParseEmbeddedStatement();
             return _syntaxFactory.ElseClause(elseToken, elseStatement);
         }
 
@@ -7715,7 +7723,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             return _syntaxFactory.LockStatement(@lock, openParen, expression, closeParen, statement);
         }
 
@@ -7935,7 +7943,7 @@ tryAgain:
             this.Release(ref resetPoint);
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
 
             return _syntaxFactory.UsingStatement(awaitTokenOpt, @using, openParen, declaration, expression, closeParen, statement);
         }
@@ -8041,7 +8049,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var condition = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             return _syntaxFactory.WhileStatement(@while, openParen, condition, closeParen, statement);
         }
 
@@ -8056,7 +8064,7 @@ tryAgain:
             var label = this.ParseIdentifierToken();
             var colon = this.EatToken(SyntaxKind.ColonToken);
             Debug.Assert(!colon.IsMissing);
-            var statement = this.ParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             return _syntaxFactory.LabeledStatement(label, colon, statement);
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7161,7 +7161,7 @@ done:;
             _termState = saveTerm;
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            StatementSyntax statement = ParseEmbeddedStatement();
+            StatementSyntax statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.FixedStatement(@fixed, openParen, decl, closeParen, statement);
         }
 
@@ -7375,7 +7375,7 @@ done:;
         {
             Debug.Assert(this.CurrentToken.Kind == SyntaxKind.DoKeyword);
             var @do = this.EatToken(SyntaxKind.DoKeyword);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             var @while = this.EatToken(SyntaxKind.WhileKeyword);
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
 
@@ -7496,7 +7496,7 @@ done:;
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var statement = ParseEmbeddedStatement();
+                var statement = this.ParseEmbeddedStatement();
                 return _syntaxFactory.ForStatement(forToken, openParen, decl, initializers, semi, condition, semi2, incrementors, closeParen, statement);
             }
             finally
@@ -7596,7 +7596,7 @@ tryAgain:
 
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
 
             if (variable is DeclarationExpressionSyntax decl)
             {
@@ -7712,7 +7712,7 @@ tryAgain:
             }
 
             var elseToken = this.EatToken(SyntaxKind.ElseKeyword);
-            var elseStatement = ParseEmbeddedStatement();
+            var elseStatement = this.ParseEmbeddedStatement();
             return _syntaxFactory.ElseClause(elseToken, elseStatement);
         }
 
@@ -7723,7 +7723,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.LockStatement(@lock, openParen, expression, closeParen, statement);
         }
 
@@ -7943,7 +7943,7 @@ tryAgain:
             this.Release(ref resetPoint);
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
 
             return _syntaxFactory.UsingStatement(awaitTokenOpt, @using, openParen, declaration, expression, closeParen, statement);
         }
@@ -8049,7 +8049,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var condition = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.WhileStatement(@while, openParen, condition, closeParen, statement);
         }
 
@@ -8064,7 +8064,7 @@ tryAgain:
             var label = this.ParseIdentifierToken();
             var colon = this.EatToken(SyntaxKind.ColonToken);
             Debug.Assert(!colon.IsMissing);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.LabeledStatement(label, colon, statement);
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7696,9 +7696,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var condition = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = firstTokenIsElse
-                ? this.ParseExpressionStatement()
-                : this.ParseEmbeddedStatement();
+            var statement = firstTokenIsElse ? this.ParseExpressionStatement() : this.ParseEmbeddedStatement();
             var elseClause = this.ParseElseClauseOpt();
 
             return _syntaxFactory.IfStatement(@if, openParen, condition, closeParen, statement, elseClause);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -1380,6 +1380,22 @@ goto Label;");
                 );
         }
 
+        [WorkItem(6676, "https://github.com/dotnet/roslyn/issues/6676")]
+        [Fact]
+        public void EmbeddedStatementNeedsSemicolon()
+        {
+            string source =
+@"if (true)
+    System.Console.WriteLine(true)
+";
+
+            var compilation = CreateCompilationWithMscorlib45(new[] { Parse(source, options: TestOptions.Script) });
+            compilation.VerifyDiagnostics(
+                // (2,35): error CS1002: ; expected
+                //     System.Console.WriteLine(true)
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(2, 35));
+        }
+
         private static MemberAccessExpressionSyntax ErrorTestsGetNode(SyntaxTree syntaxTree)
         {
             var node1 = (CompilationUnitSyntax)syntaxTree.GetRoot();

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -2419,11 +2419,6 @@ System.Console.WriteLine(true)
             var reparsedTree = startTree.WithChangedText(newText);
             var parsedTree = SyntaxFactory.ParseSyntaxTree(newText, options: TestOptions.Script);
 
-            parsedTree.GetDiagnostics().Verify(
-                // (2,31): error CS1002: ; expected
-                // System.Console.WriteLine(true)
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(2, 31));
-
             CompareIncToFullParseErrors(reparsedTree, parsedTree);
         }
 


### PR DESCRIPTION
The stack is a premium during recursive statement parsing.  To make that scenario nicer, we simplify ParseEmbeddedStatement so it can be inlined by the jit.  To help with that, a lot of complexity of that method was simply moved out of the parser entirely (since it doesn't need to be there) into the binder.  