### PR TITLE
Fix definite assignment analysis of local function out parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1301,7 +1301,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         protected virtual void VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
         {
-            Debug.Assert(!(method.OriginalDefinition is LocalFunctionSymbol));
+            Debug.Assert(method?.OriginalDefinition.MethodKind != MethodKind.LocalFunction);
             VisitArgumentsBeforeCall(arguments, refKindsOpt);
             VisitArgumentsAfterCall(arguments, refKindsOpt, method);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1303,22 +1303,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitArgumentsAfterCall(arguments, refKindsOpt, method);
         }
 
-        /// <summary>
-        /// Writes ref and out parameters
-        /// </summary>
-        private void VisitArgumentsAfterCall(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
-        {
-            for (int i = 0; i < arguments.Length; i++)
-            {
-                RefKind refKind = GetRefKind(refKindsOpt, i);
-                // passing as a byref argument is also a potential write
-                if (refKind != RefKind.None)
-                {
-                    WriteArgument(arguments[i], refKind, method);
-                }
-            }
-        }
-
         private void VisitArgumentsBeforeCall(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt)
         {
             // first value and ref parameters are read...
@@ -1332,6 +1316,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     VisitLvalue(arguments[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes ref and out parameters
+        /// </summary>
+        private void VisitArgumentsAfterCall(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
+        {
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                RefKind refKind = GetRefKind(refKindsOpt, i);
+                // passing as a byref argument is also a potential write
+                if (refKind != RefKind.None)
+                {
+                    WriteArgument(arguments[i], refKind, method);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -1296,8 +1296,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        /// <summary>
+        /// Do not call for a local function.
+        /// </summary>
         protected virtual void VisitArguments(ImmutableArray<BoundExpression> arguments, ImmutableArray<RefKind> refKindsOpt, MethodSymbol method)
         {
+            Debug.Assert(!(method.OriginalDefinition is LocalFunctionSymbol));
             VisitArgumentsBeforeCall(arguments, refKindsOpt);
             VisitArgumentsAfterCall(arguments, refKindsOpt, method);
         }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1594,5 +1594,25 @@ public class C
     }
 }").VerifyDiagnostics();
         }
+
+        [Fact]
+        public void UseOfCapturedVariableAssignedInArgument()
+        {
+            CreateCompilation(@"
+public class C
+{
+    void M()
+    {
+        string s0;
+        local1(s0 = ""hello"", out s0);
+    
+        void local1(string s1, out string s2)
+        {
+               s0.ToString();
+               s2 = ""bye"";
+        }
+    }
+}").VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1550,5 +1550,49 @@ class c
                 //         System.Collections.Generic.IEnumerable<string> getGoo(int count, out bool goobar)
                 Diagnostic(ErrorCode.ERR_ParamUnassigned, "getGoo").WithArguments("output").WithLocation(6, 56));
         }
+
+        [Fact]
+        [WorkItem(41631, "https://github.com/dotnet/roslyn/issues/41631")]
+        public void UseOfCapturedVariableAssignedByOutParameter()
+        {
+            CreateCompilation(@"
+public class C
+{
+    void M()
+    {
+        string s0;
+        local1(out s0);
+    
+        void local1(out string s1)
+        {
+            s0.ToString(); // should produce an error, but doesn't
+            s1 = ""hello"";
+        }
+    }
+}").VerifyDiagnostics(
+                    // (7,9): error CS0165: Use of unassigned local variable 's0'
+                    //         local1(out s0);
+                    Diagnostic(ErrorCode.ERR_UseDefViolation, "local1(out s0)").WithArguments("s0").WithLocation(7, 9));
+        }
+
+        [Fact]
+        public void OutParameterIsAssignedByLocalFunction()
+        {
+            CreateCompilation(@"
+public class C
+{
+    void M()
+    {
+        string s0;
+        local1(out s0);
+        s0.ToString();
+    
+        void local1(out string s1)
+        {
+            s1 = ""hello"";
+        }
+    }
+}").VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1561,11 +1561,11 @@ public class C
     void M()
     {
         string s0;
-        local1(out s0);
+        local1(out s0); // 1
     
         void local1(out string s1)
         {
-            s0.ToString(); // should produce an error, but doesn't
+            s0.ToString();
             s1 = ""hello"";
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/41631

cc @RikkiGibson 

I did not address https://github.com/dotnet/roslyn/pull/41597#issuecomment-585488435 since I don't believe the issue is reproducible until https://github.com/dotnet/roslyn/issues/41898 is fixed.