### PR TITLE
Add discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 [//]: # (End current test results)
 
-[![Join the chat at https://gitter.im/dotnet/roslyn](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/roslyn?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/dotnet/roslyn](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/roslyn?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Chat on Discord](https://discordapp.com/api/guilds/143867839282020352/widget.png)](http://aka.ms/discord-csharp-roslyn)
 
 
 Roslyn provides open-source C# and Visual Basic compilers with rich code analysis APIs.  It enables building code analysis tools with the same APIs that are used by Visual Studio.


### PR DESCRIPTION
Adds a discord badge to the README, which takes you directly to the #roslyn channel on the C# community discord. The discord is already linked by the .NET Foundation as a community location (https://dotnet.microsoft.com/platform/community), and several members of the team are active on there.