### PR TITLE
Add OptionSet.AsAnalyzerConfigOptions

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet+AnalyzerConfigOptionsImpl.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet+AnalyzerConfigOptionsImpl.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#nullable enable
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal sealed partial class AnalyzerConfigOptionSet
+    {
+        private sealed class AnalyzerConfigOptionsImpl : AnalyzerConfigOptions
+        {
+            private readonly AnalyzerConfigOptions _options;
+            private readonly AnalyzerConfigOptions _fallbackOptions;
+
+            public AnalyzerConfigOptionsImpl(AnalyzerConfigOptions options, AnalyzerConfigOptions fallbackOptions)
+            {
+                _options = options;
+                _fallbackOptions = fallbackOptions;
+            }
+
+            public override bool TryGetValue(string key, out string value)
+            {
+                if (_options.TryGetValue(key, out value))
+                {
+                    return true;
+                }
+
+                return _fallbackOptions.TryGetValue(key, out value);
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// <summary>
     /// This class proxies requests for option values first to the <see cref="AnalyzerConfigOptions" /> then to a backup <see cref="OptionSet" /> if provided.
     /// </summary>
-    internal sealed class AnalyzerConfigOptionSet : OptionSet
+    internal sealed partial class AnalyzerConfigOptionSet : OptionSet
     {
         private readonly AnalyzerConfigOptions _analyzerConfigOptions;
         private readonly OptionSet? _optionSet;
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             throw new NotImplementedException();
         }
 
-        internal override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
+        private protected override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
         {
             if (_optionSet is null)
             {
@@ -52,28 +52,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
         {
             throw new NotImplementedException();
-        }
-
-        private sealed class AnalyzerConfigOptionsImpl : AnalyzerConfigOptions
-        {
-            private readonly AnalyzerConfigOptions _options;
-            private readonly AnalyzerConfigOptions _fallbackOptions;
-
-            public AnalyzerConfigOptionsImpl(AnalyzerConfigOptions options, AnalyzerConfigOptions fallbackOptions)
-            {
-                _options = options;
-                _fallbackOptions = fallbackOptions;
-            }
-
-            public override bool TryGetValue(string key, out string value)
-            {
-                if (_options.TryGetValue(key, out value))
-                {
-                    return true;
-                }
-
-                return _fallbackOptions.TryGetValue(key, out value);
-            }
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerConfigOptionSet.cs
@@ -39,9 +39,41 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             throw new NotImplementedException();
         }
 
+        internal override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
+        {
+            if (_optionSet is null)
+            {
+                return _analyzerConfigOptions;
+            }
+
+            return new AnalyzerConfigOptionsImpl(_analyzerConfigOptions, _optionSet.AsAnalyzerConfigOptions(optionService, language));
+        }
+
         internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
         {
             throw new NotImplementedException();
+        }
+
+        private sealed class AnalyzerConfigOptionsImpl : AnalyzerConfigOptions
+        {
+            private readonly AnalyzerConfigOptions _options;
+            private readonly AnalyzerConfigOptions _fallbackOptions;
+
+            public AnalyzerConfigOptionsImpl(AnalyzerConfigOptions options, AnalyzerConfigOptions fallbackOptions)
+            {
+                _options = options;
+                _fallbackOptions = fallbackOptions;
+            }
+
+            public override bool TryGetValue(string key, out string value)
+            {
+                if (_options.TryGetValue(key, out value))
+                {
+                    return true;
+                }
+
+                return _fallbackOptions.TryGetValue(key, out value);
+            }
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/PersistentStorage/OptionServiceMock.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/OptionServiceMock.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
@@ -51,6 +52,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
         }
 
         public IEnumerable<IOption> GetRegisteredOptions()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryMapEditorConfigKeyToOption(string key, string language, [NotNullWhen(true)] out IEditorConfigStorageLocation2 storageLocation, out OptionKey optionKey)
         {
             throw new NotImplementedException();
         }

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             var formattedText = addedDocument.GetTextSynchronously(cancellationToken).WithChanges(formattedTextChanges);
 
             // Ensure the line endings are normalized. The formatter doesn't touch everything if it doesn't need to.
-            var targetLineEnding = documentOptions.GetOption(FormattingOptions.NewLine);
+            var targetLineEnding = documentOptions.GetOption(FormattingOptions.NewLine)!;
 
             var originalText = formattedText;
             foreach (var originalLine in originalText.Lines)

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -22,17 +26,19 @@ namespace Microsoft.CodeAnalysis.Options
             _language = language;
         }
 
+        [return: MaybeNull]
         public override object GetOption(OptionKey optionKey)
         {
             return _backingOptionSet.GetOption(optionKey);
         }
 
+        [return: MaybeNull]
         public T GetOption<T>(PerLanguageOption<T> option)
         {
             return _backingOptionSet.GetOption(option, _language);
         }
 
-        public override OptionSet WithChangedOption(OptionKey optionAndLanguage, object value)
+        public override OptionSet WithChangedOption(OptionKey optionAndLanguage, object? value)
         {
             return new DocumentOptionSet(_backingOptionSet.WithChangedOption(optionAndLanguage, value), _language);
         }
@@ -44,6 +50,9 @@ namespace Microsoft.CodeAnalysis.Options
         {
             return (DocumentOptionSet)WithChangedOption(option, _language, value);
         }
+
+        internal override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
+            => _backingOptionSet.AsAnalyzerConfigOptions(optionService, language ?? _language);
 
         internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
         {

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Options
             return (DocumentOptionSet)WithChangedOption(option, _language, value);
         }
 
-        internal override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
+        private protected override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
             => _backingOptionSet.AsAnalyzerConfigOptions(optionService, language ?? _language);
 
         internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -52,7 +53,10 @@ namespace Microsoft.CodeAnalysis.Options
         }
 
         private protected override AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
-            => _backingOptionSet.AsAnalyzerConfigOptions(optionService, language ?? _language);
+        {
+            Debug.Assert((language ?? _language) == _language, $"Use of a {nameof(DocumentOptionSet)} is not expected to differ from the language it was constructed with.");
+            return _backingOptionSet.AsAnalyzerConfigOptions(optionService, language ?? _language);
+        }
 
         internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
         {

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigStorageLocation2.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigStorageLocation2.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Options
 {
     internal interface IEditorConfigStorageLocation2 : IEditorConfigStorageLocation
     {
+        string KeyName { get; }
+
         /// <summary>
         /// Gets the editorconfig string representation for this storage location.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
@@ -53,6 +53,8 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         IEnumerable<IOption> GetRegisteredOptions();
 
+        bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey);
+
         /// <summary>
         /// Returns the set of all registered serializable options applicable for the given <paramref name="languages"/>.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
@@ -53,6 +53,16 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         IEnumerable<IOption> GetRegisteredOptions();
 
+        /// <summary>
+        /// Map an <strong>.editorconfig</strong> key to a corresponding <see cref="IEditorConfigStorageLocation2"/> and
+        /// <see cref="OptionKey"/> that can be used to read and write the value stored in an <see cref="OptionSet"/>.
+        /// </summary>
+        /// <param name="key">The <strong>.editorconfig</strong> key.</param>
+        /// <param name="language">The language to use for the <paramref name="optionKey"/>, if the matching option has
+        /// <see cref="IOption.IsPerLanguage"/> set.</param>
+        /// <param name="storageLocation">The <see cref="IEditorConfigStorageLocation2"/> for the key.</param>
+        /// <param name="optionKey">The <see cref="OptionKey"/> for the key and language.</param>
+        /// <returns><see langword="true"/> if a matching option was found; otherwise, <see langword="false"/>.</returns>
         bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey);
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Options/IOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IOptionService.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         IEnumerable<IOption> GetRegisteredOptions();
 
+        bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey);
+
         /// <summary>
         /// Returns the set of all registered serializable options applicable for the given <paramref name="languages"/>.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Options/IOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IOptionService.cs
@@ -61,6 +61,7 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         IEnumerable<IOption> GetRegisteredOptions();
 
+        /// <inheritdoc cref="IGlobalOptionService.TryMapEditorConfigKeyToOption"/>
         bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey);
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.Options
             [return: MaybeNull] public T GetOption<T>(Option<T> option) => _globalOptionService.GetOption(option);
             [return: MaybeNull] public T GetOption<T>(PerLanguageOption<T> option, string? languageName) => _globalOptionService.GetOption(option, languageName);
             public IEnumerable<IOption> GetRegisteredOptions() => _globalOptionService.GetRegisteredOptions();
+            public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey) => _globalOptionService.TryMapEditorConfigKeyToOption(key, language, out storageLocation, out optionKey);
             public ImmutableHashSet<IOption> GetRegisteredSerializableOptions(ImmutableHashSet<string> languages) => _globalOptionService.GetRegisteredSerializableOptions(languages);
             public void SetOptions(OptionSet optionSet) => _globalOptionService.SetOptions(optionSet);
             public void RegisterWorkspace(Workspace workspace) => _globalOptionService.RegisterWorkspace(workspace);

--- a/src/Workspaces/Core/Portable/Options/OptionSet+AnalyzerConfigOptionsImpl.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet+AnalyzerConfigOptionsImpl.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Options
+{
+    public abstract partial class OptionSet
+    {
+        private sealed class AnalyzerConfigOptionsImpl : AnalyzerConfigOptions
+        {
+            private readonly OptionSet _optionSet;
+            private readonly IOptionService _optionService;
+            private readonly string? _language;
+
+            public AnalyzerConfigOptionsImpl(OptionSet optionSet, IOptionService optionService, string? language)
+            {
+                _optionSet = optionSet;
+                _optionService = optionService;
+                _language = language;
+            }
+
+            public override bool TryGetValue(string key, out string? value)
+            {
+                if (!_optionService.TryMapEditorConfigKeyToOption(key, _language, out var storageLocation, out var optionKey))
+                {
+                    value = null;
+                    return false;
+                }
+
+                var typedValue = _optionSet.GetOption(optionKey);
+                value = storageLocation.GetEditorConfigString(typedValue, _optionSet);
+                return true;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -4,13 +4,25 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Options
 {
     public abstract class OptionSet
     {
+        private const string NoLanguageSentinel = "\0";
+        private static readonly ImmutableDictionary<string, AnalyzerConfigOptions> s_emptyAnalyzerConfigOptions =
+            ImmutableDictionary.Create<string, AnalyzerConfigOptions>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Map from language name to the <see cref="AnalyzerConfigOptions"/> wrapper.
+        /// </summary>
+        private ImmutableDictionary<string, AnalyzerConfigOptions> _lazyAnalyzerConfigOptions = s_emptyAnalyzerConfigOptions;
+
         /// <summary>
         /// Gets the value of the option.
         /// </summary>
@@ -55,6 +67,47 @@ namespace Microsoft.CodeAnalysis.Options
             return WithChangedOption(new OptionKey(option, language), value);
         }
 
+        internal AnalyzerConfigOptions AsAnalyzerConfigOptions(IOptionService optionService, string? language)
+        {
+            return ImmutableInterlocked.GetOrAdd(
+                ref _lazyAnalyzerConfigOptions,
+                language ?? NoLanguageSentinel,
+                (string language, (OptionSet self, IOptionService optionService) arg) => arg.self.CreateAnalyzerConfigOptions(arg.optionService, (object)language == NoLanguageSentinel ? null : language),
+                (this, optionService));
+        }
+
         internal abstract IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet);
+
+        internal virtual AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
+        {
+            return new AnalyzerConfigOptionsImpl(this, optionService, language);
+        }
+
+        private sealed class AnalyzerConfigOptionsImpl : AnalyzerConfigOptions
+        {
+            private readonly OptionSet _optionSet;
+            private readonly IOptionService _optionService;
+            private readonly string? _language;
+
+            public AnalyzerConfigOptionsImpl(OptionSet optionSet, IOptionService optionService, string? language)
+            {
+                _optionSet = optionSet;
+                _optionService = optionService;
+                _language = language;
+            }
+
+            public override bool TryGetValue(string key, out string? value)
+            {
+                if (!_optionService.TryMapEditorConfigKeyToOption(key, _language, out var storageLocation, out var optionKey))
+                {
+                    value = null;
+                    return false;
+                }
+
+                var typedValue = _optionSet.GetOption(optionKey);
+                value = storageLocation.GetEditorConfigString(typedValue, _optionSet);
+                return true;
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Options
 {
-    public abstract class OptionSet
+    public abstract partial class OptionSet
     {
         private const string NoLanguageSentinel = "\0";
         private static readonly ImmutableDictionary<string, AnalyzerConfigOptions> s_emptyAnalyzerConfigOptions =
@@ -78,36 +78,9 @@ namespace Microsoft.CodeAnalysis.Options
 
         internal abstract IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet);
 
-        internal virtual AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
+        private protected virtual AnalyzerConfigOptions CreateAnalyzerConfigOptions(IOptionService optionService, string? language)
         {
             return new AnalyzerConfigOptionsImpl(this, optionService, language);
-        }
-
-        private sealed class AnalyzerConfigOptionsImpl : AnalyzerConfigOptions
-        {
-            private readonly OptionSet _optionSet;
-            private readonly IOptionService _optionService;
-            private readonly string? _language;
-
-            public AnalyzerConfigOptionsImpl(OptionSet optionSet, IOptionService optionService, string? language)
-            {
-                _optionSet = optionSet;
-                _optionService = optionService;
-                _language = language;
-            }
-
-            public override bool TryGetValue(string key, out string? value)
-            {
-                if (!_optionService.TryMapEditorConfigKeyToOption(key, _language, out var storageLocation, out var optionKey))
-                {
-                    value = null;
-                    return false;
-                }
-
-                var typedValue = _optionSet.GetOption(optionKey);
-                value = storageLocation.GetEditorConfigString(typedValue, _optionSet);
-                return true;
-            }
         }
     }
 }


### PR DESCRIPTION
This helper allows the workspace layer to call into the code style layer with fewer dependency problems.