### PR TITLE
Support VBCSCompiler being compiled with --self-contained (or equivalent)

### DIFF
--- a/src/Compilers/Shared/RuntimeHostInfo.cs
+++ b/src/Compilers/Shared/RuntimeHostInfo.cs
@@ -7,7 +7,9 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.IO.Pipes;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -20,6 +22,7 @@ namespace Microsoft.CodeAnalysis
         internal static bool IsCoreClrRuntime => !IsDesktopRuntime;
 
         internal static string ToolExtension => IsCoreClrRuntime ? "dll" : "exe";
+        private static string NativeToolSuffix => PlatformInformation.IsWindows ? ".exe" : "";
 
         /// <summary>
         /// This gets information about invoking a tool on the current runtime. This will attempt to 
@@ -29,6 +32,11 @@ namespace Microsoft.CodeAnalysis
         {
             Debug.Assert(!toolFilePathWithoutExtension.EndsWith(".dll") && !toolFilePathWithoutExtension.EndsWith(".exe"));
 
+            var nativeToolFilePath = $"{toolFilePathWithoutExtension}{NativeToolSuffix}";
+            if (IsCoreClrRuntime && File.Exists(nativeToolFilePath))
+            {
+                return (nativeToolFilePath, commandLineArguments, nativeToolFilePath);
+            }
             var toolFilePath = $"{toolFilePathWithoutExtension}.{ToolExtension}";
             if (IsDotNetHost(out string? pathToDotNet))
             {


### PR DESCRIPTION
Seems like @jaredpar is the one who touches this file the most, hi!

When building vbcscompiler (and presumably csc and vbc too) with `dotnet publish --self-contained`, we should prefer to use that version first.

The `File.Exists` is really nasty and I'd love to do that another way, but I'm not sure how. There's other uses of `File.Exists` in the vicinity, though, so it might be okay? https://github.com/dotnet/roslyn/blob/0e107357141ee51b61dcf81a69d1c7c0b6bb5efd/src/Compilers/Shared/BuildServerConnection.cs#L415

---

(the reason we need to do a `--self-contained` publish is because the license for the windows dotnet sdk build explicitly disallows redistribution, so it's much easier to use the dotnet bundled with a self-contained app)