### PR TITLE
Annotate IDebugStateChangeListener with UIContext guid.

### DIFF
--- a/src/VisualStudio/Core/Def/Guids.cs
+++ b/src/VisualStudio/Core/Def/Guids.cs
@@ -29,9 +29,15 @@ namespace Microsoft.VisualStudio.LanguageServices
         public const string CSharpReplPackageIdString = "c5edd1ee-c43b-4360-9ce4-6b993ca12897";
 
         /// <summary>
+        /// <see cref="UIContext"/> that indicates <see cref="VisualStudioWorkspace"/> contains a project that supports Edit and Continue.
+        /// </summary>
+        public const string EncCapableProjectExistsInWorkspaceUIContextString = "0C89AE24-6D19-474C-A3AA-DC3B66FDBB5F";
+
+        /// <summary>
         /// A <see cref="UIContext"/> that is set if there is a C# project in the <see cref="VisualStudioWorkspace"/>.
         /// </summary>
-        public static readonly Guid CSharpProjectExistsInWorkspaceUIContext = new Guid("CA719A03-D55C-48F9-85DE-D934346E7F70");
+        public const string CSharpProjectExistsInWorkspaceUIContextString = "CA719A03-D55C-48F9-85DE-D934346E7F70";
+        public static readonly Guid CSharpProjectExistsInWorkspaceUIContext = new Guid(CSharpProjectExistsInWorkspaceUIContextString);
 
         public const string CSharpProjectRootIdString = "C7FEDB89-B36D-4a62-93F4-DC7A95999921";
 
@@ -81,7 +87,8 @@ namespace Microsoft.VisualStudio.LanguageServices
         /// <summary>
         /// A <see cref="UIContext"/> that is set if there is a Visual Basic project in the <see cref="VisualStudioWorkspace"/>.
         /// </summary>
-        public static readonly Guid VisualBasicProjectExistsInWorkspaceUIContext = new Guid("EEC3DF0D-6D3F-4544-ABF9-8E26E6A90275");
+        public const string VisualBasicProjectExistsInWorkspaceUIContextString = "EEC3DF0D-6D3F-4544-ABF9-8E26E6A90275";
+        public static readonly Guid VisualBasicProjectExistsInWorkspaceUIContext = new Guid(VisualBasicProjectExistsInWorkspaceUIContextString);
 
         public static readonly Guid VisualBasicPackageId = new Guid(VisualBasicPackageIdString);
         public static readonly Guid VisualBasicCompilerServiceId = new Guid(VisualBasicCompilerServiceIdString);

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioDebugStateChangeListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VisualStudioDebugStateChangeListener.cs
@@ -18,6 +18,7 @@ using Roslyn.Utilities;
 namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue
 {
     [Export(typeof(IDebugStateChangeListener))]
+    [ExportMetadata("UIContext", Guids.EncCapableProjectExistsInWorkspaceUIContextString)]
     internal sealed class VisualStudioDebugStateChangeListener : IDebugStateChangeListener
     {
         private readonly Workspace _workspace;

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -41,6 +41,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
     [Guid(Guids.RoslynPackageIdString)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [ProvideMenuResource("Menus.ctmenu", version: 17)]
+    [ProvideUIContextRule(
+        Guids.EncCapableProjectExistsInWorkspaceUIContextString,
+        name: "Managed Edit and Continue capability",
+        expression: "CS | VB",
+        termNames: new[] { "CS", "VB" },
+        termValues: new[] { Guids.CSharpProjectExistsInWorkspaceUIContextString, Guids.VisualBasicProjectExistsInWorkspaceUIContextString })]
     internal class RoslynPackage : AbstractPackage
     {
         private VisualStudioWorkspace _workspace;


### PR DESCRIPTION
The debugger will use this to delay loading Roslyn EnC until its needed. 

See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1006594/
