### PR TITLE
Null-check conversion group nested in identity conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5722,8 +5722,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // and that any warnings caught by this recursive call of VisitConversion won't be redundant.
                     if (useLegacyWarnings && conversionOperand is BoundConversion operandConversion && !operandConversion.ConversionKind.IsUserDefinedConversion())
                     {
-                        var explicitType = operandConversion.ConversionGroupOpt.ExplicitType;
-                        if (explicitType.Equals(targetTypeWithNullability, TypeCompareKind.ConsiderEverything))
+                        var explicitType = operandConversion.ConversionGroupOpt?.ExplicitType;
+                        if (explicitType?.Equals(targetTypeWithNullability, TypeCompareKind.ConsiderEverything) == true)
                         {
                             TrackAnalyzedNullabilityThroughConversionGroup(
                                 calculateResultType(targetTypeWithNullability, fromExplicitCast, operandType.State, isSuppressed, targetType),


### PR DESCRIPTION
Closes #41763

The root cause of this ConversionGroupOpt being null is here:

https://github.com/dotnet/roslyn/blob/91571a3bb038e05e7bf2ab87510273a1017faed0/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs#L6680

It seems the language specifies that an enum member will be treated as a value of its underlying type in the context of an enum member initializer. So by design we produce this conversion that has a null conversion group.

We don't normally analyze these enum initializers in NullableWalker because we don't expect such constant-valued initializers to yield any nullability warnings. But it's possible to do it by passing the initializer value into GetSymbolInfo.

There may be other similar crashes that we haven't discovered yet. So it feels like we might as well solve this by null checking the conversion group.