### PR TITLE
Clean up project, document and solution infos

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Roslyn.Utilities
 {
@@ -13,6 +14,12 @@ namespace Roslyn.Utilities
     {
         private partial class Empty
         {
+            internal static class ImmutableArrayList<T>
+            {
+                // empty boxed immutable array
+                public static readonly IReadOnlyList<T> Instance = ImmutableArray<T>.Empty;
+            }
+
             internal class List<T> : Collection<T>, IList<T>, IReadOnlyList<T>
             {
                 public static readonly new List<T> Instance = new List<T>();

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.List.cs
@@ -14,7 +14,7 @@ namespace Roslyn.Utilities
     {
         private partial class Empty
         {
-            internal static class ImmutableArrayList<T>
+            internal static class BoxedImmutableArray<T>
             {
                 // empty boxed immutable array
                 public static readonly IReadOnlyList<T> Instance = ImmutableArray<T>.Empty;

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
@@ -30,6 +30,11 @@ namespace Roslyn.Utilities
             return Empty.List<T>.Instance;
         }
 
+        public static IReadOnlyList<T> EmptyImmutableArrayList<T>()
+        {
+            return Empty.ImmutableArrayList<T>.Instance;
+        }
+
         public static IReadOnlyList<T> EmptyReadOnlyList<T>()
         {
             return Empty.List<T>.Instance;

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
@@ -30,9 +30,9 @@ namespace Roslyn.Utilities
             return Empty.List<T>.Instance;
         }
 
-        public static IReadOnlyList<T> EmptyImmutableArrayList<T>()
+        public static IReadOnlyList<T> EmptyBoxedImmutableArray<T>()
         {
-            return Empty.ImmutableArrayList<T>.Instance;
+            return Empty.BoxedImmutableArray<T>.Instance;
         }
 
         public static IReadOnlyList<T> EmptyReadOnlyList<T>()

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestHostProject.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestHostProject.cs
@@ -344,28 +344,24 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public ProjectInfo ToProjectInfo()
         {
             return ProjectInfo.Create(
-                this.Id,
-                this.Version,
-                this.Name,
-                this.AssemblyName,
-                this.Language,
-                this.FilePath,
-                this.OutputFilePath,
-                outputRefFilePath: null,
-                defaultNamespace: null,
-                this.CompilationOptions,
-                this.ParseOptions,
-                this.Documents.Select(d => d.ToDocumentInfo()),
-                this.ProjectReferences,
-                this.MetadataReferences,
-                this.AnalyzerReferences,
-                this.AdditionalDocuments.Select(d => d.ToDocumentInfo()),
-                this.AnalyzerConfigDocuments.Select(d => d.ToDocumentInfo()),
-                this.IsSubmission,
-                this.HostObjectType,
-                hasAllInformation: true,
-                runAnalyzers: true)
-                .WithDefaultNamespace(this.DefaultNamespace);
+                Id,
+                Version,
+                Name,
+                AssemblyName,
+                Language,
+                FilePath,
+                OutputFilePath,
+                CompilationOptions,
+                ParseOptions,
+                Documents.Select(d => d.ToDocumentInfo()),
+                ProjectReferences,
+                MetadataReferences,
+                AnalyzerReferences,
+                AdditionalDocuments.Select(d => d.ToDocumentInfo()),
+                IsSubmission,
+                HostObjectType)
+                .WithAnalyzerConfigDocuments(AnalyzerConfigDocuments.Select(d => d.ToDocumentInfo()))
+                .WithDefaultNamespace(DefaultNamespace);
         }
 
         // It is identical with the internal extension method 'GetDefaultExtension' defined in OutputKind.cs.

--- a/src/Test/Utilities/Portable/Mocks/TestAnalyzerReference.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestAnalyzerReference.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Immutable;
 using System.IO;

--- a/src/Test/Utilities/Portable/Mocks/TestAnalyzerReference.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestAnalyzerReference.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Roslyn.Test.Utilities
+{
+    internal class TestAnalyzerReference : AnalyzerReference
+    {
+        public override string FullPath => throw new NotImplementedException();
+        public override object Id => throw new NotImplementedException();
+        public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => throw new NotImplementedException();
+        public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => throw new NotImplementedException();
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProject.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 var documentInfo = DocumentInfo.Create(
                     documentId,
                     FileNameUtilities.GetFileName(fullPath),
-                    folders: folders.IsDefault ? null : (IEnumerable<string>)folders,
+                    folders: folders.NullToEmpty(),
                     sourceCodeKind: sourceCodeKind,
                     loader: textLoader,
                     filePath: fullPath,
@@ -1590,8 +1590,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            private DocumentInfo CreateDocumentInfoFromFileInfo(DynamicFileInfo fileInfo, IEnumerable<string> folders)
+            private DocumentInfo CreateDocumentInfoFromFileInfo(DynamicFileInfo fileInfo, ImmutableArray<string> folders)
             {
+                Contract.ThrowIfTrue(folders.IsDefault);
+
                 // we use this file path for editorconfig. 
                 var filePath = fileInfo.FilePath;
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3842,15 +3842,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode ValueReturningLambdaExpression(IEnumerable<SyntaxNode> parameterDeclarations, SyntaxNode expression)
         {
-            var prms = parameterDeclarations?.Cast<ParameterSyntax>().ToList();
+            var parameters = parameterDeclarations?.Cast<ParameterSyntax>().ToList();
 
-            if (prms.Count == 1 && IsSimpleLambdaParameter(prms[0]))
+            if (parameters != null && parameters.Count == 1 && IsSimpleLambdaParameter(parameters[0]))
             {
-                return SyntaxFactory.SimpleLambdaExpression(prms[0], (CSharpSyntaxNode)expression);
+                return SyntaxFactory.SimpleLambdaExpression(parameters[0], (CSharpSyntaxNode)expression);
             }
             else
             {
-                return SyntaxFactory.ParenthesizedLambdaExpression(AsParameterList(prms), (CSharpSyntaxNode)expression);
+                return SyntaxFactory.ParenthesizedLambdaExpression(AsParameterList(parameters), (CSharpSyntaxNode)expression);
             }
         }
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -21,21 +21,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
         private readonly CSharpCompilation _emptyCompilation = CSharpCompilation.Create("empty",
                 references: new[] { TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System });
 
-        private readonly INamedTypeSymbol _ienumerableInt;
-
-        private Workspace _ws;
-        private SyntaxGenerator _g;
+        private Workspace _workspace;
+        private SyntaxGenerator _generator;
 
         public SyntaxGeneratorTests()
         {
-            _ienumerableInt = _emptyCompilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T).Construct(_emptyCompilation.GetSpecialType(SpecialType.System_Int32));
         }
 
         private Workspace Workspace
-            => _ws ?? (_ws = new AdhocWorkspace());
+            => _workspace ??= new AdhocWorkspace();
 
         private SyntaxGenerator Generator
-            => _g ?? (_g = SyntaxGenerator.GetGenerator(Workspace, LanguageNames.CSharp));
+            => _generator ??= SyntaxGenerator.GetGenerator(Workspace, LanguageNames.CSharp);
 
         public Compilation Compile(string code)
         {
@@ -3404,7 +3401,7 @@ public class C : IDisposable
             var newDecl = Generator.AddInterfaceType(decl, Generator.IdentifierName("IDisposable"));
             var newRoot = root.ReplaceNode(decl, newDecl);
 
-            var elasticOnlyFormatted = Formatter.Format(newRoot, SyntaxAnnotation.ElasticAnnotation, _ws).ToFullString();
+            var elasticOnlyFormatted = Formatter.Format(newRoot, SyntaxAnnotation.ElasticAnnotation, _workspace).ToFullString();
             Assert.Equal(expected, elasticOnlyFormatted);
         }
 

--- a/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editing
         public async Task<IReadOnlyList<SyntaxNode>> GetCurrentDeclarationsAsync(ISymbol symbol, CancellationToken cancellationToken = default)
         {
             var currentSymbol = await this.GetCurrentSymbolAsync(symbol, cancellationToken).ConfigureAwait(false);
-            return this.GetDeclarations(currentSymbol).ToImmutableReadOnlyListOrEmpty();
+            return this.GetDeclarations(currentSymbol).ToBoxedImmutableArray();
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -836,7 +836,7 @@ namespace Microsoft.CodeAnalysis.Editing
         {
             var args = attribute.ConstructorArguments.Select(a => this.AttributeArgument(this.TypedConstantExpression(a)))
                     .Concat(attribute.NamedArguments.Select(n => this.AttributeArgument(n.Key, this.TypedConstantExpression(n.Value))))
-                    .ToImmutableReadOnlyListOrEmpty();
+                    .ToBoxedImmutableArray();
 
             return Attribute(
                 name: this.TypeExpression(attribute.AttributeClass),

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis
             return Create(
                 id ?? throw new ArgumentNullException(nameof(id)),
                 name ?? throw new ArgumentNullException(nameof(name)),
-                folders.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(folders)),
+                folders.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(folders)),
                 sourceCodeKind,
                 loader,
                 filePath,
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis
             => With(attributes: Attributes.With(name: name ?? throw new ArgumentNullException(nameof(name))));
 
         public DocumentInfo WithFolders(IEnumerable<string>? folders)
-            => With(attributes: Attributes.With(folders: folders.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(folders))));
+            => With(attributes: Attributes.With(folders: folders.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(folders))));
 
         public DocumentInfo WithSourceCodeKind(SourceCodeKind kind)
             => With(attributes: Attributes.With(sourceCodeKind: kind));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Host;
@@ -82,13 +83,21 @@ namespace Microsoft.CodeAnalysis
             string? filePath = null,
             bool isGenerated = false)
         {
-            return Create(id, name, folders, sourceCodeKind, loader, filePath, isGenerated, documentServiceProvider: null);
+            return Create(
+                id ?? throw new ArgumentNullException(nameof(id)),
+                name ?? throw new ArgumentNullException(nameof(name)),
+                folders.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(folders)),
+                sourceCodeKind,
+                loader,
+                filePath,
+                isGenerated,
+                documentServiceProvider: null);
         }
 
         internal static DocumentInfo Create(
             DocumentId id,
             string name,
-            IEnumerable<string>? folders,
+            IReadOnlyList<string> folders,
             SourceCodeKind sourceCodeKind,
             TextLoader? loader,
             string? filePath,
@@ -118,46 +127,34 @@ namespace Microsoft.CodeAnalysis
         }
 
         public DocumentInfo WithId(DocumentId id)
-        {
-            return With(attributes: Attributes.With(id: id));
-        }
+            => With(attributes: Attributes.With(id: id ?? throw new ArgumentNullException(nameof(id))));
 
         public DocumentInfo WithName(string name)
-        {
-            return this.With(attributes: Attributes.With(name: name));
-        }
+            => With(attributes: Attributes.With(name: name ?? throw new ArgumentNullException(nameof(name))));
 
         public DocumentInfo WithFolders(IEnumerable<string>? folders)
-        {
-            return this.With(attributes: Attributes.With(folders: folders.ToImmutableReadOnlyListOrEmpty()));
-        }
+            => With(attributes: Attributes.With(folders: folders.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(folders))));
 
         public DocumentInfo WithSourceCodeKind(SourceCodeKind kind)
-        {
-            return this.With(attributes: Attributes.With(sourceCodeKind: kind));
-        }
-
-        public DocumentInfo WithTextLoader(TextLoader? loader)
-        {
-            return With(loader: loader);
-        }
+            => With(attributes: Attributes.With(sourceCodeKind: kind));
 
         public DocumentInfo WithFilePath(string? filePath)
-        {
-            return this.With(attributes: Attributes.With(filePath: filePath));
-        }
+            => With(attributes: Attributes.With(filePath: filePath));
+
+        public DocumentInfo WithTextLoader(TextLoader? loader)
+            => With(loader: loader);
 
         private string GetDebuggerDisplay()
-        {
-            return (FilePath == null) ? (nameof(Name) + " = " + Name) : (nameof(FilePath) + " = " + FilePath);
-        }
+            => (FilePath == null) ? (nameof(Name) + " = " + Name) : (nameof(FilePath) + " = " + FilePath);
 
         /// <summary>
         /// type that contains information regarding this document itself but
         /// no tree information such as document info
         /// </summary>
-        internal class DocumentAttributes : IChecksummedObject, IObjectWritable
+        internal sealed class DocumentAttributes : IChecksummedObject, IObjectWritable
         {
+            private Checksum? _lazyChecksum;
+
             /// <summary>
             /// The Id of the document.
             /// </summary>
@@ -191,14 +188,14 @@ namespace Microsoft.CodeAnalysis
             public DocumentAttributes(
                 DocumentId id,
                 string name,
-                IEnumerable<string>? folders,
+                IReadOnlyList<string> folders,
                 SourceCodeKind sourceCodeKind,
                 string? filePath,
                 bool isGenerated)
             {
-                Id = id ?? throw new ArgumentNullException(nameof(id));
-                Name = name ?? throw new ArgumentNullException(nameof(name));
-                Folders = folders.ToImmutableReadOnlyListOrEmpty();
+                Id = id;
+                Name = name;
+                Folders = folders;
                 SourceCodeKind = sourceCodeKind;
                 FilePath = filePath;
                 IsGenerated = isGenerated;
@@ -207,14 +204,14 @@ namespace Microsoft.CodeAnalysis
             public DocumentAttributes With(
                 DocumentId? id = null,
                 string? name = null,
-                IEnumerable<string>? folders = null,
+                IReadOnlyList<string>? folders = null,
                 Optional<SourceCodeKind> sourceCodeKind = default,
                 Optional<string?> filePath = default,
                 Optional<bool> isGenerated = default)
             {
                 var newId = id ?? Id;
                 var newName = name ?? Name;
-                var newFolders = folders?.ToImmutableReadOnlyListOrEmpty() ?? Folders;
+                var newFolders = folders ?? Folders;
                 var newSourceCodeKind = sourceCodeKind.HasValue ? sourceCodeKind.Value : SourceCodeKind;
                 var newFilePath = filePath.HasValue ? filePath.Value : FilePath;
                 var newIsGenerated = isGenerated.HasValue ? isGenerated.Value : IsGenerated;
@@ -258,19 +255,8 @@ namespace Microsoft.CodeAnalysis
                 return new DocumentAttributes(documentId, name, folders, (SourceCodeKind)sourceCodeKind, filePath, isGenerated);
             }
 
-            private Checksum? _lazyChecksum;
             Checksum IChecksummedObject.Checksum
-            {
-                get
-                {
-                    if (_lazyChecksum == null)
-                    {
-                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKind.DocumentAttributes, this);
-                    }
-
-                    return _lazyChecksum;
-                }
-            }
+                => _lazyChecksum ??= Checksum.Create(WellKnownSynchronizationKind.DocumentAttributes, this);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis
                 _treeSource);
         }
 
-        public DocumentState UpdateFolders(IList<string> folders)
+        public DocumentState UpdateFolders(ImmutableArray<string> folders)
         {
             return new DocumentState(
                 _languageServices,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -303,26 +303,17 @@ namespace Microsoft.CodeAnalysis
             return list;
         }
 
-        public ProjectInfo WithDocuments(IEnumerable<DocumentInfo>? documents)
-            => With(documents: ToImmutableReadOnlyListWithNonNullItems(documents));
-
-        public ProjectInfo WithAdditionalDocuments(IEnumerable<DocumentInfo>? additionalDocuments)
-            => With(additionalDocuments: ToImmutableReadOnlyListWithNonNullItems(additionalDocuments));
-
-        public ProjectInfo WithAnalyzerConfigDocuments(IEnumerable<DocumentInfo>? analyzerConfigDocuments)
-            => With(analyzerConfigDocuments: ToImmutableReadOnlyListWithNonNullItems(analyzerConfigDocuments));
-
         public ProjectInfo WithVersion(VersionStamp version)
             => With(attributes: Attributes.With(version: version));
 
         public ProjectInfo WithName(string name)
             => With(attributes: Attributes.With(name: name ?? throw new ArgumentNullException(nameof(name))));
 
-        public ProjectInfo WithFilePath(string? filePath)
-            => With(attributes: Attributes.With(filePath: filePath));
-
         public ProjectInfo WithAssemblyName(string assemblyName)
             => With(attributes: Attributes.With(assemblyName: assemblyName ?? throw new ArgumentNullException(nameof(assemblyName))));
+
+        public ProjectInfo WithFilePath(string? filePath)
+            => With(attributes: Attributes.With(filePath: filePath));
 
         public ProjectInfo WithOutputFilePath(string? outputFilePath)
             => With(attributes: Attributes.With(outputPath: outputFilePath));
@@ -333,11 +324,26 @@ namespace Microsoft.CodeAnalysis
         public ProjectInfo WithDefaultNamespace(string? defaultNamespace)
             => With(attributes: Attributes.With(defaultNamespace: defaultNamespace));
 
+        internal ProjectInfo WithHasAllInformation(bool hasAllInformation)
+            => With(attributes: Attributes.With(hasAllInformation: hasAllInformation));
+
+        internal ProjectInfo WithRunAnalyzers(bool runAnalyzers)
+            => With(attributes: Attributes.With(runAnalyzers: runAnalyzers));
+
         public ProjectInfo WithCompilationOptions(CompilationOptions? compilationOptions)
             => With(compilationOptions: compilationOptions);
 
         public ProjectInfo WithParseOptions(ParseOptions? parseOptions)
             => With(parseOptions: parseOptions);
+
+        public ProjectInfo WithDocuments(IEnumerable<DocumentInfo>? documents)
+            => With(documents: ToImmutableReadOnlyListWithNonNullItems(documents));
+
+        public ProjectInfo WithAdditionalDocuments(IEnumerable<DocumentInfo>? additionalDocuments)
+            => With(additionalDocuments: ToImmutableReadOnlyListWithNonNullItems(additionalDocuments));
+
+        public ProjectInfo WithAnalyzerConfigDocuments(IEnumerable<DocumentInfo>? analyzerConfigDocuments)
+            => With(analyzerConfigDocuments: ToImmutableReadOnlyListWithNonNullItems(analyzerConfigDocuments));
 
         public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference>? projectReferences)
             => With(projectReferences: ToImmutableReadOnlyListWithNonNullItems(projectReferences));
@@ -347,12 +353,6 @@ namespace Microsoft.CodeAnalysis
 
         public ProjectInfo WithAnalyzerReferences(IEnumerable<AnalyzerReference>? analyzerReferences)
             => With(analyzerReferences: ToImmutableReadOnlyListWithNonNullItems(analyzerReferences));
-
-        internal ProjectInfo WithHasAllInformation(bool hasAllInformation)
-            => With(attributes: Attributes.With(hasAllInformation: hasAllInformation));
-
-        internal ProjectInfo WithRunAnalyzers(bool runAnalyzers)
-            => With(attributes: Attributes.With(runAnalyzers: runAnalyzers));
 
         internal string GetDebuggerDisplay()
             => nameof(ProjectInfo) + " " + Name + (!string.IsNullOrWhiteSpace(FilePath) ? " " + FilePath : "");

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -229,12 +229,12 @@ namespace Microsoft.CodeAnalysis
                     runAnalyzers: true),
                 compilationOptions,
                 parseOptions,
-                documents.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(documents)),
-                projectReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(projectReferences)),
-                metadataReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(metadataReferences)),
-                analyzerReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerReferences)),
-                additionalDocuments.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(additionalDocuments)),
-                analyzerConfigDocuments: SpecializedCollections.EmptyImmutableArrayList<DocumentInfo>(),
+                documents.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(documents)),
+                projectReferences.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(projectReferences)),
+                metadataReferences.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(metadataReferences)),
+                analyzerReferences.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerReferences)),
+                additionalDocuments.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(additionalDocuments)),
+                analyzerConfigDocuments: SpecializedCollections.EmptyBoxedImmutableArray<DocumentInfo>(),
                 hostObjectType);
         }
 
@@ -322,22 +322,22 @@ namespace Microsoft.CodeAnalysis
             => With(parseOptions: parseOptions);
 
         public ProjectInfo WithDocuments(IEnumerable<DocumentInfo>? documents)
-            => With(documents: documents.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(documents)));
+            => With(documents: documents.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(documents)));
 
         public ProjectInfo WithAdditionalDocuments(IEnumerable<DocumentInfo>? additionalDocuments)
-            => With(additionalDocuments: additionalDocuments.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(additionalDocuments)));
+            => With(additionalDocuments: additionalDocuments.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(additionalDocuments)));
 
         public ProjectInfo WithAnalyzerConfigDocuments(IEnumerable<DocumentInfo>? analyzerConfigDocuments)
-            => With(analyzerConfigDocuments: analyzerConfigDocuments.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerConfigDocuments)));
+            => With(analyzerConfigDocuments: analyzerConfigDocuments.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerConfigDocuments)));
 
         public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference>? projectReferences)
-            => With(projectReferences: projectReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(projectReferences)));
+            => With(projectReferences: projectReferences.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(projectReferences)));
 
         public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference>? metadataReferences)
-            => With(metadataReferences: metadataReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(metadataReferences)));
+            => With(metadataReferences: metadataReferences.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(metadataReferences)));
 
         public ProjectInfo WithAnalyzerReferences(IEnumerable<AnalyzerReference>? analyzerReferences)
-            => With(analyzerReferences: analyzerReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerReferences)));
+            => With(analyzerReferences: analyzerReferences.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerReferences)));
 
         internal string GetDebuggerDisplay()
             => nameof(ProjectInfo) + " " + Name + (!string.IsNullOrWhiteSpace(FilePath) ? " " + FilePath : "");

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Serialization;
@@ -161,7 +162,6 @@ namespace Microsoft.CodeAnalysis
             HostObjectType = hostObjectType;
         }
 
-
         // 2.7.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
         /// <summary>
         /// Create a new instance of a <see cref="ProjectInfo"/>.
@@ -229,11 +229,11 @@ namespace Microsoft.CodeAnalysis
                     runAnalyzers: true),
                 compilationOptions,
                 parseOptions,
-                ToImmutableReadOnlyListWithNonNullItems(documents),
-                ToImmutableReadOnlyListWithNonNullItems(projectReferences),
-                ToImmutableReadOnlyListWithNonNullItems(metadataReferences),
-                ToImmutableReadOnlyListWithNonNullItems(analyzerReferences),
-                ToImmutableReadOnlyListWithNonNullItems(additionalDocuments),
+                documents.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(documents)),
+                projectReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(projectReferences)),
+                metadataReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(metadataReferences)),
+                analyzerReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerReferences)),
+                additionalDocuments.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(additionalDocuments)),
                 analyzerConfigDocuments: SpecializedCollections.EmptyImmutableArrayList<DocumentInfo>(),
                 hostObjectType);
         }
@@ -288,21 +288,6 @@ namespace Microsoft.CodeAnalysis
                 newHostObjectType);
         }
 
-        private static IReadOnlyList<T> ToImmutableReadOnlyListWithNonNullItems<T>(IEnumerable<T>? sequence) where T : class
-        {
-            var list = sequence.ToImmutableReadOnlyListOrEmpty();
-
-            foreach (var item in list)
-            {
-                if (item is null)
-                {
-                    throw new ArgumentNullException();
-                }
-            }
-
-            return list;
-        }
-
         public ProjectInfo WithVersion(VersionStamp version)
             => With(attributes: Attributes.With(version: version));
 
@@ -337,22 +322,22 @@ namespace Microsoft.CodeAnalysis
             => With(parseOptions: parseOptions);
 
         public ProjectInfo WithDocuments(IEnumerable<DocumentInfo>? documents)
-            => With(documents: ToImmutableReadOnlyListWithNonNullItems(documents));
+            => With(documents: documents.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(documents)));
 
         public ProjectInfo WithAdditionalDocuments(IEnumerable<DocumentInfo>? additionalDocuments)
-            => With(additionalDocuments: ToImmutableReadOnlyListWithNonNullItems(additionalDocuments));
+            => With(additionalDocuments: additionalDocuments.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(additionalDocuments)));
 
         public ProjectInfo WithAnalyzerConfigDocuments(IEnumerable<DocumentInfo>? analyzerConfigDocuments)
-            => With(analyzerConfigDocuments: ToImmutableReadOnlyListWithNonNullItems(analyzerConfigDocuments));
+            => With(analyzerConfigDocuments: analyzerConfigDocuments.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerConfigDocuments)));
 
         public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference>? projectReferences)
-            => With(projectReferences: ToImmutableReadOnlyListWithNonNullItems(projectReferences));
+            => With(projectReferences: projectReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(projectReferences)));
 
         public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference>? metadataReferences)
-            => With(metadataReferences: ToImmutableReadOnlyListWithNonNullItems(metadataReferences));
+            => With(metadataReferences: metadataReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(metadataReferences)));
 
         public ProjectInfo WithAnalyzerReferences(IEnumerable<AnalyzerReference>? analyzerReferences)
-            => With(analyzerReferences: ToImmutableReadOnlyListWithNonNullItems(analyzerReferences));
+            => With(analyzerReferences: analyzerReferences.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(analyzerReferences)));
 
         internal string GetDebuggerDisplay()
             => nameof(ProjectInfo) + " " + Name + (!string.IsNullOrWhiteSpace(FilePath) ? " " + FilePath : "");

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -141,80 +141,30 @@ namespace Microsoft.CodeAnalysis
             ProjectAttributes attributes,
             CompilationOptions? compilationOptions,
             ParseOptions? parseOptions,
-            IEnumerable<DocumentInfo>? documents,
-            IEnumerable<ProjectReference>? projectReferences,
-            IEnumerable<MetadataReference>? metadataReferences,
-            IEnumerable<AnalyzerReference>? analyzerReferences,
-            IEnumerable<DocumentInfo>? additionalDocuments,
-            IEnumerable<DocumentInfo>? analyzerConfigDocuments,
+            IReadOnlyList<DocumentInfo> documents,
+            IReadOnlyList<ProjectReference> projectReferences,
+            IReadOnlyList<MetadataReference> metadataReferences,
+            IReadOnlyList<AnalyzerReference> analyzerReferences,
+            IReadOnlyList<DocumentInfo> additionalDocuments,
+            IReadOnlyList<DocumentInfo> analyzerConfigDocuments,
             Type? hostObjectType)
         {
             Attributes = attributes;
             CompilationOptions = compilationOptions;
             ParseOptions = parseOptions;
-            Documents = documents.ToImmutableReadOnlyListOrEmpty();
-            ProjectReferences = projectReferences.ToImmutableReadOnlyListOrEmpty();
-            MetadataReferences = metadataReferences.ToImmutableReadOnlyListOrEmpty();
-            AnalyzerReferences = analyzerReferences.ToImmutableReadOnlyListOrEmpty();
-            AdditionalDocuments = additionalDocuments.ToImmutableReadOnlyListOrEmpty();
-            AnalyzerConfigDocuments = analyzerConfigDocuments.ToImmutableReadOnlyListOrEmpty();
+            Documents = documents;
+            ProjectReferences = projectReferences;
+            MetadataReferences = metadataReferences;
+            AnalyzerReferences = analyzerReferences;
+            AdditionalDocuments = additionalDocuments;
+            AnalyzerConfigDocuments = analyzerConfigDocuments;
             HostObjectType = hostObjectType;
         }
 
-        /// <summary>
-        /// Create a new instance of a ProjectInfo.
-        /// </summary>
-        internal static ProjectInfo Create(
-            ProjectId id,
-            VersionStamp version,
-            string name,
-            string assemblyName,
-            string language,
-            string? filePath,
-            string? outputFilePath,
-            string? outputRefFilePath,
-            string? defaultNamespace,
-            CompilationOptions? compilationOptions,
-            ParseOptions? parseOptions,
-            IEnumerable<DocumentInfo>? documents,
-            IEnumerable<ProjectReference>? projectReferences,
-            IEnumerable<MetadataReference>? metadataReferences,
-            IEnumerable<AnalyzerReference>? analyzerReferences,
-            IEnumerable<DocumentInfo>? additionalDocuments,
-            IEnumerable<DocumentInfo>? analyzerConfigDocuments,
-            bool isSubmission,
-            Type? hostObjectType,
-            bool hasAllInformation,
-            bool runAnalyzers)
-        {
-            return new ProjectInfo(
-                new ProjectAttributes(
-                    id,
-                    version,
-                    name,
-                    assemblyName,
-                    language,
-                    filePath,
-                    outputFilePath,
-                    outputRefFilePath,
-                    defaultNamespace,
-                    isSubmission,
-                    hasAllInformation,
-                    runAnalyzers),
-                compilationOptions,
-                parseOptions,
-                documents,
-                projectReferences,
-                metadataReferences,
-                analyzerReferences,
-                additionalDocuments,
-                analyzerConfigDocuments,
-                hostObjectType);
-        }
 
         // 2.7.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
         /// <summary>
-        /// Create a new instance of a ProjectInfo.
+        /// Create a new instance of a <see cref="ProjectInfo"/>.
         /// </summary>
         public static ProjectInfo Create(
             ProjectId id,
@@ -236,13 +186,13 @@ namespace Microsoft.CodeAnalysis
         {
             return Create(
                 id, version, name, assemblyName, language,
-                filePath, outputFilePath, outputRefFilePath: null, defaultNamespace: null, compilationOptions, parseOptions,
-                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments, analyzerConfigDocuments: null,
-                isSubmission, hostObjectType, hasAllInformation: true, runAnalyzers: true);
+                filePath, outputFilePath, compilationOptions, parseOptions,
+                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments,
+                isSubmission, hostObjectType, outputRefFilePath: null);
         }
 
         /// <summary>
-        /// Create a new instance of a ProjectInfo.
+        /// Create a new instance of a <see cref="ProjectInfo"/>.
         /// </summary>
         public static ProjectInfo Create(
             ProjectId id,
@@ -263,28 +213,46 @@ namespace Microsoft.CodeAnalysis
             Type? hostObjectType = null,
             string? outputRefFilePath = null)
         {
-            return Create(
-                id, version, name, assemblyName, language,
-                filePath, outputFilePath, outputRefFilePath, defaultNamespace: null, compilationOptions, parseOptions,
-                documents, projectReferences, metadataReferences, analyzerReferences, additionalDocuments, analyzerConfigDocuments: null,
-                isSubmission, hostObjectType, hasAllInformation: true, runAnalyzers: true);
+            return new ProjectInfo(
+                new ProjectAttributes(
+                    id ?? throw new ArgumentNullException(nameof(id)),
+                    version,
+                    name ?? throw new ArgumentNullException(nameof(name)),
+                    assemblyName ?? throw new ArgumentNullException(nameof(assemblyName)),
+                    language ?? throw new ArgumentNullException(nameof(language)),
+                    filePath,
+                    outputFilePath,
+                    outputRefFilePath,
+                    defaultNamespace: null,
+                    isSubmission,
+                    hasAllInformation: true,
+                    runAnalyzers: true),
+                compilationOptions,
+                parseOptions,
+                ToImmutableReadOnlyListWithNonNullItems(documents),
+                ToImmutableReadOnlyListWithNonNullItems(projectReferences),
+                ToImmutableReadOnlyListWithNonNullItems(metadataReferences),
+                ToImmutableReadOnlyListWithNonNullItems(analyzerReferences),
+                ToImmutableReadOnlyListWithNonNullItems(additionalDocuments),
+                analyzerConfigDocuments: SpecializedCollections.EmptyImmutableArrayList<DocumentInfo>(),
+                hostObjectType);
         }
 
         private ProjectInfo With(
             ProjectAttributes? attributes = null,
-            CompilationOptions? compilationOptions = null,
-            ParseOptions? parseOptions = null,
-            IEnumerable<DocumentInfo>? documents = null,
-            IEnumerable<ProjectReference>? projectReferences = null,
-            IEnumerable<MetadataReference>? metadataReferences = null,
-            IEnumerable<AnalyzerReference>? analyzerReferences = null,
-            IEnumerable<DocumentInfo>? additionalDocuments = null,
-            IEnumerable<DocumentInfo>? analyzerConfigDocuments = null,
+            Optional<CompilationOptions?> compilationOptions = default,
+            Optional<ParseOptions?> parseOptions = default,
+            IReadOnlyList<DocumentInfo>? documents = null,
+            IReadOnlyList<ProjectReference>? projectReferences = null,
+            IReadOnlyList<MetadataReference>? metadataReferences = null,
+            IReadOnlyList<AnalyzerReference>? analyzerReferences = null,
+            IReadOnlyList<DocumentInfo>? additionalDocuments = null,
+            IReadOnlyList<DocumentInfo>? analyzerConfigDocuments = null,
             Optional<Type?> hostObjectType = default)
         {
             var newAttributes = attributes ?? Attributes;
-            var newCompilationOptions = compilationOptions ?? CompilationOptions;
-            var newParseOptions = parseOptions ?? ParseOptions;
+            var newCompilationOptions = compilationOptions.HasValue ? compilationOptions.Value : CompilationOptions;
+            var newParseOptions = parseOptions.HasValue ? parseOptions.Value : ParseOptions;
             var newDocuments = documents ?? Documents;
             var newProjectReferences = projectReferences ?? ProjectReferences;
             var newMetadataReferences = metadataReferences ?? MetadataReferences;
@@ -320,104 +288,83 @@ namespace Microsoft.CodeAnalysis
                 newHostObjectType);
         }
 
-        public ProjectInfo WithDocuments(IEnumerable<DocumentInfo>? documents)
+        private static IReadOnlyList<T> ToImmutableReadOnlyListWithNonNullItems<T>(IEnumerable<T>? sequence) where T : class
         {
-            return With(documents: documents.ToImmutableReadOnlyListOrEmpty());
+            var list = sequence.ToImmutableReadOnlyListOrEmpty();
+
+            foreach (var item in list)
+            {
+                if (item is null)
+                {
+                    throw new ArgumentNullException();
+                }
+            }
+
+            return list;
         }
+
+        public ProjectInfo WithDocuments(IEnumerable<DocumentInfo>? documents)
+            => With(documents: ToImmutableReadOnlyListWithNonNullItems(documents));
 
         public ProjectInfo WithAdditionalDocuments(IEnumerable<DocumentInfo>? additionalDocuments)
-        {
-            return With(additionalDocuments: additionalDocuments.ToImmutableReadOnlyListOrEmpty());
-        }
+            => With(additionalDocuments: ToImmutableReadOnlyListWithNonNullItems(additionalDocuments));
 
         public ProjectInfo WithAnalyzerConfigDocuments(IEnumerable<DocumentInfo>? analyzerConfigDocuments)
-        {
-            return With(analyzerConfigDocuments: analyzerConfigDocuments.ToImmutableReadOnlyListOrEmpty());
-        }
+            => With(analyzerConfigDocuments: ToImmutableReadOnlyListWithNonNullItems(analyzerConfigDocuments));
 
         public ProjectInfo WithVersion(VersionStamp version)
-        {
-            return With(attributes: Attributes.With(version: version));
-        }
+            => With(attributes: Attributes.With(version: version));
 
         public ProjectInfo WithName(string name)
-        {
-            return With(attributes: Attributes.With(name: name));
-        }
+            => With(attributes: Attributes.With(name: name ?? throw new ArgumentNullException(nameof(name))));
 
         public ProjectInfo WithFilePath(string? filePath)
-        {
-            return With(attributes: Attributes.With(filePath: filePath));
-        }
+            => With(attributes: Attributes.With(filePath: filePath));
 
         public ProjectInfo WithAssemblyName(string assemblyName)
-        {
-            return With(attributes: Attributes.With(assemblyName: assemblyName));
-        }
+            => With(attributes: Attributes.With(assemblyName: assemblyName ?? throw new ArgumentNullException(nameof(assemblyName))));
 
         public ProjectInfo WithOutputFilePath(string? outputFilePath)
-        {
-            return With(attributes: Attributes.With(outputPath: outputFilePath));
-        }
+            => With(attributes: Attributes.With(outputPath: outputFilePath));
 
         public ProjectInfo WithOutputRefFilePath(string? outputRefFilePath)
-        {
-            return With(attributes: Attributes.With(outputRefPath: outputRefFilePath));
-        }
+            => With(attributes: Attributes.With(outputRefPath: outputRefFilePath));
 
         public ProjectInfo WithDefaultNamespace(string? defaultNamespace)
-        {
-            return With(attributes: Attributes.With(defaultNamespace: defaultNamespace));
-        }
+            => With(attributes: Attributes.With(defaultNamespace: defaultNamespace));
 
         public ProjectInfo WithCompilationOptions(CompilationOptions? compilationOptions)
-        {
-            // The With method here doesn't correctly handle the null value, tracked by https://github.com/dotnet/roslyn/issues/37880
-            return With(compilationOptions: compilationOptions);
-        }
+            => With(compilationOptions: compilationOptions);
 
         public ProjectInfo WithParseOptions(ParseOptions? parseOptions)
-        {
-            // The With method here doesn't correctly handle the null value, tracked by https://github.com/dotnet/roslyn/issues/37880
-            return With(parseOptions: parseOptions);
-        }
+            => With(parseOptions: parseOptions);
 
         public ProjectInfo WithProjectReferences(IEnumerable<ProjectReference>? projectReferences)
-        {
-            return With(projectReferences: projectReferences.ToImmutableReadOnlyListOrEmpty());
-        }
+            => With(projectReferences: ToImmutableReadOnlyListWithNonNullItems(projectReferences));
 
         public ProjectInfo WithMetadataReferences(IEnumerable<MetadataReference>? metadataReferences)
-        {
-            return With(metadataReferences: metadataReferences.ToImmutableReadOnlyListOrEmpty());
-        }
+            => With(metadataReferences: ToImmutableReadOnlyListWithNonNullItems(metadataReferences));
 
         public ProjectInfo WithAnalyzerReferences(IEnumerable<AnalyzerReference>? analyzerReferences)
-        {
-            return With(analyzerReferences: analyzerReferences.ToImmutableReadOnlyListOrEmpty());
-        }
+            => With(analyzerReferences: ToImmutableReadOnlyListWithNonNullItems(analyzerReferences));
 
         internal ProjectInfo WithHasAllInformation(bool hasAllInformation)
-        {
-            return With(attributes: Attributes.With(hasAllInformation: hasAllInformation));
-        }
+            => With(attributes: Attributes.With(hasAllInformation: hasAllInformation));
 
         internal ProjectInfo WithRunAnalyzers(bool runAnalyzers)
-        {
-            return With(attributes: Attributes.With(runAnalyzers: runAnalyzers));
-        }
+            => With(attributes: Attributes.With(runAnalyzers: runAnalyzers));
 
         internal string GetDebuggerDisplay()
-        {
-            return nameof(ProjectInfo) + " " + Name + (!string.IsNullOrWhiteSpace(FilePath) ? " " + FilePath : "");
-        }
+            => nameof(ProjectInfo) + " " + Name + (!string.IsNullOrWhiteSpace(FilePath) ? " " + FilePath : "");
 
         /// <summary>
         /// type that contains information regarding this project itself but
         /// no tree information such as document info
         /// </summary>
-        internal class ProjectAttributes : IChecksummedObject, IObjectWritable
+        internal sealed class ProjectAttributes : IChecksummedObject, IObjectWritable
         {
+            private Checksum? _lazyChecksum;
+
             /// <summary>
             /// The unique Id of the project.
             /// </summary>
@@ -494,10 +441,10 @@ namespace Microsoft.CodeAnalysis
                 bool hasAllInformation,
                 bool runAnalyzers)
             {
-                Id = id ?? throw new ArgumentNullException(nameof(id));
-                Name = name ?? throw new ArgumentNullException(nameof(name));
-                Language = language ?? throw new ArgumentNullException(nameof(language));
-                AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+                Id = id;
+                Name = name;
+                Language = language;
+                AssemblyName = assemblyName;
 
                 Version = version;
                 FilePath = filePath;
@@ -522,7 +469,7 @@ namespace Microsoft.CodeAnalysis
                 Optional<bool> hasAllInformation = default,
                 Optional<bool> runAnalyzers = default)
             {
-                var newVersion = version.HasValue ? version.Value : Version;
+                var newVersion = version ?? Version;
                 var newName = name ?? Name;
                 var newAssemblyName = assemblyName ?? AssemblyName;
                 var newLanguage = language ?? Language;
@@ -607,19 +554,8 @@ namespace Microsoft.CodeAnalysis
                 return new ProjectAttributes(projectId, VersionStamp.Create(), name, assemblyName, language, filePath, outputFilePath, outputRefFilePath, defaultNamespace, isSubmission, hasAllInformation, runAnalyzers);
             }
 
-            private Checksum? _lazyChecksum;
             Checksum IChecksummedObject.Checksum
-            {
-                get
-                {
-                    if (_lazyChecksum == null)
-                    {
-                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKind.ProjectAttributes, this);
-                    }
-
-                    return _lazyChecksum;
-                }
-            }
+                => _lazyChecksum ??= Checksum.Create(WellKnownSynchronizationKind.ProjectAttributes, this);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -985,7 +985,9 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new solution instance with the document specified updated to be contained in
         /// the sequence of logical folders.
         /// </summary>
-        public Solution WithDocumentFolders(DocumentId documentId, IEnumerable<string> folders)
+        /// <param name="documentId">Document id.</param>
+        /// <param name="folders">Sequence of folders. <see langword="null"/> values are ignored.</param>
+        public Solution WithDocumentFolders(DocumentId documentId, IEnumerable<string?> folders)
         {
             var newState = _state.WithDocumentFolders(documentId, folders);
             if (newState == _state)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis
                     id ?? throw new ArgumentNullException(nameof(id)),
                     version,
                     filePath),
-                projects.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(projects)));
+                projects.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(projects)));
         }
 
         internal ImmutableHashSet<string> GetProjectLanguages()

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -42,10 +42,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public IReadOnlyList<ProjectInfo> Projects { get; }
 
-        private SolutionInfo(SolutionAttributes attributes, IEnumerable<ProjectInfo>? projects)
+        private SolutionInfo(SolutionAttributes attributes, IReadOnlyList<ProjectInfo> projects)
         {
             Attributes = attributes;
-            Projects = projects.ToImmutableReadOnlyListOrEmpty();
+            Projects = projects;
         }
 
         /// <summary>
@@ -57,38 +57,12 @@ namespace Microsoft.CodeAnalysis
             string? filePath = null,
             IEnumerable<ProjectInfo>? projects = null)
         {
-            return new SolutionInfo(new SolutionAttributes(id, version, filePath), projects);
-        }
-
-        private SolutionInfo With(
-            SolutionAttributes? attributes = null,
-            IEnumerable<ProjectInfo>? projects = null)
-        {
-            var newAttributes = attributes ?? Attributes;
-            var newProjects = projects ?? Projects;
-
-            if (newAttributes == Attributes &&
-                newProjects == Projects)
-            {
-                return this;
-            }
-
-            return new SolutionInfo(newAttributes, newProjects);
-        }
-
-        internal SolutionInfo WithVersion(VersionStamp version)
-        {
-            return With(attributes: new SolutionAttributes(Attributes.Id, version, Attributes.FilePath));
-        }
-
-        internal SolutionInfo WithFilePath(string? filePath)
-        {
-            return With(attributes: new SolutionAttributes(Attributes.Id, Attributes.Version, filePath));
-        }
-
-        internal SolutionInfo WithProjects(IEnumerable<ProjectInfo> projects)
-        {
-            return With(projects: projects);
+            return new SolutionInfo(
+                new SolutionAttributes(
+                    id ?? throw new ArgumentNullException(nameof(id)),
+                    version,
+                    filePath),
+                projects.AsImmutableReadOnlyListWithNonNullItems() ?? throw new ArgumentNullException(nameof(projects)));
         }
 
         internal ImmutableHashSet<string> GetProjectLanguages()
@@ -98,8 +72,10 @@ namespace Microsoft.CodeAnalysis
         /// type that contains information regarding this solution itself but
         /// no tree information such as project info
         /// </summary>
-        internal class SolutionAttributes : IChecksummedObject, IObjectWritable
+        internal sealed class SolutionAttributes : IChecksummedObject, IObjectWritable
         {
+            private Checksum? _lazyChecksum;
+
             /// <summary>
             /// The unique Id of the solution.
             /// </summary>
@@ -117,7 +93,7 @@ namespace Microsoft.CodeAnalysis
 
             public SolutionAttributes(SolutionId id, VersionStamp version, string? filePath)
             {
-                Id = id ?? throw new ArgumentNullException(nameof(id));
+                Id = id;
                 Version = version;
                 FilePath = filePath;
             }
@@ -149,19 +125,8 @@ namespace Microsoft.CodeAnalysis
                 return new SolutionAttributes(solutionId, VersionStamp.Create(), filePath);
             }
 
-            private Checksum? _lazyChecksum;
             Checksum IChecksummedObject.Checksum
-            {
-                get
-                {
-                    if (_lazyChecksum == null)
-                    {
-                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKind.SolutionAttributes, this);
-                    }
-
-                    return _lazyChecksum;
-                }
-            }
+                => _lazyChecksum ??= Checksum.Create(WellKnownSynchronizationKind.SolutionAttributes, this);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1660,11 +1660,6 @@ namespace Microsoft.CodeAnalysis
 
         private SolutionState WithDocumentState(DocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
         {
-            if (newDocument == null)
-            {
-                throw new ArgumentNullException(nameof(newDocument));
-            }
-
             CheckContainsDocument(newDocument.Id);
 
             if (newDocument == this.GetDocumentState(newDocument.Id))
@@ -1697,11 +1692,6 @@ namespace Microsoft.CodeAnalysis
 
         private SolutionState WithAdditionalDocumentState(TextDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
         {
-            if (newDocument == null)
-            {
-                throw new ArgumentNullException(nameof(newDocument));
-            }
-
             CheckContainsAdditionalDocument(newDocument.Id);
 
             if (newDocument == this.GetAdditionalDocumentState(newDocument.Id))
@@ -1724,11 +1714,6 @@ namespace Microsoft.CodeAnalysis
 
         private SolutionState WithAnalyzerConfigDocumentState(AnalyzerConfigDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
         {
-            if (newDocument == null)
-            {
-                throw new ArgumentNullException(nameof(newDocument));
-            }
-
             CheckContainsAnalyzerConfigDocument(newDocument.Id);
 
             if (newDocument == this.GetAnalyzerConfigDocumentState(newDocument.Id))
@@ -1956,7 +1941,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new solution instance with all the documents specified updated to have the same specified text.
         /// </summary>
-        public SolutionState WithDocumentText(IEnumerable<DocumentId> documentIds, SourceText text, PreservationMode mode = PreservationMode.PreserveValue)
+        public SolutionState WithDocumentText(IEnumerable<DocumentId> documentIds, SourceText text, PreservationMode mode)
         {
             if (documentIds == null)
             {
@@ -2228,26 +2213,6 @@ namespace Microsoft.CodeAnalysis
                 {
                     throw new InvalidOperationException(WorkspacesResources.This_submission_already_references_another_submission_project);
                 }
-            }
-        }
-
-        private void CheckNotContainsDocument(DocumentId documentId)
-        {
-            Debug.Assert(!this.ContainsDocument(documentId));
-
-            if (this.ContainsDocument(documentId))
-            {
-                throw new InvalidOperationException(WorkspacesResources.The_solution_already_contains_the_specified_document);
-            }
-        }
-
-        private void CheckNotContainsAdditionalDocument(DocumentId documentId)
-        {
-            Debug.Assert(!this.ContainsAdditionalDocument(documentId));
-
-            if (this.ContainsAdditionalDocument(documentId))
-            {
-                throw new InvalidOperationException(WorkspacesResources.The_solution_already_contains_the_specified_document);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -41,7 +41,6 @@ namespace Microsoft.CodeAnalysis
 
         private readonly SolutionInfo.SolutionAttributes _solutionAttributes;
         private readonly SolutionServices _solutionServices;
-        private readonly IReadOnlyList<ProjectId> _projectIds;
         private readonly ImmutableDictionary<ProjectId, ProjectState> _projectIdToProjectStateMap;
         private readonly ImmutableDictionary<string, ImmutableArray<DocumentId>> _filePathToDocumentIdsMap;
         private readonly ProjectDependencyGraph _dependencyGraph;
@@ -57,7 +56,7 @@ namespace Microsoft.CodeAnalysis
             int workspaceVersion,
             SolutionServices solutionServices,
             SolutionInfo.SolutionAttributes solutionAttributes,
-            IEnumerable<ProjectId> projectIds,
+            IReadOnlyList<ProjectId> projectIds,
             SerializableOptionSet options,
             ImmutableDictionary<ProjectId, ProjectState> idToProjectStateMap,
             ImmutableDictionary<ProjectId, CompilationTracker> projectIdToTrackerMap,
@@ -68,8 +67,8 @@ namespace Microsoft.CodeAnalysis
             _workspaceVersion = workspaceVersion;
             _solutionAttributes = solutionAttributes;
             _solutionServices = solutionServices;
-            _projectIds = projectIds.ToImmutableReadOnlyListOrEmpty();
-            Options = options ?? throw new ArgumentNullException(nameof(options));
+            ProjectIds = projectIds;
+            Options = options;
             _projectIdToProjectStateMap = idToProjectStateMap;
             _projectIdToTrackerMap = projectIdToTrackerMap;
             _filePathToDocumentIdsMap = filePathToDocumentIdsMap;
@@ -91,7 +90,7 @@ namespace Microsoft.CodeAnalysis
                 workspaceVersion: 0,
                 solutionServices,
                 solutionAttributes,
-                projectIds: ImmutableArray<ProjectId>.Empty,
+                projectIds: SpecializedCollections.EmptyImmutableArrayList<ProjectId>(),
                 options,
                 idToProjectStateMap: ImmutableDictionary<ProjectId, ProjectState>.Empty,
                 projectIdToTrackerMap: ImmutableDictionary<ProjectId, CompilationTracker>.Empty,
@@ -157,12 +156,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// A list of all the ids for all the projects contained by the solution.
         /// </summary>
-        public IReadOnlyList<ProjectId> ProjectIds => _projectIds;
+        public IReadOnlyList<ProjectId> ProjectIds { get; }
 
         // [Conditional("DEBUG")]
         private void CheckInvariants()
         {
-            Contract.ThrowIfTrue(_projectIds.Count != _projectIdToProjectStateMap.Count);
+            Contract.ThrowIfTrue(ProjectIds.Count != _projectIdToProjectStateMap.Count);
 
             // An id shouldn't point at a tracker for a different project.
             Contract.ThrowIfTrue(_projectIdToTrackerMap.Any(kvp => kvp.Key != kvp.Value.ProjectState.Id));
@@ -170,7 +169,7 @@ namespace Microsoft.CodeAnalysis
 
         private SolutionState Branch(
             SolutionInfo.SolutionAttributes? solutionAttributes = null,
-            IEnumerable<ProjectId>? projectIds = null,
+            IReadOnlyList<ProjectId>? projectIds = null,
             SerializableOptionSet? options = null,
             ImmutableDictionary<ProjectId, ProjectState>? idToProjectStateMap = null,
             ImmutableDictionary<ProjectId, CompilationTracker>? projectIdToTrackerMap = null,
@@ -180,7 +179,7 @@ namespace Microsoft.CodeAnalysis
             var branchId = GetBranchId();
 
             solutionAttributes ??= _solutionAttributes;
-            projectIds ??= _projectIds;
+            projectIds ??= ProjectIds;
             idToProjectStateMap ??= _projectIdToProjectStateMap;
             options ??= Options.WithLanguages(GetProjectLanguages(idToProjectStateMap));
             projectIdToTrackerMap ??= _projectIdToTrackerMap;
@@ -189,7 +188,7 @@ namespace Microsoft.CodeAnalysis
 
             if (branchId == _branchId &&
                 solutionAttributes == _solutionAttributes &&
-                projectIds == _projectIds &&
+                projectIds == ProjectIds &&
                 options == Options &&
                 idToProjectStateMap == _projectIdToProjectStateMap &&
                 projectIdToTrackerMap == _projectIdToTrackerMap &&
@@ -230,7 +229,7 @@ namespace Microsoft.CodeAnalysis
                 workspaceVersion,
                 services,
                 _solutionAttributes,
-                _projectIds,
+                ProjectIds,
                 Options,
                 _projectIdToProjectStateMap,
                 _projectIdToTrackerMap,
@@ -441,7 +440,7 @@ namespace Microsoft.CodeAnalysis
             // changed project list so, increment version.
             var newSolutionAttributes = _solutionAttributes.WithVersion(this.Version.GetNewerVersion());
 
-            var newProjectIds = _projectIds.ToImmutableArray().Add(projectId);
+            var newProjectIds = ProjectIds.ToImmutableArray().Add(projectId);
             var newStateMap = _projectIdToProjectStateMap.Add(projectId, projectState);
             var newDependencyGraph = _dependencyGraph
                                         .WithAdditionalProjects(SpecializedCollections.SingletonEnumerable(projectId))
@@ -555,7 +554,7 @@ namespace Microsoft.CodeAnalysis
             // changed project list so, increment version.
             var newSolutionAttributes = _solutionAttributes.WithVersion(this.Version.GetNewerVersion());
 
-            var newProjectIds = _projectIds.ToImmutableArray().Remove(projectId);
+            var newProjectIds = ProjectIds.ToImmutableArray().Remove(projectId);
             var newStateMap = _projectIdToProjectStateMap.Remove(projectId);
             var newDependencyGraph = _dependencyGraph.WithProjectRemoved(projectId);
             var newTrackerMap = CreateCompilationTrackerMap(projectId, newDependencyGraph);
@@ -1376,12 +1375,10 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(folders));
             }
 
-            var folderCollection = folders.WhereNotNull().ToReadOnlyCollection();
+            var oldDocument = GetDocumentState(documentId)!;
+            var newDocument = oldDocument.UpdateFolders(folders.WhereNotNull().ToImmutableArray());
 
-            var oldDocument = this.GetDocumentState(documentId)!;
-            var newDocument = oldDocument.UpdateFolders(folderCollection);
-
-            return this.WithDocumentState(newDocument);
+            return WithDocumentState(newDocument);
         }
 
         /// <summary>
@@ -1940,7 +1937,7 @@ namespace Microsoft.CodeAnalysis
                     currentPartialSolution = this.Branch(
                         idToProjectStateMap: newIdToProjectStateMap,
                         projectIdToTrackerMap: newIdToTrackerMap,
-                        dependencyGraph: CreateDependencyGraph(_projectIds, newIdToProjectStateMap));
+                        dependencyGraph: CreateDependencyGraph(ProjectIds, newIdToProjectStateMap));
 
                     _latestSolutionWithPartialCompilation = new WeakReference<SolutionState>(currentPartialSolution);
                     _timeOfLatestSolutionWithPartialCompilation = DateTime.UtcNow;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1363,7 +1363,7 @@ namespace Microsoft.CodeAnalysis
         /// Creates a new solution instance with the document specified updated to be contained in
         /// the sequence of logical folders.
         /// </summary>
-        public SolutionState WithDocumentFolders(DocumentId documentId, IEnumerable<string> folders)
+        public SolutionState WithDocumentFolders(DocumentId documentId, IEnumerable<string?> folders)
         {
             if (documentId == null)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis
                 workspaceVersion: 0,
                 solutionServices,
                 solutionAttributes,
-                projectIds: SpecializedCollections.EmptyImmutableArrayList<ProjectId>(),
+                projectIds: SpecializedCollections.EmptyBoxedImmutableArray<ProjectId>(),
                 options,
                 idToProjectStateMap: ImmutableDictionary<ProjectId, ProjectState>.Empty,
                 projectIdToTrackerMap: ImmutableDictionary<ProjectId, CompilationTracker>.Empty,

--- a/src/Workspaces/CoreTest/SolutionTests/DocumentInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/DocumentInfoTests.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class DocumentInfoTests
+    {
+        [Fact]
+        public void Create_Errors()
+        {
+            var documentId = DocumentId.CreateNewId(ProjectId.CreateNewId());
+
+            Assert.Throws<ArgumentNullException>(() => DocumentInfo.Create(id: null, "doc"));
+            Assert.Throws<ArgumentNullException>(() => DocumentInfo.Create(documentId, name: null));
+
+            Assert.Throws<ArgumentNullException>(() => DocumentInfo.Create(documentId, "doc", folders: new[] { "folder", null }));
+        }
+
+        [Fact]
+        public void Create()
+        {
+            var loader = new FileTextLoader(Path.GetTempPath(), defaultEncoding: null);
+            var id = DocumentId.CreateNewId(ProjectId.CreateNewId());
+
+            var info = DocumentInfo.Create(
+                id,
+                name: "doc",
+                sourceCodeKind: SourceCodeKind.Script,
+                loader: loader,
+                isGenerated: true);
+
+            Assert.Equal(id, info.Id);
+            Assert.Equal("doc", info.Name);
+            Assert.Equal(SourceCodeKind.Script, info.SourceCodeKind);
+            Assert.Same(loader, info.TextLoader);
+            Assert.True(info.IsGenerated);
+        }
+
+        [Fact]
+        public void Create_Folders()
+        {
+            var documentId = DocumentId.CreateNewId(ProjectId.CreateNewId());
+
+            var info1 = DocumentInfo.Create(documentId, "doc", folders: new[] { "folder" });
+            Assert.Equal("folder", ((ImmutableArray<string>)info1.Folders).Single());
+
+            var info2 = DocumentInfo.Create(documentId, "doc");
+            Assert.True(((ImmutableArray<string>)info2.Folders).IsEmpty);
+
+            var info3 = DocumentInfo.Create(documentId, "doc", folders: new string[0]);
+            Assert.True(((ImmutableArray<string>)info3.Folders).IsEmpty);
+
+            var info4 = DocumentInfo.Create(documentId, "doc", folders: ImmutableArray<string>.Empty);
+            Assert.True(((ImmutableArray<string>)info4.Folders).IsEmpty);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("path")]
+        public void Create_FilePath(string path)
+        {
+            var info = DocumentInfo.Create(DocumentId.CreateNewId(ProjectId.CreateNewId()), "doc", filePath: path);
+            Assert.Equal(path, info.FilePath);
+        }
+
+        private static void TestProperty<T>(Func<DocumentInfo, T, DocumentInfo> factory, Func<DocumentInfo, T> getter, T validNonDefaultValue, bool defaultThrows = false)
+        {
+            Assert.NotEqual<T>(default, validNonDefaultValue);
+
+            var instance = DocumentInfo.Create(DocumentId.CreateNewId(ProjectId.CreateNewId()), "doc");
+
+            var instanceWithValue = factory(instance, validNonDefaultValue);
+            Assert.Equal(validNonDefaultValue, getter(instanceWithValue));
+
+            var instanceWithValue2 = factory(instanceWithValue, validNonDefaultValue);
+            Assert.Same(instanceWithValue2, instanceWithValue);
+
+            if (defaultThrows)
+            {
+                Assert.Throws<ArgumentNullException>(() => factory(instance, default));
+            }
+            else
+            {
+                Assert.NotNull(factory(instance, default));
+            }
+        }
+
+        private static void TestListProperty<T>(Func<DocumentInfo, IEnumerable<T>, DocumentInfo> factory, Func<DocumentInfo, IEnumerable<T>> getter, T item)
+        {
+            TestProperty(factory, getter, ImmutableArray.Create(item), defaultThrows: false);
+
+            var instanceWithNoItem = DocumentInfo.Create(DocumentId.CreateNewId(ProjectId.CreateNewId()), "doc");
+            Assert.Empty(getter(instanceWithNoItem));
+
+            var instanceWithItem = factory(instanceWithNoItem, ImmutableArray.Create(item));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, default));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, Array.Empty<T>()));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, ImmutableArray<T>.Empty));
+
+            Assert.Throws<ArgumentNullException>(() => factory(instanceWithNoItem, new T[] { item, default }));
+        }
+
+        [Fact]
+        public void TestProperties()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+
+            TestProperty((old, value) => old.WithId(value), opt => opt.Id, documentId, defaultThrows: true);
+            TestProperty((old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
+            TestProperty((old, value) => old.WithSourceCodeKind(value), opt => opt.SourceCodeKind, SourceCodeKind.Script);
+            TestProperty((old, value) => old.WithTextLoader(value), opt => opt.TextLoader, new FileTextLoader(Path.GetTempPath(), defaultEncoding: null));
+
+            TestListProperty((old, value) => old.WithFolders(value), opt => opt.Folders, "folder");
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/SolutionTests/DocumentInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/DocumentInfoTests.cs
@@ -72,55 +72,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(path, info.FilePath);
         }
 
-        private static void TestProperty<T>(Func<DocumentInfo, T, DocumentInfo> factory, Func<DocumentInfo, T> getter, T validNonDefaultValue, bool defaultThrows = false)
-        {
-            Assert.NotEqual<T>(default, validNonDefaultValue);
-
-            var instance = DocumentInfo.Create(DocumentId.CreateNewId(ProjectId.CreateNewId()), "doc");
-
-            var instanceWithValue = factory(instance, validNonDefaultValue);
-            Assert.Equal(validNonDefaultValue, getter(instanceWithValue));
-
-            var instanceWithValue2 = factory(instanceWithValue, validNonDefaultValue);
-            Assert.Same(instanceWithValue2, instanceWithValue);
-
-            if (defaultThrows)
-            {
-                Assert.Throws<ArgumentNullException>(() => factory(instance, default));
-            }
-            else
-            {
-                Assert.NotNull(factory(instance, default));
-            }
-        }
-
-        private static void TestListProperty<T>(Func<DocumentInfo, IEnumerable<T>, DocumentInfo> factory, Func<DocumentInfo, IEnumerable<T>> getter, T item)
-        {
-            TestProperty(factory, getter, ImmutableArray.Create(item), defaultThrows: false);
-
-            var instanceWithNoItem = DocumentInfo.Create(DocumentId.CreateNewId(ProjectId.CreateNewId()), "doc");
-            Assert.Empty(getter(instanceWithNoItem));
-
-            var instanceWithItem = factory(instanceWithNoItem, ImmutableArray.Create(item));
-            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, default));
-            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, Array.Empty<T>()));
-            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, ImmutableArray<T>.Empty));
-
-            Assert.Throws<ArgumentNullException>(() => factory(instanceWithNoItem, new T[] { item, default }));
-        }
-
         [Fact]
         public void TestProperties()
         {
             var projectId = ProjectId.CreateNewId();
             var documentId = DocumentId.CreateNewId(projectId);
+            var instance = DocumentInfo.Create(DocumentId.CreateNewId(ProjectId.CreateNewId()), "doc");
 
-            TestProperty((old, value) => old.WithId(value), opt => opt.Id, documentId, defaultThrows: true);
-            TestProperty((old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
-            TestProperty((old, value) => old.WithSourceCodeKind(value), opt => opt.SourceCodeKind, SourceCodeKind.Script);
-            TestProperty((old, value) => old.WithTextLoader(value), opt => opt.TextLoader, new FileTextLoader(Path.GetTempPath(), defaultEncoding: null));
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithId(value), opt => opt.Id, documentId, defaultThrows: true);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithSourceCodeKind(value), opt => opt.SourceCodeKind, SourceCodeKind.Script);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithTextLoader(value), opt => opt.TextLoader, (TextLoader)new FileTextLoader(Path.GetTempPath(), defaultEncoding: null));
 
-            TestListProperty((old, value) => old.WithFolders(value), opt => opt.Folders, "folder");
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithFolders(value), opt => opt.Folders, "folder");
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -148,65 +148,29 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(@"ProjectInfo Goo", projectInfo.GetDebuggerDisplay());
         }
 
-        private static void TestProperty<T>(Func<ProjectInfo, T, ProjectInfo> factory, Func<ProjectInfo, T> getter, T validNonDefaultValue, bool defaultThrows = false)
-        {
-            Assert.NotEqual<T>(default, validNonDefaultValue);
-
-            var instance = ProjectInfo.Create(name: "Name", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "AssemblyName", language: "C#");
-
-            var instanceWithValue = factory(instance, validNonDefaultValue);
-            Assert.Equal(validNonDefaultValue, getter(instanceWithValue));
-
-            var instanceWithValue2 = factory(instanceWithValue, validNonDefaultValue);
-            Assert.Same(instanceWithValue2, instanceWithValue);
-
-            if (defaultThrows)
-            {
-                Assert.Throws<ArgumentNullException>(() => factory(instance, default));
-            }
-            else
-            {
-                Assert.NotNull(factory(instance, default));
-            }
-        }
-
-        private static void TestListProperty<T>(Func<ProjectInfo, IEnumerable<T>, ProjectInfo> factory, Func<ProjectInfo, IEnumerable<T>> getter, T item)
-        {
-            TestProperty(factory, getter, ImmutableArray.Create(item), defaultThrows: false);
-
-            var instanceWithNoItem = ProjectInfo.Create(name: "Name", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "AssemblyName", language: "C#");
-            Assert.Empty(getter(instanceWithNoItem));
-
-            var instanceWithItem = factory(instanceWithNoItem, ImmutableArray.Create(item));
-            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, default));
-            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, Array.Empty<T>()));
-            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, ImmutableArray<T>.Empty));
-
-            Assert.Throws<ArgumentNullException>(() => factory(instanceWithNoItem, new T[] { item, default }));
-        }
-
         [Fact]
         public void TestProperties()
         {
             var projectId = ProjectId.CreateNewId();
             var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(projectId), "doc");
+            var instance = ProjectInfo.Create(name: "Name", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "AssemblyName", language: "C#");
 
-            TestProperty((old, value) => old.WithVersion(value), opt => opt.Version, VersionStamp.Create());
-            TestProperty((old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
-            TestProperty((old, value) => old.WithAssemblyName(value), opt => opt.AssemblyName, "New", defaultThrows: true);
-            TestProperty((old, value) => old.WithFilePath(value), opt => opt.FilePath, "New");
-            TestProperty((old, value) => old.WithOutputFilePath(value), opt => opt.OutputFilePath, "New");
-            TestProperty((old, value) => old.WithOutputRefFilePath(value), opt => opt.OutputRefFilePath, "New");
-            TestProperty((old, value) => old.WithDefaultNamespace(value), opt => opt.DefaultNamespace, "New");
-            TestProperty((old, value) => old.WithHasAllInformation(value), opt => opt.HasAllInformation, true);
-            TestProperty((old, value) => old.WithRunAnalyzers(value), opt => opt.RunAnalyzers, true);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithVersion(value), opt => opt.Version, VersionStamp.Create());
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithAssemblyName(value), opt => opt.AssemblyName, "New", defaultThrows: true);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithFilePath(value), opt => opt.FilePath, "New");
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithOutputFilePath(value), opt => opt.OutputFilePath, "New");
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithOutputRefFilePath(value), opt => opt.OutputRefFilePath, "New");
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithDefaultNamespace(value), opt => opt.DefaultNamespace, "New");
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithHasAllInformation(value), opt => opt.HasAllInformation, true);
+            SolutionTestHelpers.TestProperty(instance, (old, value) => old.WithRunAnalyzers(value), opt => opt.RunAnalyzers, true);
 
-            TestListProperty((old, value) => old.WithDocuments(value), opt => opt.Documents, documentInfo);
-            TestListProperty((old, value) => old.WithAdditionalDocuments(value), opt => opt.AdditionalDocuments, documentInfo);
-            TestListProperty((old, value) => old.WithAnalyzerConfigDocuments(value), opt => opt.AnalyzerConfigDocuments, documentInfo);
-            TestListProperty((old, value) => old.WithAnalyzerReferences(value), opt => opt.AnalyzerReferences, new TestAnalyzerReference());
-            TestListProperty((old, value) => old.WithMetadataReferences(value), opt => opt.MetadataReferences, new TestMetadataReference());
-            TestListProperty((old, value) => old.WithProjectReferences(value), opt => opt.ProjectReferences, new ProjectReference(projectId));
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithDocuments(value), opt => opt.Documents, documentInfo);
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithAdditionalDocuments(value), opt => opt.AdditionalDocuments, documentInfo);
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithAnalyzerConfigDocuments(value), opt => opt.AnalyzerConfigDocuments, documentInfo);
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithAnalyzerReferences(value), opt => opt.AnalyzerReferences, (AnalyzerReference)new TestAnalyzerReference());
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithMetadataReferences(value), opt => opt.MetadataReferences, (MetadataReference)new TestMetadataReference());
+            SolutionTestHelpers.TestListProperty(instance, (old, value) => old.WithProjectReferences(value), opt => opt.ProjectReferences, new ProjectReference(projectId));
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -3,6 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
@@ -31,6 +37,67 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var projectInfo = ProjectInfo.Create(name: "Goo", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "Bar", language: "C#");
             Assert.Equal(@"ProjectInfo Goo", projectInfo.GetDebuggerDisplay());
+        }
+
+        private static void TestProperty<T>(Func<ProjectInfo, T, ProjectInfo> factory, Func<ProjectInfo, T> getter, T validNonDefaultValue, bool defaultThrows = false)
+        {
+            Assert.NotEqual<T>(default, validNonDefaultValue);
+
+            var instance = ProjectInfo.Create(name: "Name", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "AssemblyName", language: "C#");
+
+            var instanceWithValue = factory(instance, validNonDefaultValue);
+            Assert.Equal(validNonDefaultValue, getter(instanceWithValue));
+
+            var instanceWithValue2 = factory(instanceWithValue, validNonDefaultValue);
+            Assert.Same(instanceWithValue2, instanceWithValue);
+
+            if (defaultThrows)
+            {
+                Assert.Throws<ArgumentNullException>(() => factory(instance, default));
+            }
+            else
+            {
+                Assert.NotNull(factory(instance, default));
+            }
+        }
+
+        private static void TestListProperty<T>(Func<ProjectInfo, IEnumerable<T>, ProjectInfo> factory, Func<ProjectInfo, IEnumerable<T>> getter, T item)
+        {
+            TestProperty(factory, getter, ImmutableArray.Create(item), defaultThrows: false);
+
+            var instanceWithNoItem = ProjectInfo.Create(name: "Name", id: ProjectId.CreateNewId(), version: VersionStamp.Default, assemblyName: "AssemblyName", language: "C#");
+            Assert.Empty(getter(instanceWithNoItem));
+
+            var instanceWithItem = factory(instanceWithNoItem, ImmutableArray.Create(item));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, default));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, Array.Empty<T>()));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, ImmutableArray<T>.Empty));
+
+            Assert.Throws<ArgumentNullException>(() => factory(instanceWithNoItem, new T[] { item, default }));
+        }
+
+        [Fact]
+        public void TestProperties()
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(projectId), "doc");
+
+            TestProperty((old, value) => old.WithVersion(value), opt => opt.Version, VersionStamp.Create());
+            TestProperty((old, value) => old.WithName(value), opt => opt.Name, "New", defaultThrows: true);
+            TestProperty((old, value) => old.WithAssemblyName(value), opt => opt.AssemblyName, "New", defaultThrows: true);
+            TestProperty((old, value) => old.WithFilePath(value), opt => opt.FilePath, "New");
+            TestProperty((old, value) => old.WithOutputFilePath(value), opt => opt.OutputFilePath, "New");
+            TestProperty((old, value) => old.WithOutputRefFilePath(value), opt => opt.OutputRefFilePath, "New");
+            TestProperty((old, value) => old.WithDefaultNamespace(value), opt => opt.DefaultNamespace, "New");
+            TestProperty((old, value) => old.WithHasAllInformation(value), opt => opt.HasAllInformation, true);
+            TestProperty((old, value) => old.WithRunAnalyzers(value), opt => opt.RunAnalyzers, true);
+
+            TestListProperty((old, value) => old.WithDocuments(value), opt => opt.Documents, documentInfo);
+            TestListProperty((old, value) => old.WithAdditionalDocuments(value), opt => opt.AdditionalDocuments, documentInfo);
+            TestListProperty((old, value) => old.WithAnalyzerConfigDocuments(value), opt => opt.AnalyzerConfigDocuments, documentInfo);
+            TestListProperty((old, value) => old.WithAnalyzerReferences(value), opt => opt.AnalyzerReferences, new TestAnalyzerReference());
+            TestListProperty((old, value) => old.WithMetadataReferences(value), opt => opt.MetadataReferences, new TestMetadataReference());
+            TestListProperty((old, value) => old.WithProjectReferences(value), opt => opt.ProjectReferences, new ProjectReference(projectId));
         }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionInfoTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class SolutionInfoTests
+    {
+        [Fact]
+        public void Create_Errors()
+        {
+            var solutionId = SolutionId.CreateNewId();
+            var version = VersionStamp.Default;
+            var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), version, "proj", "assembly", "C#");
+
+            Assert.Throws<ArgumentNullException>(() => SolutionInfo.Create(null, version));
+            Assert.Throws<ArgumentNullException>(() => SolutionInfo.Create(solutionId, version, projects: new[] { projectInfo, null }));
+        }
+
+        [Fact]
+        public void Create_Projects()
+        {
+            var solutionId = SolutionId.CreateNewId();
+            var version = VersionStamp.Default;
+            var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), version, "proj", "assembly", "C#");
+
+            var info1 = SolutionInfo.Create(solutionId, version, projects: new[] { projectInfo });
+            Assert.Same(projectInfo, ((ImmutableArray<ProjectInfo>)info1.Projects).Single());
+
+            var info2 = SolutionInfo.Create(solutionId, version);
+            Assert.True(((ImmutableArray<ProjectInfo>)info2.Projects).IsEmpty);
+
+            var info3 = SolutionInfo.Create(solutionId, version, projects: new ProjectInfo[0]);
+            Assert.True(((ImmutableArray<ProjectInfo>)info3.Projects).IsEmpty);
+
+            var info4 = SolutionInfo.Create(solutionId, version, projects: ImmutableArray<ProjectInfo>.Empty);
+            Assert.True(((ImmutableArray<ProjectInfo>)info4.Projects).IsEmpty);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("path")]
+        public void Create_FilePath(string path)
+        {
+            var info = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, filePath: path);
+            Assert.Equal(path, info.FilePath);
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTestHelpers.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    internal static class SolutionTestHelpers
+    {
+        public static void TestProperty<T, TValue>(T instance, Func<T, TValue, T> factory, Func<T, TValue> getter, TValue validNonDefaultValue, bool defaultThrows = false)
+            where T : class
+        {
+            Assert.NotEqual<TValue>(default, validNonDefaultValue);
+
+
+            var instanceWithValue = factory(instance, validNonDefaultValue);
+            Assert.Equal(validNonDefaultValue, getter(instanceWithValue));
+
+            var instanceWithValue2 = factory(instanceWithValue, validNonDefaultValue);
+            Assert.Same(instanceWithValue2, instanceWithValue);
+
+            if (defaultThrows)
+            {
+                Assert.Throws<ArgumentNullException>(() => factory(instance, default));
+            }
+            else
+            {
+                Assert.NotNull(factory(instance, default));
+            }
+        }
+
+        public static void TestListProperty<T, TValue>(T instance, Func<T, IEnumerable<TValue>, T> factory, Func<T, IEnumerable<TValue>> getter, TValue item)
+            where T : class
+        {
+            var boxedItems = (IEnumerable<TValue>)ImmutableArray.Create(item);
+            TestProperty(instance, factory, getter, boxedItems, defaultThrows: false);
+
+            var instanceWithNoItem = factory(instance, default);
+            Assert.Empty(getter(instanceWithNoItem));
+
+            var instanceWithItem = factory(instanceWithNoItem, boxedItems);
+
+            // the factory preserves the identity of a boxed immutable array:
+            Assert.Same(boxedItems, getter(instanceWithItem));
+
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, default));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, Array.Empty<TValue>()));
+            Assert.Same(instanceWithNoItem, factory(instanceWithNoItem, ImmutableArray<TValue>.Empty));
+
+            // the factory makes an immutable copy if given a mutable list:
+            var mutableItems = new[] { item };
+            var instanceWithMutableItems = factory(instanceWithNoItem, mutableItems);
+            var items = getter(instanceWithMutableItems);
+            Assert.NotSame(mutableItems, items);
+
+            Assert.Throws<ArgumentNullException>(() => factory(instanceWithNoItem, new TValue[] { item, default }));
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
@@ -61,6 +61,21 @@ namespace Roslyn.Utilities
             return ImmutableArray.CreateRange(items);
         }
 
+        internal static IReadOnlyList<T>? AsImmutableReadOnlyListWithNonNullItems<T>(this IEnumerable<T>? sequence) where T : class
+        {
+            var list = sequence.ToImmutableReadOnlyListOrEmpty();
+
+            foreach (var item in list)
+            {
+                if (item is null)
+                {
+                    return null;
+                }
+            }
+
+            return list;
+        }
+
         internal static ConcatImmutableArray<T> ConcatFast<T>(this ImmutableArray<T> first, ImmutableArray<T> second)
         {
             return new ConcatImmutableArray<T>(first, second);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
@@ -41,19 +41,24 @@ namespace Roslyn.Utilities
             return ImmutableArray.CreateRange<T>(items);
         }
 
-        internal static ImmutableArray<T> ToImmutableArrayOrEmpty<T>(this ImmutableArray<T> items)
-            => items.IsDefault ? ImmutableArray<T>.Empty : items;
-
         internal static IReadOnlyList<T> ToImmutableReadOnlyListOrEmpty<T>(this IEnumerable<T>? items)
         {
-            if (items is ImmutableArray<T> array && !array.IsDefault)
+            if (items is null)
             {
-                return (IReadOnlyList<T>)items;
+                return SpecializedCollections.EmptyImmutableArrayList<T>();
             }
-            else
+
+            if (items is ImmutableArray<T> array)
             {
-                return items.ToImmutableArrayOrEmpty();
+                return array.IsDefaultOrEmpty ? SpecializedCollections.EmptyImmutableArrayList<T>() : (IReadOnlyList<T>)items;
             }
+
+            if (items is ICollection<T> collection && collection.Count == 0)
+            {
+                return SpecializedCollections.EmptyImmutableArrayList<T>();
+            }
+
+            return ImmutableArray.CreateRange(items);
         }
 
         internal static ConcatImmutableArray<T> ConcatFast<T>(this ImmutableArray<T> first, ImmutableArray<T> second)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
@@ -41,29 +41,37 @@ namespace Roslyn.Utilities
             return ImmutableArray.CreateRange<T>(items);
         }
 
-        internal static IReadOnlyList<T> ToImmutableReadOnlyListOrEmpty<T>(this IEnumerable<T>? items)
+        internal static IReadOnlyList<T> ToBoxedImmutableArray<T>(this IEnumerable<T>? items)
         {
             if (items is null)
             {
-                return SpecializedCollections.EmptyImmutableArrayList<T>();
+                return SpecializedCollections.EmptyBoxedImmutableArray<T>();
             }
 
             if (items is ImmutableArray<T> array)
             {
-                return array.IsDefaultOrEmpty ? SpecializedCollections.EmptyImmutableArrayList<T>() : (IReadOnlyList<T>)items;
+                return array.IsDefaultOrEmpty ? SpecializedCollections.EmptyBoxedImmutableArray<T>() : (IReadOnlyList<T>)items;
             }
 
             if (items is ICollection<T> collection && collection.Count == 0)
             {
-                return SpecializedCollections.EmptyImmutableArrayList<T>();
+                return SpecializedCollections.EmptyBoxedImmutableArray<T>();
             }
 
             return ImmutableArray.CreateRange(items);
         }
 
-        internal static IReadOnlyList<T>? AsImmutableReadOnlyListWithNonNullItems<T>(this IEnumerable<T>? sequence) where T : class
+        /// <summary>
+        /// Use to validate public API input for properties that are exposed as <see cref="IReadOnlyList{T}"/>.
+        /// 
+        /// Pattern:
+        /// <code>
+        /// argument.AsBoxedImmutableArrayWithNonNullItems() ?? throw new ArgumentNullException(nameof(argument)),
+        /// </code>
+        /// </summary>
+        internal static IReadOnlyList<T>? AsBoxedImmutableArrayWithNonNullItems<T>(this IEnumerable<T>? sequence) where T : class
         {
-            var list = sequence.ToImmutableReadOnlyListOrEmpty();
+            var list = sequence.ToBoxedImmutableArray();
 
             foreach (var item in list)
             {

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -703,15 +703,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 #End Region
 
 #Region "Declarations"
-        Private Function AsReadOnlyList(Of T)(sequence As IEnumerable(Of T)) As IReadOnlyList(Of T)
-            Dim list = TryCast(sequence, IReadOnlyList(Of T))
-
-            If list Is Nothing Then
-                list = sequence.ToImmutableReadOnlyListOrEmpty()
-            End If
-
-            Return list
-        End Function
 
         Private Shared s_fieldModifiers As DeclarationModifiers = DeclarationModifiers.Const Or DeclarationModifiers.[New] Or DeclarationModifiers.ReadOnly Or DeclarationModifiers.Static Or DeclarationModifiers.WithEvents
         Private Shared s_methodModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.Async Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.Partial Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
@@ -3960,36 +3951,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function Flatten(members As IReadOnlyList(Of SyntaxNode)) As IReadOnlyList(Of SyntaxNode)
-            If members.Count = 0 OrElse Not members.Any(Function(m) GetDeclarationCount(m) > 1) Then
-                Return members
-            End If
-
-            Dim list = New List(Of SyntaxNode)
-            Flatten(members, list)
-            Return list.ToImmutableReadOnlyListOrEmpty()
+            Dim builder = ArrayBuilder(Of SyntaxNode).GetInstance()
+            Flatten(builder, members)
+            Return New ImmutableArrayBox(Of SyntaxNode)(builder.ToImmutableAndFree())
         End Function
 
-        Private Sub Flatten(members As IReadOnlyList(Of SyntaxNode), list As List(Of SyntaxNode))
-            For Each m In members
-                If GetDeclarationCount(m) > 1 Then
-                    Select Case m.Kind
+        Private Sub Flatten(builder As ArrayBuilder(Of SyntaxNode), members As IReadOnlyList(Of SyntaxNode))
+            For Each member In members
+                If GetDeclarationCount(member) > 1 Then
+                    Select Case member.Kind
                         Case SyntaxKind.FieldDeclaration
-                            Flatten(DirectCast(m, FieldDeclarationSyntax).Declarators, list)
+                            Flatten(builder, DirectCast(member, FieldDeclarationSyntax).Declarators)
                         Case SyntaxKind.LocalDeclarationStatement
-                            Flatten(DirectCast(m, LocalDeclarationStatementSyntax).Declarators, list)
+                            Flatten(builder, DirectCast(member, LocalDeclarationStatementSyntax).Declarators)
                         Case SyntaxKind.VariableDeclarator
-                            Flatten(DirectCast(m, VariableDeclaratorSyntax).Names, list)
+                            Flatten(builder, DirectCast(member, VariableDeclaratorSyntax).Names)
                         Case SyntaxKind.AttributesStatement
-                            Flatten(DirectCast(m, AttributesStatementSyntax).AttributeLists, list)
+                            Flatten(builder, DirectCast(member, AttributesStatementSyntax).AttributeLists)
                         Case SyntaxKind.AttributeList
-                            Flatten(DirectCast(m, AttributeListSyntax).Attributes, list)
+                            Flatten(builder, DirectCast(member, AttributeListSyntax).Attributes)
                         Case SyntaxKind.ImportsStatement
-                            Flatten(DirectCast(m, ImportsStatementSyntax).ImportsClauses, list)
+                            Flatten(builder, DirectCast(member, ImportsStatementSyntax).ImportsClauses)
                         Case Else
-                            list.Add(m)
+                            builder.Add(member)
                     End Select
                 Else
-                    list.Add(m)
+                    builder.Add(member)
                 End If
             Next
         End Sub

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -3673,7 +3673,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function GetBaseAndInterfaceTypes(declaration As SyntaxNode) As IReadOnlyList(Of SyntaxNode)
-            Return Me.GetInherits(declaration).SelectMany(Function(ih) ih.Types).Concat(Me.GetImplements(declaration).SelectMany(Function(imp) imp.Types)).ToImmutableReadOnlyListOrEmpty()
+            Return Me.GetInherits(declaration).SelectMany(Function(ih) ih.Types).Concat(Me.GetImplements(declaration).SelectMany(Function(imp) imp.Types)).ToBoxedImmutableArray()
         End Function
 
         Public Overrides Function AddBaseType(declaration As SyntaxNode, baseType As SyntaxNode) As SyntaxNode
@@ -3938,9 +3938,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Private Function GetSubDeclarations(declaration As SyntaxNode) As IReadOnlyList(Of SyntaxNode)
             Select Case declaration.Kind
                 Case SyntaxKind.FieldDeclaration
-                    Return DirectCast(declaration, FieldDeclarationSyntax).Declarators.SelectMany(Function(d) d.Names).ToImmutableReadOnlyListOrEmpty()
+                    Return DirectCast(declaration, FieldDeclarationSyntax).Declarators.SelectMany(Function(d) d.Names).ToBoxedImmutableArray()
                 Case SyntaxKind.LocalDeclarationStatement
-                    Return DirectCast(declaration, LocalDeclarationStatementSyntax).Declarators.SelectMany(Function(d) d.Names).ToImmutableReadOnlyListOrEmpty()
+                    Return DirectCast(declaration, LocalDeclarationStatementSyntax).Declarators.SelectMany(Function(d) d.Names).ToBoxedImmutableArray()
                 Case SyntaxKind.AttributeList
                     Return DirectCast(declaration, AttributeListSyntax).Attributes
                 Case SyntaxKind.ImportsStatement

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -3953,7 +3953,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Private Function Flatten(members As IReadOnlyList(Of SyntaxNode)) As IReadOnlyList(Of SyntaxNode)
             Dim builder = ArrayBuilder(Of SyntaxNode).GetInstance()
             Flatten(builder, members)
-            Return New ImmutableArrayBox(Of SyntaxNode)(builder.ToImmutableAndFree())
+            Return builder.ToImmutableAndFree()
         End Function
 
         Private Sub Flatten(builder As ArrayBuilder(Of SyntaxNode), members As IReadOnlyList(Of SyntaxNode))


### PR DESCRIPTION
Adds missing tests and argument validation. Moves argument validation closer to exposed public surface.

Fixes https://github.com/dotnet/roslyn/issues/37880