### PR TITLE
Revert changes to AnalyzerConfigOptions

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerConfigOptions.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerConfigOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -22,11 +23,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Get an analyzer config value for the given key, using the <see cref="KeyComparer"/>.
         /// </summary>
         public abstract bool TryGetValue(string key, out string value);
-
-        /// <summary>
-        /// Get the keys of the defined options.
-        /// </summary>
-        public abstract IEnumerable<string> Keys { get; }
     }
 
     internal sealed class CompilerAnalyzerConfigOptions : AnalyzerConfigOptions
@@ -41,7 +37,5 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public override bool TryGetValue(string key, out string value) => _backing.TryGetValue(key, out value);
-
-        public override IEnumerable<string> Keys => _backing.Keys;
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -21,7 +21,6 @@ Microsoft.CodeAnalysis.SarifVersion.Latest = 2147483647 -> Microsoft.CodeAnalysi
 Microsoft.CodeAnalysis.SarifVersion.Sarif1 = 1 -> Microsoft.CodeAnalysis.SarifVersion
 Microsoft.CodeAnalysis.SarifVersion.Sarif2 = 2 -> Microsoft.CodeAnalysis.SarifVersion
 Microsoft.CodeAnalysis.SarifVersionFacts
-abstract Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptions.Keys.get -> System.Collections.Generic.IEnumerable<string>
 Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions.IncludeNotNullableReferenceTypeModifier = 256 -> Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions
 static Microsoft.CodeAnalysis.SarifVersionFacts.TryParse(string version, out Microsoft.CodeAnalysis.SarifVersion result) -> bool
 Microsoft.CodeAnalysis.IMethodSymbol.IsConditional.get -> bool

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocationExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Roslyn.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -11,15 +10,17 @@ namespace Microsoft.CodeAnalysis.Options
     {
         public static bool TryGetOption(this IEditorConfigStorageLocation editorConfigStorageLocation, AnalyzerConfigOptions analyzerConfigOptions, Type type, out object value)
         {
-            var optionDictionary = analyzerConfigOptions.Keys.ToImmutableDictionary(
-                key => key,
-                key =>
-                {
-                    analyzerConfigOptions.TryGetValue(key, out var optionValue);
-                    return optionValue;
-                });
+            // This is a workaround until we have an API for enumeratings AnalyzerConfigOptions.
+            var backingField = analyzerConfigOptions.GetType().GetField("_backing", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var backing = backingField?.GetValue(analyzerConfigOptions);
 
-            return editorConfigStorageLocation.TryGetOption(optionDictionary, type, out value);
+            if (backing is IReadOnlyDictionary<string, string> backingDictionary)
+            {
+                return editorConfigStorageLocation.TryGetOption(backingDictionary, type, out value);
+            }
+
+            value = null;
+            return false;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocationExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Options
     {
         public static bool TryGetOption(this IEditorConfigStorageLocation editorConfigStorageLocation, AnalyzerConfigOptions analyzerConfigOptions, Type type, out object value)
         {
-            // This is a workaround until we have an API for enumeratings AnalyzerConfigOptions.
+            // This is a workaround until we have an API for enumeratings AnalyzerConfigOptions. See https://github.com/dotnet/roslyn/issues/41840
             var backingField = analyzerConfigOptions.GetType().GetField("_backing", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var backing = backingField?.GetValue(analyzerConfigOptions);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -319,8 +319,6 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 public override bool TryGetValue(string key, out string value) => _backing.TryGetValue(key, out value);
-
-                public override IEnumerable<string> Keys => _backing.Keys;
             }
         }
 


### PR DESCRIPTION
Revert changes to compiler API (https://github.com/dotnet/roslyn/pull/38675/files#diff-ce534c5b033b26e340c00c86351ebef8) and work around using reflection to access the backing dictionary of option values.