### PR TITLE
Remove intermediary stack frame from statement parsing.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7514,7 +7514,7 @@ done:;
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var statement = this.ParseEmbeddedStatement();
+                var statement = ParseEmbeddedStatement();
                 return _syntaxFactory.ForStatement(attributes, forToken, openParen, decl, initializers, semi, condition, semi2, incrementors, closeParen, statement);
             }
             finally

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7181,20 +7181,23 @@ done:;
             return _syntaxFactory.FixedStatement(attributes, @fixed, openParen, decl, closeParen, statement);
         }
 
-        private StatementSyntax ParseEmbeddedStatement()
-        {
-            return this.TryParseStatementCore() ?? ParseEmptyStatement();
-        }
-
-        private EmptyStatementSyntax ParseEmptyStatement()
-            => SyntaxFactory.EmptyStatement(attributeLists: default, EatToken(SyntaxKind.SemicolonToken));
-
         private bool IsEndOfFixedStatement()
         {
             return this.CurrentToken.Kind == SyntaxKind.CloseParenToken
                 || this.CurrentToken.Kind == SyntaxKind.OpenBraceToken
                 || this.CurrentToken.Kind == SyntaxKind.SemicolonToken;
         }
+
+        private StatementSyntax ParseEmbeddedStatement()
+        {
+            // The consumers of embedded statements are expecting to receive a non-null statement 
+            // yet there are several error conditions that can lead ParseStatementCore to return 
+            // null.  When that occurs create an error empty Statement and return it to the caller.
+            return this.TryParseStatementCore() ?? ParseEmptyStatement();
+        }
+
+        private EmptyStatementSyntax ParseEmptyStatement()
+            => SyntaxFactory.EmptyStatement(attributeLists: default, EatToken(SyntaxKind.SemicolonToken));
 
         private BreakStatementSyntax ParseBreakStatement(SyntaxList<AttributeListSyntax> attributes)
         {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7177,8 +7177,13 @@ done:;
             _termState = saveTerm;
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            StatementSyntax statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            StatementSyntax statement = ParseEmbeddedStatement();
             return _syntaxFactory.FixedStatement(attributes, @fixed, openParen, decl, closeParen, statement);
+        }
+
+        private StatementSyntax ParseEmbeddedStatement()
+        {
+            return this.TryParseStatementCore() ?? ParseEmptyStatement();
         }
 
         private EmptyStatementSyntax ParseEmptyStatement()
@@ -7385,7 +7390,7 @@ done:;
         {
             Debug.Assert(this.CurrentToken.Kind == SyntaxKind.DoKeyword);
             var @do = this.EatToken(SyntaxKind.DoKeyword);
-            var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             var @while = this.EatToken(SyntaxKind.WhileKeyword);
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
 
@@ -7506,7 +7511,7 @@ done:;
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+                var statement = ParseEmbeddedStatement();
                 return _syntaxFactory.ForStatement(attributes, forToken, openParen, decl, initializers, semi, condition, semi2, incrementors, closeParen, statement);
             }
             finally
@@ -7607,7 +7612,7 @@ tryAgain:
 
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
 
             if (variable is DeclarationExpressionSyntax decl)
             {
@@ -7709,7 +7714,7 @@ tryAgain:
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
             var statement = firstTokenIsElse
                 ? this.ParseExpressionStatement(attributes: default)
-                : (this.TryParseStatementCore() ?? ParseEmptyStatement());
+                : ParseEmbeddedStatement();
             var elseClause = this.ParseElseClauseOpt();
 
             return _syntaxFactory.IfStatement(attributes, @if, openParen, condition, closeParen, statement, elseClause);
@@ -7723,7 +7728,7 @@ tryAgain:
             }
 
             var elseToken = this.EatToken(SyntaxKind.ElseKeyword);
-            var elseStatement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var elseStatement = ParseEmbeddedStatement();
             return _syntaxFactory.ElseClause(elseToken, elseStatement);
         }
 
@@ -7734,7 +7739,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             return _syntaxFactory.LockStatement(attributes, @lock, openParen, expression, closeParen, statement);
         }
 
@@ -7954,7 +7959,7 @@ tryAgain:
             this.Release(ref resetPoint);
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
 
             return _syntaxFactory.UsingStatement(attributes, awaitTokenOpt, @using, openParen, declaration, expression, closeParen, statement);
         }
@@ -8060,7 +8065,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var condition = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             return _syntaxFactory.WhileStatement(attributes, @while, openParen, condition, closeParen, statement);
         }
 
@@ -8075,7 +8080,7 @@ tryAgain:
             var label = this.ParseIdentifierToken();
             var colon = this.EatToken(SyntaxKind.ColonToken);
             Debug.Assert(!colon.IsMissing);
-            var statement = this.TryParseStatementCore() ?? ParseEmptyStatement();
+            var statement = ParseEmbeddedStatement();
             return _syntaxFactory.LabeledStatement(attributes, label, colon, statement);
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7177,7 +7177,7 @@ done:;
             _termState = saveTerm;
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            StatementSyntax statement = ParseEmbeddedStatement();
+            StatementSyntax statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.FixedStatement(attributes, @fixed, openParen, decl, closeParen, statement);
         }
 
@@ -7393,7 +7393,7 @@ done:;
         {
             Debug.Assert(this.CurrentToken.Kind == SyntaxKind.DoKeyword);
             var @do = this.EatToken(SyntaxKind.DoKeyword);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             var @while = this.EatToken(SyntaxKind.WhileKeyword);
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
 
@@ -7514,7 +7514,7 @@ done:;
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var statement = ParseEmbeddedStatement();
+                var statement = this.ParseEmbeddedStatement();
                 return _syntaxFactory.ForStatement(attributes, forToken, openParen, decl, initializers, semi, condition, semi2, incrementors, closeParen, statement);
             }
             finally
@@ -7615,7 +7615,7 @@ tryAgain:
 
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
 
             if (variable is DeclarationExpressionSyntax decl)
             {
@@ -7717,7 +7717,7 @@ tryAgain:
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
             var statement = firstTokenIsElse
                 ? this.ParseExpressionStatement(attributes: default)
-                : ParseEmbeddedStatement();
+                : this.ParseEmbeddedStatement();
             var elseClause = this.ParseElseClauseOpt();
 
             return _syntaxFactory.IfStatement(attributes, @if, openParen, condition, closeParen, statement, elseClause);
@@ -7731,7 +7731,7 @@ tryAgain:
             }
 
             var elseToken = this.EatToken(SyntaxKind.ElseKeyword);
-            var elseStatement = ParseEmbeddedStatement();
+            var elseStatement = this.ParseEmbeddedStatement();
             return _syntaxFactory.ElseClause(elseToken, elseStatement);
         }
 
@@ -7742,7 +7742,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var expression = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.LockStatement(attributes, @lock, openParen, expression, closeParen, statement);
         }
 
@@ -7962,7 +7962,7 @@ tryAgain:
             this.Release(ref resetPoint);
 
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
 
             return _syntaxFactory.UsingStatement(attributes, awaitTokenOpt, @using, openParen, declaration, expression, closeParen, statement);
         }
@@ -8068,7 +8068,7 @@ tryAgain:
             var openParen = this.EatToken(SyntaxKind.OpenParenToken);
             var condition = this.ParseExpressionCore();
             var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.WhileStatement(attributes, @while, openParen, condition, closeParen, statement);
         }
 
@@ -8083,7 +8083,7 @@ tryAgain:
             var label = this.ParseIdentifierToken();
             var colon = this.EatToken(SyntaxKind.ColonToken);
             Debug.Assert(!colon.IsMissing);
-            var statement = ParseEmbeddedStatement();
+            var statement = this.ParseEmbeddedStatement();
             return _syntaxFactory.LabeledStatement(attributes, label, colon, statement);
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ScriptSemanticsTests.cs
@@ -1380,6 +1380,22 @@ goto Label;");
                 );
         }
 
+        [WorkItem(6676, "https://github.com/dotnet/roslyn/issues/6676")]
+        [Fact]
+        public void EmbeddedStatementNeedsSemicolon()
+        {
+            string source =
+@"if (true)
+    System.Console.WriteLine(true)
+";
+
+            var compilation = CreateCompilationWithMscorlib45(new[] { Parse(source, options: TestOptions.Script) });
+            compilation.VerifyDiagnostics(
+                // (2,35): error CS1002: ; expected
+                //     System.Console.WriteLine(true)
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(2, 35));
+        }
+
         private static MemberAccessExpressionSyntax ErrorTestsGetNode(SyntaxTree syntaxTree)
         {
             var node1 = (CompilationUnitSyntax)syntaxTree.GetRoot();

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -2419,11 +2419,6 @@ System.Console.WriteLine(true)
             var reparsedTree = startTree.WithChangedText(newText);
             var parsedTree = SyntaxFactory.ParseSyntaxTree(newText, options: TestOptions.Script);
 
-            parsedTree.GetDiagnostics().Verify(
-                // (2,31): error CS1002: ; expected
-                // System.Console.WriteLine(true)
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(2, 31));
-
             CompareIncToFullParseErrors(reparsedTree, parsedTree);
         }
 


### PR DESCRIPTION
By moving some complex logic to the binder from the parser, we both make the parser able to inline a method, and we ensure less error nodes in the parse tree.  

This is a port of https://github.com/dotnet/roslyn/pull/41589 oer to the local-function-attribute branch.  Had to do this separately as parsing has diverged.  