### PR TITLE
Increase the amount of recursive parsing calls for statements+blocks.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6936,21 +6936,19 @@ done:;
                 return (BlockSyntax)this.EatNode();
 
             // There's a special error code for a missing token after an accessor keyword
-            var openBrace = isAccessorBody && this.CurrentToken.Kind != SyntaxKind.OpenBraceToken
+            CSharpSyntaxNode openBrace = isAccessorBody && this.CurrentToken.Kind != SyntaxKind.OpenBraceToken
                 ? this.AddError(
                     SyntaxFactory.MissingToken(SyntaxKind.OpenBraceToken),
                     IsFeatureEnabled(MessageID.IDS_FeatureExpressionBodiedAccessor)
-                            ? ErrorCode.ERR_SemiOrLBraceOrArrowExpected
-                            : ErrorCode.ERR_SemiOrLBraceExpected)
+                        ? ErrorCode.ERR_SemiOrLBraceOrArrowExpected
+                        : ErrorCode.ERR_SemiOrLBraceExpected)
                 : this.EatToken(SyntaxKind.OpenBraceToken);
 
             var statements = _pool.Allocate<StatementSyntax>();
-
-            CSharpSyntaxNode tmp = openBrace;
-            this.ParseStatements(ref tmp, statements, stopOnSwitchSections: false);
+            this.ParseStatements(ref openBrace, statements, stopOnSwitchSections: false);
 
             var block = _syntaxFactory.Block(
-                (SyntaxToken)tmp,
+                (SyntaxToken)openBrace,
                 // Force creation a many-children list, even if only 1, 2, or 3 elements in the statement list.
                 IsLargeEnoughNonEmptyStatementList(statements)
                     ? new SyntaxList<StatementSyntax>(SyntaxList.List(((SyntaxListBuilder)statements).ToArray()))
@@ -6973,15 +6971,13 @@ done:;
                 return (BlockSyntax)this.EatNode();
 
             // There's a special error code for a missing token after an accessor keyword
-            var openBrace = this.EatToken(SyntaxKind.OpenBraceToken);
+            CSharpSyntaxNode openBrace = this.EatToken(SyntaxKind.OpenBraceToken);
 
             var statements = _pool.Allocate<StatementSyntax>();
-
-            CSharpSyntaxNode tmp = openBrace;
-            this.ParseStatements(ref tmp, statements, stopOnSwitchSections: false);
+            this.ParseStatements(ref openBrace, statements, stopOnSwitchSections: false);
 
             var block = _syntaxFactory.Block(
-                (SyntaxToken)tmp,
+                (SyntaxToken)openBrace,
                 statements,
                 this.EatToken(SyntaxKind.CloseBraceToken));
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6970,7 +6970,6 @@ done:;
             if (this.IsIncrementalAndFactoryContextMatches && this.CurrentNodeKind == SyntaxKind.Block)
                 return (BlockSyntax)this.EatNode();
 
-            // There's a special error code for a missing token after an accessor keyword
             CSharpSyntaxNode openBrace = this.EatToken(SyntaxKind.OpenBraceToken);
 
             var statements = _pool.Allocate<StatementSyntax>();


### PR DESCRIPTION
Before this, we can parse 1333 nested if-statements.  Afterwards, we get up to 1443.  This is a simple increase of >8%.  

We do this by breaking out block-parsing into two separate helpers.  One used for method/accessor blocks and one for normal statement-blocks.  

This allows us to keep all specialized parsing/stack-space for the method case, while keeping the statement-version extremely simple and lightweight.