### PR TITLE
Implement relational patterns for decimal.

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.87
+# Visual Studio 15
+VisualStudioVersion = 15.0.27102.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.UnitTests", "src\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -159,8 +159,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildBoss", "src\Tools\BuildBoss\BuildBoss.csproj", "{8A02AFAF-F622-4E3E-9E1A-8CFDACC7C7E1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Net.Compilers.Toolset.Package", "src\NuGet\Microsoft.Net.Compilers.Toolset\Microsoft.Net.Compilers.Toolset.Package.csproj", "{6D407402-CC4A-4125-9B00-C70562A636A5}"
-EndProject
-Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "vbi", "src\Interactive\vbi\vbi.vbproj", "{706CFC25-B6E0-4DAA-BCC4-F6FAAFEEDF87}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -437,10 +435,6 @@ Global
 		{6D407402-CC4A-4125-9B00-C70562A636A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D407402-CC4A-4125-9B00-C70562A636A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D407402-CC4A-4125-9B00-C70562A636A5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{706CFC25-B6E0-4DAA-BCC4-F6FAAFEEDF87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{706CFC25-B6E0-4DAA-BCC4-F6FAAFEEDF87}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{706CFC25-B6E0-4DAA-BCC4-F6FAAFEEDF87}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{706CFC25-B6E0-4DAA-BCC4-F6FAAFEEDF87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -514,7 +508,6 @@ Global
 		{B446E771-AB52-41C9-ACFC-FDF8EACAF291} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{8A02AFAF-F622-4E3E-9E1A-8CFDACC7C7E1} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{6D407402-CC4A-4125-9B00-C70562A636A5} = {274B96B7-F815-47E3-9CA4-4024A57A478F}
-		{706CFC25-B6E0-4DAA-BCC4-F6FAAFEEDF87} = {3FF38FD4-DF16-44B0-924F-0D5AE155495B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F599E08-A9EA-4FAA-897F-5D824B0210E6}

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -1262,6 +1262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SpecialType.System_UInt32 => BinaryOperatorKind.UInt,
                 SpecialType.System_Int64 => BinaryOperatorKind.Long,
                 SpecialType.System_UInt64 => BinaryOperatorKind.ULong,
+                SpecialType.System_Decimal => BinaryOperatorKind.Decimal,
                 _ => BinaryOperatorKind.Error,
             };
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         literal = _factory.Literal(literal.ConstantValue.Int32Value);
                     }
 
-                    return _factory.Binary(operatorKind, comparisonType, input, literal);
+                    return this._localRewriter.MakeBinaryOperator(_factory.Syntax, operatorKind, input, literal, comparisonType, method: null);
                 }
 
                 BoundExpression makeEqualityTest(BoundExpression loweredLiteral, BoundExpression input)

--- a/src/Compilers/CSharp/Portable/Utilities/IValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/IValueSet.cs
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// <summary>
     /// An interface representing a set of values of a specific type.  During construction of the state machine
     /// for pattern-matching, we track the set of values of each intermediate result that can reach each state.
-    /// That permits us to determine when tests can be eliminated either because they are impossible (can be
+    /// That permits us to determine when tests can be eliminated either because they are impossible (and can be
     /// replaced by an always-false test) or always true with the set of values that can reach that state (and
-    /// can be replaced by an always true test).
+    /// can be replaced by an always-true test).
     /// </summary>
     internal interface IValueSet
     {
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Test if the value set contains any values that satisfy the given relation with the given value.  Supported values for <paramref name="relation"/>
-        /// Are <see cref="BinaryOperatorKind.Equal"/> for all supported types, and for numeric types (except decimal) we also support
+        /// are <see cref="BinaryOperatorKind.Equal"/> for all supported types, and for numeric types we also support
         /// <see cref="BinaryOperatorKind.LessThan"/>, <see cref="BinaryOperatorKind.LessThanOrEqual"/>, <see cref="BinaryOperatorKind.GreaterThan"/>, and
         /// <see cref="BinaryOperatorKind.GreaterThanOrEqual"/>.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ByteTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ByteTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct ByteTC : NumericTC<byte>
+        private struct ByteTC : INumericTC<byte>
         {
-            byte NumericTC<byte>.MinValue => byte.MinValue;
+            byte INumericTC<byte>.MinValue => byte.MinValue;
 
-            byte NumericTC<byte>.MaxValue => byte.MaxValue;
+            byte INumericTC<byte>.MaxValue => byte.MaxValue;
 
-            (byte leftMax, byte rightMin) NumericTC<byte>.Partition(byte min, byte max)
+            (byte leftMax, byte rightMin) INumericTC<byte>.Partition(byte min, byte max)
             {
                 Debug.Assert(min < max);
                 int half = (max - min) / 2;
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, rightMin);
             }
 
-            bool NumericTC<byte>.Related(BinaryOperatorKind relation, byte left, byte right)
+            bool INumericTC<byte>.Related(BinaryOperatorKind relation, byte left, byte right)
             {
                 switch (relation)
                 {
@@ -47,15 +47,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            byte NumericTC<byte>.Next(byte value)
+            byte INumericTC<byte>.Next(byte value)
             {
                 Debug.Assert(value != byte.MaxValue);
                 return (byte)(value + 1);
             }
 
-            byte EqualableValueTC<byte>.FromConstantValue(ConstantValue constantValue) => constantValue.ByteValue;
+            byte INumericTC<byte>.FromConstantValue(ConstantValue constantValue) => constantValue.ByteValue;
 
-            string NumericTC<byte>.ToString(byte value) => value.ToString();
+            string INumericTC<byte>.ToString(byte value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.CharTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.CharTC.cs
@@ -59,13 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             string INumericTC<char>.ToString(char c)
             {
-                // The set of Unicode character categories containing non-rendering,
-                // unknown, or incomplete characters.
-                var nonRenderingCategories = new UnicodeCategory[] {
-                    UnicodeCategory.Control,
-                    UnicodeCategory.OtherNotAssigned,
-                    UnicodeCategory.Surrogate };
-                var isPrintable = char.IsWhiteSpace(c) || !nonRenderingCategories.Contains(char.GetUnicodeCategory(c));
+                var isPrintable = char.IsWhiteSpace(c) ||
+                    // exclude the Unicode character categories containing non-rendering,
+                    // unknown, or incomplete characters.
+                    char.GetUnicodeCategory(c) switch { UnicodeCategory.Control => false, UnicodeCategory.OtherNotAssigned => false, UnicodeCategory.Surrogate => false, _ => true };
                 return isPrintable ? $"'{c}'" : $"\\u{(int)c:X4}";
             }
         }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.DecimalTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.DecimalTC.cs
@@ -4,13 +4,250 @@
 
 #nullable enable
 
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using Roslyn.Utilities;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    using static BinaryOperatorKind;
+
     internal static partial class ValueSetFactory
     {
-        private struct DecimalTC : EqualableValueTC<decimal>
+        private struct DecimalTC : INumericTC<decimal>
         {
-            decimal EqualableValueTC<decimal>.FromConstantValue(ConstantValue constantValue) => constantValue.DecimalValue;
+            // These are the smallest nonzero normal mantissa value (in three parts) below which you could use a higher scale.
+            // This is the 96-bit representation of ((2^96)-1) / 10;
+            private const uint transitionLow = 0x99999999;
+            private const uint transitionMid = 0x99999999;
+            private const uint transitionHigh = 0x19999999;
+            private const byte maxScale = 28;
+
+            private static readonly decimal normalZero = new decimal(lo: 0, mid: 0, hi: 0, isNegative: false, scale: maxScale);
+            private static readonly decimal epsilon = new decimal(lo: 1, mid: 0, hi: 0, isNegative: false, scale: maxScale);
+
+            decimal INumericTC<decimal>.MinValue => decimal.MinValue;
+
+            decimal INumericTC<decimal>.MaxValue => decimal.MaxValue;
+
+            decimal INumericTC<decimal>.FromConstantValue(ConstantValue constantValue) => constantValue.DecimalValue;
+
+            public decimal Next(decimal value)
+            {
+                Debug.Assert(value != decimal.MaxValue);
+                if (value == 0m)
+                    return epsilon;
+                var (low, mid, high, isNegative, scale) = DecimalRep.FromValue(value);
+                Debug.Assert(scale == DecimalRep.FromValue(value).Normalize().scale); // assert that the input is normalized
+                if (isNegative)
+                {
+                    // get the next value closer to zero.(less negative)
+                    if (value == -epsilon)
+                        return normalZero; // skip negative zero
+
+                    // This should not occur, as numbers such as this are not in our normal form (not at maximum scale).
+                    Debug.Assert(!(scale < 28 && low == transitionLow && mid == transitionMid && high == transitionHigh));
+
+                    if (low != 0)
+                        return new DecimalRep(low: low - 1, mid: mid, high: high, isNegative: isNegative, scale: scale).Value;
+                    if (mid != 0)
+                        return new DecimalRep(low: uint.MaxValue, mid: mid - 1, high: high, isNegative: isNegative, scale: scale).Value;
+                    Debug.Assert(high > 0); // otherwise value == 0m
+                    return new DecimalRep(low: uint.MaxValue, mid: uint.MaxValue, high: high - 1, isNegative: isNegative, scale: scale).Value;
+                }
+                else
+                {
+                    // get the next value farther from zero.(more positive)
+                    if (low != uint.MaxValue)
+                        return new DecimalRep(low: low + 1, mid: mid, high: high, isNegative: isNegative, scale: scale).Value;
+                    if (mid != uint.MaxValue)
+                        return new DecimalRep(low: 0, mid: mid + 1, high: high, isNegative: isNegative, scale: scale).Value;
+                    if (high != uint.MaxValue)
+                        return new DecimalRep(low: 0, mid: 0, high: high + 1, isNegative: isNegative, scale: scale).Value;
+
+                    // the mantissa it at maximum value.  Divide the mantissa by 10 and decrease the scale.
+                    // Since we know the value of the mantissa, we can simply assign mantissa/10 here.
+                    low = transitionLow;
+                    mid = transitionMid;
+                    high = transitionHigh;
+                    Debug.Assert(scale > 0); // otherwise value == decimal.MaxValue
+                    scale -= 1;
+
+                    var result = new DecimalRep(low: low + 1, mid: mid, high: high, isNegative: isNegative, scale: scale).Value;
+
+                    // Assert that the value returned really is the next possible value.
+                    Debug.Assert(new DecimalRep(low: low, mid: mid, high: high, isNegative: isNegative, scale: scale).Value <= value);
+                    Debug.Assert(result > value);
+                    return result;
+                }
+            }
+
+            public (decimal leftMax, decimal rightMin) Partition(decimal min, decimal max)
+            {
+                // Assert that the input is in our normal form
+                Debug.Assert(DecimalRep.FromValue(min).Normalize().scale == DecimalRep.FromValue(min).scale);
+                Debug.Assert(DecimalRep.FromValue(max).Normalize().scale == DecimalRep.FromValue(max).scale);
+
+                if (min == decimal.MinValue && max == decimal.MaxValue)
+                    return (-epsilon, normalZero);
+
+                Debug.Assert(min < 0 == max < 0);
+                Debug.Assert(min < max);
+                if (min < 0)
+                {
+                    var (m1, m2) = Partition(-max, -min);
+                    return (-m2, -m1);
+                }
+                var (low1, mid1, high1, isNegative1, scale1) = DecimalRep.FromValue(min);
+                var (low2, mid2, high2, isNegative2, scale2) = DecimalRep.FromValue(max);
+                Debug.Assert(!isNegative1 && !isNegative2);
+                Debug.Assert(min != 0 || scale1 == maxScale);
+                Debug.Assert(scale1 >= scale2);
+                decimal value, next;
+
+                if (scale1 > scale2 + 1)
+                {
+                    var m = new DecimalRep(low: uint.MaxValue, mid: uint.MaxValue, high: uint.MaxValue, isNegative: isNegative2, scale: (byte)((scale1 + scale2) / 2));
+                    value = m.Value;
+                    next = Next(value);
+                    Debug.Assert(value > min);
+                    Debug.Assert(next < max);
+                }
+                else if (scale1 == scale2 + 1)
+                {
+                    var m = new DecimalRep(low: uint.MaxValue, mid: uint.MaxValue, high: uint.MaxValue, isNegative: isNegative2, scale: scale1);
+                    value = m.Value;
+                    next = Next(value);
+                    Debug.Assert(value > min);
+                    Debug.Assert(next < max);
+                }
+                else
+                {
+                    Debug.Assert(scale1 == scale2);
+                    uint highm = high1 + (high2 - high1) / 2;
+                    if (highm != high2)
+                    {
+                        value = new DecimalRep(low: uint.MaxValue, mid: uint.MaxValue, high: highm, isNegative: isNegative1, scale: scale1).Value;
+                        next = Next(value);
+                        Debug.Assert(value > min);
+                        Debug.Assert(next < max);
+                    }
+                    else
+                    {
+                        Debug.Assert(highm == high1);
+                        uint midm = mid1 + (mid2 - mid1) / 2;
+                        if (midm != mid2)
+                        {
+                            value = new DecimalRep(low: uint.MaxValue, mid: midm, high: highm, isNegative: isNegative1, scale: scale1).Value;
+                            next = Next(value);
+                            Debug.Assert(value > min);
+                            Debug.Assert(next < max);
+                        }
+                        else
+                        {
+                            Debug.Assert(midm == mid1);
+                            uint lowm = low1 + (low2 - low1) / 2;
+                            Debug.Assert(lowm != low2);
+                            value = new DecimalRep(low: lowm, mid: midm, high: highm, isNegative: isNegative1, scale: scale1).Value;
+                            next = Next(value);
+                            Debug.Assert(value >= min);
+                            Debug.Assert(next <= max);
+                        }
+                    }
+                }
+
+                return (value, next);
+            }
+
+            bool INumericTC<decimal>.Related(BinaryOperatorKind relation, decimal left, decimal right)
+            {
+                switch (relation)
+                {
+                    case Equal:
+                        return left == right;
+                    case GreaterThanOrEqual:
+                        return left >= right;
+                    case GreaterThan:
+                        return left > right;
+                    case LessThanOrEqual:
+                        return left <= right;
+                    case LessThan:
+                        return left < right;
+                    default:
+                        throw new ArgumentException("relation");
+                }
+            }
+
+            string INumericTC<decimal>.ToString(decimal value) => FormattableString.Invariant($"{value:G}");
+
+            private struct DecimalRep
+            {
+                public readonly uint low;
+                public readonly uint mid;
+                public readonly uint high;
+                public readonly bool isNegative;
+                public readonly byte scale;
+
+                public DecimalRep(uint low, uint mid, uint high, bool isNegative, byte scale)
+                {
+                    if (scale > maxScale)
+                        throw new ArgumentException("scale");
+
+                    this.low = low;
+                    this.mid = mid;
+                    this.high = high;
+                    this.isNegative = isNegative;
+                    this.scale = scale;
+                }
+
+                public decimal Value => new decimal(lo: (int)low, mid: (int)mid, hi: (int)high, isNegative: isNegative, scale: scale);
+
+                public DecimalRep Normalize()
+                {
+                    // return the number in the highest possible scale (containing the most precision)
+                    if (this.scale == maxScale)
+                        return this;
+
+                    var (low, mid, high, isNegative, scale) = this;
+
+                    while (scale < maxScale)
+                    {
+                        if (high * 10L > uint.MaxValue)
+                            break;
+
+                        long newHigh = 10L * high;
+                        long newMid = 10L * mid;
+                        long newLow = 10L * low;
+                        newMid += newLow >> 32;
+                        newLow &= uint.MaxValue;
+                        newHigh += newMid >> 32;
+                        newMid &= uint.MaxValue;
+                        if (newHigh > uint.MaxValue)
+                            break;
+
+                        low = (uint)newLow;
+                        mid = (uint)newMid;
+                        high = (uint)newHigh;
+                        scale += 1;
+                    }
+
+                    return new DecimalRep(low, mid, high, isNegative, scale);
+                }
+
+                public static DecimalRep FromValue(decimal value)
+                {
+                    value.GetBits(out bool isNegative, out byte scale, out uint low, out uint mid, out uint high);
+                    Debug.Assert(scale <= maxScale);
+                    return new DecimalRep(low: low, mid: mid, high: high, isNegative: isNegative, scale: scale);
+                }
+
+                public void Deconstruct(out uint low, out uint mid, out uint high, out bool isNegative, out byte scale) =>
+                    (low, mid, high, isNegative, scale) = (this.low, this.mid, this.high, this.isNegative, this.scale);
+
+                public override string ToString() => $"Decimal({(isNegative ? "-" : "+")}, 0x{high:08X} 0x{mid:08X} 0x{low:08X} *10^-{scale})";
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.DecimalTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.DecimalTC.cs
@@ -5,9 +5,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -67,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (high != uint.MaxValue)
                         return new DecimalRep(low: 0, mid: 0, high: high + 1, isNegative: isNegative, scale: scale).Value;
 
-                    // the mantissa it at maximum value.  Divide the mantissa by 10 and decrease the scale.
+                    // the mantissa it at its maximum value.  Divide the mantissa by 10 and decrease the scale.
                     // Since we know the value of the mantissa, we can simply assign mantissa/10 here.
                     low = transitionLow;
                     mid = transitionMid;

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.DoubleTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.DoubleTC.cs
@@ -13,11 +13,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct DoubleTC : FloatingTC<double>, NumericTC<double>
+        private struct DoubleTC : FloatingTC<double>, INumericTC<double>
         {
-            double NumericTC<double>.MinValue => double.MinValue;
+            double INumericTC<double>.MinValue => double.MinValue;
 
-            double NumericTC<double>.MaxValue => double.MaxValue;
+            double INumericTC<double>.MaxValue => double.MaxValue;
 
             double FloatingTC<double>.NaN => double.NaN;
 
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// number.  Every bit sequence between the representation of 0 and MaxValue represents a distinct
             /// value, and the integer representations are ordered by value the same as the floating-point numbers they represent.
             /// </summary>
-            double NumericTC<double>.Next(double value)
+            double INumericTC<double>.Next(double value)
             {
                 Debug.Assert(!double.IsNaN(value));
                 Debug.Assert(!double.IsInfinity(value));
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// number.  Every bit sequence between the representation of 0 and MaxValue represents a distinct
             /// value, and the integer representations are ordered by value the same as the floating-point numbers they represent.
             /// </summary>
-            (double leftMax, double rightMin) NumericTC<double>.Partition(double min, double max)
+            (double leftMax, double rightMin) INumericTC<double>.Partition(double min, double max)
             {
                 Debug.Assert(min < max);
 
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            bool NumericTC<double>.Related(BinaryOperatorKind relation, double left, double right)
+            bool INumericTC<double>.Related(BinaryOperatorKind relation, double left, double right)
             {
                 switch (relation)
                 {
@@ -107,12 +107,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            double EqualableValueTC<double>.FromConstantValue(ConstantValue constantValue) => constantValue.DoubleValue;
+            double INumericTC<double>.FromConstantValue(ConstantValue constantValue) => constantValue.DoubleValue;
 
             /// <summary>
             /// Produce a string for testing purposes that is likely to be the same independent of platform and locale.
             /// </summary>
-            string NumericTC<double>.ToString(double value) => FormattableString.Invariant($"{value:G17}");
+            string INumericTC<double>.ToString(double value) => FormattableString.Invariant($"{value:G17}");
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.EnumeratedValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.EnumeratedValueSet.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// relational operators for it; such a set can be formed only by including explicitly mentioned
         /// members (or the inverse, excluding them, by complementing the set).
         /// </summary>
-        private sealed class EnumeratedValueSet<T, TTC> : IValueSet<T> where TTC : struct, EqualableValueTC<T>
+        private sealed class EnumeratedValueSet<T, TTC> : IValueSet<T> where TTC : struct, IEquatableValueTC<T>
         {
             /// <summary>
             /// In <see cref="_included"/>, then members are listed by inclusion.  Otherwise all members

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.EnumeratedValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.EnumeratedValueSetFactory.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using Roslyn.Utilities;
 
 #nullable enable
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A value set factory that only supports equality and works by including or excluding specific values.
         /// </summary>
-        private sealed class EnumeratedValueSetFactory<T, TTC> : IValueSetFactory<T> where TTC : struct, EqualableValueTC<T>
+        private sealed class EnumeratedValueSetFactory<T, TTC> : IValueSetFactory<T> where TTC : struct, IEquatableValueTC<T>
         {
             public static EnumeratedValueSetFactory<T, TTC> Instance = new EnumeratedValueSetFactory<T, TTC>();
 
@@ -38,7 +39,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             IValueSet<T> IValueSetFactory<T>.Random(int expectedSize, Random random)
             {
-                throw new NotImplementedException($"IValueSetFactory<{typeof(T).ToString()}>.Random");
+                TTC tc = default;
+                T[] values = tc.RandomValues(expectedSize, random, expectedSize * 2);
+                IValueSet<T> result = EnumeratedValueSet<T, TTC>.AllValues.Complement();
+                Debug.Assert(result.IsEmpty);
+                foreach (T value in values)
+                    result = result.Union(Related(Equal, value));
+
+                return result;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.FloatingTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.FloatingTC.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// A type class providing primitive operations needed to support a value set for a floating-point type.
         /// </summary>
-        private interface FloatingTC<T> : NumericTC<T>
+        private interface FloatingTC<T> : INumericTC<T>
         {
             /// <summary>
             /// A "not a number" value for the floating-point type <typeparamref name="T"/>.

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.FloatingValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.FloatingValueSet.cs
@@ -42,6 +42,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool hasNan = random.Next(2) < 1;
                 bool hasMinusInf = random.Next(2) < 1;
                 bool hasPlusInf = random.Next(2) < 1;
+                if (hasNan)
+                    expectedSize--;
+                if (hasMinusInf)
+                    expectedSize--;
+                if (hasPlusInf)
+                    expectedSize--;
+                if (expectedSize < 1)
+                    expectedSize = 2;
                 return new FloatingValueSet<TFloating, TFloatingTC>(
                     hasNaN: hasNan, hasMinusInf: hasMinusInf, hasPlusInf: hasPlusInf, numbers: NumericValueSetFactory<TFloating, TFloatingTC>.Instance.Random(expectedSize, random));
             }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.IEqualableValueTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.IEqualableValueTC.cs
@@ -4,6 +4,8 @@
 
 #nullable enable
 
+using System;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal static partial class ValueSetFactory
@@ -12,13 +14,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// A type class for values (of type <typeparamref name="T"/>) that can be directly compared for equality 
         /// using <see cref="System.Object.Equals(object?, object?)"/>.
         /// </summary>
-        private interface EqualableValueTC<T>
+        private interface IEquatableValueTC<T>
         {
             /// <summary>
             /// Get the constant value of type <typeparamref name="T"/> from a <see cref="ConstantValue"/>. This method is shared among all
             /// typeclasses for value sets.
             /// </summary>
             T FromConstantValue(ConstantValue constantValue);
+
+            /// <summary>
+            /// Generate <paramref name="count"/> random values of type <typeparamref name="T"/>.
+            /// If the domain of <typeparamref name="T"/> is infinite (for example, a string type),
+            /// the <paramref name="count"/> parameter is used to identify the size of a restricted
+            /// domain.  If the domain is finite (for example the numeric types), then
+            /// <paramref name="scope"/> is ignored.
+            /// </summary>
+            T[] RandomValues(int count, Random random, int scope = 0);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.INumericTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.INumericTC.cs
@@ -12,8 +12,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// A type class providing the primitive operations needed to support a value set.
         /// </summary>
         /// <typeparam name="T">the underlying primitive numeric type</typeparam>
-        private interface NumericTC<T> : EqualableValueTC<T>
+        private interface INumericTC<T>
         {
+            /// <summary>
+            /// Get the constant value of type <typeparamref name="T"/> from a <see cref="ConstantValue"/>. This method is shared among all
+            /// typeclasses for value sets.
+            /// </summary>
+            T FromConstantValue(ConstantValue constantValue);
+
             /// <summary>
             /// Compute the value of the binary relational operator on the given operands.
             /// </summary>

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.IntTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.IntTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct IntTC : NumericTC<int>
+        private struct IntTC : INumericTC<int>
         {
-            int NumericTC<int>.MinValue => int.MinValue;
+            int INumericTC<int>.MinValue => int.MinValue;
 
-            int NumericTC<int>.MaxValue => int.MaxValue;
+            int INumericTC<int>.MaxValue => int.MaxValue;
 
-            (int leftMax, int rightMin) NumericTC<int>.Partition(int min, int max)
+            (int leftMax, int rightMin) INumericTC<int>.Partition(int min, int max)
             {
                 Debug.Assert(min < max);
 
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, leftMax + 1);
             }
 
-            bool NumericTC<int>.Related(BinaryOperatorKind relation, int left, int right)
+            bool INumericTC<int>.Related(BinaryOperatorKind relation, int left, int right)
             {
                 switch (relation)
                 {
@@ -52,15 +52,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            int NumericTC<int>.Next(int value)
+            int INumericTC<int>.Next(int value)
             {
                 Debug.Assert(value != int.MaxValue);
                 return value + 1;
             }
 
-            int EqualableValueTC<int>.FromConstantValue(ConstantValue constantValue) => constantValue.Int32Value;
+            int INumericTC<int>.FromConstantValue(ConstantValue constantValue) => constantValue.Int32Value;
 
-            string NumericTC<int>.ToString(int value) => value.ToString();
+            string INumericTC<int>.ToString(int value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.LongTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.LongTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct LongTC : NumericTC<long>
+        private struct LongTC : INumericTC<long>
         {
-            long NumericTC<long>.MinValue => long.MinValue;
+            long INumericTC<long>.MinValue => long.MinValue;
 
-            long NumericTC<long>.MaxValue => long.MaxValue;
+            long INumericTC<long>.MaxValue => long.MaxValue;
 
-            (long leftMax, long rightMin) NumericTC<long>.Partition(long min, long max)
+            (long leftMax, long rightMin) INumericTC<long>.Partition(long min, long max)
             {
                 Debug.Assert(min < max);
 
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, leftMax + 1);
             }
 
-            bool NumericTC<long>.Related(BinaryOperatorKind relation, long left, long right)
+            bool INumericTC<long>.Related(BinaryOperatorKind relation, long left, long right)
             {
                 switch (relation)
                 {
@@ -52,15 +52,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            long NumericTC<long>.Next(long value)
+            long INumericTC<long>.Next(long value)
             {
                 Debug.Assert(value != long.MaxValue);
                 return value + 1;
             }
 
-            long EqualableValueTC<long>.FromConstantValue(ConstantValue constantValue) => constantValue.Int64Value;
+            long INumericTC<long>.FromConstantValue(ConstantValue constantValue) => constantValue.Int64Value;
 
-            string NumericTC<long>.ToString(long value) => value.ToString();
+            string INumericTC<long>.ToString(long value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.NumericValueSet.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.NumericValueSet.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// When used for floating-point values, only numeric values are represented (i.e. values between
         /// MinValue and MaxValue, inclusive).
         /// </summary>
-        private sealed class NumericValueSet<T, TTC> : IValueSet<T> where TTC : struct, NumericTC<T>
+        private sealed class NumericValueSet<T, TTC> : IValueSet<T> where TTC : struct, INumericTC<T>
         {
             private readonly Interval _rootInterval;
 

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.NumericValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.NumericValueSetFactory.cs
@@ -17,9 +17,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// The implementation of a value set factory of any numeric type <typeparamref name="T"/>,
         /// parameterized by a type class
-        /// <see cref="NumericTC{T}"/> that provides the primitives for that type.
+        /// <see cref="INumericTC{T}"/> that provides the primitives for that type.
         /// </summary>
-        private sealed class NumericValueSetFactory<T, TTC> : IValueSetFactory<T> where TTC : struct, NumericTC<T>
+        private sealed class NumericValueSetFactory<T, TTC> : IValueSetFactory<T> where TTC : struct, INumericTC<T>
         {
             public static readonly NumericValueSetFactory<T, TTC> Instance = new NumericValueSetFactory<T, TTC>();
 

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.SByteTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.SByteTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct SByteTC : NumericTC<sbyte>
+        private struct SByteTC : INumericTC<sbyte>
         {
-            sbyte NumericTC<sbyte>.MinValue => sbyte.MinValue;
+            sbyte INumericTC<sbyte>.MinValue => sbyte.MinValue;
 
-            sbyte NumericTC<sbyte>.MaxValue => sbyte.MaxValue;
+            sbyte INumericTC<sbyte>.MaxValue => sbyte.MaxValue;
 
-            (sbyte leftMax, sbyte rightMin) NumericTC<sbyte>.Partition(sbyte min, sbyte max)
+            (sbyte leftMax, sbyte rightMin) INumericTC<sbyte>.Partition(sbyte min, sbyte max)
             {
                 Debug.Assert(min < max);
                 int half = (max - min) / 2;
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, rightMin);
             }
 
-            bool NumericTC<sbyte>.Related(BinaryOperatorKind relation, sbyte left, sbyte right)
+            bool INumericTC<sbyte>.Related(BinaryOperatorKind relation, sbyte left, sbyte right)
             {
                 switch (relation)
                 {
@@ -47,15 +47,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            sbyte NumericTC<sbyte>.Next(sbyte value)
+            sbyte INumericTC<sbyte>.Next(sbyte value)
             {
                 Debug.Assert(value != sbyte.MaxValue);
                 return (sbyte)(value + 1);
             }
 
-            sbyte EqualableValueTC<sbyte>.FromConstantValue(ConstantValue constantValue) => constantValue.SByteValue;
+            sbyte INumericTC<sbyte>.FromConstantValue(ConstantValue constantValue) => constantValue.SByteValue;
 
-            string NumericTC<sbyte>.ToString(sbyte value) => value.ToString();
+            string INumericTC<sbyte>.ToString(sbyte value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ShortTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ShortTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct ShortTC : NumericTC<short>
+        private struct ShortTC : INumericTC<short>
         {
-            short NumericTC<short>.MinValue => short.MinValue;
+            short INumericTC<short>.MinValue => short.MinValue;
 
-            short NumericTC<short>.MaxValue => short.MaxValue;
+            short INumericTC<short>.MaxValue => short.MaxValue;
 
-            (short leftMax, short rightMin) NumericTC<short>.Partition(short min, short max)
+            (short leftMax, short rightMin) INumericTC<short>.Partition(short min, short max)
             {
                 Debug.Assert(min < max);
                 int half = (max - min) / 2;
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, rightMin);
             }
 
-            bool NumericTC<short>.Related(BinaryOperatorKind relation, short left, short right)
+            bool INumericTC<short>.Related(BinaryOperatorKind relation, short left, short right)
             {
                 switch (relation)
                 {
@@ -47,15 +47,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            short NumericTC<short>.Next(short value)
+            short INumericTC<short>.Next(short value)
             {
                 Debug.Assert(value != short.MaxValue);
                 return (short)(value + 1);
             }
 
-            short EqualableValueTC<short>.FromConstantValue(ConstantValue constantValue) => constantValue.Int16Value;
+            short INumericTC<short>.FromConstantValue(ConstantValue constantValue) => constantValue.Int16Value;
 
-            string NumericTC<short>.ToString(short value) => value.ToString();
+            string INumericTC<short>.ToString(short value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.SingleTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.SingleTC.cs
@@ -13,11 +13,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct SingleTC : FloatingTC<float>, NumericTC<float>
+        private struct SingleTC : FloatingTC<float>, INumericTC<float>
         {
-            float NumericTC<float>.MinValue => float.MinValue;
+            float INumericTC<float>.MinValue => float.MinValue;
 
-            float NumericTC<float>.MaxValue => float.MaxValue;
+            float INumericTC<float>.MaxValue => float.MaxValue;
 
             float FloatingTC<float>.NaN => float.NaN;
 
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// number.  Every bit sequence between the representation of 0 and MaxValue represents a distinct
             /// value, and the integer representations are ordered by value the same as the floating-point numbers they represent.
             /// </summary>
-            float NumericTC<float>.Next(float value)
+            float INumericTC<float>.Next(float value)
             {
                 Debug.Assert(!float.IsNaN(value));
                 Debug.Assert(!float.IsInfinity(value));
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// number.  Every bit sequence between the representation of 0 and MaxValue represents a distinct
             /// value, and the integer representations are ordered by value the same as the floating-point numbers they represent.
             /// </summary>
-            (float leftMax, float rightMin) NumericTC<float>.Partition(float min, float max)
+            (float leftMax, float rightMin) INumericTC<float>.Partition(float min, float max)
             {
                 Debug.Assert(min < max);
 
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            bool NumericTC<float>.Related(BinaryOperatorKind relation, float left, float right)
+            bool INumericTC<float>.Related(BinaryOperatorKind relation, float left, float right)
             {
                 switch (relation)
                 {
@@ -111,12 +111,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            float EqualableValueTC<float>.FromConstantValue(ConstantValue constantValue) => constantValue.SingleValue;
+            float INumericTC<float>.FromConstantValue(ConstantValue constantValue) => constantValue.SingleValue;
 
             /// <summary>
             /// Produce a string for testing purposes that is likely to be the same independent of platform and locale.
             /// </summary>
-            string NumericTC<float>.ToString(float value) => FormattableString.Invariant($"{value:G9}");
+            string INumericTC<float>.ToString(float value) => FormattableString.Invariant($"{value:G9}");
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.StringTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.StringTC.cs
@@ -4,13 +4,36 @@
 
 #nullable enable
 
+using System;
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal static partial class ValueSetFactory
     {
-        private struct StringTC : EqualableValueTC<string>
+        private struct StringTC : IEquatableValueTC<string>
         {
-            string EqualableValueTC<string>.FromConstantValue(ConstantValue constantValue) => constantValue.StringValue!;
+            string IEquatableValueTC<string>.FromConstantValue(ConstantValue constantValue) => constantValue.StringValue!;
+
+            string[] IEquatableValueTC<string>.RandomValues(int count, Random random, int scope)
+            {
+                Debug.Assert(count > 0);
+                Debug.Assert(scope > count);
+                string[] result = new string[count];
+                int next = 0;
+                for (int i = 0; i < scope; i++)
+                {
+                    int need = count - next;
+                    int remain = scope - i;
+                    if (random.NextDouble() * remain < need)
+                    {
+                        result[next++] = i.ToString();
+                    }
+                }
+
+                Debug.Assert(next == count);
+                return result;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UIntTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UIntTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct UIntTC : NumericTC<uint>
+        private struct UIntTC : INumericTC<uint>
         {
-            uint NumericTC<uint>.MinValue => uint.MinValue;
+            uint INumericTC<uint>.MinValue => uint.MinValue;
 
-            uint NumericTC<uint>.MaxValue => uint.MaxValue;
+            uint INumericTC<uint>.MaxValue => uint.MaxValue;
 
-            (uint leftMax, uint rightMin) NumericTC<uint>.Partition(uint min, uint max)
+            (uint leftMax, uint rightMin) INumericTC<uint>.Partition(uint min, uint max)
             {
                 Debug.Assert(min < max);
                 uint half = (max - min) / 2;
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, leftMax + 1);
             }
 
-            bool NumericTC<uint>.Related(BinaryOperatorKind relation, uint left, uint right)
+            bool INumericTC<uint>.Related(BinaryOperatorKind relation, uint left, uint right)
             {
                 switch (relation)
                 {
@@ -46,15 +46,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            uint NumericTC<uint>.Next(uint value)
+            uint INumericTC<uint>.Next(uint value)
             {
                 Debug.Assert(value != uint.MaxValue);
                 return value + 1;
             }
 
-            uint EqualableValueTC<uint>.FromConstantValue(ConstantValue constantValue) => constantValue.UInt32Value;
+            uint INumericTC<uint>.FromConstantValue(ConstantValue constantValue) => constantValue.UInt32Value;
 
-            string NumericTC<uint>.ToString(uint value) => value.ToString();
+            string INumericTC<uint>.ToString(uint value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ULongTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ULongTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct ULongTC : NumericTC<ulong>
+        private struct ULongTC : INumericTC<ulong>
         {
-            ulong NumericTC<ulong>.MinValue => ulong.MinValue;
+            ulong INumericTC<ulong>.MinValue => ulong.MinValue;
 
-            ulong NumericTC<ulong>.MaxValue => ulong.MaxValue;
+            ulong INumericTC<ulong>.MaxValue => ulong.MaxValue;
 
-            (ulong leftMax, ulong rightMin) NumericTC<ulong>.Partition(ulong min, ulong max)
+            (ulong leftMax, ulong rightMin) INumericTC<ulong>.Partition(ulong min, ulong max)
             {
                 Debug.Assert(min < max);
                 ulong half = (max - min) / 2;
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, leftMax + 1);
             }
 
-            bool NumericTC<ulong>.Related(BinaryOperatorKind relation, ulong left, ulong right)
+            bool INumericTC<ulong>.Related(BinaryOperatorKind relation, ulong left, ulong right)
             {
                 switch (relation)
                 {
@@ -46,15 +46,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ulong NumericTC<ulong>.Next(ulong value)
+            ulong INumericTC<ulong>.Next(ulong value)
             {
                 Debug.Assert(value != ulong.MaxValue);
                 return value + 1;
             }
 
-            ulong EqualableValueTC<ulong>.FromConstantValue(ConstantValue constantValue) => constantValue.UInt64Value;
+            ulong INumericTC<ulong>.FromConstantValue(ConstantValue constantValue) => constantValue.UInt64Value;
 
-            string NumericTC<ulong>.ToString(ulong value) => value.ToString();
+            string INumericTC<ulong>.ToString(ulong value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UShortTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UShortTC.cs
@@ -13,13 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal static partial class ValueSetFactory
     {
-        private struct UShortTC : NumericTC<ushort>
+        private struct UShortTC : INumericTC<ushort>
         {
-            ushort NumericTC<ushort>.MinValue => ushort.MinValue;
+            ushort INumericTC<ushort>.MinValue => ushort.MinValue;
 
-            ushort NumericTC<ushort>.MaxValue => ushort.MaxValue;
+            ushort INumericTC<ushort>.MaxValue => ushort.MaxValue;
 
-            (ushort leftMax, ushort rightMin) NumericTC<ushort>.Partition(ushort min, ushort max)
+            (ushort leftMax, ushort rightMin) INumericTC<ushort>.Partition(ushort min, ushort max)
             {
                 Debug.Assert(min < max);
                 int half = (max - min) / 2;
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return (leftMax, rightMin);
             }
 
-            bool NumericTC<ushort>.Related(BinaryOperatorKind relation, ushort left, ushort right)
+            bool INumericTC<ushort>.Related(BinaryOperatorKind relation, ushort left, ushort right)
             {
                 switch (relation)
                 {
@@ -47,15 +47,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ushort NumericTC<ushort>.Next(ushort value)
+            ushort INumericTC<ushort>.Next(ushort value)
             {
                 Debug.Assert(value != ushort.MaxValue);
                 return (ushort)(value + 1);
             }
 
-            ushort EqualableValueTC<ushort>.FromConstantValue(ConstantValue constantValue) => constantValue.UInt16Value;
+            ushort INumericTC<ushort>.FromConstantValue(ConstantValue constantValue) => constantValue.UInt16Value;
 
-            string NumericTC<ushort>.ToString(ushort value) => value.ToString();
+            string INumericTC<ushort>.ToString(ushort value) => value.ToString();
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static readonly IValueSetFactory<float> ForFloat = FloatingValueSetFactory<float, SingleTC>.Instance;
         internal static readonly IValueSetFactory<double> ForDouble = FloatingValueSetFactory<double, DoubleTC>.Instance;
         internal static readonly IValueSetFactory<string> ForString = EnumeratedValueSetFactory<string, StringTC>.Instance;
-        internal static readonly IValueSetFactory<decimal> ForDecimal = EnumeratedValueSetFactory<decimal, DecimalTC>.Instance;
+        internal static readonly IValueSetFactory<decimal> ForDecimal = NumericValueSetFactory<decimal, DecimalTC>.Instance;
 
         public static IValueSetFactory? ForSpecialType(SpecialType specialType)
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests3.cs
@@ -2926,23 +2926,6 @@ class C
         }
 
         [Fact]
-        public void TEMP()
-        {
-            var source = @"
-public static class C
-{
-    static int M(string s) => s switch
-    {
-        ""a"" => 1,
-        ""b"" => 2,
-        _ => 3
-    };
-}";
-            CreateCompilation(source).VerifyDiagnostics(
-                );
-        }
-
-        [Fact]
         public void Relational_10()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Utilities/ValueSetTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Utilities/ValueSetTests.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Reflection.Metadata.Ecma335;
+using ICSharpCode.Decompiler.IL.Transforms;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -237,6 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 IValueSet<int> values1 = ForInt.Related(LessThanOrEqual, i1).Union(ForInt.Related(GreaterThanOrEqual, i2));
                 Assert.Equal($"[{int.MinValue}..{i1}],[{i2}..{int.MaxValue}]", values1.ToString());
                 IValueSet<int> values2 = values1.Complement();
+                Assert.Equal(values1, values2.Complement());
                 Assert.Equal($"[{i1 + 1}..{i2 - 1}]", values2.ToString());
             }
         }
@@ -259,8 +262,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 if (i2 != int.MinValue) test(i2 - 1);
                 test(i2);
                 test(i2 + 1);
-                test(Random.Next(int.MinValue, int.MaxValue));
-                test(Random.Next(int.MinValue, int.MaxValue));
                 void test(int val)
                 {
                     Assert.Equal(val >= i1 && val <= i2, values.Any(Equal, val));
@@ -360,6 +361,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var mi = ForDouble.Related(Equal, double.NegativeInfinity);
             Assert.True(mi.All(LessThan, 0.0));
+            Assert.True(mi.Any(LessThan, 0.0));
+            Assert.True(mi.All(LessThanOrEqual, 0.0));
+            Assert.True(mi.Any(LessThanOrEqual, 0.0));
+            Assert.False(mi.All(GreaterThan, 0.0));
+            Assert.False(mi.Any(GreaterThan, 0.0));
+            Assert.False(mi.All(GreaterThanOrEqual, 0.0));
+            Assert.False(mi.Any(GreaterThanOrEqual, 0.0));
+
+            var i = ForDouble.Related(Equal, double.PositiveInfinity);
+            Assert.False(i.All(LessThan, 0.0));
+            Assert.False(i.Any(LessThan, 0.0));
+            Assert.False(i.All(LessThanOrEqual, 0.0));
+            Assert.False(i.Any(LessThanOrEqual, 0.0));
+            Assert.True(i.All(GreaterThan, 0.0));
+            Assert.True(i.Any(GreaterThan, 0.0));
+            Assert.True(i.All(GreaterThanOrEqual, 0.0));
+            Assert.True(i.Any(GreaterThanOrEqual, 0.0));
         }
 
         [Fact]
@@ -383,7 +401,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             IValueSet b = t;
             Assert.Same(b.Intersect(b), b);
             Assert.Same(b.Union(b), b);
-            IValueSetFactory bf = ForBool;
         }
 
         [Fact]
@@ -404,7 +421,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             IValueSet b = s1;
             Assert.Same(b.Intersect(b), b);
             Assert.Same(b.Union(b), b);
-            IValueSetFactory bf = ForString;
             Assert.False(s1.Union(s2).All(Equal, "a"));
         }
 
@@ -492,23 +508,72 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void TestDecimalRelationsErrorTolerance()
+        public void TestDecimalRelations_01()
         {
-            Assert.Equal("~{}", ForDecimal.Related(LessThan, 0.0m).ToString());
-            Assert.Equal("~{}", ForDecimal.Related(LessThanOrEqual, 0.0m).ToString());
-            Assert.Equal("~{}", ForDecimal.Related(GreaterThan, 0.0m).ToString());
-            Assert.Equal("~{}", ForDecimal.Related(GreaterThanOrEqual, 0.0m).ToString());
+            Assert.Equal("[-79228162514264337593543950335..-0.0000000000000000000000000001]", ForDecimal.Related(LessThan, 0.0m).ToString());
+            Assert.Equal("[-79228162514264337593543950335..0.0000000000000000000000000000]", ForDecimal.Related(LessThanOrEqual, 0.0m).ToString());
+            Assert.Equal("[0.0000000000000000000000000001..79228162514264337593543950335]", ForDecimal.Related(GreaterThan, 0.0m).ToString());
+            Assert.Equal("[0.0000000000000000000000000000..79228162514264337593543950335]", ForDecimal.Related(GreaterThanOrEqual, 0.0m).ToString());
         }
 
         [Fact]
-        public void TestFuzz_01()
+        public void TestDecimalEdges_01()
         {
-            const int K = 10;
+            for (byte scale = 0; scale < 29; scale++)
+            {
+                var l = new decimal(~0, ~0, ~0, false, scale);
+                check(l);
+                l = new decimal(~0, ~0, ~0, true, scale);
+                check(l);
+            }
 
+            for (byte scale = 0; scale < 29; scale++)
+            {
+                var l = new decimal(unchecked((int)0x99999999), unchecked((int)0x99999999), 0x19999999, false, scale);
+                check(l);
+                l = new decimal(unchecked((int)0x99999999), unchecked((int)0x99999999), 0x19999999, true, scale);
+                check(l);
+                l = new decimal(unchecked((int)0x99999998), unchecked((int)0x99999999), 0x19999999, false, scale);
+                check(l);
+                l = new decimal(unchecked((int)0x99999998), unchecked((int)0x99999999), 0x19999999, true, scale);
+                check(l);
+                l = new decimal(unchecked((int)0x9999999A), unchecked((int)0x99999999), 0x19999999, false, scale);
+                check(l);
+                l = new decimal(unchecked((int)0x9999999A), unchecked((int)0x99999999), 0x19999999, true, scale);
+                check(l);
+            }
+
+            for (int high = 0; high < 2; high++)
+            {
+                for (int mid = 0; mid < 2; mid++)
+                {
+                    for (int p2 = 0; p2 < 32; p2++)
+                    {
+                        int low = 1 << p2;
+                        var l = new decimal(low, mid, high, false, 28);
+                        check(l);
+                        l = new decimal(low, mid, high, true, 28);
+                        check(l);
+                    }
+                }
+            }
+
+            void check(decimal d)
+            {
+                Assert.False(ForDecimal.Related(LessThan, d).Any(Equal, d));
+                Assert.True(ForDecimal.Related(LessThanOrEqual, d).Any(Equal, d));
+                Assert.False(ForDecimal.Related(GreaterThan, d).Any(Equal, d));
+                Assert.True(ForDecimal.Related(GreaterThanOrEqual, d).Any(Equal, d));
+            }
+        }
+
+        [Fact]
+        public void TestDouble_Fuzz_01()
+        {
             for (int i = 0; i < 100; i++)
             {
-                var s1 = ForDouble.Random(K, Random);
-                var s2 = ForDouble.Random(K, Random);
+                var s1 = ForDouble.Random(10, Random);
+                var s2 = ForDouble.Random(10, Random);
                 var u1 = s1.Union(s2);
                 var u2 = s1.Complement().Intersect(s2.Complement()).Complement();
                 Assert.Equal(u1, u2);
@@ -519,14 +584,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void TestFuzz_02()
+        public void TestString_Fuzz_02()
         {
-            const int K = 13; // half of the alphabet
-
             for (int i = 0; i < 100; i++)
             {
-                var s1 = randomStringSet(K - 1);
-                var s2 = randomStringSet(K + 1);
+                var s1 = ForString.Random(9, Random);
+                var s2 = ForString.Random(11, Random);
+
+                Assert.Equal(s1.Complement().Complement(), s1);
 
                 var u1 = s1.Union(s2);
                 var u2 = s1.Complement().Intersect(s2.Complement()).Complement();
@@ -580,48 +645,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Assert.Equal(i1, i3);
                 Assert.Equal(i1, i4);
             }
-
-            // produce a uniformly random subset of letters of the alphabet of the given size.
-            static IValueSet<string> randomStringSet(int size)
-            {
-                Assert.True(size > 0);
-                Assert.True(size < 26);
-                IValueSet<string> result = null;
-                int need = size;
-                for (char c = 'a'; c <= 'z'; c++)
-                {
-                    int cand = 'z' - c + 1;
-                    if (Random.NextDouble() < (1.0 * need / cand))
-                    {
-                        var added = ForString.Related(Equal, c.ToString());
-                        result = result?.Union(added) ?? added;
-                        need--;
-                    }
-                }
-
-                // check that we have `size` members
-                int found = 0;
-                for (char c = 'a'; c <= 'z'; c++)
-                {
-                    if (result.Any(Equal, c.ToString()))
-                        found++;
-                }
-                Assert.Equal(size, found);
-
-                Debug.Assert(need == 0);
-                return result;
-            }
         }
 
         [Fact]
-        public void TestFuzz_03()
+        public void TestChar_Fuzz_03()
         {
-            const int K = 13; // half of the alphabet
-
             for (int i = 0; i < 100; i++)
             {
-                var s1 = randomCharSet();
-                var s2 = randomCharSet();
+                var s1 = ForChar.Random(10, Random);
+                var s2 = ForChar.Random(10, Random);
                 var u1 = s1.Union(s2);
                 var u2 = s1.Complement().Intersect(s2.Complement()).Complement();
                 Assert.Equal(u1, u2);
@@ -629,34 +661,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 var i2 = s1.Complement().Union(s2.Complement()).Complement();
                 Assert.Equal(i1, i2);
             }
+        }
 
-            // produce a uniformly random subset of 13 letters of the alphabet.
-            IValueSet<char> randomCharSet()
+        [Fact]
+        public void TestDecimal_Fuzz_01()
+        {
+            for (int i = 0; i < 100; i++)
             {
-                IValueSet<char> result = null;
-                int need = K;
-                for (char c = 'a'; c <= 'z'; c++)
-                {
-                    int cand = 'z' - c + 1;
-                    if (Random.NextDouble() < (1.0 * need / cand))
-                    {
-                        var added = ForChar.Related(Equal, c);
-                        result = result?.Union(added) ?? added;
-                        need--;
-                    }
-                }
-
-                // check that we have 13 members
-                int found = 0;
-                for (char c = 'a'; c <= 'z'; c++)
-                {
-                    if (result.Any(Equal, c))
-                        found++;
-                }
-                Assert.Equal(K, found);
-
-                Debug.Assert(need == 0);
-                return result;
+                var s1 = ForDecimal.Random(10, Random);
+                var s2 = ForDecimal.Random(10, Random);
+                var u1 = s1.Union(s2);
+                var u2 = s1.Complement().Intersect(s2.Complement()).Complement();
+                Assert.Equal(u1, u2);
+                var i1 = s1.Intersect(s2);
+                var i2 = s1.Complement().Union(s2.Complement()).Complement();
+                Assert.Equal(i1, i2);
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Utilities/ValueSetTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Utilities/ValueSetTests.cs
@@ -3,15 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Reflection.Metadata.Ecma335;
-using ICSharpCode.Decompiler.IL.Transforms;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    using static Microsoft.CodeAnalysis.CSharp.ValueSetFactory;
     using static BinaryOperatorKind;
+    using static Microsoft.CodeAnalysis.CSharp.ValueSetFactory;
 
     /// <summary>
     /// Test some internal implementation data structures used in <see cref="DecisionDagBuilder"/>.


### PR DESCRIPTION
* Implement relational patterns for decimal.
* Implements and tests null purity checking for the type pattern `object` (e.g. in `is not object`).
* Significantly improves the debug dumper for the decision dag builder.
* Fixed a bug in EnumeratedValueSet and enhanced the fuzz tests to catch it.
* Move to common random-set generation code.
* Rename the typeclass interfaces xTC to IxTC.
* Improve the `ToString` for `char`.
* Add double complement tests.
* Changes recommended in previous PR code review.

@RikkiGibson @agocke Can you review this please?  It addresses one of the outstanding pattern-matching issues from https://github.com/dotnet/roslyn/issues/41502

Relates to https://github.com/dotnet/roslyn/issues/40727 (test plan)
