### PR TITLE
Return `null` rather than `this` from INamedTypeSymbol.TupleUnderlyingType

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -450,12 +450,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <returns></returns>
         private bool CanUseTupleSyntax(INamedTypeSymbol tupleSymbol)
         {
-            INamedTypeSymbol currentUnderlying = tupleSymbol.TupleUnderlyingType;
             if (containsModopt(tupleSymbol))
             {
                 return false;
             }
 
+            INamedTypeSymbol currentUnderlying = getTupleUnderlyingTypeOrSelf(tupleSymbol);
             if (currentUnderlying.Arity <= 1)
             {
                 return false;
@@ -473,11 +473,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                currentUnderlying = tupleSymbol.TupleUnderlyingType;
+                currentUnderlying = getTupleUnderlyingTypeOrSelf(tupleSymbol);
             }
 
             return true;
-
 
             bool containsModopt(INamedTypeSymbol symbol)
             {
@@ -490,6 +489,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return modifiers.Any(m => !m.IsEmpty);
             }
+
+            static INamedTypeSymbol getTupleUnderlyingTypeOrSelf(INamedTypeSymbol type) => type.TupleUnderlyingType ?? type;
         }
 
         private static bool HasNonDefaultTupleElements(INamedTypeSymbol tupleSymbol)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -455,7 +455,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            INamedTypeSymbol currentUnderlying = getTupleUnderlyingTypeOrSelf(tupleSymbol);
+            INamedTypeSymbol currentUnderlying = GetTupleUnderlyingTypeOrSelf(tupleSymbol);
             if (currentUnderlying.Arity <= 1)
             {
                 return false;
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                currentUnderlying = getTupleUnderlyingTypeOrSelf(tupleSymbol);
+                currentUnderlying = GetTupleUnderlyingTypeOrSelf(tupleSymbol);
             }
 
             return true;
@@ -489,8 +489,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return modifiers.Any(m => !m.IsEmpty);
             }
+        }
 
-            static INamedTypeSymbol getTupleUnderlyingTypeOrSelf(INamedTypeSymbol type) => type.TupleUnderlyingType ?? type;
+        private static INamedTypeSymbol GetTupleUnderlyingTypeOrSelf(INamedTypeSymbol type)
+        {
+            return type.TupleUnderlyingType ?? type;
         }
 
         private static bool HasNonDefaultTupleElements(INamedTypeSymbol tupleSymbol)

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/NamedTypeSymbol.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 {
@@ -162,14 +163,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
         }
 
         /// <summary>
-        /// If this is a tuple type symbol, returns the symbol for its underlying type.
+        /// If this is a tuple type with element names, returns the symbol for the tuple type without names.
         /// Otherwise, returns null.
         /// </summary>
         INamedTypeSymbol INamedTypeSymbol.TupleUnderlyingType
         {
             get
             {
-                return UnderlyingNamedTypeSymbol.TupleUnderlyingType.GetPublicSymbol();
+                var type = UnderlyingNamedTypeSymbol;
+                var tupleUnderlyingType = type.TupleUnderlyingType;
+                return type.Equals(tupleUnderlyingType, TypeCompareKind.ConsiderEverything) ?
+                    null :
+                    tupleUnderlyingType.GetPublicSymbol();
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -5816,7 +5816,8 @@ namespace System
             var vt0 = comp.GetWellKnownType(WellKnownType.System_ValueTuple);
             var tupleWithoutNames = comp.CreateTupleTypeSymbol(vt0, ImmutableArray<string>.Empty);
             Assert.True(tupleWithoutNames.IsTupleType);
-            Assert.Equal(SymbolKind.NamedType, tupleWithoutNames.TupleUnderlyingType.Kind);
+            Assert.Equal(SymbolKind.NamedType, tupleWithoutNames.Kind);
+            Assert.Null(tupleWithoutNames.TupleUnderlyingType);
             Assert.Equal("System.ValueTuple", tupleWithoutNames.ToTestDisplayString());
             Assert.True(GetTupleElementNames(tupleWithoutNames).IsDefault);
             Assert.Empty(ElementTypeNames(tupleWithoutNames));
@@ -5873,7 +5874,8 @@ namespace System
 
             Assert.Same(vt2, ((Symbols.PublicModel.NamedTypeSymbol)tupleWithoutNames).UnderlyingNamedTypeSymbol);
             Assert.True(tupleWithoutNames.IsTupleType);
-            Assert.Equal(SymbolKind.NamedType, tupleWithoutNames.TupleUnderlyingType.Kind);
+            Assert.Equal(SymbolKind.NamedType, tupleWithoutNames.Kind);
+            Assert.Null(tupleWithoutNames.TupleUnderlyingType);
             Assert.Equal("(System.Int32, System.String)", tupleWithoutNames.ToTestDisplayString());
             Assert.True(GetTupleElementNames(tupleWithoutNames).IsDefault);
             Assert.Equal(new[] { "System.Int32", "System.String" }, ElementTypeNames(tupleWithoutNames));
@@ -5950,7 +5952,8 @@ namespace System
             var tupleWithoutNames = comp.CreateTupleTypeSymbol(vt2, default(ImmutableArray<string>));
 
             Assert.True(tupleWithoutNames.IsTupleType);
-            Assert.Equal(SymbolKind.ErrorType, tupleWithoutNames.TupleUnderlyingType.Kind);
+            Assert.Equal(SymbolKind.ErrorType, tupleWithoutNames.Kind);
+            Assert.Null(tupleWithoutNames.TupleUnderlyingType);
             Assert.Equal("(System.Int32, System.String)[missing]", tupleWithoutNames.ToTestDisplayString());
             Assert.True(GetTupleElementNames(tupleWithoutNames).IsDefault);
             Assert.Equal(new[] { "System.Int32", "System.String" }, ElementTypeNames(tupleWithoutNames));
@@ -6631,7 +6634,8 @@ class C
 }";
             var comp = (Compilation)CreateCompilation(source);
             var tuple1 = (INamedTypeSymbol)((IFieldSymbol)comp.GetMember("Program.F")).Type;
-            var underlyingType = tuple1.TupleUnderlyingType;
+            Assert.Null(tuple1.TupleUnderlyingType);
+            var underlyingType = tuple1;
 
             var tuple2 = comp.CreateTupleTypeSymbol(underlyingType);
             Assert.True(tuple1.Equals(tuple2, TypeCompareKind.ConsiderEverything));
@@ -6672,7 +6676,8 @@ class C
 }";
             var comp = (Compilation)CreateCompilation(source);
             var tuple1 = (INamedTypeSymbol)((IFieldSymbol)comp.GetMember("Program.F")).Type;
-            var underlyingType = tuple1.TupleUnderlyingType;
+            Assert.Null(tuple1.TupleUnderlyingType);
+            var underlyingType = tuple1;
 
             var tuple2 = comp.CreateTupleTypeSymbol(underlyingType);
             Assert.True(tuple1.Equals(tuple2, TypeCompareKind.ConsiderEverything));
@@ -6789,7 +6794,8 @@ class C
 }";
             var comp = CreateCompilation(source);
             var tuple1 = (INamedTypeSymbol)((FieldSymbol)comp.GetMember("Program.F")).GetPublicSymbol().Type;
-            var underlyingType = tuple1.TupleUnderlyingType;
+            Assert.Null(tuple1.TupleUnderlyingType);
+            var underlyingType = tuple1;
 
             var tuple2 = comp.CreateTupleTypeSymbol(underlyingType, elementNullableAnnotations: default);
             Assert.True(tuple1.Equals(tuple2, TypeCompareKind.ConsiderEverything));
@@ -16100,7 +16106,7 @@ class C
             Assert.True(xSymbol.IsTupleType);
             Assert.Equal("(System.Int32, System.Int32)[missing]", xSymbol.ToTestDisplayString());
 
-            Assert.True(xSymbol.TupleUnderlyingType.IsErrorType());
+            Assert.Null(xSymbol.TupleUnderlyingType);
             Assert.True(xSymbol.IsErrorType());
             Assert.True(xSymbol.IsReferenceType);
 
@@ -18506,10 +18512,10 @@ class Program
             ITypeSymbol stringType = comp.GetSpecialType(SpecialType.System_String);
             ITypeSymbol objectType = comp.GetSpecialType(SpecialType.System_Object);
 
-            var int_string1 = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType)).TupleUnderlyingType;
+            var int_string1 = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType));
             var int_string2 = tupleComp2.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType));
-
             var int_object = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, objectType));
+            Assert.Null(int_string1.TupleUnderlyingType);
 
             Assert.Equal(ConversionKind.ImplicitTuple, comp.ClassifyConversion(int_string1, int_string2).Kind);
             Assert.Equal(ConversionKind.ImplicitTuple, comp.ClassifyConversion(int_string2, int_string1).Kind);
@@ -18531,10 +18537,11 @@ class Program
             ITypeSymbol stringType = comp.GetSpecialType(SpecialType.System_String);
             ITypeSymbol objectType = comp.GetSpecialType(SpecialType.System_Object);
 
-            var int_string1 = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType)).TupleUnderlyingType;
-            var int_string2 = tupleComp2.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType)).TupleUnderlyingType;
-
+            var int_string1 = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType));
+            var int_string2 = tupleComp2.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType));
             var int_object = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, objectType));
+            Assert.Null(int_string1.TupleUnderlyingType);
+            Assert.Null(int_string2.TupleUnderlyingType);
 
             Assert.Equal(ConversionKind.ImplicitTuple, comp.ClassifyConversion(int_string1, int_string2).Kind);
             Assert.Equal(ConversionKind.ImplicitTuple, comp.ClassifyConversion(int_string2, int_string1).Kind);
@@ -18556,10 +18563,12 @@ class Program
             ITypeSymbol stringType = comp.GetSpecialType(SpecialType.System_String);
             ITypeSymbol objectType = comp.GetSpecialType(SpecialType.System_Object);
 
-            var int_string1 = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType)).TupleUnderlyingType;
-            var int_string2 = tupleComp2.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType)).TupleUnderlyingType;
-
-            var int_object = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, objectType)).TupleUnderlyingType;
+            var int_string1 = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType));
+            var int_string2 = tupleComp2.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType));
+            var int_object = tupleComp1.CreateTupleTypeSymbol(ImmutableArray.Create(intType, objectType));
+            Assert.Null(int_string1.TupleUnderlyingType);
+            Assert.Null(int_string2.TupleUnderlyingType);
+            Assert.Null(int_object.TupleUnderlyingType);
 
             Assert.Equal(ConversionKind.ImplicitTuple, comp.ClassifyConversion(int_string1, int_string2).Kind);
             Assert.Equal(ConversionKind.ImplicitTuple, comp.ClassifyConversion(int_string2, int_string1).Kind);
@@ -26548,6 +26557,97 @@ class Program
 
             var comp6 = CreateCompilation(source2, targetFramework: TargetFramework.Mscorlib46, options: TestOptions.DebugExe, references: comp1ImageRef);
             CompileAndVerify(comp6, expectedOutput: "123");
+        }
+
+        [Fact]
+        [WorkItem(41702, "https://github.com/dotnet/roslyn/issues/41702")]
+        public void TupleUnderlyingType()
+        {
+            var source =
+@"#pragma warning disable 169
+class Program
+{
+    static System.ValueTuple F0;
+    static (int, int) F1;
+    static (int A, int B) F2;
+    static (object, object, object, object, object, object, object, object) F3;
+    static (object, object B, object, object D, object, object F, object, object H) F4;
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            verifyType((NamedTypeSymbol)comp.GetMember<FieldSymbol>("Program.F0").Type, hasNames: false, "System.ValueTuple");
+            verifyType((NamedTypeSymbol)comp.GetMember<FieldSymbol>("Program.F1").Type, hasNames: false, "(System.Int32, System.Int32)");
+            verifyType((NamedTypeSymbol)comp.GetMember<FieldSymbol>("Program.F2").Type, hasNames: true, "(System.Int32 A, System.Int32 B)");
+            verifyType((NamedTypeSymbol)comp.GetMember<FieldSymbol>("Program.F3").Type, hasNames: false, "(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)");
+            verifyType((NamedTypeSymbol)comp.GetMember<FieldSymbol>("Program.F4").Type, hasNames: true, "(System.Object, System.Object B, System.Object, System.Object D, System.Object, System.Object F, System.Object, System.Object H)");
+
+            static void verifyType(NamedTypeSymbol type, bool hasNames, string expected)
+            {
+                Assert.Equal(expected, type.ToTestDisplayString());
+                verifyUnderlyingTypes(type, hasNames);
+                verifyUnderlyingTypes(type.OriginalDefinition, hasNames: false);
+            }
+
+            static void verifyUnderlyingTypes(NamedTypeSymbol type, bool hasNames)
+            {
+                verifyInternalType(type, hasNames);
+                verifyPublicType(type.GetPublicSymbol(), hasNames);
+            }
+
+            static void verifyInternalType(NamedTypeSymbol type, bool hasNames)
+            {
+                if (hasNames)
+                {
+                    Assert.True(type.IsTupleType);
+                }
+
+                var underlyingType = type.TupleUnderlyingType;
+
+                if (hasNames)
+                {
+                    Assert.NotEqual(type, underlyingType);
+                    Assert.True(type.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions));
+                    Assert.False(type.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
+
+                    verifyInternalType(underlyingType, hasNames: false);
+                }
+                else if (type.IsTupleType)
+                {
+                    // NamedTypeSymbol.TupleUnderlyingType should return `this` if the type is unnamed.
+                    Assert.Equal(type, underlyingType);
+                    Assert.True(type.Equals(underlyingType, TypeCompareKind.ConsiderEverything));
+                }
+                else
+                {
+                    // NamedTypeSymbol.TupleUnderlyingType should return null if the type is not a tuple type.
+                    Assert.Null(underlyingType);
+                }
+            }
+
+            static void verifyPublicType(INamedTypeSymbol type, bool hasNames)
+            {
+                if (hasNames)
+                {
+                    Assert.True(type.IsTupleType);
+                }
+
+                var underlyingType = type.TupleUnderlyingType;
+
+                if (hasNames)
+                {
+                    Assert.NotEqual(type, underlyingType);
+                    Assert.False(type.Equals(underlyingType, SymbolEqualityComparer.Default));
+                    Assert.False(type.Equals(underlyingType, SymbolEqualityComparer.ConsiderEverything));
+
+                    verifyPublicType(underlyingType, hasNames: false);
+                }
+                else
+                {
+                    // INamedTypeSymbol.TupleUnderlyingType should return null if the type is unnamed.
+                    Assert.Null(underlyingType);
+                }
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis
         bool MightContainExtensionMethods { get; }
 
         /// <summary>
-        /// If this is a tuple type symbol, returns the symbol for its underlying type (ie. without element names).
+        /// If this is a tuple type with element names, returns the symbol for the tuple type without names.
         /// Otherwise, returns null.
         /// The type argument corresponding to the type of the extension field (VT[8].Rest),
         /// which is at the 8th (one based) position is always a symbol for another tuple, 

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -330,7 +330,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="tupleSymbol"></param>
         ''' <returns></returns>
         Private Shared Function CanUseTupleTypeName(tupleSymbol As INamedTypeSymbol) As Boolean
-            Dim currentUnderlying As INamedTypeSymbol = tupleSymbol.TupleUnderlyingType
+            Dim currentUnderlying As INamedTypeSymbol = GetTupleUnderlyingTypeOrSelf(tupleSymbol)
 
             If currentUnderlying.Arity = 1 Then
                 Return False
@@ -344,10 +344,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return False
                 End If
 
-                currentUnderlying = tupleSymbol.TupleUnderlyingType
+                currentUnderlying = GetTupleUnderlyingTypeOrSelf(tupleSymbol)
             End While
 
             Return True
+        End Function
+
+        Private Shared Function GetTupleUnderlyingTypeOrSelf(tupleSymbol As INamedTypeSymbol) As INamedTypeSymbol
+            Return If(tupleSymbol.TupleUnderlyingType, tupleSymbol)
         End Function
 
         Private Shared Function HasNonDefaultTupleElements(tupleSymbol As INamedTypeSymbol) As Boolean

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -22913,7 +22913,30 @@ End Class
 
         <Fact>
         <WorkItem(41702, "https://github.com/dotnet/roslyn/issues/41702")>
-        Public Sub TupleUnderlyingType()
+        Public Sub TupleUnderlyingType_FromCSharp()
+            Dim source =
+"#pragma warning disable 169
+class Program
+{
+    static System.ValueTuple F0;
+    static (int, int) F1;
+    static (int A, int B) F2;
+    static (object, object, object, object, object, object, object, object) F3;
+    static (object, object B, object, object D, object, object F, object, object H) F4;
+}"
+            Dim comp = CreateCSharpCompilation(source, referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.Standard))
+            comp.VerifyDiagnostics()
+            Dim containingType = comp.GlobalNamespace.GetTypeMembers("Program").Single()
+            VerifyTypeFromCSharp(DirectCast(DirectCast(containingType.GetMembers("F0").Single(), IFieldSymbol).Type, INamedTypeSymbol), TupleUnderlyingTypeValue.Nothing, "System.ValueTuple", "()")
+            VerifyTypeFromCSharp(DirectCast(DirectCast(containingType.GetMembers("F1").Single(), IFieldSymbol).Type, INamedTypeSymbol), TupleUnderlyingTypeValue.Nothing, "(System.Int32, System.Int32)", "(System.Int32, System.Int32)")
+            VerifyTypeFromCSharp(DirectCast(DirectCast(containingType.GetMembers("F2").Single(), IFieldSymbol).Type, INamedTypeSymbol), TupleUnderlyingTypeValue.Distinct, "(System.Int32 A, System.Int32 B)", "(A As System.Int32, B As System.Int32)")
+            VerifyTypeFromCSharp(DirectCast(DirectCast(containingType.GetMembers("F3").Single(), IFieldSymbol).Type, INamedTypeSymbol), TupleUnderlyingTypeValue.Nothing, "(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)", "(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)")
+            VerifyTypeFromCSharp(DirectCast(DirectCast(containingType.GetMembers("F4").Single(), IFieldSymbol).Type, INamedTypeSymbol), TupleUnderlyingTypeValue.Distinct, "(System.Object, System.Object B, System.Object, System.Object D, System.Object, System.Object F, System.Object, System.Object H)", "(System.Object, B As System.Object, System.Object, D As System.Object, System.Object, F As System.Object, System.Object, H As System.Object)")
+        End Sub
+
+        <Fact>
+        <WorkItem(41702, "https://github.com/dotnet/roslyn/issues/41702")>
+        Public Sub TupleUnderlyingType_FromVisualBasic()
             Dim source =
 "Class Program
     Private F0 As System.ValueTuple
@@ -22924,59 +22947,74 @@ End Class
 End Class"
             Dim comp = CreateCompilation(source)
             comp.AssertNoDiagnostics()
-
-            VerifyType(DirectCast(comp.GetMember(Of FieldSymbol)("Program.F0").Type, NamedTypeSymbol), hasNames:=False, "System.ValueTuple")
-            VerifyType(DirectCast(comp.GetMember(Of FieldSymbol)("Program.F1").Type, NamedTypeSymbol), hasNames:=False, "(System.Int32, System.Int32)")
-            VerifyType(DirectCast(comp.GetMember(Of FieldSymbol)("Program.F2").Type, NamedTypeSymbol), hasNames:=True, "(A As System.Int32, B As System.Int32)")
-            VerifyType(DirectCast(comp.GetMember(Of FieldSymbol)("Program.F3").Type, NamedTypeSymbol), hasNames:=False, "(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)")
-            VerifyType(DirectCast(comp.GetMember(Of FieldSymbol)("Program.F4").Type, NamedTypeSymbol), hasNames:=True, "(System.Object, B As System.Object, System.Object, D As System.Object, System.Object, F As System.Object, System.Object, H As System.Object)")
+            Dim containingType = comp.GlobalNamespace.GetTypeMembers("Program").Single()
+            VerifyTypeFromVisualBasic(DirectCast(DirectCast(containingType.GetMembers("F0").Single(), FieldSymbol).Type, NamedTypeSymbol), TupleUnderlyingTypeValue.Nothing, "System.ValueTuple", "System.ValueTuple")
+            VerifyTypeFromVisualBasic(DirectCast(DirectCast(containingType.GetMembers("F1").Single(), FieldSymbol).Type, NamedTypeSymbol), TupleUnderlyingTypeValue.Distinct, "(System.Int32, System.Int32)", "(System.Int32, System.Int32)")
+            VerifyTypeFromVisualBasic(DirectCast(DirectCast(containingType.GetMembers("F2").Single(), FieldSymbol).Type, NamedTypeSymbol), TupleUnderlyingTypeValue.Distinct, "(System.Int32 A, System.Int32 B)", "(A As System.Int32, B As System.Int32)")
+            VerifyTypeFromVisualBasic(DirectCast(DirectCast(containingType.GetMembers("F3").Single(), FieldSymbol).Type, NamedTypeSymbol), TupleUnderlyingTypeValue.Distinct, "(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)", "(System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object, System.Object)")
+            VerifyTypeFromVisualBasic(DirectCast(DirectCast(containingType.GetMembers("F4").Single(), FieldSymbol).Type, NamedTypeSymbol), TupleUnderlyingTypeValue.Distinct, "(System.Object, System.Object B, System.Object, System.Object D, System.Object, System.Object F, System.Object, System.Object H)", "(System.Object, B As System.Object, System.Object, D As System.Object, System.Object, F As System.Object, System.Object, H As System.Object)")
         End Sub
 
-        Private Sub VerifyType(type As NamedTypeSymbol, hasNames As Boolean, expected As String)
-            Assert.Equal(expected, type.ToTestDisplayString())
-            VerifyUnderlyingTypes(type, hasNames)
-            VerifyUnderlyingTypes(type.OriginalDefinition, hasNames:=False)
+        Private Enum TupleUnderlyingTypeValue
+            [Nothing]
+            Distinct
+            Same
+        End Enum
+
+        Private Shared Sub VerifyTypeFromCSharp(type As INamedTypeSymbol, expectedValue As TupleUnderlyingTypeValue, expectedCSharp As String, expectedVisualBasic As String)
+            VerifyDisplay(type, expectedCSharp, expectedVisualBasic)
+            VerifyPublicType(type, expectedValue)
+            VerifyPublicType(type.OriginalDefinition, TupleUnderlyingTypeValue.Nothing)
         End Sub
 
-        Private Sub VerifyUnderlyingTypes(type As NamedTypeSymbol, hasNames As Boolean)
-            VerifyInternalType(type, hasNames)
-            VerifyPublicType(type, hasNames)
+        Private Shared Sub VerifyTypeFromVisualBasic(type As NamedTypeSymbol, expectedValue As TupleUnderlyingTypeValue, expectedCSharp As String, expectedVisualBasic As String)
+            VerifyDisplay(type, expectedCSharp, expectedVisualBasic)
+            VerifyInternalType(type, expectedValue)
+            VerifyPublicType(type, expectedValue)
+            type = type.OriginalDefinition
+            VerifyInternalType(type, expectedValue)
+            VerifyPublicType(type, expectedValue)
         End Sub
 
-        Private Sub VerifyInternalType(type As NamedTypeSymbol, hasNames As Boolean)
-            If hasNames Then
-                Assert.True(type.IsTupleType)
-            End If
+        Private Shared Sub VerifyDisplay(type As INamedTypeSymbol, expectedCSharp As String, expectedVisualBasic As String)
+            Assert.Equal(expectedCSharp, CSharp.SymbolDisplay.ToDisplayString(type, SymbolDisplayFormat.TestFormat))
+            Assert.Equal(expectedVisualBasic, VisualBasic.SymbolDisplay.ToDisplayString(type, SymbolDisplayFormat.TestFormat))
+        End Sub
 
+        Private Shared Sub VerifyInternalType(type As NamedTypeSymbol, expectedValue As TupleUnderlyingTypeValue)
             Dim underlyingType = type.TupleUnderlyingType
 
-            If type.IsTupleType Then
-                Assert.NotEqual(type, underlyingType)
-                Assert.False(type.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
-                Assert.False(type.Equals(underlyingType, TypeCompareKind.ConsiderEverything))
-            Else
-                ' NamedTypeSymbol.TupleUnderlyingType should return null if the type is not a tuple type.
-                Assert.Null(underlyingType)
-            End If
+            Select Case expectedValue
+                Case TupleUnderlyingTypeValue.Nothing
+                    Assert.Null(underlyingType)
+
+                Case TupleUnderlyingTypeValue.Distinct
+                    Assert.NotEqual(type, underlyingType)
+                    Assert.False(type.Equals(underlyingType, TypeCompareKind.AllIgnoreOptions))
+                    Assert.False(type.Equals(underlyingType, TypeCompareKind.ConsiderEverything))
+                    VerifyPublicType(underlyingType, expectedValue:=TupleUnderlyingTypeValue.Nothing)
+
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(expectedValue)
+            End Select
         End Sub
 
-        Private Sub VerifyPublicType(type As INamedTypeSymbol, hasNames As Boolean)
-            If hasNames Then
-                Assert.True(type.IsTupleType)
-            End If
-
+        Private Shared Sub VerifyPublicType(type As INamedTypeSymbol, expectedValue As TupleUnderlyingTypeValue)
             Dim underlyingType = type.TupleUnderlyingType
 
-            If type.IsTupleType Then
-                Assert.NotEqual(type, underlyingType)
-                Assert.False(type.Equals(underlyingType, SymbolEqualityComparer.Default))
-                Assert.False(type.Equals(underlyingType, SymbolEqualityComparer.ConsiderEverything))
+            Select Case expectedValue
+                Case TupleUnderlyingTypeValue.Nothing
+                    Assert.Null(underlyingType)
 
-                VerifyPublicType(underlyingType, hasNames:=False)
-            Else
-                ' INamedTypeSymbol.TupleUnderlyingType should return null if the type is not a tuple type.
-                Assert.Null(underlyingType)
-            End If
+                Case TupleUnderlyingTypeValue.Distinct
+                    Assert.NotEqual(type, underlyingType)
+                    Assert.False(type.Equals(underlyingType, SymbolEqualityComparer.Default))
+                    Assert.False(type.Equals(underlyingType, SymbolEqualityComparer.ConsiderEverything))
+                    VerifyPublicType(underlyingType, expectedValue:=TupleUnderlyingTypeValue.Nothing)
+
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(expectedValue)
+            End Select
         End Sub
 
     End Class

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis
                     WriteType(SymbolKeyType.ErrorType);
                     ErrorTypeSymbolKey.Create(namedTypeSymbol, this);
                 }
-                else if (namedTypeSymbol.IsTupleType && namedTypeSymbol.TupleUnderlyingType != namedTypeSymbol)
+                else if (namedTypeSymbol.IsTupleType && namedTypeSymbol.TupleUnderlyingType is INamedTypeSymbol underlyingType && underlyingType != namedTypeSymbol)
                 {
                     // A tuple is a named type with some added information
                     // We only need to store this extra information if there is some


### PR DESCRIPTION
Fixes #41702