### PR TITLE
Inline statement parsing

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6344,10 +6344,15 @@ done:;
                 Debug.Assert(!IsInAsync);
 
                 // Let's see if we're in case (5). Pretend that we're in an async method and retry.
+                //
+                // Because we know we started with 'await' and because we're attempting to parse out
+                // an await-expression, we can call directly into ParseExpressionStatement here
+                // instead of calling into another top-level ParseStatement function that will
+                // eventually bottom out there.
 
                 this.Reset(ref resetPointBeforeStatement);
                 IsInAsync = true;
-                result = ParseStatementNoDeclaration(isGlobalScriptLevel: false);
+                result = ParseExpressionStatement();
                 IsInAsync = false;
 
                 return result;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6288,11 +6288,7 @@ done:;
                 _recursionDepth++;
                 StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
 
-                // Can only reuse a global-script or regular statement if we're in the same
-                // global-script context we were originally in.
-                if (this.IsIncrementalAndFactoryContextMatches &&
-                    this.CurrentNode is CSharp.Syntax.StatementSyntax &&
-                    isGlobalScriptLevel == (this.CurrentNode.Parent is Syntax.GlobalStatementSyntax))
+                if (canReuseStatement(isGlobalScriptLevel))
                 {
                     return (StatementSyntax)this.EatNode();
                 }
@@ -6362,6 +6358,15 @@ done:;
             {
                 _recursionDepth--;
                 this.Release(ref resetPointBeforeStatement);
+            }
+
+            bool canReuseStatement(bool isGlobalScriptLevel)
+            {
+                // Can only reuse a global-script or regular statement if we're in the same
+                // global-script context we were originally in.
+                return this.IsIncrementalAndFactoryContextMatches &&
+                       this.CurrentNode is CSharp.Syntax.StatementSyntax &&
+                       isGlobalScriptLevel == (this.CurrentNode.Parent is Syntax.GlobalStatementSyntax);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6444,14 +6444,12 @@ done:;
                     break;
             }
 
-            if (this.IsPossibleLocalDeclarationStatement(isGlobalScriptLevel))
-            {
-                return null;
-            }
-            else
+            if (!this.IsPossibleLocalDeclarationStatement(isGlobalScriptLevel))
             {
                 return this.ParseExpressionStatement();
             }
+
+            return null;
         }
 
         private StatementSyntax TryParseStatementStartingWithIdentifier(bool isGlobalScriptLevel)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6278,6 +6278,7 @@ done:;
 
         private StatementSyntax ParseStatementCore()
         {
+            ResetPoint resetPointBeforeStatement = this.GetResetPoint();
             try
             {
                 _recursionDepth++;
@@ -6302,19 +6303,6 @@ done:;
                 // it as either a declaration or as an "await X();" statement that is in a non-async
                 // method. 
 
-                return TryParsePossibleDeclarationOrBadAwaitStatement();
-            }
-            finally
-            {
-                _recursionDepth--;
-            }
-        }
-
-        private StatementSyntax TryParsePossibleDeclarationOrBadAwaitStatement()
-        {
-            ResetPoint resetPointBeforeStatement = this.GetResetPoint();
-            try
-            {
                 // Precondition: We have already attempted to parse the statement as a non-declaration and failed.
                 //
                 // That means that we are in one of the following cases:
@@ -6334,7 +6322,7 @@ done:;
                 //    semantic code will error out that this isn't legal.
 
                 bool beginsWithAwait = this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
-                StatementSyntax result = ParseLocalDeclarationStatement();
+                result = ParseLocalDeclarationStatement();
 
                 // Case (1)
                 if (result == null)
@@ -6366,6 +6354,7 @@ done:;
             }
             finally
             {
+                _recursionDepth--;
                 this.Release(ref resetPointBeforeStatement);
             }
         }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6449,7 +6449,8 @@ done:;
 
         private StatementSyntax TryParseStatementStartingWithIdentifier(bool allowAnyExpression)
         {
-            if (isPossibleAwaitForEach())
+            if (this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword &&
+                this.PeekToken(1).Kind == SyntaxKind.ForEachKeyword)
             {
                 return this.ParseForEachStatement(ParseAwaitKeyword(MessageID.IDS_FeatureAsyncStreams));
             }
@@ -6479,12 +6480,6 @@ done:;
             }
 
             return null;
-
-            bool isPossibleAwaitForEach()
-            {
-                return this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword &&
-                    this.PeekToken(1).Kind == SyntaxKind.ForEachKeyword;
-            }
         }
 
         private StatementSyntax ParseStatementStartingWithUsing()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6380,34 +6380,14 @@ done:;
                 return null;
             }
 
-            // We could not successfully parse the statement as a non-declaration. Try to parse
-            // it as either a declaration or as an "await X();" statement that is in a non-async
-            // method. 
-
-            // Precondition: We have already attempted to parse the statement as a non-declaration and failed.
-            //
-            // That means that we are in one of the following cases:
-            //
-            // 1) This is not a statement. This can happen if the start of the statement was an
-            //    accessibility modifier, but the rest of the statement did not parse as a local
-            //    function. If there was an accessibility modifier and the statement parsed as
-            //    local function, that should be marked as a mistake with local function visibility.
-            //    Otherwise, it's likely the user just forgot a closing brace on their method.
-            // 2) This is a perfectly mundane and correct local declaration statement like "int x;"
-            // 3) This is a perfectly mundane but erroneous local declaration statement, like "int X();"
-            // 4) We are in the rare case of the code containing "await x;" and the intention is that
-            //    "await" is the type of "x".  This only works in a non-async method.
-            // 5) We have a misplaced await statement in a non-async method, like "await X();",
-            //    so the parse failed. Had we been in an async method then the parse attempt
-            //    done by our caller would have succeeded.  Retry as if we were async.  Later
-            //    semantic code will error out that this isn't legal.
-
             bool beginsWithAwait = this.CurrentToken.ContextualKind == SyntaxKind.AwaitKeyword;
             var result = ParseLocalDeclarationStatement();
 
-            // Case (1)
             if (result == null)
             {
+                // didn't get any sort of statement.  This was something else entirely (like just a
+                // `}`).  No need to retry anything here.  Just reset back to where we started from
+                // and bail entirely from parsing a statement.
                 this.Reset(ref resetPointBeforeStatement);
                 return null;
             }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -6495,7 +6495,7 @@ class Program
     {
 ");
 
-            const int depth = 10000;
+            const int depth = 100000;
             for (int i = 0; i < depth; i++)
             {
                 var line = string.Format("Action a{0} = delegate d{0} {{", i);


### PR DESCRIPTION
This reduces teh amount of stack frames we need when parsing. It should actually routinely halve the number as there's no need for all the indirections.

This should be reviewed one commit at a time.