### PR TITLE
Revert compiler update that slowed down the build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,6 +33,7 @@
     <VisualStudioEditorPackagesVersion>16.4.248</VisualStudioEditorPackagesVersion>
     <ILToolsPackageVersion>5.0.0-alpha1.19409.1</ILToolsPackageVersion>
     <MicrosoftVisualStudioLanguageServerPackagesVersion>16.3.27-develop-gdd55e997</MicrosoftVisualStudioLanguageServerPackagesVersion>
+    <MicrosoftNetCompilersToolsetVersion>3.5.0-beta2-20074-05</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <!-- 
     Dependency versions


### PR DESCRIPTION
This restores the compiler toolset from prior to #41575 to mitigate the build performance regression.

Compile time prior to this change: 6:34
Compile time with this change: 2:22