### PR TITLE
Enable analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -208,3 +208,7 @@ csharp_preserve_single_line_statements = true
 
 # warning RS0037: PublicAPI.txt is missing '#nullable enable'
 dotnet_diagnostic.RS0037.severity = none
+
+[src/CodeStyle/**.{cs,vb}]
+# warning RS0005: Do not use generic CodeAction.Create to create CodeAction
+dotnet_diagnostic.RS0005.severity = none

--- a/src/CodeStyle/Directory.Build.targets
+++ b/src/CodeStyle/Directory.Build.targets
@@ -1,7 +1,3 @@
 <Project>
   <Import Project="..\..\Directory.Build.targets"/>
-  <ItemGroup>
-    <!-- The analyzer does not apply to CodeStyle layer -->
-    <PackageReference Remove="Roslyn.Diagnostics.Analyzers"/>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Public APIs in the CodeStyle layer cause problems related to ambiguous references during development. This change enables analyzers for these projects to help ensure quality and maintainability of the layer.