### PR TITLE
Avoid use-site diagnostics in TupleTypeDecoder

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -159,11 +159,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             switch (type.Kind)
             {
                 case SymbolKind.ErrorType:
-                    if (type.HasUseSiteError)
-                    {
-                        _foundUsableErrorType = true;
-                    }
+                    _foundUsableErrorType = true;
                     return type;
+
                 case SymbolKind.DynamicType:
                 case SymbolKind.TypeParameter:
                 case SymbolKind.PointerType:

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
@@ -126,10 +126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         Private Function DecodeType(type As TypeSymbol) As TypeSymbol
             Select Case type.Kind
                 Case SymbolKind.ErrorType
-
-                    If type.GetUseSiteErrorInfo() IsNot Nothing Then
-                        _foundUsableErrorType = True
-                    End If
+                    _foundUsableErrorType = True
                     Return type
 
                 Case SymbolKind.DynamicType,

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -22819,11 +22819,18 @@ End Class"
             Dim sourceC =
 "Module Program
     Sub Main()
-        Dim o As Object = New B()
+        Dim b = New B()
+        b.ToString()
     End Sub
 End Module"
             comp = CreateCompilation(sourceC, references:={refB})
-            comp.VerifyDiagnostics()
+            comp.AssertTheseDiagnostics(
+"BC30456: 'ToString' is not a member of 'B'.
+        b.ToString()
+        ~~~~~~~~~~
+BC30652: Reference required to assembly 'A, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'A(Of )'. Add one to your project.
+        b.ToString()
+        ~~~~~~~~~~")
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -22801,6 +22801,32 @@ End Class
         End Sub
 
         <Fact>
+        <WorkItem(41699, "https://github.com/dotnet/roslyn/issues/41699")>
+        Public Sub MissingBaseType_TupleTypeArgumentWithNames()
+            Dim sourceA =
+"Public Class A(Of T)
+End Class"
+            Dim comp = CreateCompilation(sourceA, assemblyName:="A")
+            Dim refA = comp.EmitToImageReference()
+
+            Dim sourceB =
+"Public Class B
+    Inherits A(Of (X As Object, Y As B))
+End Class"
+            comp = CreateCompilation(sourceB, references:={refA})
+            Dim refB = comp.EmitToImageReference()
+
+            Dim sourceC =
+"Module Program
+    Sub Main()
+        Dim o As Object = New B()
+    End Sub
+End Module"
+            comp = CreateCompilation(sourceC, references:={refB})
+            comp.VerifyDiagnostics()
+        End Sub
+
+        <Fact>
         <WorkItem(41207, "https://github.com/dotnet/roslyn/issues/41207")>
         <WorkItem(1056281, "https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1056281")>
         Public Sub CustomFields_01()


### PR DESCRIPTION
Fixes #41699

Relates to https://github.com/dotnet/roslyn/pull/40704