### PR TITLE
Improve SubstitutedMethodSymbol.GetHashCode

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -368,7 +368,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // (e.g, ignoring nullability) and want to retain the same hashcode. As such, consider only
             // the original definition for the hashcode when we know equality is possible
             var containingHashCode = _containingType.GetHashCode();
-            if (containingHashCode == this.OriginalDefinition.ContainingType.GetHashCode())
+            if (containingHashCode == this.OriginalDefinition.ContainingType.GetHashCode() &&
+                wasConstructedForAnnotations(this))
             {
                 return code;
             }
@@ -402,6 +403,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return code;
+
+            static bool wasConstructedForAnnotations(SubstitutedMethodSymbol method)
+            {
+                var typeArguments = method.TypeArgumentsWithAnnotations;
+                var typeParameters = method.OriginalDefinition.TypeParameters;
+
+                for (int i = 0; i < typeArguments.Length; i++)
+                {
+                    if (!typeParameters[i].Equals(
+                         typeArguments[i].Type,
+                         TypeCompareKind.ConsiderEverything))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
 
         public sealed override bool Equals(Symbol obj, TypeCompareKind compareKind)


### PR DESCRIPTION
The changes made in https://github.com/dotnet/roslyn/pull/41123 fix the
GetHashCode for SubstitutedMethodSymbol for more nullability scenarios,
but end up hashing all generic methods with a non-generic containing
type into the same bucket. This can cause large performance regressions
for the compiler.

This change ensures that substituted symbols which have substitutions
equivalent to their original method's type parameters have the same
hash code, but substituted methods with different type substitutions
do not have the same hash code.